### PR TITLE
[backport v4.28.0] fix(backports): require draft plans and base-aware retire

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,13 @@ What was wrong, missing, or confusing before this change?
 - Manual checks performed
 - External projects or worktrees exercised
 
+## Primary Review
+
+For paired backport PRs:
+
+- Primary review: #<default-dev-pr>
+- Keep discussion there unless this backport diverges materially.
+
 ## Backports
 
 Draft `v4.29.0` PRs should declare one line per required backport target as
@@ -29,6 +36,13 @@ Once a `v4.29.0` PR is ready for review, replace each `pending` line with:
 
 - `Backport v4.28.0: #123`
 - `Backport v4.28.0: exempt: <reason>`
+
+## Backport Delta
+
+For paired backport PRs:
+
+- No intentional release-specific changes
+- Or describe the release-line-specific adaptation
 
 ## Risks and Follow-Ups
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,8 +19,13 @@ What was wrong, missing, or confusing before this change?
 
 ## Backports
 
-Draft `v4.29.0` PRs skip the paired-backport gate. Once a `v4.29.0` PR is
-ready for review, add one line per required backport target:
+Draft `v4.29.0` PRs should declare one line per required backport target as
+soon as the draft exists. While the PR is still draft, `pending` is allowed:
+
+- `Backport v4.28.0: pending`
+- `Backport v4.28.0: exempt: <reason>`
+
+Once a `v4.29.0` PR is ready for review, replace each `pending` line with:
 
 - `Backport v4.28.0: #123`
 - `Backport v4.28.0: exempt: <reason>`

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -70,6 +70,7 @@ subjects such as `Update files` or `misc cleanup`.
   - run `python3 -m scripts.blueprint_harness prepare-backports` and paste the
     emitted lines into the draft PR body
   - once it is ready for review, open the paired `v4.28.0` PR
+  - use `python3 -m scripts.blueprint_harness prepare-backport-pr v4.28.0 --main-pr <pr>` to scaffold the paired backport PR branch name, title, and body
   - replace each `Backport ...: pending` line with `Backport ...: #<pr>` or
     `Backport ...: exempt: <reason>`
   - wait for CI on both PRs before merging the `v4.29.0` PR

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -65,6 +65,11 @@ subjects such as `Update files` or `misc cleanup`.
   paired backport PR number or an explicit exemption reason.
 - The default-development PR is the primary review surface. Paired backport PRs
   exist mainly so CI and merge state are visible on the maintenance line.
+- Paired backport branches should be built with `git cherry-pick -x` so every
+  backport commit records the source commit SHA from the default-development PR.
+- The paired-backport check now verifies both the recorded source SHAs and the
+  patch IDs for the commit series, so a paired backport PR should remain a
+  one-to-one cherry-pick of the default-development series.
 - The expected workflow is:
   - keep the `v4.29.0` PR in draft while the change is still converging
   - run `python3 -m scripts.blueprint_harness prepare-backports` and paste the

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -76,6 +76,7 @@ subjects such as `Update files` or `misc cleanup`.
     emitted lines into the draft PR body
   - once it is ready for review, open the paired `v4.28.0` PR
   - use `python3 -m scripts.blueprint_harness prepare-backport-pr v4.28.0 --main-pr <pr>` to scaffold the paired backport PR branch name, title, and body
+  - when several releases are required, use `python3 -m scripts.blueprint_harness prepare-backport-pr --all-required --main-pr <pr>` to emit one scaffold block per release, then let the agent apply the `git cherry-pick -x` series and resolve conflicts in each backport worktree
   - replace each `Backport ...: pending` line with `Backport ...: #<pr>` or
     `Backport ...: exempt: <reason>`
   - wait for CI on both PRs before merging the `v4.29.0` PR

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -52,14 +52,20 @@ subjects such as `Update files` or `misc cleanup`.
   - notable risks or follow-up
 - When the work came from a local worktree, include the worktree name and write
   scope in the PR body or draft notes.
-- Non-draft PRs targeting `v4.29.0` must include paired backport metadata for
-  each required backport release branch listed in `branch-policy.json`, unless
-  the PR explicitly records an exemption with a reason.
+- Draft PRs targeting `v4.29.0` must declare one backport plan line for each
+  required backport release branch listed in `branch-policy.json`.
+- Non-draft PRs targeting `v4.29.0` must replace each `pending` entry with a
+  paired backport PR number or an explicit exemption reason.
 - The expected workflow is:
   - keep the `v4.29.0` PR in draft while the change is still converging
+  - run `python3 -m scripts.blueprint_harness prepare-backports` and paste the
+    emitted lines into the draft PR body
   - once it is ready for review, open the paired `v4.28.0` PR
+  - replace each `Backport ...: pending` line with `Backport ...: #<pr>` or
+    `Backport ...: exempt: <reason>`
   - wait for CI on both PRs before merging the `v4.29.0` PR
 - Record the pairing in the PR body using lines like:
+  - `Backport v4.28.0: pending`
   - `Backport v4.28.0: #123`
   - `Backport v4.28.0: exempt: docs-only change`
 

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -22,6 +22,13 @@ This repository keeps local parallel work simple:
 - Use `chore/<slug>` for maintenance and cleanup.
 - Use `wip/<slug>` only for local-only exploratory branches that are not ready
   for review.
+- For paired backport branches, keep the same top-level prefix and reuse the
+  default-dev slug with a release marker in front of it.
+  Examples:
+  - default-dev branch: `fix/backport-discipline`
+  - paired `v4.28.0` backport branch: `fix/backport-v428-backport-discipline`
+  - default-dev docs branch: `docs/manual-cleanup`
+  - paired `v4.28.0` docs backport branch: `docs/backport-v428-manual-cleanup`
 
 Prefer short, descriptive slugs over opaque branch names.
 
@@ -56,6 +63,8 @@ subjects such as `Update files` or `misc cleanup`.
   required backport release branch listed in `branch-policy.json`.
 - Non-draft PRs targeting `v4.29.0` must replace each `pending` entry with a
   paired backport PR number or an explicit exemption reason.
+- The default-development PR is the primary review surface. Paired backport PRs
+  exist mainly so CI and merge state are visible on the maintenance line.
 - The expected workflow is:
   - keep the `v4.29.0` PR in draft while the change is still converging
   - run `python3 -m scripts.blueprint_harness prepare-backports` and paste the
@@ -64,6 +73,9 @@ subjects such as `Update files` or `misc cleanup`.
   - replace each `Backport ...: pending` line with `Backport ...: #<pr>` or
     `Backport ...: exempt: <reason>`
   - wait for CI on both PRs before merging the `v4.29.0` PR
+- Keep review comments and design discussion on the default-dev PR unless the
+  backport itself diverges materially, for example because of a conflict or a
+  release-line-specific adaptation.
 - Record the pairing in the PR body using lines like:
   - `Backport v4.28.0: pending`
   - `Backport v4.28.0: #123`

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -443,6 +443,18 @@ with either:
 - link the paired `v4.28.0` PR in the PR body with `Backport v4.28.0: #<pr>`
 - or record `Backport v4.28.0: exempt: <reason>`
 
+Use the default-development PR as the main review surface. The paired backport
+PR is primarily a maintenance-line artifact for CI, merge state, and any
+release-specific conflict resolution. Unless the backport diverges materially,
+keep review comments and substantive discussion on the default-development PR.
+
+When you do open the paired backport branch, keep the same top-level branch
+prefix and reuse the default-development slug with a release marker. For
+example:
+
+- default-development branch: `fix/backport-discipline`
+- paired `v4.28.0` branch: `fix/backport-v428-backport-discipline`
+
 CI keeps the `Paired Backport` check visible on draft PRs so the declared plan
 is part of PR health, and once the PR is ready it additionally checks that the
 paired PR targets the required backport branch and that its checks are green

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -465,6 +465,17 @@ That helper prints a standardized paired branch name, a title of the form
 `[backport v4.28.0] ...`, and a PR body that points back to the primary
 default-development review.
 
+When several backport releases are required, use:
+
+```bash
+python3 -m scripts.blueprint_harness prepare-backport-pr --all-required --main-pr <pr>
+```
+
+That batch mode emits one scaffold block per required release, including the
+paired worktree name, branch name, and the exact `git cherry-pick -x ...`
+series to apply. An agent can then create each worktree, apply the series, and
+resolve conflicts release by release.
+
 When populating the paired backport branch itself, use `git cherry-pick -x` so
 each backport commit records `(cherry picked from commit <sha>)`. The
 paired-backport check verifies those recorded source SHAs and also compares the

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -465,6 +465,11 @@ That helper prints a standardized paired branch name, a title of the form
 `[backport v4.28.0] ...`, and a PR body that points back to the primary
 default-development review.
 
+When populating the paired backport branch itself, use `git cherry-pick -x` so
+each backport commit records `(cherry picked from commit <sha>)`. The
+paired-backport check verifies those recorded source SHAs and also compares the
+patch IDs of the default-development and backport commit series.
+
 CI keeps the `Paired Backport` check visible on draft PRs so the declared plan
 is part of PR health, and once the PR is ready it additionally checks that the
 paired PR targets the required backport branch and that its checks are green

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -423,15 +423,30 @@ python3 -m scripts.blueprint_harness require-branch-role default_dev
 Use `require-branch-role default_dev` when a script or agent should refuse to
 do non-backport work from a backport-only checkout.
 
-Ready non-draft PRs that target the default development branch also follow a
-paired-backport gate. In this repository that means `v4.29.0` PRs stay draft
-while the change is converging; once they are ready for review they must either:
+Default-development PRs also follow a paired-backport gate. In this repository
+that means draft `v4.29.0` PRs must still declare one line per required
+backport target, usually by running:
+
+```bash
+python3 -m scripts.blueprint_harness prepare-backports
+```
+
+Paste the emitted lines into the draft PR body. While the PR is still draft,
+each required line may remain:
+
+- `Backport v4.28.0: pending`
+- or `Backport v4.28.0: exempt: <reason>`
+
+Once the `v4.29.0` PR is ready for review it must replace each `pending` line
+with either:
 
 - link the paired `v4.28.0` PR in the PR body with `Backport v4.28.0: #<pr>`
 - or record `Backport v4.28.0: exempt: <reason>`
 
-CI checks that the paired PR targets the required backport branch and that its
-checks are green before the `v4.29.0` PR can merge.
+CI keeps the `Paired Backport` check visible on draft PRs so the declared plan
+is part of PR health, and once the PR is ready it additionally checks that the
+paired PR targets the required backport branch and that its checks are green
+before the `v4.29.0` PR can merge.
 
 To land one reviewed branch onto the active release branch safely from the root
 checkout, use:
@@ -502,7 +517,7 @@ The local coordination layer is now machine-readable and untracked.
 - `worktree-retire` removes one merged clean linked worktree, deletes its local
   branch when one exists, and prunes its stale reference clones
 - detached linked worktrees are also retireable once their `HEAD` commit is
-  reachable from the preferred active release ref
+  reachable from that worktree's preferred release ref
 - by default, each session should only retire or delete worktrees and branches
   it created or landed itself; broader cleanup should be explicit
 

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -455,6 +455,16 @@ example:
 - default-development branch: `fix/backport-discipline`
 - paired `v4.28.0` branch: `fix/backport-v428-backport-discipline`
 
+To keep paired backport PRs consistent, scaffold them with:
+
+```bash
+python3 -m scripts.blueprint_harness prepare-backport-pr v4.28.0 --main-pr <pr>
+```
+
+That helper prints a standardized paired branch name, a title of the form
+`[backport v4.28.0] ...`, and a PR body that points back to the primary
+default-development review.
+
 CI keeps the `Paired Backport` check visible on draft PRs so the declared plan
 is part of PR health, and once the PR is ready it additionally checks that the
 paired PR targets the required backport branch and that its checks are green

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,11 +51,17 @@ with the preferred release ref before branching or landing, use:
 ```bash
 python3 -m scripts.blueprint_harness release-status
 python3 -m scripts.blueprint_harness release-status --require-sync
+python3 -m scripts.blueprint_harness prepare-backports
 python3 -m scripts.blueprint_harness require-branch-role default_dev
 ```
 
 `require-branch-role default_dev` is the explicit machine check for
 automation that must refuse non-backport work on backport-only release lines.
+
+`prepare-backports` prints the `Backport ...` lines that should be pasted into a
+draft default-dev PR body. Draft PRs may keep those lines as `pending`; before
+ready for review, replace each `pending` entry with `#<pr>` or
+`exempt: <reason>`.
 
 To land one reviewed branch onto the active release branch from the root
 checkout, use:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -53,6 +53,7 @@ python3 -m scripts.blueprint_harness release-status
 python3 -m scripts.blueprint_harness release-status --require-sync
 python3 -m scripts.blueprint_harness prepare-backports
 python3 -m scripts.blueprint_harness prepare-backport-pr v4.28.0 --main-pr <pr>
+python3 -m scripts.blueprint_harness prepare-backport-pr --all-required --main-pr <pr>
 python3 -m scripts.blueprint_harness require-branch-role default_dev
 ```
 
@@ -67,6 +68,10 @@ ready for review, replace each `pending` entry with `#<pr>` or
 `prepare-backport-pr` prints a standardized paired backport branch name, PR
 title, and PR body scaffold that points review back to the default-dev PR and
 limits the paired PR to release-line-specific deltas.
+
+With `--all-required`, it emits one scaffold block per required release plus
+the exact `git cherry-pick -x ...` commit series an agent should apply while
+resolving conflicts release by release.
 
 Paired backport branches themselves should be created with `git cherry-pick -x`.
 The paired-backport check validates both the recorded source SHAs and the patch

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -68,6 +68,10 @@ ready for review, replace each `pending` entry with `#<pr>` or
 title, and PR body scaffold that points review back to the default-dev PR and
 limits the paired PR to release-line-specific deltas.
 
+Paired backport branches themselves should be created with `git cherry-pick -x`.
+The paired-backport check validates both the recorded source SHAs and the patch
+IDs of the resulting commit series.
+
 To land one reviewed branch onto the active release branch from the root
 checkout, use:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -52,6 +52,7 @@ with the preferred release ref before branching or landing, use:
 python3 -m scripts.blueprint_harness release-status
 python3 -m scripts.blueprint_harness release-status --require-sync
 python3 -m scripts.blueprint_harness prepare-backports
+python3 -m scripts.blueprint_harness prepare-backport-pr v4.28.0 --main-pr <pr>
 python3 -m scripts.blueprint_harness require-branch-role default_dev
 ```
 
@@ -62,6 +63,10 @@ automation that must refuse non-backport work on backport-only release lines.
 draft default-dev PR body. Draft PRs may keep those lines as `pending`; before
 ready for review, replace each `pending` entry with `#<pr>` or
 `exempt: <reason>`.
+
+`prepare-backport-pr` prints a standardized paired backport branch name, PR
+title, and PR body scaffold that points review back to the default-dev PR and
+limits the paired PR to release-line-specific deltas.
 
 To land one reviewed branch onto the active release branch from the root
 checkout, use:

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+import re
 import shutil
 import subprocess
 import sys
@@ -17,6 +18,7 @@ from scripts.blueprint_harness_branches import (
     checkout_is_backport_only,
     load_branch_policy,
     local_release_ref,
+    normalize_lean_release_ref,
     preferred_release_ref,
     require_checkout_role,
     root_checkout_namespace,
@@ -138,6 +140,19 @@ def current_branch_name(repo_root: Path) -> str | None:
         capture_output=True,
     ).stdout.strip()
     return branch or None
+
+
+def current_commit_subject(repo_root: Path) -> str:
+    subject = subprocess.run(
+        ["git", "log", "-1", "--format=%s"],
+        cwd=repo_root,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+    if not subject:
+        raise SystemExit("[blueprint-harness] unable to derive a PR title from the current commit subject")
+    return subject
 
 
 def ref_oid(repo_root: Path, ref: str) -> str | None:
@@ -440,6 +455,28 @@ def parse_prepare_backports_exemptions(values: list[str] | None) -> dict[str, st
     return exemptions
 
 
+def release_marker(release_ref: str) -> str:
+    normalized = normalize_lean_release_ref(release_ref)
+    match = re.match(r"^v(\d+)\.(\d+)", normalized)
+    if match is not None:
+        return f"v{match.group(1)}{match.group(2)}"
+    return "v" + re.sub(r"[^A-Za-z0-9]+", "", normalized.removeprefix("v"))
+
+
+def slugify_backport_fragment(text: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", text.strip())
+    cleaned = re.sub(r"-{2,}", "-", cleaned).strip("-")
+    return cleaned or "change"
+
+
+def default_backport_branch_name(source_branch: str, release_ref: str) -> str:
+    marker = release_marker(release_ref)
+    if "/" in source_branch:
+        prefix, slug = source_branch.split("/", 1)
+        return f"{prefix}/backport-{marker}-{slugify_backport_fragment(slug)}"
+    return f"backport-{marker}-{slugify_backport_fragment(source_branch)}"
+
+
 def command_prepare_backports(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
     policy = load_branch_policy(layout.package_root)
@@ -467,6 +504,47 @@ def command_prepare_backports(args: argparse.Namespace) -> int:
     print()
     print("[blueprint-harness] paste these lines into the default-dev PR body while it is draft")
     print("[blueprint-harness] replace each `pending` entry with `#<pr>` or `exempt: <reason>` before ready for review")
+    return 0
+
+
+def command_prepare_backport_pr(args: argparse.Namespace) -> int:
+    layout = detect_harness_layout(Path(__file__))
+    backport_release = normalize_lean_release_ref(args.release)
+    source_branch = args.source_branch or current_branch_name(layout.package_root)
+    if not source_branch:
+        raise SystemExit("[blueprint-harness] unable to determine a source branch; pass `--source-branch` explicitly")
+
+    main_title = args.main_title or current_commit_subject(layout.package_root)
+    paired_branch = default_backport_branch_name(source_branch, backport_release)
+    paired_title = f"[backport {backport_release}] {main_title}"
+
+    print(f"default_dev_branch={default_dev_branch(layout.package_root)}")
+    print(f"backport_release={backport_release}")
+    print(f"source_branch={source_branch}")
+    print(f"paired_branch={paired_branch}")
+    print(f"paired_title={paired_title}")
+    print()
+    print("## Summary")
+    print(f"Backport #{args.main_pr} to `{backport_release}`.")
+    print()
+    print("## Primary Review")
+    print(f"- Primary review: #{args.main_pr}")
+    print(f"- Keep review comments on #{args.main_pr} unless this backport diverges materially.")
+    print()
+    print("## Scope")
+    print(f"- Backport the already-reviewed default-development change onto `{backport_release}`.")
+    print("- Keep this PR limited to release-line-specific conflict resolution.")
+    print()
+    print("## Backport Delta")
+    print("- No intentional release-specific changes.")
+    print("- If conflict resolution requires deviations from the default-development PR, describe them here.")
+    print()
+    print("## Validation")
+    print(f"- Describe the validation run on `{backport_release}`.")
+    print()
+    print("## Coordination")
+    print(f"- Default-dev PR: #{args.main_pr}")
+    print(f"- Default-dev branch: `{source_branch}`")
     return 0
 
 
@@ -818,6 +896,29 @@ def build_parser() -> argparse.ArgumentParser:
         help="Pre-fill one required branch as `exempt: <reason>` using `--exempt <branch>=<reason>`. Repeat as needed.",
     )
     prepare_backports.set_defaults(func=command_prepare_backports)
+
+    prepare_backport_pr = subparsers.add_parser(
+        "prepare-backport-pr",
+        help="Print a standardized paired backport branch name, PR title, and PR body scaffold.",
+    )
+    prepare_backport_pr.add_argument("release", help="Backport release branch such as `v4.28.0`.")
+    prepare_backport_pr.add_argument(
+        "--main-pr",
+        type=int,
+        required=True,
+        help="Default-development PR number that remains the primary review surface.",
+    )
+    prepare_backport_pr.add_argument(
+        "--main-title",
+        default=None,
+        help="Override the default-development PR title. Defaults to the current commit subject.",
+    )
+    prepare_backport_pr.add_argument(
+        "--source-branch",
+        default=None,
+        help="Override the default-development branch name. Defaults to the current branch.",
+    )
+    prepare_backport_pr.set_defaults(func=command_prepare_backport_pr)
 
     require_role = subparsers.add_parser(
         "require-branch-role",

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -15,6 +15,7 @@ from scripts.blueprint_harness_branches import (
     checkout_branch_role,
     default_dev_branch,
     checkout_is_backport_only,
+    load_branch_policy,
     local_release_ref,
     preferred_release_ref,
     require_checkout_role,
@@ -230,6 +231,17 @@ def ref_merged_into_main(repo_root: Path, ref: str) -> bool:
     return is_ancestor(repo_root, ref, preferred_main_ref(repo_root))
 
 
+def preferred_worktree_base_ref(path: Path) -> str:
+    return preferred_release_ref(path)
+
+
+def ref_merged_into_worktree_base(repo_root: Path, ref: str, worktree_path: Path) -> bool:
+    base_ref = preferred_worktree_base_ref(worktree_path)
+    if ref_oid(repo_root, ref) is None or ref_oid(repo_root, base_ref) is None:
+        return False
+    return is_ancestor(repo_root, ref, base_ref)
+
+
 def merged_clean_worktree_candidates(repo_root: Path, current_path: Path) -> list[tuple[str, Path, str]]:
     candidates: list[tuple[str, Path, str]] = []
     records, _registry = worktree_record_map(repo_root)
@@ -414,6 +426,50 @@ def command_main_status(args: argparse.Namespace) -> int:
     return 0
 
 
+def parse_prepare_backports_exemptions(values: list[str] | None) -> dict[str, str]:
+    exemptions: dict[str, str] = {}
+    for value in values or []:
+        branch, separator, reason = value.partition("=")
+        branch = branch.strip()
+        reason = reason.strip()
+        if not separator or not branch or not reason:
+            raise SystemExit(
+                "[blueprint-harness] expected `--exempt <branch>=<reason>` with both a branch and a reason"
+            )
+        exemptions[branch] = reason
+    return exemptions
+
+
+def command_prepare_backports(args: argparse.Namespace) -> int:
+    layout = detect_harness_layout(Path(__file__))
+    policy = load_branch_policy(layout.package_root)
+    exemptions = parse_prepare_backports_exemptions(args.exempt)
+    unknown = sorted(branch for branch in exemptions if branch not in policy.required_backport_branches)
+    if unknown:
+        raise SystemExit(
+            "[blueprint-harness] unknown required backport branch(es): "
+            + ", ".join(unknown)
+            + ". Update `branch-policy.json` or remove the extra `--exempt` entries."
+        )
+
+    print(f"default_dev_branch={policy.default_dev_branch}")
+    print(f"required_backports={','.join(policy.required_backport_branches)}")
+    if not policy.required_backport_branches:
+        print("[blueprint-harness] no required backports are configured for this checkout")
+        return 0
+
+    print()
+    for branch in policy.required_backport_branches:
+        if branch in exemptions:
+            print(f"Backport {branch}: exempt: {exemptions[branch]}")
+        else:
+            print(f"Backport {branch}: pending")
+    print()
+    print("[blueprint-harness] paste these lines into the default-dev PR body while it is draft")
+    print("[blueprint-harness] replace each `pending` entry with `#<pr>` or `exempt: <reason>` before ready for review")
+    return 0
+
+
 def command_require_branch_role(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
     print_branch_policy_status(layout)
@@ -579,13 +635,14 @@ def command_worktree_retire(args: argparse.Namespace) -> int:
     if branch == release_branch:
         raise SystemExit(f"[blueprint-harness] cannot retire a linked worktree attached to `{release_branch}`")
     merge_subject = branch or worktree.head
-    if not ref_merged_into_main(layout.repo_root, merge_subject):
+    base_ref = preferred_worktree_base_ref(path)
+    if not ref_merged_into_worktree_base(layout.repo_root, merge_subject, path):
         if branch is None:
             raise SystemExit(
                 f"[blueprint-harness] detached worktree `{name}` is at `{worktree.head}` "
-                "which is not merged into the preferred release ref"
+                f"which is not merged into `{base_ref}`"
             )
-        raise SystemExit(f"[blueprint-harness] branch `{branch}` is not merged into the preferred release ref")
+        raise SystemExit(f"[blueprint-harness] branch `{branch}` is not merged into `{base_ref}`")
     if not worktree_is_clean(path):
         raise SystemExit(f"[blueprint-harness] worktree `{name}` has local modifications")
 
@@ -650,6 +707,7 @@ def command_worktree_status(args: argparse.Namespace) -> int:
     print(f"dirty={bool_or_blank(record.dirty)}")
     print(f"tracked_changes={text_or_blank(record.tracked_changes)}")
     print(f"untracked_changes={text_or_blank(record.untracked_changes)}")
+    print(f"base_ref={record.base_ref or ''}")
     print(f"merged_into_base={bool_or_blank(record.merged_into_main)}")
     print(f"base_ahead={text_or_blank(record.main_ahead)}")
     print(f"base_behind={text_or_blank(record.main_behind)}")
@@ -748,6 +806,18 @@ def build_parser() -> argparse.ArgumentParser:
         help="Exit nonzero when the active local release branch is not in sync with its preferred upstream ref.",
     )
     main_status.set_defaults(func=command_main_status)
+
+    prepare_backports = subparsers.add_parser(
+        "prepare-backports",
+        help="Print PR-body lines for the required backport plan on the current default-dev release line.",
+    )
+    prepare_backports.add_argument(
+        "--exempt",
+        action="append",
+        default=None,
+        help="Pre-fill one required branch as `exempt: <reason>` using `--exempt <branch>=<reason>`. Repeat as needed.",
+    )
+    prepare_backports.set_defaults(func=command_prepare_backports)
 
     require_role = subparsers.add_parser(
         "require-branch-role",

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -155,6 +155,17 @@ def current_commit_subject(repo_root: Path) -> str:
     return subject
 
 
+def source_commit_series(repo_root: Path, source_branch: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "rev-list", "--reverse", f"{preferred_main_ref(repo_root)}..{source_branch}"],
+        cwd=repo_root,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
 def ref_oid(repo_root: Path, ref: str) -> str | None:
     result = subprocess.run(
         ["git", "rev-parse", "--verify", "--quiet", ref],
@@ -477,6 +488,80 @@ def default_backport_branch_name(source_branch: str, release_ref: str) -> str:
     return f"backport-{marker}-{slugify_backport_fragment(source_branch)}"
 
 
+def default_backport_worktree_name(source_branch: str, release_ref: str) -> str:
+    branch_name = default_backport_branch_name(source_branch, release_ref)
+    return branch_name.split("/", 1)[1] if "/" in branch_name else branch_name
+
+
+def prepare_backport_targets(layout, args: argparse.Namespace) -> tuple[str, ...]:
+    policy = load_branch_policy(layout.package_root)
+    if args.all_required:
+        if args.release is not None:
+            raise SystemExit("[blueprint-harness] pass either one <release> or `--all-required`, not both")
+        return policy.required_backport_branches
+    if args.release is None:
+        raise SystemExit("[blueprint-harness] expected one <release> or `--all-required`")
+    return (normalize_lean_release_ref(args.release),)
+
+
+def print_prepare_backport_pr_scaffold(
+    *,
+    default_dev: str,
+    backport_release: str,
+    source_branch: str,
+    main_pr: int,
+    main_title: str,
+    source_commits: list[str],
+) -> None:
+    paired_branch = default_backport_branch_name(source_branch, backport_release)
+    paired_worktree = default_backport_worktree_name(source_branch, backport_release)
+    paired_title = f"[backport {backport_release}] {main_title}"
+
+    print(f"default_dev_branch={default_dev}")
+    print(f"backport_release={backport_release}")
+    print(f"source_branch={source_branch}")
+    print(f"paired_worktree={paired_worktree}")
+    print(f"paired_branch={paired_branch}")
+    print(f"paired_title={paired_title}")
+    print(f"source_commits={','.join(source_commits)}")
+    print(f"base_ref=origin/{backport_release}")
+    print()
+    print("## Batch Apply")
+    print(
+        f"- Create the linked worktree on `origin/{backport_release}` and attach it to `{paired_branch}`."
+    )
+    if source_commits:
+        print(f"- Cherry-pick the default-development series with `git cherry-pick -x {' '.join(source_commits)}`.")
+    else:
+        print("- No source commits were detected beyond the default-development base.")
+    print("- Let the agent resolve any cherry-pick conflicts in the backport worktree.")
+    print("- Run validation on the backport branch before opening the paired PR.")
+    print()
+    print("## Summary")
+    print(f"Backport #{main_pr} to `{backport_release}`.")
+    print()
+    print("## Primary Review")
+    print(f"- Primary review: #{main_pr}")
+    print(f"- Keep review comments on #{main_pr} unless this backport diverges materially.")
+    print()
+    print("## Scope")
+    print(f"- Backport the already-reviewed default-development change onto `{backport_release}`.")
+    print("- Keep this PR limited to release-line-specific conflict resolution.")
+    print("- Preserve one-to-one commit provenance with `cherry-pick -x`.")
+    print()
+    print("## Backport Delta")
+    print("- No intentional release-specific changes.")
+    print("- If conflict resolution requires deviations from the default-development PR, describe them here.")
+    print()
+    print("## Validation")
+    print(f"- Describe the validation run on `{backport_release}`.")
+    print()
+    print("## Coordination")
+    print(f"- Default-dev PR: #{main_pr}")
+    print(f"- Default-dev branch: `{source_branch}`")
+    print(f"- Backport branch: `{paired_branch}`")
+
+
 def command_prepare_backports(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
     policy = load_branch_policy(layout.package_root)
@@ -509,42 +594,27 @@ def command_prepare_backports(args: argparse.Namespace) -> int:
 
 def command_prepare_backport_pr(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
-    backport_release = normalize_lean_release_ref(args.release)
+    require_checkout_role(layout.package_root, required_role="default_dev", operation="prepare-backport-pr")
+    targets = prepare_backport_targets(layout, args)
     source_branch = args.source_branch or current_branch_name(layout.package_root)
     if not source_branch:
         raise SystemExit("[blueprint-harness] unable to determine a source branch; pass `--source-branch` explicitly")
 
     main_title = args.main_title or current_commit_subject(layout.package_root)
-    paired_branch = default_backport_branch_name(source_branch, backport_release)
-    paired_title = f"[backport {backport_release}] {main_title}"
+    source_commits = source_commit_series(layout.package_root, source_branch)
+    default_dev = default_dev_branch(layout.package_root)
 
-    print(f"default_dev_branch={default_dev_branch(layout.package_root)}")
-    print(f"backport_release={backport_release}")
-    print(f"source_branch={source_branch}")
-    print(f"paired_branch={paired_branch}")
-    print(f"paired_title={paired_title}")
-    print()
-    print("## Summary")
-    print(f"Backport #{args.main_pr} to `{backport_release}`.")
-    print()
-    print("## Primary Review")
-    print(f"- Primary review: #{args.main_pr}")
-    print(f"- Keep review comments on #{args.main_pr} unless this backport diverges materially.")
-    print()
-    print("## Scope")
-    print(f"- Backport the already-reviewed default-development change onto `{backport_release}`.")
-    print("- Keep this PR limited to release-line-specific conflict resolution.")
-    print()
-    print("## Backport Delta")
-    print("- No intentional release-specific changes.")
-    print("- If conflict resolution requires deviations from the default-development PR, describe them here.")
-    print()
-    print("## Validation")
-    print(f"- Describe the validation run on `{backport_release}`.")
-    print()
-    print("## Coordination")
-    print(f"- Default-dev PR: #{args.main_pr}")
-    print(f"- Default-dev branch: `{source_branch}`")
+    for index, backport_release in enumerate(targets):
+        if index:
+            print("\n---\n")
+        print_prepare_backport_pr_scaffold(
+            default_dev=default_dev,
+            backport_release=backport_release,
+            source_branch=source_branch,
+            main_pr=args.main_pr,
+            main_title=main_title,
+            source_commits=source_commits,
+        )
     return 0
 
 
@@ -901,7 +971,16 @@ def build_parser() -> argparse.ArgumentParser:
         "prepare-backport-pr",
         help="Print a standardized paired backport branch name, PR title, and PR body scaffold.",
     )
-    prepare_backport_pr.add_argument("release", help="Backport release branch such as `v4.28.0`.")
+    prepare_backport_pr.add_argument(
+        "release",
+        nargs="?",
+        help="Backport release branch such as `v4.28.0`. Omit with `--all-required`.",
+    )
+    prepare_backport_pr.add_argument(
+        "--all-required",
+        action="store_true",
+        help="Print one scaffold block for every required backport release in `branch-policy.json`.",
+    )
     prepare_backport_pr.add_argument(
         "--main-pr",
         type=int,

--- a/scripts/blueprint_harness_worktrees.py
+++ b/scripts/blueprint_harness_worktrees.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 import subprocess
 
-from scripts.blueprint_harness_branches import ROOT_WORKTREE_NAME, local_release_ref, preferred_release_ref
+from scripts.blueprint_harness_branches import ROOT_WORKTREE_NAME, preferred_release_ref
 
 
 ROOT_METADATA_FILENAME = "_root.json"
@@ -55,6 +55,7 @@ class WorktreeRecord:
     dirty: bool | None = None
     tracked_changes: int | None = None
     untracked_changes: int | None = None
+    base_ref: str | None = None
     merged_into_main: bool | None = None
     main_ahead: int | None = None
     main_behind: int | None = None
@@ -231,10 +232,6 @@ def ref_oid(repo_root: Path, ref: str) -> str | None:
     return oid or None
 
 
-def preferred_main_ref(repo_root: Path) -> str:
-    return preferred_release_ref(repo_root)
-
-
 def is_ancestor(repo_root: Path, ancestor: str, descendant: str) -> bool:
     return (
         subprocess.run(
@@ -246,11 +243,10 @@ def is_ancestor(repo_root: Path, ancestor: str, descendant: str) -> bool:
     )
 
 
-def ref_merged_into_main(repo_root: Path, ref: str) -> bool:
-    upstream = preferred_main_ref(repo_root)
-    if ref_oid(repo_root, ref) is None or ref_oid(repo_root, upstream) is None:
+def ref_merged_into_base(repo_root: Path, ref: str, base_ref: str) -> bool:
+    if ref_oid(repo_root, ref) is None or ref_oid(repo_root, base_ref) is None:
         return False
-    return is_ancestor(repo_root, ref, upstream)
+    return is_ancestor(repo_root, ref, base_ref)
 
 
 def rev_list_counts(repo_root: Path, ref: str, base_ref: str) -> tuple[int | None, int | None]:
@@ -310,7 +306,8 @@ def worktree_last_commit(path: Path) -> tuple[str | None, str | None, str | None
 def collect_worktree_facts(repo_root: Path, git_wt: GitWorktree) -> dict[str, object]:
     ref = git_wt.branch or git_wt.head
     dirty, tracked_changes, untracked_changes = worktree_status_counts(git_wt.path)
-    main_ahead, main_behind = rev_list_counts(repo_root, ref, local_release_ref(repo_root))
+    base_ref = preferred_release_ref(git_wt.path)
+    main_ahead, main_behind = rev_list_counts(repo_root, ref, base_ref)
     upstream = branch_upstream(repo_root, git_wt.branch) if git_wt.branch is not None else None
     upstream_ahead, upstream_behind = (
         rev_list_counts(repo_root, ref, upstream) if upstream is not None else (None, None)
@@ -320,7 +317,8 @@ def collect_worktree_facts(repo_root: Path, git_wt: GitWorktree) -> dict[str, ob
         "dirty": dirty,
         "tracked_changes": tracked_changes,
         "untracked_changes": untracked_changes,
-        "merged_into_main": ref_merged_into_main(repo_root, ref),
+        "base_ref": base_ref,
+        "merged_into_main": ref_merged_into_base(repo_root, ref, base_ref),
         "main_ahead": main_ahead,
         "main_behind": main_behind,
         "upstream": upstream,
@@ -370,6 +368,7 @@ def sync_worktree_registry(repo_root: Path) -> tuple[list[WorktreeRecord], Path]
             dirty=facts["dirty"],
             tracked_changes=facts["tracked_changes"],
             untracked_changes=facts["untracked_changes"],
+            base_ref=facts["base_ref"],
             merged_into_main=facts["merged_into_main"],
             main_ahead=facts["main_ahead"],
             main_behind=facts["main_behind"],

--- a/scripts/check_backport_pr.py
+++ b/scripts/check_backport_pr.py
@@ -29,6 +29,8 @@ class BackportEntry:
     branch: str
     pr_number: int | None = None
     exempt_reason: str | None = None
+    pending: bool = False
+    pending_note: str | None = None
 
 
 class BackportCheckError(RuntimeError):
@@ -77,7 +79,7 @@ class GitHubApi:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Enforce paired backport PR metadata for ready non-draft default-dev PRs."
+        description="Enforce paired backport planning for draft default-dev PRs and paired backport readiness for ready PRs."
     )
     parser.add_argument(
         "--event-path",
@@ -118,13 +120,49 @@ def parse_backport_entries(body: str) -> dict[str, BackportEntry]:
                 raise BackportCheckError(f"Backport {branch}: exemption must include a reason")
             entries[branch] = BackportEntry(branch=branch, exempt_reason=reason)
             continue
+        if lower.startswith("pending"):
+            note = value[len("pending") :].lstrip(" :-()")
+            entries[branch] = BackportEntry(branch=branch, pending=True, pending_note=note or None)
+            continue
 
         pr_match = BACKPORT_PR_RE.search(value)
         if pr_match is None:
             raise BackportCheckError(
-                f"Backport {branch}: expected `#<pr>` or `exempt: <reason>`, got `{value}`"
+                f"Backport {branch}: expected `#<pr>`, `pending`, or `exempt: <reason>`, got `{value}`"
             )
         entries[branch] = BackportEntry(branch=branch, pr_number=int(pr_match.group(1)))
+    return entries
+
+
+def validate_backport_entries(
+    body: str,
+    required_backports: tuple[str, ...],
+    *,
+    allow_pending: bool,
+) -> dict[str, BackportEntry]:
+    entries = parse_backport_entries(body)
+    missing = [branch for branch in required_backports if branch not in entries]
+    if missing:
+        if allow_pending:
+            example = "`Backport v4.28.0: pending`"
+        else:
+            example = "`Backport v4.28.0: #123`"
+        raise BackportCheckError(
+            "missing paired backport metadata for "
+            + ", ".join(missing)
+            + f". Add lines like {example} or `Backport v4.28.0: exempt: <reason>`"
+        )
+
+    if allow_pending:
+        return entries
+
+    pending = [branch for branch in required_backports if entries[branch].pending]
+    if pending:
+        raise BackportCheckError(
+            "pending backport entries are not allowed once the default-dev PR is ready for review: "
+            + ", ".join(pending)
+            + ". Replace each `pending` entry with `#<pr>` or `exempt: <reason>`"
+        )
     return entries
 
 
@@ -211,9 +249,6 @@ def should_enforce(pull_request: dict[str, Any], default_dev_branch: str, requir
             f"`{pull_request.get('base', {}).get('ref', '')}`, not default dev `{default_dev_branch}`; skipping"
         )
         return False
-    if bool(pull_request.get("draft")):
-        print("[backport-check] draft PR; skipping paired backport gate until ready for review")
-        return False
     return True
 
 
@@ -225,29 +260,40 @@ def run(event_path: str | None, token: str | None) -> int:
     if not should_enforce(pull_request, policy.default_dev_branch, policy.required_backport_branches):
         return 0
 
-    if not token:
-        raise BackportCheckError("missing GitHub token; pass --token or set GITHUB_TOKEN")
-
+    draft = bool(pull_request.get("draft"))
     body = str(pull_request.get("body") or "")
-    entries = parse_backport_entries(body)
-    missing = [branch for branch in policy.required_backport_branches if branch not in entries]
-    if missing:
-        raise BackportCheckError(
-            "missing paired backport metadata for "
-            + ", ".join(missing)
-            + ". Add lines like `Backport v4.28.0: #123` or `Backport v4.28.0: exempt: <reason>`"
-        )
+    entries = validate_backport_entries(body, policy.required_backport_branches, allow_pending=draft)
+    if draft:
+        print("[backport-check] draft PR; enforcing declared backport plan only")
+        for branch in policy.required_backport_branches:
+            entry = entries[branch]
+            if entry.exempt_reason is not None:
+                print(f"[backport-check] {branch}: exempt ({entry.exempt_reason})")
+            elif entry.pending:
+                note_suffix = f" ({entry.pending_note})" if entry.pending_note else ""
+                print(f"[backport-check] {branch}: pending{note_suffix}")
+            else:
+                print(
+                    f"[backport-check] {branch}: paired PR #{entry.pr_number} recorded; "
+                    "ready-state checks will run after ready for review"
+                )
+        return 0
 
     repository = event.get("repository")
     if not isinstance(repository, dict) or not isinstance(repository.get("full_name"), str):
         raise BackportCheckError("event payload is missing repository.full_name")
-    api = GitHubApi(repository["full_name"], token)
+    entries_to_verify = [entries[branch] for branch in policy.required_backport_branches if entries[branch].pr_number is not None]
+    if entries_to_verify and not token:
+        raise BackportCheckError("missing GitHub token; pass --token or set GITHUB_TOKEN")
+    api = GitHubApi(repository["full_name"], token) if entries_to_verify else None
 
     for branch in policy.required_backport_branches:
         entry = entries[branch]
         if entry.exempt_reason is not None:
             print(f"[backport-check] {branch}: exempt ({entry.exempt_reason})")
             continue
+        if api is None:
+            raise BackportCheckError(f"Backport {branch}: internal error; paired PR verification is unavailable")
         verify_backport_pr(api, branch, entry)
         print(f"[backport-check] {branch}: paired PR #{entry.pr_number} is ready")
     return 0

--- a/scripts/check_backport_pr.py
+++ b/scripts/check_backport_pr.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 import os
 from pathlib import Path
 import re
+import subprocess
 import sys
 from typing import Any
 from urllib.error import HTTPError
@@ -22,6 +23,7 @@ API_BASE = "https://api.github.com"
 API_VERSION = "2022-11-28"
 BACKPORT_LINE_RE = re.compile(r"(?mi)^Backport\s+([^\s:]+)\s*:\s*(.+)\s*$")
 BACKPORT_PR_RE = re.compile(r"(?:#|/pull/)(\d+)\b")
+CHERRY_PICK_SOURCE_RE = re.compile(r"(?mi)^\(cherry picked from commit ([0-9a-f]{40})\)\s*$")
 
 
 @dataclass(frozen=True)
@@ -31,6 +33,12 @@ class BackportEntry:
     exempt_reason: str | None = None
     pending: bool = False
     pending_note: str | None = None
+
+
+@dataclass(frozen=True)
+class PullRequestCommit:
+    sha: str
+    message: str
 
 
 class BackportCheckError(RuntimeError):
@@ -58,6 +66,22 @@ class GitHubApi:
             detail = err.read().decode("utf-8", errors="replace").strip()
             raise BackportCheckError(f"GitHub API request failed for {path}: {err.code} {detail}") from err
 
+    def get_text(self, path: str, *, accept: str) -> str:
+        request = Request(
+            f"{API_BASE}{path}",
+            headers={
+                "Accept": accept,
+                "Authorization": f"Bearer {self.token}",
+                "X-GitHub-Api-Version": API_VERSION,
+            },
+        )
+        try:
+            with urlopen(request) as response:
+                return response.read().decode("utf-8", errors="replace")
+        except HTTPError as err:
+            detail = err.read().decode("utf-8", errors="replace").strip()
+            raise BackportCheckError(f"GitHub API request failed for {path}: {err.code} {detail}") from err
+
     def pull_request(self, number: int) -> dict[str, Any]:
         data = self.get_json(f"/repos/{self.repo_full_name}/pulls/{number}")
         if not isinstance(data, dict):
@@ -75,6 +99,30 @@ class GitHubApi:
         if not isinstance(data, dict):
             raise BackportCheckError(f"Unexpected combined status payload for {sha}")
         return data
+
+    def pull_request_commits(self, number: int) -> list[PullRequestCommit]:
+        commits: list[PullRequestCommit] = []
+        page = 1
+        while True:
+            data = self.get_json(f"/repos/{self.repo_full_name}/pulls/{number}/commits?per_page=100&page={page}")
+            if not isinstance(data, list):
+                raise BackportCheckError(f"Unexpected commit payload for PR #{number}")
+            if not data:
+                return commits
+            for item in data:
+                if not isinstance(item, dict):
+                    continue
+                sha = str(item.get("sha") or "")
+                message = str(item.get("commit", {}).get("message") or "")
+                if not sha or not message:
+                    raise BackportCheckError(f"Unexpected commit payload shape for PR #{number}")
+                commits.append(PullRequestCommit(sha=sha, message=message))
+            if len(data) < 100:
+                return commits
+            page += 1
+
+    def commit_diff(self, sha: str) -> str:
+        return self.get_text(f"/repos/{self.repo_full_name}/commits/{sha}", accept="application/vnd.github.diff")
 
 
 def parse_args() -> argparse.Namespace:
@@ -166,6 +214,81 @@ def validate_backport_entries(
     return entries
 
 
+def parse_cherry_pick_source(message: str) -> str | None:
+    match = CHERRY_PICK_SOURCE_RE.search(message)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def git_patch_id(diff_text: str) -> str:
+    result = subprocess.run(
+        ["git", "patch-id", "--stable"],
+        input=diff_text,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise BackportCheckError(f"failed to compute patch-id: {result.stderr.strip() or result.stdout.strip()}")
+    line = result.stdout.strip()
+    if not line:
+        raise BackportCheckError("failed to compute patch-id: commit diff was empty")
+    return line.split()[0]
+
+
+def verify_backport_commit_series(api: GitHubApi, source_pr_number: int, backport_pr_number: int) -> None:
+    source_commits = api.pull_request_commits(source_pr_number)
+    backport_commits = api.pull_request_commits(backport_pr_number)
+    if len(backport_commits) != len(source_commits):
+        raise BackportCheckError(
+            f"paired backport PR #{backport_pr_number} has {len(backport_commits)} commits, "
+            f"expected {len(source_commits)} from PR #{source_pr_number}"
+        )
+
+    source_shas = [commit.sha for commit in source_commits]
+    mapped_shas: list[str] = []
+    for commit in backport_commits:
+        source_sha = parse_cherry_pick_source(commit.message)
+        if source_sha is None:
+            raise BackportCheckError(
+                f"paired backport PR #{backport_pr_number} commit `{commit.sha}` is missing "
+                "`(cherry picked from commit <sha>)` provenance"
+            )
+        mapped_shas.append(source_sha)
+
+    unexpected = [sha for sha in mapped_shas if sha not in source_shas]
+    if unexpected:
+        raise BackportCheckError(
+            f"paired backport PR #{backport_pr_number} references source commit(s) not present in PR #{source_pr_number}: "
+            + ", ".join(unexpected)
+        )
+
+    if len(set(mapped_shas)) != len(mapped_shas):
+        raise BackportCheckError(f"paired backport PR #{backport_pr_number} repeats at least one source commit")
+
+    if mapped_shas != source_shas:
+        raise BackportCheckError(
+            f"paired backport PR #{backport_pr_number} does not preserve the commit order from PR #{source_pr_number}"
+        )
+
+    patch_id_cache: dict[str, str] = {}
+
+    def commit_patch_id(sha: str) -> str:
+        cached = patch_id_cache.get(sha)
+        if cached is not None:
+            return cached
+        patch_id_cache[sha] = git_patch_id(api.commit_diff(sha))
+        return patch_id_cache[sha]
+
+    for source_commit, backport_commit in zip(source_commits, backport_commits):
+        if commit_patch_id(source_commit.sha) != commit_patch_id(backport_commit.sha):
+            raise BackportCheckError(
+                f"paired backport PR #{backport_pr_number} commit `{backport_commit.sha}` does not match "
+                f"the patch from source commit `{source_commit.sha}`"
+            )
+
+
 def check_runs_state(check_runs: dict[str, Any], combined_status: dict[str, Any]) -> None:
     failures: list[str] = []
     pending: list[str] = []
@@ -203,6 +326,7 @@ def check_runs_state(check_runs: dict[str, Any], combined_status: dict[str, Any]
 
 def verify_backport_pr(
     api: GitHubApi,
+    source_pr_number: int,
     branch: str,
     entry: BackportEntry,
 ) -> None:
@@ -221,6 +345,8 @@ def verify_backport_pr(
     state = str(pr.get("state") or "")
     if state == "closed" and not bool(pr.get("merged")):
         raise BackportCheckError(f"paired backport PR #{entry.pr_number} is closed without merge")
+
+    verify_backport_commit_series(api, source_pr_number, entry.pr_number)
 
     if bool(pr.get("merged")):
         return
@@ -283,6 +409,14 @@ def run(event_path: str | None, token: str | None) -> int:
     if not isinstance(repository, dict) or not isinstance(repository.get("full_name"), str):
         raise BackportCheckError("event payload is missing repository.full_name")
     entries_to_verify = [entries[branch] for branch in policy.required_backport_branches if entries[branch].pr_number is not None]
+    if entries_to_verify:
+        source_pr_number_raw = pull_request.get("number", event.get("number"))
+        try:
+            source_pr_number = int(source_pr_number_raw)
+        except (TypeError, ValueError) as err:
+            raise BackportCheckError("event payload is missing the default-development PR number") from err
+    else:
+        source_pr_number = 0
     if entries_to_verify and not token:
         raise BackportCheckError("missing GitHub token; pass --token or set GITHUB_TOKEN")
     api = GitHubApi(repository["full_name"], token) if entries_to_verify else None
@@ -294,7 +428,7 @@ def run(event_path: str | None, token: str | None) -> int:
             continue
         if api is None:
             raise BackportCheckError(f"Backport {branch}: internal error; paired PR verification is unavailable")
-        verify_backport_pr(api, branch, entry)
+        verify_backport_pr(api, source_pr_number, branch, entry)
         print(f"[backport-check] {branch}: paired PR #{entry.pr_number} is ready")
     return 0
 

--- a/tests/harness/test_backport_pr_check.py
+++ b/tests/harness/test_backport_pr_check.py
@@ -7,6 +7,45 @@ from pathlib import Path
 import scripts.check_backport_pr as backport_mod
 
 
+class FakeGitHubApi:
+    def __init__(
+        self,
+        *,
+        pull_requests: dict[int, dict[str, object]] | None = None,
+        pull_request_commits: dict[int, list[backport_mod.PullRequestCommit]] | None = None,
+        commit_diffs: dict[str, str] | None = None,
+    ) -> None:
+        self._pull_requests = pull_requests or {}
+        self._pull_request_commits = pull_request_commits or {}
+        self._commit_diffs = commit_diffs or {}
+
+    def pull_request(self, number: int) -> dict[str, object]:
+        return self._pull_requests[number]
+
+    def pull_request_commits(self, number: int) -> list[backport_mod.PullRequestCommit]:
+        return self._pull_request_commits[number]
+
+    def commit_diff(self, sha: str) -> str:
+        return self._commit_diffs[sha]
+
+    def check_runs(self, sha: str) -> dict[str, object]:
+        return {"check_runs": []}
+
+    def combined_status(self, sha: str) -> dict[str, object]:
+        return {"state": "success"}
+
+
+def diff_for(line: str) -> str:
+    return (
+        "diff --git a/demo.txt b/demo.txt\n"
+        "index e69de29..4b825dc 100644\n"
+        "--- a/demo.txt\n"
+        "+++ b/demo.txt\n"
+        "@@ -0,0 +1 @@\n"
+        f"+{line}\n"
+    )
+
+
 class BackportPrCheckTests(unittest.TestCase):
     def test_parse_backport_entries_accepts_pr_pending_and_exemption(self) -> None:
         body = """
@@ -86,6 +125,92 @@ Backport v4.26.0: exempt: no longer maintained
                 encoding="utf-8",
             )
             self.assertEqual(backport_mod.run(str(event_path), token=None), 0)
+
+    def test_verify_backport_commit_series_accepts_matching_cherry_picks(self) -> None:
+        api = FakeGitHubApi(
+            pull_request_commits={
+                11: [
+                    backport_mod.PullRequestCommit(sha="a" * 40, message="fix: one"),
+                    backport_mod.PullRequestCommit(sha="b" * 40, message="fix: two"),
+                ],
+                13: [
+                    backport_mod.PullRequestCommit(
+                        sha="c" * 40,
+                        message=f"fix: one\n\n(cherry picked from commit {'a' * 40})",
+                    ),
+                    backport_mod.PullRequestCommit(
+                        sha="d" * 40,
+                        message=f"fix: two\n\n(cherry picked from commit {'b' * 40})",
+                    ),
+                ],
+            },
+            commit_diffs={
+                "a" * 40: diff_for("one"),
+                "b" * 40: diff_for("two"),
+                "c" * 40: diff_for("one"),
+                "d" * 40: diff_for("two"),
+            },
+        )
+        backport_mod.verify_backport_commit_series(api, 11, 13)
+
+    def test_verify_backport_commit_series_rejects_missing_cherry_pick_provenance(self) -> None:
+        api = FakeGitHubApi(
+            pull_request_commits={
+                11: [backport_mod.PullRequestCommit(sha="a" * 40, message="fix: one")],
+                13: [backport_mod.PullRequestCommit(sha="c" * 40, message="fix: one")],
+            },
+            commit_diffs={
+                "a" * 40: diff_for("one"),
+                "c" * 40: diff_for("one"),
+            },
+        )
+        with self.assertRaisesRegex(backport_mod.BackportCheckError, "missing `\\(cherry picked from commit <sha>\\)` provenance"):
+            backport_mod.verify_backport_commit_series(api, 11, 13)
+
+    def test_verify_backport_commit_series_rejects_patch_mismatch(self) -> None:
+        api = FakeGitHubApi(
+            pull_request_commits={
+                11: [backport_mod.PullRequestCommit(sha="a" * 40, message="fix: one")],
+                13: [
+                    backport_mod.PullRequestCommit(
+                        sha="c" * 40,
+                        message=f"fix: one\n\n(cherry picked from commit {'a' * 40})",
+                    )
+                ],
+            },
+            commit_diffs={
+                "a" * 40: diff_for("one"),
+                "c" * 40: diff_for("adapted"),
+            },
+        )
+        with self.assertRaisesRegex(backport_mod.BackportCheckError, "does not match the patch from source commit"):
+            backport_mod.verify_backport_commit_series(api, 11, 13)
+
+    def test_verify_backport_pr_checks_commit_series_before_ci(self) -> None:
+        api = FakeGitHubApi(
+            pull_requests={
+                13: {
+                    "base": {"ref": "v4.28.0"},
+                    "draft": False,
+                    "state": "open",
+                    "head": {"sha": "c" * 40},
+                }
+            },
+            pull_request_commits={
+                11: [backport_mod.PullRequestCommit(sha="a" * 40, message="fix: one")],
+                13: [
+                    backport_mod.PullRequestCommit(
+                        sha="c" * 40,
+                        message=f"fix: one\n\n(cherry picked from commit {'a' * 40})",
+                    )
+                ],
+            },
+            commit_diffs={
+                "a" * 40: diff_for("one"),
+                "c" * 40: diff_for("one"),
+            },
+        )
+        backport_mod.verify_backport_pr(api, 11, "v4.28.0", backport_mod.BackportEntry(branch="v4.28.0", pr_number=13))
 
     def test_run_rejects_pending_entries_for_ready_default_dev_prs(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/harness/test_backport_pr_check.py
+++ b/tests/harness/test_backport_pr_check.py
@@ -8,15 +8,17 @@ import scripts.check_backport_pr as backport_mod
 
 
 class BackportPrCheckTests(unittest.TestCase):
-    def test_parse_backport_entries_accepts_pr_and_exemption(self) -> None:
+    def test_parse_backport_entries_accepts_pr_pending_and_exemption(self) -> None:
         body = """
 Backport v4.28.0: #42
-Backport v4.27.0: exempt: no longer maintained
+Backport v4.27.0: pending
+Backport v4.26.0: exempt: no longer maintained
 """
         entries = backport_mod.parse_backport_entries(body)
         self.assertEqual(entries["v4.28.0"].pr_number, 42)
         self.assertIsNone(entries["v4.28.0"].exempt_reason)
-        self.assertEqual(entries["v4.27.0"].exempt_reason, "no longer maintained")
+        self.assertTrue(entries["v4.27.0"].pending)
+        self.assertEqual(entries["v4.26.0"].exempt_reason, "no longer maintained")
 
     def test_parse_backport_entries_accepts_pull_request_url(self) -> None:
         body = "Backport v4.28.0: https://github.com/leanprover/verso-blueprint/pull/123\n"
@@ -27,9 +29,9 @@ Backport v4.27.0: exempt: no longer maintained
         with self.assertRaisesRegex(backport_mod.BackportCheckError, "exemption must include a reason"):
             backport_mod.parse_backport_entries("Backport v4.28.0: exempt\n")
 
-    def test_should_enforce_skips_draft_prs(self) -> None:
+    def test_should_enforce_accepts_draft_default_dev_prs(self) -> None:
         pull_request = {"base": {"ref": "v4.29.0"}, "draft": True}
-        self.assertFalse(backport_mod.should_enforce(pull_request, "v4.29.0", ("v4.28.0",)))
+        self.assertTrue(backport_mod.should_enforce(pull_request, "v4.29.0", ("v4.28.0",)))
 
     def test_should_enforce_skips_non_default_dev_targets(self) -> None:
         pull_request = {"base": {"ref": "v4.28.0"}, "draft": False}
@@ -48,7 +50,44 @@ Backport v4.27.0: exempt: no longer maintained
                 {"state": "failure"},
             )
 
-    def test_run_requires_metadata_for_ready_default_dev_prs(self) -> None:
+    def test_run_requires_metadata_for_draft_default_dev_prs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            event_path = Path(tmp) / "event.json"
+            event_path.write_text(
+                """
+{
+  "repository": {"full_name": "leanprover/verso-blueprint"},
+  "pull_request": {
+    "base": {"ref": "v4.29.0"},
+    "draft": true,
+    "body": ""
+  }
+}
+""".strip(),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(backport_mod.BackportCheckError, "missing paired backport metadata"):
+                backport_mod.run(str(event_path), token=None)
+
+    def test_run_accepts_pending_entries_for_draft_default_dev_prs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            event_path = Path(tmp) / "event.json"
+            event_path.write_text(
+                """
+{
+  "repository": {"full_name": "leanprover/verso-blueprint"},
+  "pull_request": {
+    "base": {"ref": "v4.29.0"},
+    "draft": true,
+    "body": "Backport v4.28.0: pending\\n"
+  }
+}
+""".strip(),
+                encoding="utf-8",
+            )
+            self.assertEqual(backport_mod.run(str(event_path), token=None), 0)
+
+    def test_run_rejects_pending_entries_for_ready_default_dev_prs(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             event_path = Path(tmp) / "event.json"
             event_path.write_text(
@@ -58,14 +97,32 @@ Backport v4.27.0: exempt: no longer maintained
   "pull_request": {
     "base": {"ref": "v4.29.0"},
     "draft": false,
-    "body": ""
+    "body": "Backport v4.28.0: pending\\n"
   }
 }
 """.strip(),
                 encoding="utf-8",
             )
-            with self.assertRaisesRegex(backport_mod.BackportCheckError, "missing paired backport metadata"):
-                backport_mod.run(str(event_path), token="token")
+            with self.assertRaisesRegex(backport_mod.BackportCheckError, "pending backport entries are not allowed"):
+                backport_mod.run(str(event_path), token=None)
+
+    def test_run_accepts_ready_default_dev_prs_with_only_exemptions_and_no_token(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            event_path = Path(tmp) / "event.json"
+            event_path.write_text(
+                """
+{
+  "repository": {"full_name": "leanprover/verso-blueprint"},
+  "pull_request": {
+    "base": {"ref": "v4.29.0"},
+    "draft": false,
+    "body": "Backport v4.28.0: exempt: docs-only change\\n"
+  }
+}
+""".strip(),
+                encoding="utf-8",
+            )
+            self.assertEqual(backport_mod.run(str(event_path), token=None), 0)
 
 
 if __name__ == "__main__":

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -73,6 +73,11 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         args = parser.parse_args(["release-status", "--require-sync"])
         self.assertTrue(args.require_sync)
 
+    def test_prepare_backports_parses_exemption_flag(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["prepare-backports", "--exempt", "v4.28.0=docs-only"])
+        self.assertEqual(args.exempt, ["v4.28.0=docs-only"])
+
     def test_bump_toolchain_parses_optional_flags(self) -> None:
         parser = build_parser()
         args = parser.parse_args(["bump-toolchain", "4.29.0", "--verso-ref", "v4.29.0", "--skip-validation"])
@@ -271,6 +276,51 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertIn("active_release_branch=v4.28.0", output)
         self.assertIn("checkout_role=backport", output)
         self.assertIn("backport_only=true", output)
+
+    def test_prepare_backports_prints_pending_lines(self) -> None:
+        args = argparse.Namespace(exempt=None)
+        layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
+        originals = {
+            "detect_harness_layout": harness_mod.detect_harness_layout,
+            "load_branch_policy": harness_mod.load_branch_policy,
+        }
+        out = io.StringIO()
+        try:
+            harness_mod.detect_harness_layout = lambda _start=None: layout
+            harness_mod.load_branch_policy = lambda _checkout_root: SimpleNamespace(
+                default_dev_branch="v4.29.0",
+                required_backport_branches=("v4.28.0", "v4.27.0"),
+            )
+            with redirect_stdout(out):
+                self.assertEqual(harness_mod.command_prepare_backports(args), 0)
+        finally:
+            for name, value in originals.items():
+                setattr(harness_mod, name, value)
+
+        output = out.getvalue()
+        self.assertIn("default_dev_branch=v4.29.0", output)
+        self.assertIn("required_backports=v4.28.0,v4.27.0", output)
+        self.assertIn("Backport v4.28.0: pending", output)
+        self.assertIn("Backport v4.27.0: pending", output)
+
+    def test_prepare_backports_rejects_unknown_exemption_branch(self) -> None:
+        args = argparse.Namespace(exempt=["v4.27.0=docs-only"])
+        layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
+        originals = {
+            "detect_harness_layout": harness_mod.detect_harness_layout,
+            "load_branch_policy": harness_mod.load_branch_policy,
+        }
+        try:
+            harness_mod.detect_harness_layout = lambda _start=None: layout
+            harness_mod.load_branch_policy = lambda _checkout_root: SimpleNamespace(
+                default_dev_branch="v4.29.0",
+                required_backport_branches=("v4.28.0",),
+            )
+            with self.assertRaisesRegex(SystemExit, "unknown required backport branch"):
+                harness_mod.command_prepare_backports(args)
+        finally:
+            for name, value in originals.items():
+                setattr(harness_mod, name, value)
 
     def test_land_main_rejects_unsynced_main(self) -> None:
         args = argparse.Namespace(source="feat/demo", no_push=False, cleanup=False, keep_remote=False)
@@ -723,7 +773,8 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             "detect_harness_layout": harness_mod.detect_harness_layout,
             "worktree_record_map": harness_mod.worktree_record_map,
             "git_worktree_map": harness_mod.git_worktree_map,
-            "ref_merged_into_main": harness_mod.ref_merged_into_main,
+            "preferred_worktree_base_ref": harness_mod.preferred_worktree_base_ref,
+            "ref_merged_into_worktree_base": harness_mod.ref_merged_into_worktree_base,
             "worktree_is_clean": harness_mod.worktree_is_clean,
             "local_release_ref": harness_mod.local_release_ref,
             "run": harness_mod.run,
@@ -745,7 +796,8 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 Path("/tmp/repo/.worktrees/registry.json"),
             )
             harness_mod.git_worktree_map = lambda _repo_root: {"reference-edit": detached}
-            harness_mod.ref_merged_into_main = lambda _repo_root, ref: ref == "abc123"
+            harness_mod.preferred_worktree_base_ref = lambda _path: "origin/v4.29.0"
+            harness_mod.ref_merged_into_worktree_base = lambda _repo_root, ref, _path: ref == "abc123"
             harness_mod.worktree_is_clean = lambda _path: True
             harness_mod.local_release_ref = lambda _repo_root: "v4.29.0"
             harness_mod.run = lambda command, *, cwd: commands.append(command)
@@ -760,6 +812,72 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 setattr(harness_mod, name, value)
 
         self.assertEqual(commands, [["git", "worktree", "remove", str(detached.path)]])
+
+    def test_worktree_retire_accepts_backport_branch_merged_into_its_release_base(self) -> None:
+        args = argparse.Namespace(name="backport-demo", dry_run=False)
+        layout = SimpleNamespace(
+            repo_root=Path("/tmp/repo"),
+            package_root=Path("/tmp/package"),
+            worktree_name=None,
+            reference_project_cache_root=Path("/tmp/cache"),
+            reference_project_root=Path("/tmp/reference-root"),
+        )
+        backport = GitWorktree(
+            name="backport-demo",
+            path=Path("/tmp/repo/.worktrees/backport-demo"),
+            head="def456",
+            branch="fix/backport-demo",
+            root_checkout=False,
+        )
+        originals = {
+            "detect_harness_layout": harness_mod.detect_harness_layout,
+            "worktree_record_map": harness_mod.worktree_record_map,
+            "git_worktree_map": harness_mod.git_worktree_map,
+            "preferred_worktree_base_ref": harness_mod.preferred_worktree_base_ref,
+            "ref_merged_into_worktree_base": harness_mod.ref_merged_into_worktree_base,
+            "worktree_is_clean": harness_mod.worktree_is_clean,
+            "local_release_ref": harness_mod.local_release_ref,
+            "run": harness_mod.run,
+            "resolve_manifest_path": harness_mod.resolve_manifest_path,
+            "load_project_catalog": harness_mod.load_project_catalog,
+            "git_worktrees": harness_mod.git_worktrees,
+            "reference_prune_plan": harness_mod.reference_prune_plan,
+        }
+        commands: list[list[str]] = []
+        try:
+            harness_mod.detect_harness_layout = lambda _start=None: layout
+            harness_mod.worktree_record_map = lambda _repo_root: (
+                {
+                    "backport-demo": SimpleNamespace(
+                        name="backport-demo",
+                        locked=False,
+                    )
+                },
+                Path("/tmp/repo/.worktrees/registry.json"),
+            )
+            harness_mod.git_worktree_map = lambda _repo_root: {"backport-demo": backport}
+            harness_mod.preferred_worktree_base_ref = lambda _path: "origin/v4.28.0"
+            harness_mod.ref_merged_into_worktree_base = lambda _repo_root, ref, _path: ref == "fix/backport-demo"
+            harness_mod.worktree_is_clean = lambda _path: True
+            harness_mod.local_release_ref = lambda _repo_root: "v4.29.0"
+            harness_mod.run = lambda command, *, cwd: commands.append(command)
+            harness_mod.resolve_manifest_path = lambda _path_text, _package_root: Path("/tmp/projects.json")
+            harness_mod.load_project_catalog = lambda _manifest_path: []
+            harness_mod.git_worktrees = lambda _repo_root: []
+            harness_mod.reference_prune_plan = lambda *_args, **_kwargs: []
+
+            self.assertEqual(harness_mod.command_worktree_retire(args), 0)
+        finally:
+            for name, value in originals.items():
+                setattr(harness_mod, name, value)
+
+        self.assertEqual(
+            commands,
+            [
+                ["git", "worktree", "remove", str(backport.path)],
+                ["git", "branch", "-d", backport.branch],
+            ],
+        )
 
     def test_worktree_retire_rejects_locked_worktree(self) -> None:
         args = argparse.Namespace(name="demo", dry_run=False)

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -78,6 +78,14 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         args = parser.parse_args(["prepare-backports", "--exempt", "v4.28.0=docs-only"])
         self.assertEqual(args.exempt, ["v4.28.0=docs-only"])
 
+    def test_prepare_backport_pr_parses_required_fields(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["prepare-backport-pr", "v4.28.0", "--main-pr", "11"])
+        self.assertEqual(args.release, "v4.28.0")
+        self.assertEqual(args.main_pr, 11)
+        self.assertIsNone(args.main_title)
+        self.assertIsNone(args.source_branch)
+
     def test_bump_toolchain_parses_optional_flags(self) -> None:
         parser = build_parser()
         args = parser.parse_args(["bump-toolchain", "4.29.0", "--verso-ref", "v4.29.0", "--skip-validation"])
@@ -321,6 +329,36 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         finally:
             for name, value in originals.items():
                 setattr(harness_mod, name, value)
+
+    def test_prepare_backport_pr_prints_standardized_scaffold(self) -> None:
+        args = argparse.Namespace(
+            release="v4.28.0",
+            main_pr=11,
+            main_title="fix(backports): require draft plans and base-aware retire",
+            source_branch="fix/backport-discipline",
+        )
+        layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
+        originals = {
+            "detect_harness_layout": harness_mod.detect_harness_layout,
+            "default_dev_branch": harness_mod.default_dev_branch,
+        }
+        out = io.StringIO()
+        try:
+            harness_mod.detect_harness_layout = lambda _start=None: layout
+            harness_mod.default_dev_branch = lambda _checkout_root: "v4.29.0"
+            with redirect_stdout(out):
+                self.assertEqual(harness_mod.command_prepare_backport_pr(args), 0)
+        finally:
+            for name, value in originals.items():
+                setattr(harness_mod, name, value)
+
+        output = out.getvalue()
+        self.assertIn("default_dev_branch=v4.29.0", output)
+        self.assertIn("backport_release=v4.28.0", output)
+        self.assertIn("paired_branch=fix/backport-v428-backport-discipline", output)
+        self.assertIn("paired_title=[backport v4.28.0] fix(backports): require draft plans and base-aware retire", output)
+        self.assertIn("Primary review: #11", output)
+        self.assertIn("Keep review comments on #11 unless this backport diverges materially.", output)
 
     def test_land_main_rejects_unsynced_main(self) -> None:
         args = argparse.Namespace(source="feat/demo", no_push=False, cleanup=False, keep_remote=False)

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -82,9 +82,17 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         parser = build_parser()
         args = parser.parse_args(["prepare-backport-pr", "v4.28.0", "--main-pr", "11"])
         self.assertEqual(args.release, "v4.28.0")
+        self.assertFalse(args.all_required)
         self.assertEqual(args.main_pr, 11)
         self.assertIsNone(args.main_title)
         self.assertIsNone(args.source_branch)
+
+    def test_prepare_backport_pr_parses_all_required_flag(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["prepare-backport-pr", "--all-required", "--main-pr", "11"])
+        self.assertIsNone(args.release)
+        self.assertTrue(args.all_required)
+        self.assertEqual(args.main_pr, 11)
 
     def test_bump_toolchain_parses_optional_flags(self) -> None:
         parser = build_parser()
@@ -333,6 +341,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
     def test_prepare_backport_pr_prints_standardized_scaffold(self) -> None:
         args = argparse.Namespace(
             release="v4.28.0",
+            all_required=False,
             main_pr=11,
             main_title="fix(backports): require draft plans and base-aware retire",
             source_branch="fix/backport-discipline",
@@ -340,12 +349,21 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
         originals = {
             "detect_harness_layout": harness_mod.detect_harness_layout,
+            "load_branch_policy": harness_mod.load_branch_policy,
             "default_dev_branch": harness_mod.default_dev_branch,
+            "require_checkout_role": harness_mod.require_checkout_role,
+            "source_commit_series": harness_mod.source_commit_series,
         }
         out = io.StringIO()
         try:
             harness_mod.detect_harness_layout = lambda _start=None: layout
+            harness_mod.load_branch_policy = lambda _checkout_root: SimpleNamespace(
+                default_dev_branch="v4.29.0",
+                required_backport_branches=("v4.28.0",),
+            )
             harness_mod.default_dev_branch = lambda _checkout_root: "v4.29.0"
+            harness_mod.require_checkout_role = lambda *_args, **_kwargs: None
+            harness_mod.source_commit_series = lambda _repo_root, _source_branch: ["abc123", "def456"]
             with redirect_stdout(out):
                 self.assertEqual(harness_mod.command_prepare_backport_pr(args), 0)
         finally:
@@ -355,10 +373,52 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         output = out.getvalue()
         self.assertIn("default_dev_branch=v4.29.0", output)
         self.assertIn("backport_release=v4.28.0", output)
+        self.assertIn("paired_worktree=backport-v428-backport-discipline", output)
         self.assertIn("paired_branch=fix/backport-v428-backport-discipline", output)
         self.assertIn("paired_title=[backport v4.28.0] fix(backports): require draft plans and base-aware retire", output)
+        self.assertIn("source_commits=abc123,def456", output)
+        self.assertIn("git cherry-pick -x abc123 def456", output)
         self.assertIn("Primary review: #11", output)
         self.assertIn("Keep review comments on #11 unless this backport diverges materially.", output)
+
+    def test_prepare_backport_pr_all_required_prints_multiple_scaffolds(self) -> None:
+        args = argparse.Namespace(
+            release=None,
+            all_required=True,
+            main_pr=11,
+            main_title="fix(backports): require draft plans and base-aware retire",
+            source_branch="fix/backport-discipline",
+        )
+        layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
+        originals = {
+            "detect_harness_layout": harness_mod.detect_harness_layout,
+            "load_branch_policy": harness_mod.load_branch_policy,
+            "default_dev_branch": harness_mod.default_dev_branch,
+            "require_checkout_role": harness_mod.require_checkout_role,
+            "source_commit_series": harness_mod.source_commit_series,
+        }
+        out = io.StringIO()
+        try:
+            harness_mod.detect_harness_layout = lambda _start=None: layout
+            harness_mod.load_branch_policy = lambda _checkout_root: SimpleNamespace(
+                default_dev_branch="v4.29.0",
+                required_backport_branches=("v4.28.0", "v4.27.0"),
+            )
+            harness_mod.default_dev_branch = lambda _checkout_root: "v4.29.0"
+            harness_mod.require_checkout_role = lambda *_args, **_kwargs: None
+            harness_mod.source_commit_series = lambda _repo_root, _source_branch: ["abc123"]
+            with redirect_stdout(out):
+                self.assertEqual(harness_mod.command_prepare_backport_pr(args), 0)
+        finally:
+            for name, value in originals.items():
+                setattr(harness_mod, name, value)
+
+        output = out.getvalue()
+        self.assertIn("backport_release=v4.28.0", output)
+        self.assertIn("paired_branch=fix/backport-v428-backport-discipline", output)
+        self.assertIn("backport_release=v4.27.0", output)
+        self.assertIn("paired_branch=fix/backport-v427-backport-discipline", output)
+        self.assertIn("\n---\n", output)
 
     def test_land_main_rejects_unsynced_main(self) -> None:
         args = argparse.Namespace(source="feat/demo", no_push=False, cleanup=False, keep_remote=False)

--- a/tests/harness/test_blueprint_harness_worktrees.py
+++ b/tests/harness/test_blueprint_harness_worktrees.py
@@ -75,6 +75,7 @@ branch refs/heads/feat/demo
                     "dirty": git_wt.name == ROOT_WORKTREE_NAME,
                     "tracked_changes": 1 if git_wt.name == ROOT_WORKTREE_NAME else 0,
                     "untracked_changes": 0,
+                    "base_ref": "origin/v4.29.0",
                     "merged_into_main": git_wt.name == ROOT_WORKTREE_NAME,
                     "main_ahead": 0 if git_wt.name == ROOT_WORKTREE_NAME else 1,
                     "main_behind": 0 if git_wt.name == ROOT_WORKTREE_NAME else 2,
@@ -165,6 +166,7 @@ branch refs/heads/feat/demo
                                 "dirty": True,
                                 "tracked_changes": 9,
                                 "untracked_changes": 9,
+                                "base_ref": "origin/v4.29.0",
                                 "merged_into_main": False,
                                 "main_ahead": 9,
                                 "main_behind": 9,
@@ -204,6 +206,7 @@ branch refs/heads/feat/demo
                     "dirty": git_wt.name == "demo",
                     "tracked_changes": 5 if git_wt.name == "demo" else 0,
                     "untracked_changes": 1 if git_wt.name == "demo" else 0,
+                    "base_ref": "origin/v4.29.0",
                     "merged_into_main": git_wt.name == ROOT_WORKTREE_NAME,
                     "main_ahead": 2 if git_wt.name == "demo" else 0,
                     "main_behind": 7 if git_wt.name == "demo" else 0,
@@ -272,6 +275,7 @@ branch refs/heads/feat/demo
                                 "dirty": True,
                                 "tracked_changes": 9,
                                 "untracked_changes": 9,
+                                "base_ref": "origin/v4.29.0",
                                 "merged_into_main": False,
                                 "main_ahead": 9,
                                 "main_behind": 9,
@@ -311,6 +315,7 @@ branch refs/heads/feat/demo
                     "dirty": False,
                     "tracked_changes": 0,
                     "untracked_changes": 0,
+                    "base_ref": "origin/v4.29.0",
                     "merged_into_main": False,
                     "main_ahead": 0,
                     "main_behind": 0,
@@ -374,6 +379,7 @@ branch refs/heads/feat/demo
                     "dirty": False,
                     "tracked_changes": 0,
                     "untracked_changes": 0,
+                    "base_ref": "origin/v4.29.0",
                     "merged_into_main": False,
                     "main_ahead": 0,
                     "main_behind": 0,
@@ -427,6 +433,7 @@ branch refs/heads/feat/demo
             self.assertFalse(facts["dirty"])
             self.assertEqual(facts["tracked_changes"], 0)
             self.assertEqual(facts["untracked_changes"], 0)
+            self.assertEqual(facts["base_ref"], "v4.29.0")
             self.assertFalse(facts["merged_into_main"])
             self.assertEqual((facts["main_ahead"], facts["main_behind"]), (1, 0))
             self.assertIsNone(facts["upstream"])

--- a/tests/harness/test_harness_entrypoints.py
+++ b/tests/harness/test_harness_entrypoints.py
@@ -24,6 +24,7 @@ class HarnessEntrypointSmokeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("create-worktree", result.stdout)
         self.assertIn("prepare-backports", result.stdout)
+        self.assertIn("prepare-backport-pr", result.stdout)
         self.assertIn("bump-toolchain", result.stdout)
         self.assertIn("land-release", result.stdout)
 

--- a/tests/harness/test_harness_entrypoints.py
+++ b/tests/harness/test_harness_entrypoints.py
@@ -23,6 +23,7 @@ class HarnessEntrypointSmokeTests(unittest.TestCase):
         result = self.run_command([sys.executable, "-m", "scripts.blueprint_harness", "--help"])
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("create-worktree", result.stdout)
+        self.assertIn("prepare-backports", result.stdout)
         self.assertIn("bump-toolchain", result.stdout)
         self.assertIn("land-release", result.stdout)
 


### PR DESCRIPTION
## Summary
Backport #11 to `v4.28.0`.

## Primary Review
- Primary review: #11
- Keep review comments on #11 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.28.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x` so the paired-backport check can verify the series.
- Carry the batch backport scaffold helper so future multi-release backports can be prepared consistently.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.

## Validation
- `python3 -m unittest tests.harness.test_backport_pr_check tests.harness.test_blueprint_harness_cli tests.harness.test_blueprint_harness_worktrees tests.harness.test_harness_entrypoints`

## Coordination
- Default-dev PR: #11
- Default-dev branch: `feat/backport-workflow`
- Backport branch: `feat/backport-v428-backport-workflow`
