### PR TITLE
Backport basic inline Rust code attachments to v4.28.0

### DIFF
--- a/.github/workflows/blueprint-pages.yml
+++ b/.github/workflows/blueprint-pages.yml
@@ -22,7 +22,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: ${{ github.repository }}-blueprint-pages
+  group: ${{ github.repository }}-blueprint-pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/reference-blueprints-deploy.yml
+++ b/.github/workflows/reference-blueprints-deploy.yml
@@ -16,12 +16,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: >-
-    ${{
-      github.event_name == 'workflow_dispatch'
-      && format('{0}-reference-blueprints-pages-dispatch-{1}', github.repository, github.ref_name)
-      || format('{0}-reference-blueprints-pages-release', github.repository)
-    }}
+  group: ${{ github.repository }}-reference-blueprints-pages-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Blueprint project combines:
 
 - informal mathematical exposition
 - links to local Lean code or existing Lean declarations
+- optional attached Rust code blocks on labeled nodes for mixed-language notes
 - optional raw TeX source attachments on labeled nodes to help port existing TeX
 - automatic tracking of formalization progress by analyzing the associated Lean
   code and declarations, including incomplete declarations such as `sorry`
@@ -92,6 +93,30 @@ This informal node is linked to existing compiled Lean declarations.
 :::
 ```
 
+### Attached Rust code
+
+Blueprint also supports labeled inline Rust code blocks:
+
+````md
+:::definition "ffi_helper"
+Helper routine mirrored in Rust.
+:::
+
+```rust "ffi_helper"
+pub fn ffi_helper(x: i32) -> i32 {
+    x + 1
+}
+```
+````
+
+Current behavior:
+
+- the Rust block attaches to the Blueprint node with the same label
+- the rendered page shows an associated Rust code panel
+- rendering uses a small built-in syntax highlighter
+- Rust blocks do not currently affect Blueprint progress/status semantics
+- Rust diagnostics and external Rust references are not part of the current surface
+
 ### Math and TeX
 
 Blueprint supports inline math such as ``$`n + 0 = n` `` and display math such as
@@ -127,6 +152,7 @@ Blueprint can render:
 - an overview and progress summary page with `blueprint_summary`
 - a bibliography page with `blueprint_bibliography`
 - math-enabled previews and cross-links
+- associated Rust code panels for labeled inline Rust blocks
 
 Progress is computed automatically from the status of the associated Lean code
 and declarations, so the HTML summary and graph views stay aligned with the

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -15,6 +15,7 @@ If you are starting a first project, read
 - [A First Chapter](#a-first-chapter)
 - [Core Block Forms](#core-block-forms)
 - [Connecting Blocks to Lean](#connecting-blocks-to-lean)
+- [Attached Rust Code](#attached-rust-code)
 - [Math and TeX](#math-and-tex)
 - [Groups, Authors, and Metadata](#groups-authors-and-metadata)
 - [Rendering Surface](#rendering-surface)
@@ -50,6 +51,7 @@ These identifiers are used by:
 
 - `{uses "addition_spec"}[]` references
 - labeled inline Lean code blocks
+- labeled inline Rust code blocks
 - `tex` code blocks carrying raw TeX source
 - `@[blueprint "label"]` on compiled Lean declarations
 - summary and graph nodes
@@ -269,6 +271,33 @@ Notes:
 - Blueprint labels are Blueprint-owned metadata
 - Blueprint label conventions do not rewrite external Lean names
 
+## Attached Rust Code
+
+Blueprint also supports labeled inline Rust code blocks as attached source:
+
+````md
+:::definition "ffi_helper"
+Helper routine mirrored in Rust.
+:::
+
+```rust "ffi_helper"
+pub fn ffi_helper(x: i32) -> i32 {
+    x + 1
+}
+```
+````
+
+Current behavior:
+
+- the `rust` block label is parsed the same way as a labeled `lean` block
+- the block attaches to the Blueprint node with the same label
+- the rendered page shows an associated Rust code panel for that node
+- Rust rendering currently uses a small built-in syntax highlighter
+- Rust attachments do not currently participate in Blueprint progress or proof
+  status computation
+- Rust diagnostics, hover information, and external Rust refs are not currently
+  part of the supported surface
+
 ## Math and TeX
 
 Blueprint supports ordinary Verso math syntax inside the informal text.
@@ -403,6 +432,9 @@ views.
 Rendered statement headers show a Lean status badge and related metadata.
 When local or external Lean material is available, the rendered page links or
 previews the associated content.
+
+When labeled inline Rust code is attached to a node, the rendered page also
+shows an associated Rust code panel below the statement body.
 
 ### Dependency graph
 
@@ -598,5 +630,9 @@ wants to use it.
 - group labels are metadata, not first-class reference targets
 - unresolved Blueprint references currently degrade locally at the call site;
   they are not accumulated into a global diagnostics report
+- Rust support currently covers only labeled inline Rust blocks with basic
+  built-in syntax coloring
+- Rust attachments currently do not provide diagnostics, hover data, or
+  external Rust symbol references
 - some rendering details and summary ranking policies are still expected to
   evolve

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -20,7 +20,41 @@ lean_lib VersoBlueprint where
 @[default_target, test_driver]
 lean_lib VersoBlueprintTests where
   srcDir := "tests"
-  roots := #[`VersoBlueprintTests]
+  roots := #[
+    `VersoBlueprintTests.Blueprint.Support,
+    `VersoBlueprintTests.BlueprintAttribute,
+    `VersoBlueprintTests.BlueprintCodeRenderMatrix,
+    `VersoBlueprintTests.BlueprintImportedDuplicates.Direct,
+    `VersoBlueprintTests.BlueprintImportedDuplicates.ProviderA,
+    `VersoBlueprintTests.BlueprintImportedDuplicates.ProviderB,
+    `VersoBlueprintTests.BlueprintImportedDuplicates.Reexport,
+    `VersoBlueprintTests.BlueprintImportedDuplicates.Transitive,
+    `VersoBlueprintTests.BlueprintExternalHeadingStatus,
+    `VersoBlueprintTests.BlueprintGraph,
+    `VersoBlueprintTests.BlueprintInformal,
+    `VersoBlueprintTests.BlueprintInlinePrecision,
+    `VersoBlueprintTests.BlueprintLinkHover,
+    `VersoBlueprintTests.BlueprintMainWrapper,
+    `VersoBlueprintTests.BlueprintMathLint,
+    `VersoBlueprintTests.BlueprintMetadataPanel,
+    `VersoBlueprintTests.BlueprintNumbering,
+    `VersoBlueprintTests.BlueprintPreviewPanels,
+    `VersoBlueprintTests.BlueprintPreviewSchema,
+    `VersoBlueprintTests.BlueprintPreviewSource,
+    `VersoBlueprintTests.BlueprintPreviewWiring,
+    `VersoBlueprintTests.BlueprintRustCode,
+    `VersoBlueprintTests.BlueprintSummaryLinks,
+    `VersoBlueprintTests.BlueprintSummaryStatus,
+    `VersoBlueprintTests.BlueprintTexMacros,
+    `VersoBlueprintTests.BlueprintTexSource,
+    `VersoBlueprintTests.DocGenNameRender,
+    `VersoBlueprintTests.TestBlueprintRegistryMeta,
+    `VersoBlueprintTests.TestBlueprintRegistryChecks
+  ]
+
+lean_lib VersoBlueprintTestDocs where
+  srcDir := "tests"
+  roots := #[`VersoBlueprintTests.TestBlueprintRegistry]
 
 lean_exe «blueprint-test-docs» where
   root := `BlueprintTestDocsMain

--- a/project_template/.github/workflows/blueprint-pages.yml
+++ b/project_template/.github/workflows/blueprint-pages.yml
@@ -22,7 +22,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: ${{ github.repository }}-blueprint-pages
+  group: ${{ github.repository }}-blueprint-pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/project_template/ProjectTemplate/Chapters/Addition.lean
+++ b/project_template/ProjectTemplate/Chapters/Addition.lean
@@ -47,3 +47,14 @@ This is another consequence of {uses "addition_spec"}[].
 Lean already provides this theorem as `Nat.add_assoc`, so this Blueprint entry
 links to an existing declaration instead of restating the code locally.
 :::
+
+:::definition "addition_runtime_note" (parent := "addition_core")
+Some projects keep implementation notes or helper snippets next to the informal
+statement surface. Blueprint can attach a small Rust block for that purpose.
+:::
+
+```rust "addition_runtime_note"
+pub fn add_preview(x: i32, y: i32) -> i32 {
+    x + y
+}
+```

--- a/project_template/README.md
+++ b/project_template/README.md
@@ -58,6 +58,7 @@ The important files are:
 - labels that identify Blueprint nodes
 - `:::definition`, `:::theorem`, and `:::proof`
 - local Lean code attached to a Blueprint label
+- local Rust code attached to a Blueprint label
 - a statement linked to an existing Lean declaration
 - group and author metadata
 - rendered progress summary and dependency graph pages

--- a/src/VersoBlueprint.lean
+++ b/src/VersoBlueprint.lean
@@ -18,6 +18,7 @@ import VersoBlueprint.ProvedStatus
 import VersoBlueprint.ExternalRefSnapshot
 import VersoBlueprint.Macros
 import VersoBlueprint.Math
+import VersoBlueprint.Rust
 import VersoBlueprint.Environment
 import VersoBlueprint.Attribute
 import VersoBlueprint.Cite
@@ -26,6 +27,7 @@ import VersoBlueprint.Commands.Summary
 import VersoBlueprint.Commands.Bibliography
 import VersoBlueprint.Informal.Block.Assets
 import VersoBlueprint.Informal.Code
+import VersoBlueprint.Informal.RustBlock
 import VersoBlueprint.Informal.Block
 import VersoBlueprint.Informal.Block.Store
 import VersoBlueprint.Informal.MetadataView

--- a/src/VersoBlueprint/Data.lean
+++ b/src/VersoBlueprint/Data.lean
@@ -319,6 +319,14 @@ instance : Quote ExternalRef where
 def ExternalRef.ofName (name : Name) (origin : ExternalOrigin := .directiveLean) : ExternalRef :=
   { written := name, canonical := name.eraseMacroScopes, origin, kind := .definition }
 
+structure RustInlineCode where
+  raw : String
+deriving Repr, Inhabited, DecidableEq, ToJson, FromJson
+
+open Syntax in
+instance : Quote RustInlineCode where
+  quote code := mkCApp ``RustInlineCode.mk #[quote code.raw]
+
 inductive CodeRef where
   /-
   Blueprint code references can currently come from two sources:
@@ -351,6 +359,7 @@ structure Node where
   statement : Option InformalData := none -- Informal Object statement
   proof : Option InformalData := none -- Informal Object proof
   code : Option CodeRef := none -- Informal Object associated code status
+  rustCode : Option RustInlineCode := none -- Informal object associated Rust code
   texSources : Array (String × TexSource) := #[] -- Raw TeX witnesses keyed by slot
   parent : Option Parent := none -- Optional parent group for summaries/graphs
   priority : Option String := none -- Optional author-provided triage hint
@@ -393,6 +402,14 @@ private def mergeCodeRef (label : Label) (current : Option CodeRef) (incoming : 
     return some (.literate code)
   | some (.literate _), .external _ =>
     logError m!"Label {label} has both an associated Lean code block and '(lean := ...)'; preferring inline code"
+    return current
+
+private def mergeRustCode (label : Label) (current : Option RustInlineCode) (incoming : RustInlineCode) :
+    m (Option RustInlineCode) := do
+  match current with
+  | none => return some incoming
+  | some _ =>
+    logError m!"Label {label} already has associated Rust code"
     return current
 
 private def mergeParent (label : Label) (current incoming : Option Parent) : m (Option Parent) := do
@@ -486,24 +503,17 @@ def Data.register (data : Data) (label : Label) (kind : InProgressKind) (payload
     (owner : Option AuthorId := none) (tags : Array String := #[]) (effort : Option String := none)
     (prUrl : Option String := none) : m Data := do
   let applyHints (node : Node) : m Node := do
-    match codeHint with
-    | none =>
-      let parent ← mergeParent label node.parent parent
-      let priority ← mergePriority label node.priority priority
-      let owner ← mergeOwner label node.owner owner
-      let effort ← mergeEffort label node.effort effort
-      let prUrl ← mergePrUrl label node.prUrl prUrl
-      let tags := mergeTags node.tags tags
-      return { node with parent, priority, owner, tags, effort, prUrl }
-    | some hint =>
-      let code ← mergeCodeRef label node.code hint
-      let parent ← mergeParent label node.parent parent
-      let priority ← mergePriority label node.priority priority
-      let owner ← mergeOwner label node.owner owner
-      let effort ← mergeEffort label node.effort effort
-      let prUrl ← mergePrUrl label node.prUrl prUrl
-      let tags := mergeTags node.tags tags
-      return { node with code, parent, priority, owner, tags, effort, prUrl }
+    let code ←
+      match codeHint with
+      | none => pure node.code
+      | some hint => mergeCodeRef label node.code hint
+    let parent ← mergeParent label node.parent parent
+    let priority ← mergePriority label node.priority priority
+    let owner ← mergeOwner label node.owner owner
+    let effort ← mergeEffort label node.effort effort
+    let prUrl ← mergePrUrl label node.prUrl prUrl
+    let tags := mergeTags node.tags tags
+    return { node with code, parent, priority, owner, tags, effort, prUrl }
   let nextCount := data.size + 1
   match data.get? label, kind with
   -- First statement for a fresh label.
@@ -558,6 +568,14 @@ def Data.registerCode (data : Data) (label : Label) (code : Syntax)
   | some node =>
     let code ← mergeCodeRef label node.code literate
     return data.insert label { node with code }
+
+def Data.registerRustCode (data : Data) (label : Label) (code : RustInlineCode) : m Data := do
+  match data.get? label with
+  | none =>
+    return data.insert label { rustCode := some code }
+  | some node =>
+    let rustCode ← mergeRustCode label node.rustCode code
+    return data.insert label { node with rustCode }
 
 /-- Register raw TeX source for an informal object label. -/
 def Data.registerTexSource (data : Data) (label : Label) (slot : String) (texSource : TexSource) : m Data := do

--- a/src/VersoBlueprint/Environment.lean
+++ b/src/VersoBlueprint/Environment.lean
@@ -282,6 +282,15 @@ def registerCode (label : Label) (code : Syntax)
       | none => state.localData
     return { state with data, localData }
 
+def registerRustCode (label : Label) (code : RustInlineCode) : m Unit := do
+  modifyM fun state => do
+    let data ← state.data.registerRustCode label code
+    let localData :=
+      match data.get? label with
+      | some node => state.localData.insert label node
+      | none => state.localData
+    return { state with data, localData }
+
 def registerTexSource (label : Label) (slot : String) (texSource : TexSource) : m Unit := do
   modifyM fun state => do
     let data ← state.data.registerTexSource label slot texSource

--- a/src/VersoBlueprint/Informal/Block/Common.lean
+++ b/src/VersoBlueprint/Informal/Block/Common.lean
@@ -229,15 +229,15 @@ deriving Repr, Inhabited
 
 def codePanelHeader (data : BlockData) (numberText : String) : CodePanelHeader :=
   match data.kind with
-  | .proof => { caption := "Code for proof" }
+  | .proof => { caption := "Lean code for proof" }
   | .statement nodeKind =>
     {
-      caption := s!"Code for {nodeKind}"
+      caption := s!"Lean code for {nodeKind}"
       number? := some numberText
     }
 
 def fallbackCodePanelHeader : CodePanelHeader := {
-  caption := "Code"
+  caption := "Lean code"
 }
 
 register_option verso.blueprint.foldProofs : Bool := {

--- a/src/VersoBlueprint/Informal/CodeSummary.lean
+++ b/src/VersoBlueprint/Informal/CodeSummary.lean
@@ -505,7 +505,7 @@ private def renderInlinePanelIndicator (label : Data.Label) (codeData : InlineCo
   open Verso.Output.Html in
   let orderedDecls := sortDeclsByCommand (codeData.definedDefs ++ codeData.definedTheorems)
   let previewBody := renderSummaryPreview label { source := some (.inline codeData) } hrefOf
-  let summaryTitle := codeSummaryText label codeData.definedDefs codeData.definedTheorems
+  let summaryTitle := s!"Lean code for {label}: {codeSummaryText label codeData.definedDefs codeData.definedTheorems}"
   let indicator : Output.Html :=
     if orderedDecls.isEmpty then
       .empty
@@ -597,7 +597,7 @@ private def renderExternalPanelIndicator (decls : Array Data.ExternalRef)
   let (iconClass, iconText, iconTitle) := externalIndicatorStatus health
   let badgeText := externalIndicatorText decls health
   let summaryTitle :=
-    appendRenderHealthSummary
+    s!"Lean code for {label}: " ++ appendRenderHealthSummary
       (externalCodeEntryTitle health.presentDecls health.totalDecls health.missingDecls health.anyGapCount)
       renderHealth
   let badgeTitle :=
@@ -628,7 +628,7 @@ def renderPanelIndicator (label : Data.Label) (cdata : ComputedData)
   | some (.external decls) =>
     renderExternalPanelIndicator decls label hrefOf
   | none =>
-    { summaryTitle := "No associated Lean declarations" }
+    { summaryTitle := s!"Lean code for {label}: no associated Lean declarations" }
 
 /--
 Render Lean summary UI for an informal block heading.

--- a/src/VersoBlueprint/Informal/RustBlock.lean
+++ b/src/VersoBlueprint/Informal/RustBlock.lean
@@ -1,0 +1,80 @@
+/- 
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoManual
+import VersoBlueprint.Environment
+import VersoBlueprint.Informal.Block.Assets
+import VersoBlueprint.Informal.Block.Common
+import VersoBlueprint.Informal.Block.Store
+import VersoBlueprint.Informal.Code
+import VersoBlueprint.Profiling
+import VersoBlueprint.Rust
+import VersoBlueprint.Resolve
+
+open Verso Doc Elab
+open Verso.Genre Manual
+open Lean Lean.Elab
+
+namespace Informal
+
+block_extension Block.informalRustCode (data : Informal.Rust.InlineCodeData) where
+  data := toJson data
+  traverse id data _contents := do
+    let .ok cdata := fromJson? (α := Informal.Rust.InlineCodeData) data
+      | logError s!"Malformed Rust data: {data}"
+        pure none
+    if let some _ := (← get).getDomainObject? Informal.Rust.informalRustCodeDomain cdata.label.toString then
+      pure none
+    else
+      let path ← (·.path) <$> read
+      let _ ← Verso.Genre.Manual.externalTag id path s!"--informal-rust-code-{cdata.label}"
+      modify fun s => s.saveDomainObject Informal.Rust.informalRustCodeDomain cdata.label.toString id
+      modify fun s => s.saveDomainObjectData Informal.Rust.informalRustCodeDomain cdata.label.toString (toJson cdata)
+      pure none
+  toTeX := none
+  extraCss := Informal.Block.Assets.codeCssAssets ++ [Informal.Rust.css]
+  extraJs := ([] : List String)
+  toHtml :=
+    open Verso.Doc.Html in
+    open Verso.Output.Html in
+    some <| fun _goI _goB id data _blocks => do
+      let .ok cdata := fromJson? (α := Informal.Rust.InlineCodeData) data
+        | HtmlT.logError s!"Malformed Rust code data: {data}"
+          pure .empty
+      let s ← HtmlT.state
+      let ctxt ← HtmlT.context
+      let attrs := s.htmlId id
+      let panelHeader :=
+        match s.getDomainObject? Resolve.informalDomainName cdata.label.toString with
+        | some obj =>
+          match fromJson? (α := BlockData) obj.data with
+          | .ok b =>
+            let b := b.withResolvedNumbering s (numberedPartPrefix? ctxt)
+            let caption :=
+              match b.kind with
+              | .proof => "Rust code for proof"
+              | .statement nodeKind => s!"Rust code for {nodeKind}"
+            { (codePanelHeader b (b.displayNumber s)) with caption }
+          | .error _ => { fallbackCodePanelHeader with caption := "Rust code" }
+        | none => { fallbackCodePanelHeader with caption := "Rust code" }
+      let body := Informal.Rust.highlightHtml cdata.raw
+      pure <| mkCodePanel panelHeader s!"Rust code for {cdata.label}" .empty body attrs
+
+private def rustImpl : CodeBlockExpanderOf Informal.CodeConfig
+  | cfg, contents => do
+    let data : Informal.Rust.InlineCodeData := {
+      label := cfg.label
+      raw := contents.getString
+    }
+    Environment.registerRustCode cfg.label { raw := contents.getString }
+    ``(Block.other (Block.informalRustCode $(quote data)) #[])
+
+@[code_block]
+def rust : CodeBlockExpanderOf Informal.CodeConfig
+  | cfg, contents => do
+    Profile.withDocElab "code_block" "rust" <| rustImpl cfg contents
+
+end Informal

--- a/src/VersoBlueprint/Resolve.lean
+++ b/src/VersoBlueprint/Resolve.lean
@@ -13,6 +13,7 @@ open Lean
 
 def informalDomainName : Name := Name.mkSimple "Informal.Block.informal"
 def informalCodeDomainName : Name := Name.mkSimple "Informal.Block.informalCode"
+def informalRustCodeDomainName : Name := Name.mkSimple "Informal.Block.informalRustCode"
 def informalPreviewDomainName : Name := Name.mkSimple "Informal.Block.informalPreview"
 def informalGroupDomainName : Name := Name.mkSimple "Informal.Block.group"
 /- 

--- a/src/VersoBlueprint/Rust.lean
+++ b/src/VersoBlueprint/Rust.lean
@@ -1,0 +1,162 @@
+/- 
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import Lean
+import VersoBlueprint.Data
+import VersoBlueprint.Resolve
+
+namespace Informal.Rust
+
+open Lean
+open Verso.Output.Html
+
+def informalRustCodeDomain : Name := Resolve.informalRustCodeDomainName
+
+structure InlineCodeData where
+  label : Data.Label
+  raw : String
+deriving Repr, Inhabited, DecidableEq, ToJson, FromJson
+
+open Syntax in
+instance : Quote InlineCodeData where
+  quote data := mkCApp ``InlineCodeData.mk #[quote data.label, quote data.raw]
+
+def css : String := r##"
+.bp_rust_code {
+  color: var(--bp-color-text-strong);
+  background: var(--bp-color-surface-muted);
+}
+
+.bp_rust_kw {
+  color: #7c2d12;
+  font-weight: 700;
+}
+
+.bp_rust_ty {
+  color: #0f766e;
+  font-weight: 600;
+}
+
+.bp_rust_num {
+  color: #166534;
+}
+
+.bp_rust_str {
+  color: #9f1239;
+}
+
+.bp_rust_comment {
+  color: #64748b;
+  font-style: italic;
+}
+"##
+
+private def keywordSet : List String := [
+  "as", "async", "await", "break", "const", "continue", "crate", "else",
+  "enum", "extern", "false", "fn", "for", "if", "impl", "in", "let",
+  "loop", "match", "mod", "move", "mut", "pub", "ref", "return", "self",
+  "Self", "static", "struct", "super", "trait", "true", "type", "unsafe",
+  "use", "where", "while"
+]
+
+private def builtinTypeSet : List String := [
+  "bool", "char", "i8", "i16", "i32", "i64", "i128", "isize",
+  "u8", "u16", "u32", "u64", "u128", "usize", "f32", "f64", "str"
+]
+
+private def isIdentStart (c : Char) : Bool :=
+  c.isAlpha || c == '_'
+
+private def isIdentRest (c : Char) : Bool :=
+  c.isAlphanum || c == '_'
+
+private def tokenNode (cls txt : String) : Verso.Output.Html :=
+  if cls.isEmpty then
+    Verso.Output.Html.text true txt
+  else
+    Verso.Output.Html.tag "span" #[("class", cls)] (Verso.Output.Html.text true txt)
+
+private def classifyIdent (txt : String) : String :=
+  if keywordSet.contains txt then
+    "bp_rust_kw"
+  else if builtinTypeSet.contains txt then
+    "bp_rust_ty"
+  else
+    ""
+
+private def isNumberStart (c : Char) : Bool :=
+  c.isDigit
+
+private def isNumberRest (c : Char) : Bool :=
+  c.isDigit || c == '_' || c.isAlpha
+
+private def scanWhile (source : String) (start : String.Pos.Raw) (p : Char → Bool) : String.Pos.Raw :=
+  Id.run do
+    let mut pos := start
+    while !pos.atEnd source do
+      let c := pos.get source
+      if p c then
+        pos := pos.next source
+      else
+        break
+    return pos
+
+private def scanComment (source : String) (start : String.Pos.Raw) : String.Pos.Raw :=
+  Id.run do
+    let mut pos := start
+    while !pos.atEnd source do
+      let c := pos.get source
+      if c == '\n' then
+        break
+      pos := pos.next source
+    return pos
+
+private def scanString (source : String) (start : String.Pos.Raw) : String.Pos.Raw :=
+  Id.run do
+    let mut pos := start.next source
+    let mut escaped := false
+    while !pos.atEnd source do
+      let c := pos.get source
+      pos := pos.next source
+      if escaped then
+        escaped := false
+      else if c == '\\' then
+        escaped := true
+      else if c == '"' then
+        break
+    return pos
+
+def highlightHtml (source : String) : Verso.Output.Html :=
+  Id.run do
+    let mut pos : String.Pos.Raw := 0
+    let mut out : Array Verso.Output.Html := #[]
+    while !pos.atEnd source do
+      let c := pos.get source
+      let nextPos :=
+        if pos.atEnd source then pos else pos.next source
+      if c == '/' && !nextPos.atEnd source && nextPos.get source == '/' then
+        let stop := scanComment source pos
+        out := out.push <| tokenNode "bp_rust_comment" (pos.extract source stop)
+        pos := stop
+      else if c == '"' then
+        let stop := scanString source pos
+        out := out.push <| tokenNode "bp_rust_str" (pos.extract source stop)
+        pos := stop
+      else if isIdentStart c then
+        let stop := scanWhile source pos isIdentRest
+        let txt := pos.extract source stop
+        out := out.push <| tokenNode (classifyIdent txt) txt
+        pos := stop
+      else if isNumberStart c then
+        let stop := scanWhile source pos isNumberRest
+        out := out.push <| tokenNode "bp_rust_num" (pos.extract source stop)
+        pos := stop
+      else
+        out := out.push <| Verso.Output.Html.text true (pos.extract source nextPos)
+        pos := nextPos
+    return Verso.Output.Html.tag "pre" #[("class", "bp_external_decl_stmt hl rust block bp_rust_code")] (Verso.Output.Html.seq out)
+
+end Informal.Rust

--- a/tests/BlueprintTestDocsMain.lean
+++ b/tests/BlueprintTestDocsMain.lean
@@ -1,6 +1,7 @@
 import VersoManual
 import VersoBlueprint.PreviewManifest
 import VersoBlueprintTests.TestBlueprintRegistry
+import VersoBlueprintTests.TestBlueprintRegistryMeta
 import Lean
 
 open Verso.VersoBlueprintTests.TestBlueprintRegistry
@@ -19,7 +20,7 @@ def main (args : List String) : IO UInt32 := do
       IO.println doc.slug
     pure 0
   | ["--list-json"] =>
-    IO.println <| Json.compress <| toJson <| curatedTestBlueprints.map (·.meta)
+    IO.println <| Json.compress <| toJson curatedTestBlueprintMetas
     pure 0
   | slug :: rest =>
     match findCuratedTestBlueprint? slug with

--- a/tests/VersoBlueprintTests/Blueprint.lean
+++ b/tests/VersoBlueprintTests/Blueprint.lean
@@ -20,6 +20,7 @@ import VersoBlueprintTests.BlueprintPreviewSchema
 import VersoBlueprintTests.BlueprintPreviewPanels
 import VersoBlueprintTests.BlueprintPreviewSource
 import VersoBlueprintTests.BlueprintPreviewWiring
+import VersoBlueprintTests.BlueprintRustCode
 import VersoBlueprintTests.BlueprintSummaryLinks
 import VersoBlueprintTests.BlueprintSummaryStatus
 import VersoBlueprintTests.BlueprintTexSource

--- a/tests/VersoBlueprintTests/BlueprintRustCode.lean
+++ b/tests/VersoBlueprintTests/BlueprintRustCode.lean
@@ -1,0 +1,91 @@
+/- 
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoBlueprintTests.Blueprint.Support
+
+namespace Verso.VersoBlueprintTests.BlueprintRustCode
+
+open Verso
+open Verso.Genre.Manual
+open Informal
+open Verso.VersoBlueprintTests.Blueprint.Support
+
+private def manualImpls : ExtensionImpls := extension_impls%
+
+set_option doc.verso true
+
+#docs (Genre.Manual) rustInlineDoc "Rust Inline Doc" :=
+:::::::
+:::definition "rust_inline"
+Inline Rust attachment.
+
+```rust "rust_inline"
+pub fn inline_add(x: i32, y: i32) -> i32 {
+    x + y
+}
+```
+:::
+:::::::
+
+#docs (Genre.Manual) rustCatalogDoc "Rust Attachment Showcase" :=
+:::::::
+:::definition "rust_showcase.clean"
+Clean inline Rust attachment used for rendering review.
+:::
+
+```rust "rust_showcase.clean"
+pub fn rust_example(x: i32) -> i32 {
+    // increment once
+    x + 1
+}
+```
+
+:::definition "rust_showcase.decorated"
+Rust block with strings, comments, and numbers for simple coloring coverage.
+:::
+
+```rust "rust_showcase.decorated"
+pub fn log_label() -> &'static str {
+    // starter string
+    "hello"
+}
+
+pub const RETRIES: u32 = 3;
+```
+::::::: 
+
+#docs (Genre.Manual) rustInvalidDoc "Rust Invalid Doc" :=
+:::::::
+:::definition "rust_invalid"
+Broken Rust attachment.
+
+```rust "rust_invalid"
+pub fn broken( -> i32 { 1 }
+```
+:::
+:::::::
+
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let out ← renderManualDocHtmlString manualImpls rustInlineDoc
+  pure <|
+    hasSubstr out "Inline Rust attachment." &&
+    hasSubstr out "Rust code for rust_inline" &&
+    hasSubstr out "inline_add" &&
+    hasSubstr out "bp_rust_kw"
+
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let out ← renderManualDocHtmlString manualImpls rustInvalidDoc
+  pure <|
+    hasSubstr out "Broken Rust attachment." &&
+    hasSubstr out "Rust code for rust_invalid" &&
+    hasSubstr out "broken" &&
+    hasSubstr out "bp_rust_kw"
+
+end Verso.VersoBlueprintTests.BlueprintRustCode

--- a/tests/VersoBlueprintTests/TestBlueprintRegistry.lean
+++ b/tests/VersoBlueprintTests/TestBlueprintRegistry.lean
@@ -13,6 +13,7 @@ import VersoBlueprintTests.BlueprintPreviewWiring.Shared
 import VersoBlueprintTests.BlueprintPreviewWiring.StateShowcase
 import VersoBlueprintTests.BlueprintRustCode
 import VersoBlueprintTests.BlueprintSummaryLinks.Shared
+import VersoBlueprintTests.TestBlueprintRegistryMeta
 import VersoBlueprintTests.BlueprintTexMacros
 
 namespace Verso.VersoBlueprintTests.TestBlueprintRegistry
@@ -28,191 +29,52 @@ structure CuratedTestBlueprint where
   summary : String
   tags : Array String := #[]
   doc : Doc.VersoDoc Genre.Manual
+deriving Inhabited
 
 def manualImpls : ExtensionImpls := extension_impls%
 
-def curatedTestBlueprints : Array CuratedTestBlueprint := #[
-  {
-    slug := "hover-link"
-    title := "Hover Link Doc"
-    category := "Preview"
-    summary := "Inline reference and bibliography hover coverage."
-    tags := #["hover", "inline", "citation"]
-    doc := Verso.VersoBlueprintTests.BlueprintLinkHover.hoverLinkDoc
-  },
-  {
-    slug := "hover-uses-dedup"
-    title := "Hover Uses Dedup Doc"
-    category := "Preview"
-    summary := "Repeated uses-links against the same target without duplicate templates."
-    tags := #["hover", "inline", "uses"]
-    doc := Verso.VersoBlueprintTests.BlueprintLinkHover.hoverUsesDedupDoc
-  },
-  {
-    slug := "hover-cite-only"
-    title := "Hover Cite Only Doc"
-    category := "Preview"
-    summary := "Bibliography-only inline hover coverage."
-    tags := #["hover", "inline", "citation"]
-    doc := Verso.VersoBlueprintTests.BlueprintLinkHover.hoverCiteOnlyDoc
-  },
-  {
-    slug := "widget-preview"
-    title := "Blueprint Widget Preview"
-    category := "Preview"
-    summary := "Widget-side TeX prelude and preview rendering checks."
-    tags := #["preview", "widget", "tex"]
-    doc := Verso.VersoBlueprintTests.BlueprintTexMacros.widgetPreviewDoc
-  },
-  {
-    slug := "rust-inline-preview"
-    title := "Rust Attachment Showcase"
-    category := "Code"
-    summary := "Inline Rust attachment rendering with simple syntax coloring."
-    tags := #["rust", "inline", "code"]
-    doc := Verso.VersoBlueprintTests.BlueprintRustCode.rustCatalogDoc
-  },
-  {
-    slug := "metadata-panel"
-    title := "Blueprint Metadata Panel"
-    category := "Metadata"
-    summary := "Owner, tags, effort, priority, and PR metadata rendering."
-    tags := #["metadata", "summary"]
-    doc := Verso.VersoBlueprintTests.BlueprintMetadataPanel.metadataPanelDoc
-  },
-  {
-    slug := "direct-imported-duplicates"
-    title := "Direct Imported Duplicates"
-    category := "Imports"
-    summary := "Duplicate imported node, group, and author diagnostics."
-    tags := #["imports", "providers", "diagnostics"]
-    doc := Verso.VersoBlueprintTests.BlueprintImportedDuplicates.Direct.directImportedDuplicateDoc
-  },
-  {
-    slug := "transitive-imported-duplicates"
-    title := "Transitive Imported Duplicates"
-    category := "Imports"
-    summary := "Duplicate imported diagnostics through a reexport chain."
-    tags := #["imports", "providers", "diagnostics"]
-    doc := Verso.VersoBlueprintTests.BlueprintImportedDuplicates.Transitive.transitiveImportedDuplicateDoc
-  },
-  {
-    slug := "imported-preview-source"
-    title := "Imported Preview Source"
-    category := "Imports"
-    summary := "Imported preview bodies and cross-module preview source coverage."
-    tags := #["imports", "preview", "providers"]
-    doc := Verso.VersoBlueprintTests.BlueprintPreviewSource.Provider.importedPreviewSourceDoc
-  },
-  {
-    slug := "state-showcase"
-    title := "Blueprint Graph State Showcase"
-    category := "Graph"
-    summary := "Complete graph-state matrix with graph and summary pages."
-    tags := #["graph", "summary", "state"]
-    doc := Verso.VersoBlueprintTests.BlueprintPreviewWiring.StateShowcase.stateShowcaseDoc
-  },
-  {
-    slug := "external-summary-links"
-    title := "External Summary Links"
-    category := "Summary"
-    summary := "Summary links for external Lean declarations."
-    tags := #["summary", "external", "lean"]
-    doc := Verso.VersoBlueprintTests.BlueprintSummaryLinks.Shared.externalSummaryLinksDoc
-  },
-  {
-    slug := "summary-blockers"
-    title := "Summary Blockers"
-    category := "Summary"
-    summary := "Missing declarations and incomplete Lean declarations in summary views."
-    tags := #["summary", "lean", "blockers"]
-    doc := Verso.VersoBlueprintTests.BlueprintSummaryLinks.Shared.summaryBlockersDoc
-  },
-  {
-    slug := "summary-triage"
-    title := "Summary Triage"
-    category := "Summary"
-    summary := "Summary rollups by owner, tags, parent, and triage metadata."
-    tags := #["summary", "metadata", "triage"]
-    doc := Verso.VersoBlueprintTests.BlueprintSummaryLinks.Shared.summaryTriageDoc
-  },
-  {
-    slug := "preview-wiring"
-    title := "Blueprint Preview Wiring"
-    category := "Runtime"
-    summary := "Core graph and summary preview runtime wiring."
-    tags := #["preview", "runtime", "graph", "summary"]
-    doc := Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared.previewWiringDoc
-  },
-  {
-    slug := "used-by-preview"
-    title := "Blueprint Used-By Preview Wiring"
-    category := "Relationships"
-    summary := "Used-by chips and preview panel behavior."
-    tags := #["relationships", "used-by", "preview"]
-    doc := Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared.usedByPreviewDoc
-  },
-  {
-    slug := "used-by-single-preview"
-    title := "Blueprint Used-By Single Preview Wiring"
-    category := "Relationships"
-    summary := "Single reverse-dependency used-by rendering."
-    tags := #["relationships", "used-by"]
-    doc := Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared.usedBySinglePreviewDoc
-  },
-  {
-    slug := "lean-status-chip"
-    title := "Blueprint Lean Status Chip Wiring"
-    category := "Summary"
-    summary := "Lean status chip rendering for proved, sorry, axiom, and absent code."
-    tags := #["summary", "status", "lean"]
-    doc := Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared.leanStatusChipDoc
-  },
-  {
-    slug := "lean-code-link-preview"
-    title := "Blueprint Lean Code Link Preview Wiring"
-    category := "Preview"
-    summary := "Inline Lean declaration preview links inside the summary."
-    tags := #["preview", "inline", "lean"]
-    doc := Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared.leanCodeLinkPreviewDoc
-  },
-  {
-    slug := "group-preview"
-    title := "Blueprint Group Preview Wiring"
-    category := "Relationships"
-    summary := "Declared group chips and group preview panel interactions."
-    tags := #["relationships", "group", "preview"]
-    doc := Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared.groupPreviewDoc
-  },
-  {
-    slug := "missing-group-preview"
-    title := "Blueprint Missing Group Preview Wiring"
-    category := "Relationships"
-    summary := "Fallback behavior for undeclared groups."
-    tags := #["relationships", "group", "fallback"]
-    doc := Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared.missingGroupPreviewDoc
-  },
-  {
-    slug := "single-declared-group"
-    title := "Blueprint Single Declared Group Wiring"
-    category := "Relationships"
-    summary := "Declared group with only one member."
-    tags := #["relationships", "group"]
-    doc := Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared.singleDeclaredGroupDoc
-  }
-]
+private def curatedTestBlueprintDoc? (slug : String) : Option (Doc.VersoDoc Genre.Manual) :=
+  match slug with
+  | "hover-link" => some Verso.VersoBlueprintTests.BlueprintLinkHover.hoverLinkDoc
+  | "hover-uses-dedup" => some Verso.VersoBlueprintTests.BlueprintLinkHover.hoverUsesDedupDoc
+  | "hover-cite-only" => some Verso.VersoBlueprintTests.BlueprintLinkHover.hoverCiteOnlyDoc
+  | "widget-preview" => some Verso.VersoBlueprintTests.BlueprintTexMacros.widgetPreviewDoc
+  | "rust-inline-preview" => some Verso.VersoBlueprintTests.BlueprintRustCode.rustCatalogDoc
+  | "metadata-panel" => some Verso.VersoBlueprintTests.BlueprintMetadataPanel.metadataPanelDoc
+  | "direct-imported-duplicates" => some Verso.VersoBlueprintTests.BlueprintImportedDuplicates.Direct.directImportedDuplicateDoc
+  | "transitive-imported-duplicates" => some Verso.VersoBlueprintTests.BlueprintImportedDuplicates.Transitive.transitiveImportedDuplicateDoc
+  | "imported-preview-source" => some Verso.VersoBlueprintTests.BlueprintPreviewSource.Provider.importedPreviewSourceDoc
+  | "state-showcase" => some Verso.VersoBlueprintTests.BlueprintPreviewWiring.StateShowcase.stateShowcaseDoc
+  | "external-summary-links" => some Verso.VersoBlueprintTests.BlueprintSummaryLinks.Shared.externalSummaryLinksDoc
+  | "summary-blockers" => some Verso.VersoBlueprintTests.BlueprintSummaryLinks.Shared.summaryBlockersDoc
+  | "summary-triage" => some Verso.VersoBlueprintTests.BlueprintSummaryLinks.Shared.summaryTriageDoc
+  | "preview-wiring" => some Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared.previewWiringDoc
+  | "used-by-preview" => some Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared.usedByPreviewDoc
+  | "used-by-single-preview" => some Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared.usedBySinglePreviewDoc
+  | "lean-status-chip" => some Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared.leanStatusChipDoc
+  | "lean-code-link-preview" => some Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared.leanCodeLinkPreviewDoc
+  | "group-preview" => some Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared.groupPreviewDoc
+  | "missing-group-preview" => some Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared.missingGroupPreviewDoc
+  | "single-declared-group" => some Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared.singleDeclaredGroupDoc
+  | _ => none
+
+def curatedTestBlueprints : Array CuratedTestBlueprint :=
+  curatedTestBlueprintMetas.map (fun entry =>
+    match curatedTestBlueprintDoc? entry.slug with
+    | some doc =>
+        {
+          slug := entry.slug
+          title := entry.title
+          category := entry.category
+          summary := entry.summary
+          tags := entry.tags
+          doc := doc
+        }
+    | none =>
+        panic! s!"missing curated test blueprint doc for slug `{entry.slug}`")
 
 def findCuratedTestBlueprint? (slug : String) : Option CuratedTestBlueprint :=
   curatedTestBlueprints.find? (·.slug == slug)
-
-structure CuratedTestBlueprintMeta where
-  slug : String
-  title : String
-  category : String
-  summary : String
-  tags : Array String
-  kind : String
-deriving ToJson
 
 def CuratedTestBlueprint.meta (doc : CuratedTestBlueprint) : CuratedTestBlueprintMeta :=
   {

--- a/tests/VersoBlueprintTests/TestBlueprintRegistry.lean
+++ b/tests/VersoBlueprintTests/TestBlueprintRegistry.lean
@@ -11,6 +11,7 @@ import VersoBlueprintTests.BlueprintMetadataPanel
 import VersoBlueprintTests.BlueprintPreviewSource.Provider
 import VersoBlueprintTests.BlueprintPreviewWiring.Shared
 import VersoBlueprintTests.BlueprintPreviewWiring.StateShowcase
+import VersoBlueprintTests.BlueprintRustCode
 import VersoBlueprintTests.BlueprintSummaryLinks.Shared
 import VersoBlueprintTests.BlueprintTexMacros
 
@@ -62,6 +63,14 @@ def curatedTestBlueprints : Array CuratedTestBlueprint := #[
     summary := "Widget-side TeX prelude and preview rendering checks."
     tags := #["preview", "widget", "tex"]
     doc := Verso.VersoBlueprintTests.BlueprintTexMacros.widgetPreviewDoc
+  },
+  {
+    slug := "rust-inline-preview"
+    title := "Rust Attachment Showcase"
+    category := "Code"
+    summary := "Inline Rust attachment rendering with simple syntax coloring."
+    tags := #["rust", "inline", "code"]
+    doc := Verso.VersoBlueprintTests.BlueprintRustCode.rustCatalogDoc
   },
   {
     slug := "metadata-panel"

--- a/tests/VersoBlueprintTests/TestBlueprintRegistryChecks.lean
+++ b/tests/VersoBlueprintTests/TestBlueprintRegistryChecks.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Emilio J. Gallego Arias
 -/
 
-import VersoBlueprintTests.TestBlueprintRegistry
+import VersoBlueprintTests.TestBlueprintRegistryMeta
 
 namespace Verso.VersoBlueprintTests.TestBlueprintRegistryChecks
 
@@ -13,7 +13,7 @@ open Verso.VersoBlueprintTests.TestBlueprintRegistry
 /-- info: true -/
 #guard_msgs in
 #eval
-  let metas := curatedTestBlueprints.map (·.meta)
+  let metas := curatedTestBlueprintMetas
   let categories := metas.map (·.category)
   let kinds := metas.map (·.kind)
   let tags := metas.foldl (fun acc => fun docMeta => acc ++ docMeta.tags) #[]
@@ -27,6 +27,7 @@ open Verso.VersoBlueprintTests.TestBlueprintRegistry
     categories.contains "Metadata" &&
     categories.contains "Imports" &&
     categories.contains "Graph" &&
-    categories.contains "Runtime"
+    categories.contains "Runtime" &&
+    categories.contains "Code"
 
 end Verso.VersoBlueprintTests.TestBlueprintRegistryChecks

--- a/tests/VersoBlueprintTests/TestBlueprintRegistryMeta.lean
+++ b/tests/VersoBlueprintTests/TestBlueprintRegistryMeta.lean
@@ -1,0 +1,196 @@
+/- 
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import Lean
+
+namespace Verso.VersoBlueprintTests.TestBlueprintRegistry
+
+open Lean
+
+structure CuratedTestBlueprintMeta where
+  slug : String
+  title : String
+  category : String
+  summary : String
+  tags : Array String
+  kind : String
+deriving ToJson
+
+def curatedTestBlueprintMetas : Array CuratedTestBlueprintMeta := #[
+  {
+    slug := "hover-link"
+    title := "Hover Link Doc"
+    category := "Preview"
+    summary := "Inline reference and bibliography hover coverage."
+    tags := #["hover", "inline", "citation"]
+    kind := "curated_doc"
+  },
+  {
+    slug := "hover-uses-dedup"
+    title := "Hover Uses Dedup Doc"
+    category := "Preview"
+    summary := "Repeated uses-links against the same target without duplicate templates."
+    tags := #["hover", "inline", "uses"]
+    kind := "curated_doc"
+  },
+  {
+    slug := "hover-cite-only"
+    title := "Hover Cite Only Doc"
+    category := "Preview"
+    summary := "Bibliography-only inline hover coverage."
+    tags := #["hover", "inline", "citation"]
+    kind := "curated_doc"
+  },
+  {
+    slug := "widget-preview"
+    title := "Blueprint Widget Preview"
+    category := "Preview"
+    summary := "Widget-side TeX prelude and preview rendering checks."
+    tags := #["preview", "widget", "tex"]
+    kind := "curated_doc"
+  },
+  {
+    slug := "rust-inline-preview"
+    title := "Rust Attachment Showcase"
+    category := "Code"
+    summary := "Inline Rust attachment rendering with simple syntax coloring."
+    tags := #["rust", "inline", "code"]
+    kind := "curated_doc"
+  },
+  {
+    slug := "metadata-panel"
+    title := "Blueprint Metadata Panel"
+    category := "Metadata"
+    summary := "Owner, tags, effort, priority, and PR metadata rendering."
+    tags := #["metadata", "summary"]
+    kind := "curated_doc"
+  },
+  {
+    slug := "direct-imported-duplicates"
+    title := "Direct Imported Duplicates"
+    category := "Imports"
+    summary := "Duplicate imported node, group, and author diagnostics."
+    tags := #["imports", "providers", "diagnostics"]
+    kind := "curated_doc"
+  },
+  {
+    slug := "transitive-imported-duplicates"
+    title := "Transitive Imported Duplicates"
+    category := "Imports"
+    summary := "Duplicate imported diagnostics through a reexport chain."
+    tags := #["imports", "providers", "diagnostics"]
+    kind := "curated_doc"
+  },
+  {
+    slug := "imported-preview-source"
+    title := "Imported Preview Source"
+    category := "Imports"
+    summary := "Imported preview bodies and cross-module preview source coverage."
+    tags := #["imports", "preview", "providers"]
+    kind := "curated_doc"
+  },
+  {
+    slug := "state-showcase"
+    title := "Blueprint Graph State Showcase"
+    category := "Graph"
+    summary := "Complete graph-state matrix with graph and summary pages."
+    tags := #["graph", "summary", "state"]
+    kind := "curated_doc"
+  },
+  {
+    slug := "external-summary-links"
+    title := "External Summary Links"
+    category := "Summary"
+    summary := "Summary links for external Lean declarations."
+    tags := #["summary", "external", "lean"]
+    kind := "curated_doc"
+  },
+  {
+    slug := "summary-blockers"
+    title := "Summary Blockers"
+    category := "Summary"
+    summary := "Missing declarations and incomplete Lean declarations in summary views."
+    tags := #["summary", "lean", "blockers"]
+    kind := "curated_doc"
+  },
+  {
+    slug := "summary-triage"
+    title := "Summary Triage"
+    category := "Summary"
+    summary := "Summary rollups by owner, tags, parent, and triage metadata."
+    tags := #["summary", "metadata", "triage"]
+    kind := "curated_doc"
+  },
+  {
+    slug := "preview-wiring"
+    title := "Blueprint Preview Wiring"
+    category := "Runtime"
+    summary := "Core graph and summary preview runtime wiring."
+    tags := #["preview", "runtime", "graph", "summary"]
+    kind := "curated_doc"
+  },
+  {
+    slug := "used-by-preview"
+    title := "Blueprint Used-By Preview Wiring"
+    category := "Relationships"
+    summary := "Used-by chips and preview panel behavior."
+    tags := #["relationships", "used-by", "preview"]
+    kind := "curated_doc"
+  },
+  {
+    slug := "used-by-single-preview"
+    title := "Blueprint Used-By Single Preview Wiring"
+    category := "Relationships"
+    summary := "Single reverse-dependency used-by rendering."
+    tags := #["relationships", "used-by"]
+    kind := "curated_doc"
+  },
+  {
+    slug := "lean-status-chip"
+    title := "Blueprint Lean Status Chip Wiring"
+    category := "Summary"
+    summary := "Lean status chip rendering for proved, sorry, axiom, and absent code."
+    tags := #["summary", "status", "lean"]
+    kind := "curated_doc"
+  },
+  {
+    slug := "lean-code-link-preview"
+    title := "Blueprint Lean Code Link Preview Wiring"
+    category := "Preview"
+    summary := "Inline Lean declaration preview links inside the summary."
+    tags := #["preview", "inline", "lean"]
+    kind := "curated_doc"
+  },
+  {
+    slug := "group-preview"
+    title := "Blueprint Group Preview Wiring"
+    category := "Relationships"
+    summary := "Declared group chips and group preview panel interactions."
+    tags := #["relationships", "group", "preview"]
+    kind := "curated_doc"
+  },
+  {
+    slug := "missing-group-preview"
+    title := "Blueprint Missing Group Preview Wiring"
+    category := "Relationships"
+    summary := "Fallback behavior for undeclared groups."
+    tags := #["relationships", "group", "fallback"]
+    kind := "curated_doc"
+  },
+  {
+    slug := "single-declared-group"
+    title := "Blueprint Single Declared Group Wiring"
+    category := "Relationships"
+    summary := "Declared group with only one member."
+    tags := #["relationships", "group"]
+    kind := "curated_doc"
+  }
+]
+
+def findCuratedTestBlueprintMeta? (slug : String) : Option CuratedTestBlueprintMeta :=
+  curatedTestBlueprintMetas.find? (·.slug == slug)
+
+end Verso.VersoBlueprintTests.TestBlueprintRegistry

--- a/tests/harness/test_blueprint_test_blueprints.py
+++ b/tests/harness/test_blueprint_test_blueprints.py
@@ -28,7 +28,7 @@ class StandaloneTestBlueprintTests(unittest.TestCase):
 
         self.assertEqual(
             categories,
-            ("Preview", "Relationships", "Summary", "Metadata", "Imports", "Graph", "Runtime"),
+            ("Code", "Preview", "Relationships", "Summary", "Metadata", "Imports", "Graph", "Runtime"),
         )
         self.assertEqual(fixture.slug, "preview_runtime_showcase")
         self.assertEqual(fixture.kind, "standalone_project")

--- a/tests/harness/test_blueprints.json
+++ b/tests/harness/test_blueprints.json
@@ -1,6 +1,7 @@
 {
   "version": 1,
   "categories": [
+    "Code",
     "Preview",
     "Relationships",
     "Summary",


### PR DESCRIPTION
Backport of #10.

This applies the same minimal inline Rust attachment surface to the `v4.28.0` line:

- labeled inline Rust code blocks
- rendered Rust code panels
- simple built-in syntax highlighting
- catalog and template examples
- matching docs and tests
- the same branch-scoped Pages/deploy concurrency fix used on the main PR

Validation is expected to come from the backport PR CI for the `v4.28.0` branch.