### PR TITLE
fix(refs): support inductive external references

### DIFF
--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -228,7 +228,7 @@ work in the same project.
 
 ### Compiled code tagged with `@[blueprint "addition_assoc_compiled"]`
 
-Use the `@[blueprint "label"]` attribute when a compiled definition or theorem
+Use the `@[blueprint "label"]` attribute when a compiled definition-like declaration or theorem
 should appear as a Lean-owned Blueprint node:
 
 ```lean

--- a/src/VersoBlueprint/Attribute.lean
+++ b/src/VersoBlueprint/Attribute.lean
@@ -18,22 +18,11 @@ open Lean
 
 syntax (name := blueprint) "blueprint" ppSpace str : attr
 
-private def constantInfoKind : ConstantInfo → String
-  | .axiomInfo _ => "axiom"
-  | .defnInfo _ => "definition"
-  | .thmInfo _ => "theorem"
-  | .opaqueInfo _ => "opaque"
-  | .quotInfo _ => "quot primitive"
-  | .inductInfo _ => "inductive"
-  | .ctorInfo _ => "constructor"
-  | .recInfo _ => "recursor"
-
 private def classifyDeclKind (decl : Name) (info : ConstantInfo) : CoreM Data.NodeKind :=
-  match info with
-  | .defnInfo _ => pure .definition
-  | .thmInfo _ => pure .theorem
-  | _ =>
-    throwError "invalid '[blueprint]' target '{decl}': expected a definition or theorem, got {constantInfoKind info}"
+  match Informal.Data.ConstantInfo.blueprintNodeKind? info with
+  | some kind => pure kind
+  | none =>
+    throwError "invalid '[blueprint]' target '{decl}': expected a definition-like declaration or theorem, got {Informal.Data.ConstantInfo.blueprintKindText info}"
 
 mutual
 

--- a/src/VersoBlueprint/Data.lean
+++ b/src/VersoBlueprint/Data.lean
@@ -154,7 +154,7 @@ def ConstantInfo.blueprintNodeKind? : ConstantInfo → Option NodeKind
   | .axiomInfo _ => none
   | .opaqueInfo _ => none
   | .quotInfo _ => none
-  | .inductInfo _ => none
+  | .inductInfo _ => some .definition
   | .ctorInfo _ => none
   | .recInfo _ => none
 

--- a/src/VersoBlueprint/ExternalRefSnapshot.lean
+++ b/src/VersoBlueprint/ExternalRefSnapshot.lean
@@ -117,13 +117,14 @@ def externalRefSnapshot (opts : Lean.Options) (workspaceRoot : System.FilePath)
     }
   | some cinfo =>
     let nodeKind ←
-      match cinfo with
-      | .defnInfo _ => pure Data.NodeKind.definition
-      | .thmInfo _ => pure Data.NodeKind.theorem
-      | .axiomInfo _ | .opaqueInfo _ =>
-        pure ref.kind
-      | _ =>
-        throwError m!"Unsupported external Lean reference '{ref.written}' (canonical '{canonical}') with kind '{Informal.Data.ConstantInfo.blueprintKindText cinfo}'. Only definitions, theorems, and axiom-like placeholders are currently supported."
+      match Informal.Data.ConstantInfo.blueprintNodeKind? cinfo with
+      | some nodeKind => pure nodeKind
+      | none =>
+        match cinfo with
+        | .axiomInfo _ | .opaqueInfo _ =>
+          pure ref.kind
+        | _ =>
+          throwError m!"Unsupported external Lean reference '{ref.written}' (canonical '{canonical}') with kind '{Informal.Data.ConstantInfo.blueprintKindText cinfo}'. Only definition-like declarations, theorems, and axiom-like placeholders are currently supported."
     let ref : Data.ExternalRef := {
       ref with
       canonical

--- a/tests/VersoBlueprintTests/BlueprintAttribute.lean
+++ b/tests/VersoBlueprintTests/BlueprintAttribute.lean
@@ -39,6 +39,8 @@ private def isBlueprintAttrRef (expectedDecl : Name) (expectedKind : Informal.Da
       | return false
     let some definitionNode ← importedNode? "attr.exported.definition"
       | return false
+    let some inductiveNode ← importedNode? "attr.exported.inductive"
+      | return false
     let some undocumentedNode ← importedNode? "attr.exported.undocumented"
       | return false
     pure (
@@ -48,6 +50,9 @@ private def isBlueprintAttrRef (expectedDecl : Name) (expectedKind : Informal.Da
       definitionNode.kind == .definition &&
       definitionNode.code.isSome &&
       definitionNode.statement.isSome &&
+      inductiveNode.kind == .definition &&
+      inductiveNode.code.isSome &&
+      inductiveNode.statement.isSome &&
       undocumentedNode.kind == .definition &&
       undocumentedNode.code.isSome
     )
@@ -59,6 +64,7 @@ private def isBlueprintAttrRef (expectedDecl : Name) (expectedKind : Informal.Da
     pure <|
       !(← importedNodeInLocalData "attr.exported.theorem") &&
       !(← importedNodeInLocalData "attr.exported.definition") &&
+      !(← importedNodeInLocalData "attr.exported.inductive") &&
       !(← importedNodeInLocalData "attr.exported.undocumented")
 
 /-- info: true -/
@@ -69,9 +75,12 @@ private def isBlueprintAttrRef (expectedDecl : Name) (expectedKind : Informal.Da
       | return false
     let some definitionNode ← importedNode? "attr.exported.definition"
       | return false
+    let some inductiveNode ← importedNode? "attr.exported.inductive"
+      | return false
     pure <|
       isBlueprintAttrRef `Verso.VersoBlueprintTests.BlueprintAttribute.Provider.exportedTheorem .theorem theoremNode &&
-      isBlueprintAttrRef `Verso.VersoBlueprintTests.BlueprintAttribute.Provider.exportedDefinition .definition definitionNode
+      isBlueprintAttrRef `Verso.VersoBlueprintTests.BlueprintAttribute.Provider.exportedDefinition .definition definitionNode &&
+      isBlueprintAttrRef `Verso.VersoBlueprintTests.BlueprintAttribute.Provider.exportedInductive .definition inductiveNode
 
 /-- Imported statement payloads should keep empty deps and at least one preview source. -/
 private def importedStatementExportOk (node : Informal.Data.Node) : Bool :=
@@ -87,11 +96,14 @@ private def importedStatementExportOk (node : Informal.Data.Node) : Bool :=
       | return false
     let some definitionNode ← importedNode? "attr.exported.definition"
       | return false
+    let some inductiveNode ← importedNode? "attr.exported.inductive"
+      | return false
     let some undocumentedNode ← importedNode? "attr.exported.undocumented"
       | return false
     pure <|
       importedStatementExportOk theoremNode &&
       importedStatementExportOk definitionNode &&
+      importedStatementExportOk inductiveNode &&
       undocumentedNode.statement.isNone
 
 /-- info: true -/
@@ -102,6 +114,7 @@ private def importedStatementExportOk (node : Informal.Data.Node) : Bool :=
     pure <|
       state.data.contains (Name.mkSimple "attr.exported.theorem") &&
       state.data.contains (Name.mkSimple "attr.exported.definition") &&
+      state.data.contains (Name.mkSimple "attr.exported.inductive") &&
       state.data.contains (Name.mkSimple "attr.exported.undocumented")
 
 end Verso.VersoBlueprintTests.BlueprintAttribute

--- a/tests/VersoBlueprintTests/BlueprintAttribute/Provider.lean
+++ b/tests/VersoBlueprintTests/BlueprintAttribute/Provider.lean
@@ -17,6 +17,12 @@ theorem exportedTheorem : True := by
 @[blueprint "attr.exported.definition"]
 def exportedDefinition : Nat := 7
 
+/-- Exported inductive used to verify `@[blueprint]` accepts definition-like targets. -/
+@[blueprint "attr.exported.inductive"]
+inductive exportedInductive where
+  /-- Constructor used to verify imported inductive blueprint attributes. -/
+  | mk
+
 @[blueprint "attr.exported.undocumented"]
 def exportedUndocumentedDefinition : Nat := 11
 

--- a/tests/VersoBlueprintTests/BlueprintInformal/LeanRefs.lean
+++ b/tests/VersoBlueprintTests/BlueprintInformal/LeanRefs.lean
@@ -13,6 +13,10 @@ open Verso.VersoBlueprintTests.BlueprintInformal.Shared
 
 namespace Verso.VersoBlueprintTests.BlueprintInformal.LeanRefs
 
+inductive AttachedInductive where
+  /-- Constructor used to exercise inductive external references. -/
+  | mk
+
 /-- info: true -/
 #guard_msgs in
 #eval
@@ -85,6 +89,30 @@ def conflictInlineThenExternalValue : Nat := Nat.succ 1
 Simple body.
 :::
 :::::::
+
+#docs (Manual) inductiveLeanRefAccepted "Inductive Lean Ref Accepted" :=
+:::::::
+:::definition "inductive.external" (lean := "AttachedInductive")
+Simple body.
+:::
+:::::::
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show CoreM Bool from do
+    let state ← currentState
+    let some node := state.data.get? (Name.mkSimple "inductive.external")
+      | pure false
+    pure <|
+      node.kind == .definition &&
+      match node.code with
+      | some (.external #[ref]) =>
+        ref.present &&
+        ref.kind == .definition &&
+        ref.canonical == `Verso.VersoBlueprintTests.BlueprintInformal.LeanRefs.AttachedInductive &&
+        ref.render.isOk
+      | _ => false
 
 set_option verso.blueprint.trimTeXLabelPrefix true
 

--- a/tests/VersoBlueprintTests/BlueprintInformal/LeanRefs.lean
+++ b/tests/VersoBlueprintTests/BlueprintInformal/LeanRefs.lean
@@ -13,9 +13,32 @@ open Verso.VersoBlueprintTests.BlueprintInformal.Shared
 
 namespace Verso.VersoBlueprintTests.BlueprintInformal.LeanRefs
 
+private def attachedInductiveName : Name :=
+  `Verso.VersoBlueprintTests.BlueprintInformal.LeanRefs.AttachedInductive
+
 inductive AttachedInductive where
   /-- Constructor used to exercise inductive external references. -/
   | mk
+
+private def attachedInductiveCtorAndRecursor? : CoreM (Option (Name × Name)) := do
+  let env ← getEnv
+  match env.find? attachedInductiveName with
+  | some (.inductInfo info) =>
+    pure <| info.ctors.head?.map fun ctorName =>
+      (ctorName, Lean.mkRecName info.name)
+  | _ =>
+    pure none
+
+private def externalRefRejectedWithKind (decl : Name) (expectedKind : String) : CoreM Bool := do
+  let opts ← getOptions
+  try
+    let _ ← Informal.externalRefSnapshotAtCurrentDir opts (Informal.Data.ExternalRef.ofName decl)
+    pure false
+  catch ex =>
+    let msg ← liftM <| ex.toMessageData.toString
+    pure <|
+      msg.contains s!"with kind '{expectedKind}'" &&
+      msg.contains "Only definition-like declarations, theorems, and axiom-like placeholders are currently supported."
 
 /-- info: true -/
 #guard_msgs in
@@ -113,6 +136,19 @@ Simple body.
         ref.canonical == `Verso.VersoBlueprintTests.BlueprintInformal.LeanRefs.AttachedInductive &&
         ref.render.isOk
       | _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval!
+  show CoreM Bool from do
+    let some (ctorName, recursorName) ← attachedInductiveCtorAndRecursor?
+      | pure false
+    let env ← getEnv
+    let ctorPresent := (env.find? ctorName).isSome
+    let recursorPresent := (env.find? recursorName).isSome
+    let ctorRejected ← externalRefRejectedWithKind ctorName "constructor"
+    let recursorRejected ← externalRefRejectedWithKind recursorName "recursor"
+    pure (ctorPresent && recursorPresent && ctorRejected && recursorRejected)
 
 set_option verso.blueprint.trimTeXLabelPrefix true
 


### PR DESCRIPTION
## Problem
Blueprint external references rejected inductive heads, so structure and inductive declarations could not be attached through `(lean := ...)` or `@[blueprint]` even when the blueprint node was definition-like.

## Scope
- treat `.inductInfo` as definition-like in the shared declaration classifier
- reuse that classification in external snapshots and `@[blueprint]` registration
- add directive-based and attribute-based inductive reference coverage
- update the manual wording for definition-like declarations

## Validation
- `scripts/lean-low-priority lake build VersoBlueprintTests.BlueprintAttribute VersoBlueprintTests.BlueprintInformal.LeanRefs`

## Branch Setup
- rebased onto `v4.29.0`
- supersedes the earlier `main`-based PR flow
