### PR TITLE
[codex] Deploy both v4.28 and v4.29 reference blueprints to Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Run Python harness tests
         run: python3 -m unittest discover -s tests/harness -p 'test_*.py'
       - name: Check Python harness syntax
-        run: python3 -m py_compile scripts/blueprint_harness.py scripts/blueprint_reference_harness.py scripts/blueprint_harness_cli.py scripts/blueprint_harness_paths.py scripts/blueprint_harness_projects.py scripts/blueprint_harness_worktrees.py scripts/check_project_template_fresh_repo.py scripts/check_math_lint_fresh_repo.py scripts/check_backport_pr.py scripts/prepare_reference_blueprints_pages.py
+        run: python3 -m py_compile scripts/blueprint_harness.py scripts/blueprint_reference_harness.py scripts/blueprint_harness_cli.py scripts/blueprint_harness_paths.py scripts/blueprint_harness_projects.py scripts/blueprint_harness_worktrees.py scripts/check_project_template_fresh_repo.py scripts/check_math_lint_fresh_repo.py scripts/check_backport_pr.py scripts/emit_reference_deploy_matrix.py scripts/prepare_reference_blueprints_pages.py
 
   project-template-fresh-repo:
     name: Project Template Fresh Repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,15 @@ jobs:
           key: ${{ runner.os }}-lake-packages-v2-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}
           restore-keys: |
             ${{ runner.os }}-lake-packages-v2-
+      - name: Restore Lake dependency build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .lake/packages/mathlib/.lake/build
+            .lake/packages/verso/.lake/build
+          key: ${{ runner.os }}-lake-deps-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}
+          restore-keys: |
+            ${{ runner.os }}-lake-deps-
       - name: Show tool versions
         run: |
           lean --version
@@ -54,6 +63,15 @@ jobs:
           key: ${{ runner.os }}-lake-packages-v2-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}
           restore-keys: |
             ${{ runner.os }}-lake-packages-v2-
+      - name: Restore Lake dependency build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .lake/packages/mathlib/.lake/build
+            .lake/packages/verso/.lake/build
+          key: ${{ runner.os }}-lake-deps-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}
+          restore-keys: |
+            ${{ runner.os }}-lake-deps-
       - name: Run Lean tests
         run: ./scripts/run-lean-tests.sh
       - name: Run consumer math lint smoke

--- a/.github/workflows/reference-blueprints-deploy.yml
+++ b/.github/workflows/reference-blueprints-deploy.yml
@@ -70,6 +70,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-reference-deploy-lake-packages-v2-${{ matrix.release_id }}-
             ${{ runner.os }}-reference-deploy-lake-packages-v2-
+      - name: Restore Lake dependency build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .lake/packages/mathlib/.lake/build
+            .lake/packages/verso/.lake/build
+          key: ${{ runner.os }}-reference-deploy-lake-deps-${{ matrix.release_id }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}
+          restore-keys: |
+            ${{ runner.os }}-reference-deploy-lake-deps-${{ matrix.release_id }}-
+            ${{ runner.os }}-reference-deploy-lake-deps-
       - name: Show tool versions
         run: |
           lean --version
@@ -106,6 +116,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-reference-deploy-lake-packages-v2-test-
             ${{ runner.os }}-reference-deploy-lake-packages-v2-
+      - name: Restore Lake dependency build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .lake/packages/mathlib/.lake/build
+            .lake/packages/verso/.lake/build
+          key: ${{ runner.os }}-reference-deploy-lake-deps-test-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}
+          restore-keys: |
+            ${{ runner.os }}-reference-deploy-lake-deps-test-
+            ${{ runner.os }}-reference-deploy-lake-deps-
       - name: Show tool versions
         run: |
           lean --version

--- a/.github/workflows/reference-blueprints-deploy.yml
+++ b/.github/workflows/reference-blueprints-deploy.yml
@@ -8,9 +8,9 @@ on:
       - completed
     branches:
       - v*
+  workflow_dispatch:
 
 permissions:
-  actions: read
   contents: read
   pages: write
   id-token: write
@@ -20,39 +20,134 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  resolve-reference-release:
-    name: Resolve Deploy Release
-    if: github.event.workflow_run.conclusion == 'success'
+  resolve-deploy-releases:
+    name: Resolve Deploy Releases
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     outputs:
-      release_id: ${{ steps.resolve.outputs.release_id }}
-      deploy_pages: ${{ steps.resolve.outputs.deploy_pages }}
+      manifest_path: ${{ steps.resolve.outputs.manifest_path }}
+      deployable_release_count: ${{ steps.resolve.outputs.deployable_release_count }}
+      deployable_release_matrix: ${{ steps.resolve.outputs.deployable_release_matrix }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-      - name: Resolve release metadata
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Resolve deploy release metadata
         id: resolve
-        run: python3 ./scripts/emit_reference_release_matrix.py --github-output >> "$GITHUB_OUTPUT"
+        run: python3 ./scripts/emit_reference_deploy_matrix.py --github-output >> "$GITHUB_OUTPUT"
+
+  build-reference-blueprints:
+    name: Build Release ${{ matrix.release_id }}
+    runs-on: ubuntu-latest
+    needs: resolve-deploy-releases
+    if: ${{ needs.resolve-deploy-releases.outputs.deployable_release_count != '0' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.resolve-deploy-releases.outputs.deployable_release_matrix) }}
+    env:
+      BP_REFERENCE_CHECKOUT_MODE: shared
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+      - name: Show deployable release target
+        run: |
+          echo "release_id=${{ matrix.release_id }}"
+          echo "toolchain=${{ matrix.toolchain }}"
+          echo "verso_ref=${{ matrix.verso_ref }}"
+          echo "branch=${{ matrix.branch }}"
+      - name: Install elan
+        run: |
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+      - name: Restore Lake package cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .lake/packages/mathlib
+            .lake/packages/verso
+          key: ${{ runner.os }}-reference-deploy-lake-packages-v2-${{ matrix.release_id }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}
+          restore-keys: |
+            ${{ runner.os }}-reference-deploy-lake-packages-v2-${{ matrix.release_id }}-
+            ${{ runner.os }}-reference-deploy-lake-packages-v2-
+      - name: Show tool versions
+        run: |
+          lean --version
+          lake --version
+          python3 --version
+      - name: Generate release reference blueprints
+        run: python3 -m scripts.blueprint_reference_harness generate --release ${{ matrix.release_id }} --allow-local-build --serial _out/reference-blueprints/${{ matrix.release_id }}
+      - name: Upload release reference artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.artifact_path }}
+
+  build-test-blueprints:
+    name: Build Test Blueprints
+    runs-on: ubuntu-latest
+    needs: resolve-deploy-releases
+    if: ${{ needs.resolve-deploy-releases.outputs.deployable_release_count != '0' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Install elan
+        run: |
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+      - name: Restore Lake package cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .lake/packages/mathlib
+            .lake/packages/verso
+          key: ${{ runner.os }}-reference-deploy-lake-packages-v2-test-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}
+          restore-keys: |
+            ${{ runner.os }}-reference-deploy-lake-packages-v2-test-
+            ${{ runner.os }}-reference-deploy-lake-packages-v2-
+      - name: Show tool versions
+        run: |
+          lean --version
+          lake --version
+          python3 --version
+      - name: Generate test blueprints
+        run: ./scripts/generate-test-blueprints.sh
+      - name: Upload test blueprints artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-blueprints
+          path: _out/test-blueprints
 
   upload-pages-artifact:
     name: Upload Pages Artifact
-    if: github.event.workflow_run.conclusion == 'success' && needs.resolve-reference-release.outputs.deploy_pages == 'true'
     runs-on: ubuntu-latest
-    needs: resolve-reference-release
+    needs:
+      - resolve-deploy-releases
+      - build-reference-blueprints
+      - build-test-blueprints
+    if: ${{ needs.resolve-deploy-releases.outputs.deployable_release_count != '0' }}
     steps:
-      - name: Show deploy release target
-        run: |
-          echo "release_id=${{ needs.resolve-reference-release.outputs.release_id }}"
-          echo "deploy_pages=${{ needs.resolve-reference-release.outputs.deploy_pages }}"
-      - name: Download built site artifact
-        uses: actions/download-artifact@v8
+      - uses: actions/checkout@v4
         with:
-          name: reference-blueprints-site
-          path: _site
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ github.event.workflow_run.id }}
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Show deploy release summary
+        run: |
+          echo "manifest_path=${{ needs.resolve-deploy-releases.outputs.manifest_path }}"
+          echo "deployable_release_count=${{ needs.resolve-deploy-releases.outputs.deployable_release_count }}"
+      - name: Download release reference artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: reference-blueprints-release-*
+          path: _out/reference-blueprints
+          merge-multiple: true
+      - name: Download test blueprints artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: test-blueprints
+          path: _out/test-blueprints
+      - name: Prepare combined Pages artifact
+        run: python3 ./scripts/prepare_reference_blueprints_pages.py
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -60,13 +155,13 @@ jobs:
 
   deploy:
     name: Deploy Pages
-    if: github.event.workflow_run.conclusion == 'success' && needs.resolve-reference-release.outputs.deploy_pages == 'true'
     environment:
       name: github-pages
     runs-on: ubuntu-latest
     needs:
-      - resolve-reference-release
+      - resolve-deploy-releases
       - upload-pages-artifact
+    if: ${{ needs.resolve-deploy-releases.outputs.deployable_release_count != '0' }}
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/reference-blueprints.yml
+++ b/.github/workflows/reference-blueprints.yml
@@ -59,6 +59,15 @@ jobs:
           key: ${{ runner.os }}-lake-packages-v2-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}
           restore-keys: |
             ${{ runner.os }}-lake-packages-v2-
+      - name: Restore Lake dependency build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .lake/packages/mathlib/.lake/build
+            .lake/packages/verso/.lake/build
+          key: ${{ runner.os }}-lake-deps-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}
+          restore-keys: |
+            ${{ runner.os }}-lake-deps-
       - name: Show tool versions
         run: |
           lean --version
@@ -90,6 +99,15 @@ jobs:
           key: ${{ runner.os }}-lake-packages-v2-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}
           restore-keys: |
             ${{ runner.os }}-lake-packages-v2-
+      - name: Restore Lake dependency build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .lake/packages/mathlib/.lake/build
+            .lake/packages/verso/.lake/build
+          key: ${{ runner.os }}-lake-deps-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}
+          restore-keys: |
+            ${{ runner.os }}-lake-deps-
       - name: Show tool versions
         run: |
           lean --version

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -605,25 +605,26 @@ pushes to release branches named like `v4.29.0`, and manual dispatch, it:
   release target
 - builds the local `test-blueprints/` artifact set, including
   `preview_runtime_showcase`
-- stages a site artifact under `_site/` only when the selected release target
-  has `deploy_pages: true`
+- stages a branch-local site artifact under `_site/` only when the selected
+  release target has `deploy_pages: true`
 - uploads that assembled site as a normal workflow artifact
 - uses the shared reference-checkout mode in CI to avoid duplicating warmed
   `.lake/` trees on the GitHub runner
 
 `reference-blueprints-deploy.yml` is the deployment workflow. It runs after a
 successful `reference-blueprints.yml` run on a release branch named like
-`v4.29.0`, re-resolves that branch's release target, and only uploads and
-deploys GitHub Pages when the selected target has `deploy_pages: true`.
+`v4.29.0`, checks out the repository default-development branch as the source
+of truth for deployment policy, resolves every release target with
+`deploy_pages: true`, rebuilds each deployable reference slice in isolation,
+and assembles one combined GitHub Pages artifact.
 
 At the moment that means:
 
 - `v4.29.0` deploys Pages for its selected reference targets
-- `v4.28.0` still validates its selected targets in CI, but does not deploy
-  Pages
+- `v4.28.0` also deploys Pages for its selected reference targets
 
-The staged Pages artifact layout is release-target dependent. It always
-includes:
+The branch-local site artifact produced by `reference-blueprints.yml` for one
+release includes:
 
 - `_site/index.html`
 - `_site/reference-blueprints/<project-id>/` for each deployable reference
@@ -631,6 +632,22 @@ includes:
 - `_site/test-blueprints/index.html`
 - `_site/test-blueprints/preview_runtime_showcase/`
 - `_site/test-blueprints/<slug>/`
+
+The combined Pages artifact produced by `reference-blueprints-deploy.yml`
+includes:
+
+- `_site/index.html`
+- `_site/reference-blueprints/<release-id>/<project-id>/` for each deployable
+  reference target across all deployable release slices
+- `_site/test-blueprints/index.html`
+- `_site/test-blueprints/preview_runtime_showcase/`
+- `_site/test-blueprints/<slug>/`
+
+The shared staging helper understands both input shapes:
+
+- a single-release local/CI artifact rooted at `_out/reference-blueprints/<project-id>/`
+- or a deploy-time combined artifact rooted at
+  `_out/reference-blueprints/<release-id>/<project-id>/`
 
 The staging helper is:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -192,6 +192,16 @@ Current release map:
 - `v4.28.0`: `project-template`, `spherepackingblueprint`, `verso-flt`,
   `algebraic-combinatorics`
 
+Reference blueprint deployment is release-sliced:
+
+- `generate`, `validate`, and `sync` only operate on the current checkout's
+  release slice
+- the branch-local CI artifact for `reference-blueprints.yml` only includes the
+  selected release slice for that branch
+- the Pages deployment workflow rebuilds every release target with
+  `deploy_pages: true` and assembles one combined site under
+  `reference-blueprints/<release-id>/<project-id>/`
+
 `generate`, `validate`, and `sync` refuse to run a different release target
 from the wrong checkout; switch to the corresponding release branch first.
 

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -374,3 +374,28 @@ def reference_build_matrix(projects: list[HarnessProject]) -> dict[str, list[dic
             for project in projects
         ]
     }
+
+
+def deploy_release_artifact_name(release_id: str) -> str:
+    return f"reference-blueprints-release-{release_id}"
+
+
+def deploy_release_artifact_path(release_id: str) -> str:
+    return f"_out/reference-blueprints/{release_id}"
+
+
+def deploy_release_matrix(release_targets: tuple[HarnessReleaseTarget, ...]) -> dict[str, list[dict[str, str]]]:
+    return {
+        "include": [
+            {
+                "release_id": target.release_id,
+                "toolchain": target.toolchain,
+                "verso_ref": target.verso_ref,
+                "branch": target.branch,
+                "artifact_name": deploy_release_artifact_name(target.release_id),
+                "artifact_path": deploy_release_artifact_path(target.release_id),
+            }
+            for target in release_targets
+            if target.deploy_pages
+        ]
+    }

--- a/scripts/emit_reference_deploy_matrix.py
+++ b/scripts/emit_reference_deploy_matrix.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.blueprint_harness_paths import detect_harness_layout
+from scripts.blueprint_harness_projects import (
+    default_project_manifest,
+    deploy_release_matrix,
+    load_project_catalog,
+    resolve_projects_for_release,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Emit deployable reference-release metadata for the Pages deployment workflow."
+    )
+    parser.add_argument(
+        "--manifest",
+        default=None,
+        help="Project manifest path. Defaults to tests/harness/projects.json in the current checkout.",
+    )
+    parser.add_argument(
+        "--github-output",
+        action="store_true",
+        help="Print GitHub Actions step outputs instead of plain JSON.",
+    )
+    return parser.parse_args()
+
+
+def resolve_manifest_path(layout, path_text: str | None) -> Path:
+    if path_text is None:
+        return default_project_manifest(layout.package_root)
+    path = Path(path_text)
+    if path.is_absolute():
+        return path.resolve()
+    return (Path.cwd() / path).resolve()
+
+
+def payload(args: argparse.Namespace) -> dict[str, object]:
+    layout = detect_harness_layout(Path(__file__))
+    manifest_path = resolve_manifest_path(layout, args.manifest)
+    catalog = load_project_catalog(manifest_path)
+    deployable_targets = tuple(
+        target
+        for target in catalog.release_targets
+        if target.deploy_pages and resolve_projects_for_release(catalog, target.release_id, None)
+    )
+    matrix = deploy_release_matrix(deployable_targets)
+    return {
+        "manifest_path": str(manifest_path),
+        "deployable_release_count": len(matrix["include"]),
+        "deployable_release_matrix": matrix,
+    }
+
+
+def emit_github_output(data: dict[str, object]) -> None:
+    print(f"manifest_path={data['manifest_path']}")
+    print(f"deployable_release_count={data['deployable_release_count']}")
+    print("deployable_release_matrix<<__CODEX__")
+    print(json.dumps(data["deployable_release_matrix"], separators=(",", ":")))
+    print("__CODEX__")
+
+
+def main() -> int:
+    args = parse_args()
+    data = payload(args)
+    if args.github_output:
+        emit_github_output(data)
+    else:
+        print(json.dumps(data, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prepare_reference_blueprints_pages.py
+++ b/scripts/prepare_reference_blueprints_pages.py
@@ -29,9 +29,12 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def html_link(project_id: str) -> str:
+def html_link(project_id: str, *, release: str | None = None) -> str:
     label = html.escape(project_id)
-    href = f"reference-blueprints/{label}/"
+    if release is None:
+        href = f"reference-blueprints/{label}/"
+    else:
+        href = f"reference-blueprints/{html.escape(release)}/{label}/"
     return f'<li><a href="{href}">{label}</a></li>'
 
 
@@ -39,6 +42,93 @@ def html_test_link(slug: str) -> str:
     label = html.escape(slug)
     href = f"test-blueprints/{label}/html-multi/"
     return f'<li><a href="{href}">{label}</a></li>'
+
+
+def html_release_link(release: str) -> str:
+    label = html.escape(release)
+    href = f"reference-blueprints/{label}/"
+    return f'<li><a href="{href}">{label}</a></li>'
+
+
+def write_reference_index(reference_root: Path, release_projects: dict[str | None, list[str]]) -> None:
+    if None in release_projects:
+        items = [html_link(project_id) for project_id in release_projects[None]]
+        body = [
+            "<!doctype html>",
+            "<html lang=\"en\">",
+            "<meta charset=\"utf-8\">",
+            "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">",
+            "<title>Reference Blueprints</title>",
+            "<body>",
+            "<h1>Reference Blueprints</h1>",
+            "<ul>",
+            *items,
+            "</ul>",
+            "</body>",
+            "</html>",
+        ]
+        (reference_root / "index.html").write_text("\n".join(body) + "\n", encoding="utf-8")
+        return
+
+    for release, projects in release_projects.items():
+        assert release is not None
+        release_root = reference_root / release
+        release_root.mkdir(parents=True, exist_ok=True)
+        body = [
+            "<!doctype html>",
+            "<html lang=\"en\">",
+            "<meta charset=\"utf-8\">",
+            "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">",
+            f"<title>Reference Blueprints {html.escape(release)}</title>",
+            "<body>",
+            f"<h1>Reference Blueprints {html.escape(release)}</h1>",
+            "<ul>",
+            *[html_link(project_id, release=release) for project_id in projects],
+            "</ul>",
+            "</body>",
+            "</html>",
+        ]
+        (release_root / "index.html").write_text("\n".join(body) + "\n", encoding="utf-8")
+
+    body = [
+        "<!doctype html>",
+        "<html lang=\"en\">",
+        "<meta charset=\"utf-8\">",
+        "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">",
+        "<title>Reference Blueprint Releases</title>",
+        "<body>",
+        "<h1>Reference Blueprint Releases</h1>",
+        "<ul>",
+        *[html_release_link(release) for release in sorted(release_projects)],
+        "</ul>",
+        "</body>",
+        "</html>",
+    ]
+    (reference_root / "index.html").write_text("\n".join(body) + "\n", encoding="utf-8")
+
+
+def copy_reference_sites(reference_root: Path, publish_reference_root: Path) -> dict[str | None, list[str]]:
+    release_projects: dict[str | None, list[str]] = {}
+    children = sorted(path for path in reference_root.iterdir() if path.is_dir())
+    if all((child / "html-multi").exists() for child in children):
+        projects: list[str] = []
+        for project_dir in children:
+            shutil.copytree(project_dir / "html-multi", publish_reference_root / project_dir.name)
+            projects.append(project_dir.name)
+        release_projects[None] = projects
+        return release_projects
+
+    for release_dir in children:
+        projects: list[str] = []
+        for project_dir in sorted(path for path in release_dir.iterdir() if path.is_dir()):
+            site_dir = project_dir / "html-multi"
+            if not site_dir.exists():
+                continue
+            shutil.copytree(site_dir, publish_reference_root / release_dir.name / project_dir.name)
+            projects.append(project_dir.name)
+        if projects:
+            release_projects[release_dir.name] = projects
+    return release_projects
 
 
 def main() -> int:
@@ -59,13 +149,8 @@ def main() -> int:
     publish_reference_root.mkdir(parents=True, exist_ok=True)
     publish_test_root.mkdir(parents=True, exist_ok=True)
 
-    reference_projects: list[str] = []
-    for project_dir in sorted(path for path in reference_root.iterdir() if path.is_dir()):
-        site_dir = project_dir / "html-multi"
-        if not site_dir.exists():
-            continue
-        shutil.copytree(site_dir, publish_reference_root / project_dir.name)
-        reference_projects.append(project_dir.name)
+    release_projects = copy_reference_sites(reference_root, publish_reference_root)
+    write_reference_index(publish_reference_root, release_projects)
 
     test_blueprints: list[str] = []
     for test_dir in sorted(path for path in test_root.iterdir() if path.is_dir()):
@@ -90,9 +175,23 @@ def main() -> int:
                 "<h1>Verso Blueprint Rendered Artifacts</h1>",
                 "<p>Generated reference and test sites assembled from the current workflow run.</p>",
                 "<h2>Reference Blueprints</h2>",
-                "<ul>",
-                *[html_link(project_id) for project_id in reference_projects],
-                "</ul>",
+                "<p><a href=\"reference-blueprints/\">Open reference blueprint index</a></p>",
+                *(
+                    [
+                        "<ul>",
+                        *[html_link(project_id) for project_id in release_projects[None]],
+                        "</ul>",
+                    ]
+                    if None in release_projects
+                    else [
+                        "<ul>",
+                        *[
+                            html_release_link(release)
+                            for release in sorted(release_projects)
+                        ],
+                        "</ul>",
+                    ]
+                ),
                 "<h2>Test Blueprints</h2>",
                 "<p><a href=\"test-blueprints/\">Open categorized test blueprint index</a></p>",
                 "<ul>",

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -6,7 +6,7 @@
       "toolchain": "v4.28.0",
       "verso_ref": "v4.28.0",
       "branch": "v4.28.0",
-      "deploy_pages": false
+      "deploy_pages": true
     },
     {
       "id": "v4.29.0",

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import unittest
 
 from scripts.blueprint_harness_projects import (
+    deploy_release_matrix,
     HarnessProject,
     default_project_manifest,
     load_project_catalog,
@@ -103,6 +104,34 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         for entry in matrix["include"]:
             self.assertEqual(entry["artifact_name"], f"reference-blueprints-{entry['project_id']}")
             self.assertEqual(entry["artifact_path"], f"_out/reference-blueprints/{entry['project_id']}")
+
+    def test_deploy_release_matrix_includes_only_deployable_releases(self) -> None:
+        catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
+        matrix = deploy_release_matrix(catalog.release_targets)
+
+        self.assertEqual(
+            matrix,
+            {
+                "include": [
+                    {
+                        "release_id": "v4.28.0",
+                        "toolchain": "v4.28.0",
+                        "verso_ref": "v4.28.0",
+                        "branch": "v4.28.0",
+                        "artifact_name": "reference-blueprints-release-v4.28.0",
+                        "artifact_path": "_out/reference-blueprints/v4.28.0",
+                    },
+                    {
+                        "release_id": "v4.29.0",
+                        "toolchain": "v4.29.0",
+                        "verso_ref": "v4.29.0",
+                        "branch": "v4.29.0",
+                        "artifact_name": "reference-blueprints-release-v4.29.0",
+                        "artifact_path": "_out/reference-blueprints/v4.29.0",
+                    }
+                ]
+            },
+        )
 
     def test_git_checkout_project_is_supported(self) -> None:
         manifest_data = {

--- a/tests/harness/test_prepare_reference_blueprints_pages.py
+++ b/tests/harness/test_prepare_reference_blueprints_pages.py
@@ -80,8 +80,71 @@ class PrepareReferenceBlueprintPagesTests(unittest.TestCase):
             landing_index = (output_root / "index.html").read_text(encoding="utf-8")
             self.assertIn("reference-blueprints/project-template/", landing_index)
             self.assertIn("reference-blueprints/noperthedron/", landing_index)
+            self.assertIn("Open reference blueprint index", landing_index)
             self.assertIn("test-blueprints/", landing_index)
             self.assertIn("test-blueprints/preview_runtime_showcase/html-multi/", landing_index)
+
+    def test_prepare_pages_stages_release_namespaced_reference_blueprints(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            reference_root = tmp_path / "reference-blueprints"
+            test_root = tmp_path / "test-blueprints"
+            output_root = tmp_path / "_site"
+
+            (reference_root / "v4.28.0" / "project-template" / "html-multi").mkdir(parents=True)
+            (reference_root / "v4.28.0" / "project-template" / "html-multi" / "index.html").write_text(
+                "reference project template v4.28.0",
+                encoding="utf-8",
+            )
+            (reference_root / "v4.29.0" / "project-template" / "html-multi").mkdir(parents=True)
+            (reference_root / "v4.29.0" / "project-template" / "html-multi" / "index.html").write_text(
+                "reference project template v4.29.0",
+                encoding="utf-8",
+            )
+            (reference_root / "v4.29.0" / "noperthedron" / "html-multi").mkdir(parents=True)
+            (reference_root / "v4.29.0" / "noperthedron" / "html-multi" / "index.html").write_text(
+                "reference noperthedron v4.29.0",
+                encoding="utf-8",
+            )
+
+            (test_root / "preview_runtime_showcase" / "html-multi").mkdir(parents=True)
+            (test_root / "preview_runtime_showcase" / "html-multi" / "index.html").write_text(
+                "test showcase",
+                encoding="utf-8",
+            )
+            (test_root / "index.html").write_text("test index", encoding="utf-8")
+
+            result = self.run_helper(reference_root, test_root, output_root)
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+            self.assertEqual(
+                (
+                    output_root
+                    / "reference-blueprints"
+                    / "v4.28.0"
+                    / "project-template"
+                    / "index.html"
+                ).read_text(encoding="utf-8"),
+                "reference project template v4.28.0",
+            )
+            self.assertEqual(
+                (
+                    output_root
+                    / "reference-blueprints"
+                    / "v4.29.0"
+                    / "noperthedron"
+                    / "index.html"
+                ).read_text(encoding="utf-8"),
+                "reference noperthedron v4.29.0",
+            )
+
+            release_index = (output_root / "reference-blueprints" / "index.html").read_text(encoding="utf-8")
+            self.assertIn("reference-blueprints/v4.28.0/", release_index)
+            self.assertIn("reference-blueprints/v4.29.0/", release_index)
+
+            landing_index = (output_root / "index.html").read_text(encoding="utf-8")
+            self.assertIn("reference-blueprints/v4.28.0/", landing_index)
+            self.assertIn("reference-blueprints/v4.29.0/", landing_index)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed
- add a deploy-matrix helper that resolves every release target with `deploy_pages: true`
- generalize `prepare_reference_blueprints_pages.py` to assemble either a single-release artifact or a combined multi-release artifact
- refactor `reference-blueprints-deploy.yml` so one deployment run rebuilds every deployable release slice and publishes one combined Pages site
- enable `v4.28.0` reference blueprints for Pages deployment
- update maintainer/docs wording to describe reference blueprints as release-sliced validation and deployment artifacts

## Why
The current Pages deployment model is single-release and branch-local, so it cannot safely publish both `v4.28.0` and `v4.29.0` reference blueprints at the same time. The simplest robust approach is to let one deployment workflow rebuild every deployable release slice in isolation and assemble a combined site under release-namespaced paths.

## Resulting Pages layout
- `reference-blueprints/v4.28.0/<project>/...`
- `reference-blueprints/v4.29.0/<project>/...`
- shared `test-blueprints/...` from the default-development branch

## Validation
- `python3 scripts/emit_reference_deploy_matrix.py`
- `python3 -m unittest tests.harness.test_prepare_reference_blueprints_pages tests.harness.test_blueprint_harness_projects`
- `python3 -m py_compile scripts/emit_reference_deploy_matrix.py scripts/prepare_reference_blueprints_pages.py`
