### PR TITLE
[codex] Require paired backport PRs for ready v4.29.0 changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,14 @@ What was wrong, missing, or confusing before this change?
 - Manual checks performed
 - External projects or worktrees exercised
 
+## Backports
+
+Draft `v4.29.0` PRs skip the paired-backport gate. Once a `v4.29.0` PR is
+ready for review, add one line per required backport target:
+
+- `Backport v4.28.0: #123`
+- `Backport v4.28.0: exempt: <reason>`
+
 ## Risks and Follow-Ups
 
 - Known limitations

--- a/.github/workflows/backport-discipline.yml
+++ b/.github/workflows/backport-discipline.yml
@@ -1,0 +1,31 @@
+name: Backport Discipline
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - ready_for_review
+      - converted_to_draft
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: read
+  statuses: read
+
+jobs:
+  paired-backport:
+    name: Paired Backport
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+      - name: Enforce paired backport policy
+        env:
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python3 ./scripts/check_backport_pr.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Run Python harness tests
         run: python3 -m unittest discover -s tests/harness -p 'test_*.py'
       - name: Check Python harness syntax
-        run: python3 -m py_compile scripts/blueprint_harness.py scripts/blueprint_reference_harness.py scripts/blueprint_harness_cli.py scripts/blueprint_harness_paths.py scripts/blueprint_harness_projects.py scripts/blueprint_harness_worktrees.py scripts/check_project_template_fresh_repo.py scripts/check_math_lint_fresh_repo.py scripts/prepare_reference_blueprints_pages.py
+        run: python3 -m py_compile scripts/blueprint_harness.py scripts/blueprint_reference_harness.py scripts/blueprint_harness_cli.py scripts/blueprint_harness_paths.py scripts/blueprint_harness_projects.py scripts/blueprint_harness_worktrees.py scripts/check_project_template_fresh_repo.py scripts/check_math_lint_fresh_repo.py scripts/check_backport_pr.py scripts/prepare_reference_blueprints_pages.py
 
   project-template-fresh-repo:
     name: Project Template Fresh Repo
@@ -82,7 +82,7 @@ jobs:
       - name: Lint GitHub workflows
         uses: docker://rhysd/actionlint:latest
         with:
-          args: .github/workflows/ci.yml .github/workflows/blueprint-pages.yml .github/workflows/reference-blueprints.yml project_template/.github/workflows/blueprint-pages.yml project_template/.github/workflows/pages.yml
+          args: .github/workflows/ci.yml .github/workflows/backport-discipline.yml .github/workflows/blueprint-pages.yml .github/workflows/reference-blueprints.yml project_template/.github/workflows/blueprint-pages.yml project_template/.github/workflows/pages.yml
       - name: Check reusable workflow copy stays in sync
         run: cmp .github/workflows/blueprint-pages.yml project_template/.github/workflows/blueprint-pages.yml
       - name: Install elan

--- a/branch-policy.json
+++ b/branch-policy.json
@@ -1,4 +1,5 @@
 {
   "version": 1,
-  "default_dev_branch": "v4.29.0"
+  "default_dev_branch": "v4.29.0",
+  "required_backport_branches": ["v4.28.0"]
 }

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -52,6 +52,16 @@ subjects such as `Update files` or `misc cleanup`.
   - notable risks or follow-up
 - When the work came from a local worktree, include the worktree name and write
   scope in the PR body or draft notes.
+- Non-draft PRs targeting `v4.29.0` must include paired backport metadata for
+  each required backport release branch listed in `branch-policy.json`, unless
+  the PR explicitly records an exemption with a reason.
+- The expected workflow is:
+  - keep the `v4.29.0` PR in draft while the change is still converging
+  - once it is ready for review, open the paired `v4.28.0` PR
+  - wait for CI on both PRs before merging the `v4.29.0` PR
+- Record the pairing in the PR body using lines like:
+  - `Backport v4.28.0: #123`
+  - `Backport v4.28.0: exempt: docs-only change`
 
 See the repository PR template for the preferred structure.
 

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -423,6 +423,16 @@ python3 -m scripts.blueprint_harness require-branch-role default_dev
 Use `require-branch-role default_dev` when a script or agent should refuse to
 do non-backport work from a backport-only checkout.
 
+Ready non-draft PRs that target the default development branch also follow a
+paired-backport gate. In this repository that means `v4.29.0` PRs stay draft
+while the change is converging; once they are ready for review they must either:
+
+- link the paired `v4.28.0` PR in the PR body with `Backport v4.28.0: #<pr>`
+- or record `Backport v4.28.0: exempt: <reason>`
+
+CI checks that the paired PR targets the required backport branch and that its
+checks are green before the `v4.29.0` PR can merge.
+
 To land one reviewed branch onto the active release branch safely from the root
 checkout, use:
 

--- a/scripts/blueprint_harness_branches.py
+++ b/scripts/blueprint_harness_branches.py
@@ -20,6 +20,7 @@ NUMERIC_LEAN_RELEASE_PATTERN = re.compile(r"^v?\d+\.\d+\.\d+(?:[-.A-Za-z0-9]+)?$
 class BranchPolicy:
     version: int
     default_dev_branch: str
+    required_backport_branches: tuple[str, ...]
     source_path: Path
 
 
@@ -48,7 +49,12 @@ def branch_policy_path(checkout_root: Path) -> Path:
 def load_branch_policy(checkout_root: Path) -> BranchPolicy:
     path = branch_policy_path(checkout_root)
     if not path.exists():
-        return BranchPolicy(version=1, default_dev_branch=active_release_branch(checkout_root), source_path=path)
+        return BranchPolicy(
+            version=1,
+            default_dev_branch=active_release_branch(checkout_root),
+            required_backport_branches=(),
+            source_path=path,
+        )
 
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
@@ -62,6 +68,13 @@ def load_branch_policy(checkout_root: Path) -> BranchPolicy:
     if not isinstance(raw_default, str):
         raise SystemExit(f"[blueprint-harness] invalid branch policy file `{path}`: missing string `default_dev_branch`")
 
+    raw_backports = data.get("required_backport_branches", [])
+    if not isinstance(raw_backports, list) or not all(isinstance(item, str) for item in raw_backports):
+        raise SystemExit(
+            f"[blueprint-harness] invalid branch policy file `{path}`: "
+            "`required_backport_branches` must be a list of strings"
+        )
+
     raw_version = data.get("version", 1)
     if not isinstance(raw_version, int):
         raise SystemExit(f"[blueprint-harness] invalid branch policy file `{path}`: `version` must be an integer")
@@ -69,6 +82,7 @@ def load_branch_policy(checkout_root: Path) -> BranchPolicy:
     return BranchPolicy(
         version=raw_version,
         default_dev_branch=normalize_lean_release_ref(raw_default),
+        required_backport_branches=tuple(normalize_lean_release_ref(item) for item in raw_backports),
         source_path=path,
     )
 

--- a/scripts/check_backport_pr.py
+++ b/scripts/check_backport_pr.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import re
+import sys
+from typing import Any
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+if str(Path(__file__).resolve().parents[1]) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.blueprint_harness_branches import load_branch_policy
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+API_BASE = "https://api.github.com"
+API_VERSION = "2022-11-28"
+BACKPORT_LINE_RE = re.compile(r"(?mi)^Backport\s+([^\s:]+)\s*:\s*(.+)\s*$")
+BACKPORT_PR_RE = re.compile(r"(?:#|/pull/)(\d+)\b")
+
+
+@dataclass(frozen=True)
+class BackportEntry:
+    branch: str
+    pr_number: int | None = None
+    exempt_reason: str | None = None
+
+
+class BackportCheckError(RuntimeError):
+    pass
+
+
+class GitHubApi:
+    def __init__(self, repo_full_name: str, token: str):
+        self.repo_full_name = repo_full_name
+        self.token = token
+
+    def get_json(self, path: str) -> Any:
+        request = Request(
+            f"{API_BASE}{path}",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "X-GitHub-Api-Version": API_VERSION,
+            },
+        )
+        try:
+            with urlopen(request) as response:
+                return json.load(response)
+        except HTTPError as err:
+            detail = err.read().decode("utf-8", errors="replace").strip()
+            raise BackportCheckError(f"GitHub API request failed for {path}: {err.code} {detail}") from err
+
+    def pull_request(self, number: int) -> dict[str, Any]:
+        data = self.get_json(f"/repos/{self.repo_full_name}/pulls/{number}")
+        if not isinstance(data, dict):
+            raise BackportCheckError(f"Unexpected pull request payload for #{number}")
+        return data
+
+    def check_runs(self, sha: str) -> dict[str, Any]:
+        data = self.get_json(f"/repos/{self.repo_full_name}/commits/{sha}/check-runs")
+        if not isinstance(data, dict):
+            raise BackportCheckError(f"Unexpected check run payload for {sha}")
+        return data
+
+    def combined_status(self, sha: str) -> dict[str, Any]:
+        data = self.get_json(f"/repos/{self.repo_full_name}/commits/{sha}/status")
+        if not isinstance(data, dict):
+            raise BackportCheckError(f"Unexpected combined status payload for {sha}")
+        return data
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Enforce paired backport PR metadata for ready non-draft default-dev PRs."
+    )
+    parser.add_argument(
+        "--event-path",
+        default=os.environ.get("GITHUB_EVENT_PATH"),
+        help="Path to the GitHub event JSON. Defaults to GITHUB_EVENT_PATH.",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("GITHUB_TOKEN"),
+        help="GitHub token with read access to pull requests and checks. Defaults to GITHUB_TOKEN.",
+    )
+    return parser.parse_args()
+
+
+def load_event(event_path: str | None) -> dict[str, Any]:
+    if not event_path:
+        raise BackportCheckError("missing event path; pass --event-path or set GITHUB_EVENT_PATH")
+    path = Path(event_path)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as err:
+        raise BackportCheckError(f"missing event payload: {path}") from err
+    except json.JSONDecodeError as err:
+        raise BackportCheckError(f"invalid event payload `{path}`: {err}") from err
+    if not isinstance(data, dict):
+        raise BackportCheckError(f"invalid event payload `{path}`: expected JSON object")
+    return data
+
+
+def parse_backport_entries(body: str) -> dict[str, BackportEntry]:
+    entries: dict[str, BackportEntry] = {}
+    for branch, raw_value in BACKPORT_LINE_RE.findall(body):
+        value = raw_value.strip()
+        lower = value.lower()
+        if lower.startswith("exempt"):
+            reason = value[len("exempt") :].lstrip(" :-()")
+            if not reason:
+                raise BackportCheckError(f"Backport {branch}: exemption must include a reason")
+            entries[branch] = BackportEntry(branch=branch, exempt_reason=reason)
+            continue
+
+        pr_match = BACKPORT_PR_RE.search(value)
+        if pr_match is None:
+            raise BackportCheckError(
+                f"Backport {branch}: expected `#<pr>` or `exempt: <reason>`, got `{value}`"
+            )
+        entries[branch] = BackportEntry(branch=branch, pr_number=int(pr_match.group(1)))
+    return entries
+
+
+def check_runs_state(check_runs: dict[str, Any], combined_status: dict[str, Any]) -> None:
+    failures: list[str] = []
+    pending: list[str] = []
+    seen_run = False
+
+    for run in check_runs.get("check_runs", []):
+        if not isinstance(run, dict):
+            continue
+        seen_run = True
+        name = str(run.get("name") or "<unnamed check>")
+        status = str(run.get("status") or "")
+        conclusion = run.get("conclusion")
+        if status != "completed":
+            pending.append(name)
+            continue
+        if conclusion in {"success", "neutral", "skipped"}:
+            continue
+        failures.append(f"{name} ({conclusion or 'unknown'})")
+
+    state = str(combined_status.get("state") or "")
+    if state in {"failure", "error"}:
+        failures.append(f"combined status ({state})")
+    elif state == "pending":
+        pending.append("combined status")
+
+    if failures:
+        raise BackportCheckError("paired backport PR checks are failing: " + ", ".join(failures))
+    if pending:
+        raise BackportCheckError("paired backport PR checks are still pending: " + ", ".join(pending))
+    if not seen_run and state not in {"success", ""}:
+        raise BackportCheckError(f"paired backport PR has unexpected combined status `{state}`")
+    if not seen_run and state == "":
+        raise BackportCheckError("paired backport PR does not report any check runs yet")
+
+
+def verify_backport_pr(
+    api: GitHubApi,
+    branch: str,
+    entry: BackportEntry,
+) -> None:
+    if entry.pr_number is None:
+        return
+    pr = api.pull_request(entry.pr_number)
+    base_ref = str(pr.get("base", {}).get("ref") or "")
+    if base_ref != branch:
+        raise BackportCheckError(
+            f"paired backport PR #{entry.pr_number} targets `{base_ref}`, expected `{branch}`"
+        )
+
+    if bool(pr.get("draft")):
+        raise BackportCheckError(f"paired backport PR #{entry.pr_number} is still draft")
+
+    state = str(pr.get("state") or "")
+    if state == "closed" and not bool(pr.get("merged")):
+        raise BackportCheckError(f"paired backport PR #{entry.pr_number} is closed without merge")
+
+    if bool(pr.get("merged")):
+        return
+
+    sha = str(pr.get("head", {}).get("sha") or "")
+    if not sha:
+        raise BackportCheckError(f"paired backport PR #{entry.pr_number} is missing a head SHA")
+
+    check_runs_state(api.check_runs(sha), api.combined_status(sha))
+
+
+def event_pull_request(event: dict[str, Any]) -> dict[str, Any]:
+    pull_request = event.get("pull_request")
+    if not isinstance(pull_request, dict):
+        raise BackportCheckError("event payload does not contain a pull_request object")
+    return pull_request
+
+
+def should_enforce(pull_request: dict[str, Any], default_dev_branch: str, required_backports: tuple[str, ...]) -> bool:
+    if not required_backports:
+        print("[backport-check] no required backport branches configured; skipping")
+        return False
+    if str(pull_request.get("base", {}).get("ref") or "") != default_dev_branch:
+        print(
+            "[backport-check] PR targets "
+            f"`{pull_request.get('base', {}).get('ref', '')}`, not default dev `{default_dev_branch}`; skipping"
+        )
+        return False
+    if bool(pull_request.get("draft")):
+        print("[backport-check] draft PR; skipping paired backport gate until ready for review")
+        return False
+    return True
+
+
+def run(event_path: str | None, token: str | None) -> int:
+    event = load_event(event_path)
+    pull_request = event_pull_request(event)
+    policy = load_branch_policy(PACKAGE_ROOT)
+
+    if not should_enforce(pull_request, policy.default_dev_branch, policy.required_backport_branches):
+        return 0
+
+    if not token:
+        raise BackportCheckError("missing GitHub token; pass --token or set GITHUB_TOKEN")
+
+    body = str(pull_request.get("body") or "")
+    entries = parse_backport_entries(body)
+    missing = [branch for branch in policy.required_backport_branches if branch not in entries]
+    if missing:
+        raise BackportCheckError(
+            "missing paired backport metadata for "
+            + ", ".join(missing)
+            + ". Add lines like `Backport v4.28.0: #123` or `Backport v4.28.0: exempt: <reason>`"
+        )
+
+    repository = event.get("repository")
+    if not isinstance(repository, dict) or not isinstance(repository.get("full_name"), str):
+        raise BackportCheckError("event payload is missing repository.full_name")
+    api = GitHubApi(repository["full_name"], token)
+
+    for branch in policy.required_backport_branches:
+        entry = entries[branch]
+        if entry.exempt_reason is not None:
+            print(f"[backport-check] {branch}: exempt ({entry.exempt_reason})")
+            continue
+        verify_backport_pr(api, branch, entry)
+        print(f"[backport-check] {branch}: paired PR #{entry.pr_number} is ready")
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        return run(args.event_path, args.token)
+    except BackportCheckError as err:
+        print(f"[backport-check] FAIL: {err}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/harness/test_backport_pr_check.py
+++ b/tests/harness/test_backport_pr_check.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import scripts.check_backport_pr as backport_mod
+
+
+class BackportPrCheckTests(unittest.TestCase):
+    def test_parse_backport_entries_accepts_pr_and_exemption(self) -> None:
+        body = """
+Backport v4.28.0: #42
+Backport v4.27.0: exempt: no longer maintained
+"""
+        entries = backport_mod.parse_backport_entries(body)
+        self.assertEqual(entries["v4.28.0"].pr_number, 42)
+        self.assertIsNone(entries["v4.28.0"].exempt_reason)
+        self.assertEqual(entries["v4.27.0"].exempt_reason, "no longer maintained")
+
+    def test_parse_backport_entries_accepts_pull_request_url(self) -> None:
+        body = "Backport v4.28.0: https://github.com/leanprover/verso-blueprint/pull/123\n"
+        entries = backport_mod.parse_backport_entries(body)
+        self.assertEqual(entries["v4.28.0"].pr_number, 123)
+
+    def test_parse_backport_entries_rejects_missing_exemption_reason(self) -> None:
+        with self.assertRaisesRegex(backport_mod.BackportCheckError, "exemption must include a reason"):
+            backport_mod.parse_backport_entries("Backport v4.28.0: exempt\n")
+
+    def test_should_enforce_skips_draft_prs(self) -> None:
+        pull_request = {"base": {"ref": "v4.29.0"}, "draft": True}
+        self.assertFalse(backport_mod.should_enforce(pull_request, "v4.29.0", ("v4.28.0",)))
+
+    def test_should_enforce_skips_non_default_dev_targets(self) -> None:
+        pull_request = {"base": {"ref": "v4.28.0"}, "draft": False}
+        self.assertFalse(backport_mod.should_enforce(pull_request, "v4.29.0", ("v4.28.0",)))
+
+    def test_check_runs_state_rejects_pending_and_failing_runs(self) -> None:
+        with self.assertRaisesRegex(backport_mod.BackportCheckError, "pending"):
+            backport_mod.check_runs_state(
+                {"check_runs": [{"name": "CI", "status": "in_progress", "conclusion": None}]},
+                {"state": "pending"},
+            )
+
+        with self.assertRaisesRegex(backport_mod.BackportCheckError, "failing"):
+            backport_mod.check_runs_state(
+                {"check_runs": [{"name": "CI", "status": "completed", "conclusion": "failure"}]},
+                {"state": "failure"},
+            )
+
+    def test_run_requires_metadata_for_ready_default_dev_prs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            event_path = Path(tmp) / "event.json"
+            event_path.write_text(
+                """
+{
+  "repository": {"full_name": "leanprover/verso-blueprint"},
+  "pull_request": {
+    "base": {"ref": "v4.29.0"},
+    "draft": false,
+    "body": ""
+  }
+}
+""".strip(),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(backport_mod.BackportCheckError, "missing paired backport metadata"):
+                backport_mod.run(str(event_path), token="token")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/harness/test_blueprint_harness_branches.py
+++ b/tests/harness/test_blueprint_harness_branches.py
@@ -21,7 +21,20 @@ class BlueprintHarnessBranchPolicyTests(unittest.TestCase):
 
             self.assertEqual(policy.version, 1)
             self.assertEqual(policy.default_dev_branch, "v4.29.0")
+            self.assertEqual(policy.required_backport_branches, ())
             self.assertEqual(policy.source_path, root / "branch-policy.json")
+
+    def test_load_branch_policy_reads_required_backport_branches(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write(
+                root / "branch-policy.json",
+                '{\n  "version": 1,\n  "default_dev_branch": "v4.29.0",\n  "required_backport_branches": ["4.28.0"]\n}\n',
+            )
+
+            policy = branches_mod.load_branch_policy(root)
+
+            self.assertEqual(policy.required_backport_branches, ("v4.28.0",))
 
     def test_load_branch_policy_falls_back_to_active_release_branch(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/harness/test_harness_entrypoints.py
+++ b/tests/harness/test_harness_entrypoints.py
@@ -89,6 +89,11 @@ class HarnessEntrypointSmokeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("fresh consumer Blueprint projects", result.stdout)
 
+    def test_backport_pr_check_help(self) -> None:
+        result = self.run_command([sys.executable, "scripts/check_backport_pr.py", "--help"])
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("paired backport", result.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add a paired backport PR gate for ready non-draft `v4.29.0` pull requests
- configure required backport targets in `branch-policy.json` and enforce them with a GitHub Action plus a Python checker
- update the PR template and maintainer/contributor docs to match the draft-then-backport workflow

## Why
We want normal development to converge on `v4.29.0` first, but once a PR is ready for review we need an explicit `v4.28.0` backport plan before merge. The repository did not previously enforce that discipline.

## User impact
Ready non-draft `v4.29.0` PRs now need either:
- `Backport v4.28.0: #<pr>`
- `Backport v4.28.0: exempt: <reason>`

The new `pull_request_target` workflow validates the paired PR target and requires its checks to be green while it remains open.

## Validation
- `python3 -m unittest discover -s tests/harness -p 'test_*.py'`
- `python3 -m py_compile scripts/blueprint_harness.py scripts/blueprint_reference_harness.py scripts/blueprint_harness_cli.py scripts/blueprint_harness_paths.py scripts/blueprint_harness_projects.py scripts/blueprint_harness_worktrees.py scripts/check_project_template_fresh_repo.py scripts/check_math_lint_fresh_repo.py scripts/check_backport_pr.py scripts/prepare_reference_blueprints_pages.py`
