### PR TITLE
[backport v4.28.0] chore: remove obsolete blueprint mirror support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,56 +1,21 @@
-## Summary
+# Read this section before submitting
 
-Describe the user-visible or maintainer-visible outcome in 1-3 sentences.
+- Keep the PR title and body suitable as the squash-merge commit message.
+- Start the body with a short paragraph beginning `This PR ...`.
+- Summarize the problem and useful outcome in the body itself; links to issues
+  or discussions are not a substitute for the summary.
+- Put questions, local notes, and extra review coordination in comments rather
+  than the PR description.
+- Keep the required `Backport ...` line below. Draft PRs may use `pending`;
+  ready PRs must use `#<pr>` or `exempt: <reason>`.
+- Remove this instruction block, up to and including the `---`, before
+  submitting.
 
-## Problem
+---
 
-What was wrong, missing, or confusing before this change?
+This PR <short summary of the problem solved and useful outcome>.
 
-## Scope
+<Optional: one short paragraph or a few bullets with the main behavior or
+maintainer-visible changes. Avoid module-by-module implementation inventory.>
 
-- What changed
-- What intentionally did not change
-
-## Validation
-
-- Commands run
-- Manual checks performed
-- External projects or worktrees exercised
-
-## Primary Review
-
-For paired backport PRs:
-
-- Primary review: #<default-dev-pr>
-- Keep discussion there unless this backport diverges materially.
-
-## Backports
-
-Draft `v4.29.0` PRs should declare one line per required backport target as
-soon as the draft exists. While the PR is still draft, `pending` is allowed:
-
-- `Backport v4.28.0: pending`
-- `Backport v4.28.0: exempt: <reason>`
-
-Once a `v4.29.0` PR is ready for review, replace each `pending` line with:
-
-- `Backport v4.28.0: #123`
-- `Backport v4.28.0: exempt: <reason>`
-
-## Backport Delta
-
-For paired backport PRs:
-
-- No intentional release-specific changes
-- Or describe the release-line-specific adaptation
-
-## Risks and Follow-Ups
-
-- Known limitations
-- Cleanup that should happen in a later PR
-
-## Coordination
-
-- Issue:
-- Worktree:
-- Write scope:
+Backport v4.28.0: pending

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -37,14 +37,14 @@ Prefer short, descriptive slugs over opaque branch names.
 Prefer concise imperative subjects in the form:
 
 ```text
-type(scope): summary
+type: summary
 ```
 
 Examples:
 
-- `feat(harness): add local worktree registry commands`
-- `fix(preview): preserve inline proof-gap precision`
-- `docs(maintainer): document worktree claim workflow`
+- `feat: add local worktree registry commands`
+- `fix: preserve inline proof-gap precision`
+- `docs: document worktree claim workflow`
 
 Keep the subject line tight enough for `git log --oneline`. Avoid generic
 subjects such as `Update files` or `misc cleanup`.
@@ -52,13 +52,27 @@ subjects such as `Update files` or `misc cleanup`.
 ## Pull Request Conventions
 
 - PR titles should usually match the intended squash-merge commit title.
-- PR bodies should state:
-  - the problem
-  - the scope of the change
-  - validation performed
-  - notable risks or follow-up
+- Avoid generator/tool prefixes such as `[codex]`; the title should describe
+  the change, not who or what drafted it.
+- For a draft default-development PR, generate the public-facing title/body
+  scaffold with `python3 -m scripts.blueprint_harness prepare-pr`.
+- PR title and body are used as the squash-merge commit message, following the
+  upstream Lean convention. Keep the body suitable for permanent history.
+- Start the PR body with a short paragraph beginning `This PR ...`; include the
+  motivation and contrast with previous behavior there.
+- Use extra paragraphs or bullets only when they help explain the main
+  user-visible or maintainer-visible change. Do not make the body a
+  module-by-module implementation inventory.
+- If the PR includes measurements, explain what changed and why the numbers
+  matter before listing the raw before/after values.
+- Do not add a routine validation transcript. CI is the default validation
+  record. Mention manual checks only when they add information CI cannot show,
+  or mention skipped checks when that changes the review risk.
+- Put questions, local notes, and extra review coordination in comments rather
+  than the PR description.
 - When the work came from a local worktree, include the worktree name and write
-  scope in the PR body or draft notes.
+  scope in local draft notes only when it helps coordination; do not require
+  public reviewers to understand local worktree bookkeeping.
 - Draft PRs targeting `v4.29.0` must declare one backport plan line for each
   required backport release branch listed in `branch-policy.json`.
 - Non-draft PRs targeting `v4.29.0` must replace each `pending` entry with a
@@ -72,8 +86,10 @@ subjects such as `Update files` or `misc cleanup`.
   one-to-one cherry-pick of the default-development series.
 - The expected workflow is:
   - keep the `v4.29.0` PR in draft while the change is still converging
-  - run `python3 -m scripts.blueprint_harness prepare-backports` and paste the
-    emitted lines into the draft PR body
+  - run `python3 -m scripts.blueprint_harness prepare-pr` and use the emitted
+    public title/body scaffold
+  - use `python3 -m scripts.blueprint_harness prepare-backports` only when you
+    need to refresh just the backport plan lines in an existing PR body
   - once it is ready for review, open the paired `v4.28.0` PR
   - use `python3 -m scripts.blueprint_harness prepare-backport-pr v4.28.0 --main-pr <pr>` to scaffold the paired backport PR branch name, title, and body
   - when several releases are required, use `python3 -m scripts.blueprint_harness prepare-backport-pr --all-required --main-pr <pr>` to emit one scaffold block per release, then let the agent apply the `git cherry-pick -x` series and resolve conflicts in each backport worktree
@@ -83,10 +99,13 @@ subjects such as `Update files` or `misc cleanup`.
 - Keep review comments and design discussion on the default-dev PR unless the
   backport itself diverges materially, for example because of a conflict or a
   release-line-specific adaptation.
-- Record the pairing in the PR body using lines like:
-  - `Backport v4.28.0: pending`
-  - `Backport v4.28.0: #123`
-  - `Backport v4.28.0: exempt: docs-only change`
+- Record the pairing in the PR body using plain lines like:
+
+```text
+Backport v4.28.0: pending
+Backport v4.28.0: #123
+Backport v4.28.0: exempt: docs-only change
+```
 
 See the repository PR template for the preferred structure.
 

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -425,13 +425,25 @@ do non-backport work from a backport-only checkout.
 
 Default-development PRs also follow a paired-backport gate. In this repository
 that means draft `v4.29.0` PRs must still declare one line per required
-backport target, usually by running:
+backport target. For a new public PR, generate the public-facing scaffold with:
+
+```bash
+python3 -m scripts.blueprint_harness prepare-pr
+```
+
+That helper prints the public repository, base branch, PR title, and PR body.
+It keeps local worktree and write-scope notes out of the body unless they
+materially help review. The generated body is intentionally reviewer-oriented:
+start with a short `This PR ...` paragraph that is suitable as the squash-merge
+commit body, keep implementation inventory out of the opening summary, and do
+not include routine validation transcripts that CI already records. For an
+existing PR where only the backport lines need a refresh, run:
 
 ```bash
 python3 -m scripts.blueprint_harness prepare-backports
 ```
 
-Paste the emitted lines into the draft PR body. While the PR is still draft,
+Paste the emitted backport lines into the draft PR body. While the PR is still draft,
 each required line may remain:
 
 - `Backport v4.28.0: pending`
@@ -721,10 +733,9 @@ The harness is now project-driven rather than example-hardcoded.
   external test projects exercise the local `VersoBlueprint` checkout instead
   of the committed upstream dependency
 - the current local override injection expects a `lakefile.lean` project that
-  declares `VersoBlueprint` from either the official
-  `leanprover/verso-blueprint` Git repository or the temporary
-  `ejgallego/verso-blueprint` mirror, and it tolerates different Git refs and
-  URL spellings for either source
+  declares `VersoBlueprint` from the official `leanprover/verso-blueprint` Git
+  repository, and it tolerates different Git refs and URL spellings for that
+  source
 - local worktree bookkeeping is intentionally not tracked in the repository
 
 Minimal external catalog entry shape:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,6 +51,7 @@ with the preferred release ref before branching or landing, use:
 ```bash
 python3 -m scripts.blueprint_harness release-status
 python3 -m scripts.blueprint_harness release-status --require-sync
+python3 -m scripts.blueprint_harness prepare-pr
 python3 -m scripts.blueprint_harness prepare-backports
 python3 -m scripts.blueprint_harness prepare-backport-pr v4.28.0 --main-pr <pr>
 python3 -m scripts.blueprint_harness prepare-backport-pr --all-required --main-pr <pr>
@@ -60,14 +61,21 @@ python3 -m scripts.blueprint_harness require-branch-role default_dev
 `require-branch-role default_dev` is the explicit machine check for
 automation that must refuse non-backport work on backport-only release lines.
 
-`prepare-backports` prints the `Backport ...` lines that should be pasted into a
-draft default-dev PR body. Draft PRs may keep those lines as `pending`; before
-ready for review, replace each `pending` entry with `#<pr>` or
-`exempt: <reason>`.
+`prepare-pr` prints a public draft PR title/body scaffold for the current
+default-dev work. It includes the public `leanprover/verso-blueprint`
+repository, base/head branches, and required backport lines while keeping local
+worktree bookkeeping out of the public body. The scaffold is reviewer-oriented:
+start with a short `This PR ...` paragraph suitable as the squash-merge commit
+body, then list only the main changes needed for review and avoid routine
+validation transcripts that CI already records.
+
+`prepare-backports` prints only the `Backport ...` lines for an existing draft
+default-dev PR body. Draft PRs may keep those lines as `pending`; before ready
+for review, replace each `pending` entry with `#<pr>` or `exempt: <reason>`.
 
 `prepare-backport-pr` prints a standardized paired backport branch name, PR
-title, and PR body scaffold that points review back to the default-dev PR and
-limits the paired PR to release-line-specific deltas.
+title, local apply plan, and public PR body scaffold that points review back to
+the default-dev PR and limits the paired PR to release-line-specific deltas.
 
 With `--all-required`, it emits one scaffold block per required release plus
 the exact `git cherry-pick -x ...` commit series an agent should apply while

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -46,6 +46,9 @@ from scripts.blueprint_harness_worktrees import (
     worktree_record_map,
 )
 
+PUBLIC_REPOSITORY = "leanprover/verso-blueprint"
+
+
 @dataclass(frozen=True)
 class RefSyncStatus:
     local_ref: str
@@ -466,6 +469,54 @@ def parse_prepare_backports_exemptions(values: list[str] | None) -> dict[str, st
     return exemptions
 
 
+def backport_plan_lines(required_backports: tuple[str, ...], exemptions: dict[str, str]) -> list[str]:
+    lines: list[str] = []
+    for branch in required_backports:
+        if branch in exemptions:
+            lines.append(f"Backport {branch}: exempt: {exemptions[branch]}")
+        else:
+            lines.append(f"Backport {branch}: pending")
+    return lines
+
+
+def print_public_pr_message_scaffold(
+    *,
+    default_dev: str,
+    source_branch: str,
+    title: str,
+    backport_lines: list[str],
+    summary: str | None,
+    changes: list[str] | None,
+) -> None:
+    print(f"repository={PUBLIC_REPOSITORY}")
+    print(f"base={default_dev}")
+    print(f"head={source_branch}")
+    print("draft=true")
+    print(f"pr_title={title}")
+    print()
+    print("## Submission")
+    print(f"- Push `{source_branch}` to a branch visible to `{PUBLIC_REPOSITORY}`.")
+    print(f"- Open a draft PR against `{PUBLIC_REPOSITORY}:{default_dev}` using the title and body below.")
+    print("- Keep local worktree and write-scope notes out of the public body unless they materially help review.")
+    print()
+    print("## PR Title")
+    print(title)
+    print()
+    print("## PR Body")
+    print(
+        summary
+        or "This PR <short summary of the problem solved and useful outcome>."
+    )
+    if changes:
+        print()
+        for item in changes:
+            print(f"- {item}")
+    if backport_lines:
+        print()
+        for line in backport_lines:
+            print(line)
+
+
 def release_marker(release_ref: str) -> str:
     normalized = normalize_lean_release_ref(release_ref)
     match = re.match(r"^v(\d+)\.(\d+)", normalized)
@@ -517,6 +568,9 @@ def print_prepare_backport_pr_scaffold(
     paired_worktree = default_backport_worktree_name(source_branch, backport_release)
     paired_title = f"[backport {backport_release}] {main_title}"
 
+    print("## Local Backport Plan")
+    print()
+    print(f"repository={PUBLIC_REPOSITORY}")
     print(f"default_dev_branch={default_dev}")
     print(f"backport_release={backport_release}")
     print(f"source_branch={source_branch}")
@@ -526,7 +580,7 @@ def print_prepare_backport_pr_scaffold(
     print(f"source_commits={','.join(source_commits)}")
     print(f"base_ref=origin/{backport_release}")
     print()
-    print("## Batch Apply")
+    print("### Batch Apply")
     print(
         f"- Create the linked worktree on `origin/{backport_release}` and attach it to `{paired_branch}`."
     )
@@ -537,6 +591,10 @@ def print_prepare_backport_pr_scaffold(
     print("- Let the agent resolve any cherry-pick conflicts in the backport worktree.")
     print("- Run validation on the backport branch before opening the paired PR.")
     print()
+    print("## PR Title")
+    print(paired_title)
+    print()
+    print("## PR Body")
     print("## Summary")
     print(f"Backport #{main_pr} to `{backport_release}`.")
     print()
@@ -552,14 +610,6 @@ def print_prepare_backport_pr_scaffold(
     print("## Backport Delta")
     print("- No intentional release-specific changes.")
     print("- If conflict resolution requires deviations from the default-development PR, describe them here.")
-    print()
-    print("## Validation")
-    print(f"- Describe the validation run on `{backport_release}`.")
-    print()
-    print("## Coordination")
-    print(f"- Default-dev PR: #{main_pr}")
-    print(f"- Default-dev branch: `{source_branch}`")
-    print(f"- Backport branch: `{paired_branch}`")
 
 
 def command_prepare_backports(args: argparse.Namespace) -> int:
@@ -581,14 +631,40 @@ def command_prepare_backports(args: argparse.Namespace) -> int:
         return 0
 
     print()
-    for branch in policy.required_backport_branches:
-        if branch in exemptions:
-            print(f"Backport {branch}: exempt: {exemptions[branch]}")
-        else:
-            print(f"Backport {branch}: pending")
+    for line in backport_plan_lines(policy.required_backport_branches, exemptions):
+        print(line)
     print()
     print("[blueprint-harness] paste these lines into the default-dev PR body while it is draft")
     print("[blueprint-harness] replace each `pending` entry with `#<pr>` or `exempt: <reason>` before ready for review")
+    return 0
+
+
+def command_prepare_pr(args: argparse.Namespace) -> int:
+    layout = detect_harness_layout(Path(__file__))
+    require_checkout_role(layout.package_root, required_role="default_dev", operation="prepare-pr")
+    policy = load_branch_policy(layout.package_root)
+    exemptions = parse_prepare_backports_exemptions(args.exempt)
+    unknown = sorted(branch for branch in exemptions if branch not in policy.required_backport_branches)
+    if unknown:
+        raise SystemExit(
+            "[blueprint-harness] unknown required backport branch(es): "
+            + ", ".join(unknown)
+            + ". Update `branch-policy.json` or remove the extra `--exempt` entries."
+        )
+
+    source_branch = args.source_branch or current_branch_name(layout.package_root)
+    if not source_branch:
+        raise SystemExit("[blueprint-harness] unable to determine a source branch; pass `--source-branch` explicitly")
+
+    title = args.title or current_commit_subject(layout.package_root)
+    print_public_pr_message_scaffold(
+        default_dev=policy.default_dev_branch,
+        source_branch=source_branch,
+        title=title,
+        backport_lines=backport_plan_lines(policy.required_backport_branches, exemptions),
+        summary=args.summary,
+        changes=args.change,
+    )
     return 0
 
 
@@ -966,6 +1042,39 @@ def build_parser() -> argparse.ArgumentParser:
         help="Pre-fill one required branch as `exempt: <reason>` using `--exempt <branch>=<reason>`. Repeat as needed.",
     )
     prepare_backports.set_defaults(func=command_prepare_backports)
+
+    prepare_pr = subparsers.add_parser(
+        "prepare-pr",
+        help="Print a public draft PR title and body scaffold for the current default-dev branch.",
+    )
+    prepare_pr.add_argument(
+        "--title",
+        default=None,
+        help="Override the PR title. Defaults to the current commit subject.",
+    )
+    prepare_pr.add_argument(
+        "--summary",
+        default=None,
+        help="Pre-fill the opening PR body paragraph. It should usually start with `This PR`.",
+    )
+    prepare_pr.add_argument(
+        "--change",
+        action="append",
+        default=None,
+        help="Add one Changes bullet. Repeat as needed.",
+    )
+    prepare_pr.add_argument(
+        "--source-branch",
+        default=None,
+        help="Override the PR head branch. Defaults to the current branch.",
+    )
+    prepare_pr.add_argument(
+        "--exempt",
+        action="append",
+        default=None,
+        help="Pre-fill one required backport branch as `exempt: <reason>`. Repeat as needed.",
+    )
+    prepare_pr.set_defaults(func=command_prepare_pr)
 
     prepare_backport_pr = subparsers.add_parser(
         "prepare-backport-pr",

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -12,23 +12,16 @@ from scripts.blueprint_harness_projects import HarnessProject
 from scripts.blueprint_harness_utils import lean_low_priority_command, run
 
 
-OFFICIAL_BLUEPRINT_REPOSITORIES = (
-    "leanprover/verso-blueprint",
-    "ejgallego/verso-blueprint",
-)
+OFFICIAL_BLUEPRINT_REPOSITORY = "leanprover/verso-blueprint"
 OFFICIAL_BLUEPRINT_REQUIRE = (
-    f'require VersoBlueprint from git "https://github.com/{OFFICIAL_BLUEPRINT_REPOSITORIES[0]}"@"main"'
+    f'require VersoBlueprint from git "https://github.com/{OFFICIAL_BLUEPRINT_REPOSITORY}"@"main"'
 )
-OFFICIAL_BLUEPRINT_URL_PATTERNS = tuple(
-    pattern
-    for repository in OFFICIAL_BLUEPRINT_REPOSITORIES
-    for pattern in (
-        rf"https://github\.com/{repository}(?:\.git)?",
-        rf"git@github\.com:{repository}\.git",
-        rf"ssh://git@github\.com/{repository}\.git",
-    )
+OFFICIAL_BLUEPRINT_URL_PATTERNS = (
+    rf"https://github\.com/{OFFICIAL_BLUEPRINT_REPOSITORY}(?:\.git)?",
+    rf"git@github\.com:{OFFICIAL_BLUEPRINT_REPOSITORY}\.git",
+    rf"ssh://git@github\.com/{OFFICIAL_BLUEPRINT_REPOSITORY}\.git",
 )
-OFFICIAL_BLUEPRINT_SOURCE_DESCRIPTION = " or ".join(f"`{repository}`" for repository in OFFICIAL_BLUEPRINT_REPOSITORIES)
+OFFICIAL_BLUEPRINT_SOURCE_DESCRIPTION = f"`{OFFICIAL_BLUEPRINT_REPOSITORY}`"
 COMMIT_HASH_PATTERN = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
 GITHUB_SUBMODULE_URL_REWRITE_ARGS = (
     "-c",
@@ -562,7 +555,7 @@ def bump_reference_project(
     pushed = False
 
     if commit or push:
-        message = commit_message or f"chore(deps): bump VersoBlueprint to {short_git_ref(ref)}"
+        message = commit_message or f"chore: bump VersoBlueprint to {short_git_ref(ref)}"
         committed = commit_project_tracked_changes(edit_dir, pathspec, message)
         if push and committed:
             push_reference_edit_branch(edit_dir, target_branch)

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -1269,7 +1269,7 @@ def build_parser() -> argparse.ArgumentParser:
     bump.add_argument(
         "--commit-message",
         default=None,
-        help="Commit message to use with `--commit`. Defaults to `chore(deps): bump VersoBlueprint to <ref>`.",
+        help="Commit message to use with `--commit`. Defaults to `chore: bump VersoBlueprint to <ref>`.",
     )
     bump.set_defaults(func=command_reference_bump_blueprint)
 

--- a/tests/harness/test_backport_pr_check.py
+++ b/tests/harness/test_backport_pr_check.py
@@ -47,6 +47,13 @@ def diff_for(line: str) -> str:
 
 
 class BackportPrCheckTests(unittest.TestCase):
+    def test_pr_template_backport_placeholder_is_safe_for_drafts(self) -> None:
+        template = Path(__file__).resolve().parents[2] / ".github" / "PULL_REQUEST_TEMPLATE.md"
+        entries = backport_mod.parse_backport_entries(template.read_text(encoding="utf-8"))
+
+        self.assertEqual(set(entries), {"v4.28.0"})
+        self.assertTrue(entries["v4.28.0"].pending)
+
     def test_parse_backport_entries_accepts_pr_pending_and_exemption(self) -> None:
         body = """
 Backport v4.28.0: #42

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -78,6 +78,29 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         args = parser.parse_args(["prepare-backports", "--exempt", "v4.28.0=docs-only"])
         self.assertEqual(args.exempt, ["v4.28.0=docs-only"])
 
+    def test_prepare_pr_parses_public_message_fields(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "prepare-pr",
+                "--title",
+                "fix: tighten PR scaffolds",
+                "--summary",
+                "Update the public PR scaffold.",
+                "--change",
+                "Add a public PR message helper",
+                "--source-branch",
+                "fix/public-pr-scaffold",
+                "--exempt",
+                "v4.28.0=docs-only",
+            ]
+        )
+        self.assertEqual(args.title, "fix: tighten PR scaffolds")
+        self.assertEqual(args.summary, "Update the public PR scaffold.")
+        self.assertEqual(args.change, ["Add a public PR message helper"])
+        self.assertEqual(args.source_branch, "fix/public-pr-scaffold")
+        self.assertEqual(args.exempt, ["v4.28.0=docs-only"])
+
     def test_prepare_backport_pr_parses_required_fields(self) -> None:
         parser = build_parser()
         args = parser.parse_args(["prepare-backport-pr", "v4.28.0", "--main-pr", "11"])
@@ -148,7 +171,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             {
               "name": "VersoBlueprint",
               "type": "git",
-              "url": "https://github.com/ejgallego/verso-blueprint.git",
+              "url": "https://github.com/leanprover/verso-blueprint.git",
               "inputRev": "main",
               "rev": "deadbeef"
             }
@@ -163,12 +186,31 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertEqual(pin.input_ref, "main")
         self.assertEqual(pin.resolved_ref, "deadbeef")
 
+    def test_parse_blueprint_manifest_pin_ignores_unofficial_source(self) -> None:
+        text = """
+        {
+          "packages": [
+            {
+              "name": "VersoBlueprint",
+              "type": "git",
+              "url": "https://github.com/example/verso-blueprint.git",
+              "inputRev": "main",
+              "rev": "deadbeef"
+            }
+          ]
+        }
+        """
+
+        pin = reference_harness_mod.parse_blueprint_manifest_pin(text, source_path="lake-manifest.json")
+
+        self.assertIsNone(pin)
+
     def test_parse_blueprint_lakefile_pin_handles_split_ref(self) -> None:
         text = """
         import Lake
         open Lake DSL
 
-        require VersoBlueprint from git "https://github.com/ejgallego/verso-blueprint.git" @
+        require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint.git" @
           "7e15d20e6a03859de535a359bca3760c039858b2"
         """
 
@@ -178,6 +220,19 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertEqual(pin.source_path, "lakefile.lean")
         self.assertEqual(pin.input_ref, "7e15d20e6a03859de535a359bca3760c039858b2")
         self.assertEqual(pin.resolved_ref, "7e15d20e6a03859de535a359bca3760c039858b2")
+
+    def test_parse_blueprint_lakefile_pin_ignores_unofficial_source(self) -> None:
+        text = """
+        import Lake
+        open Lake DSL
+
+        require VersoBlueprint from git "https://github.com/example/verso-blueprint.git" @
+          "7e15d20e6a03859de535a359bca3760c039858b2"
+        """
+
+        pin = reference_harness_mod.parse_blueprint_lakefile_pin(text, source_path="lakefile.lean")
+
+        self.assertIsNone(pin)
 
     def test_create_worktree_uses_preferred_main_ref_by_default(self) -> None:
         layout = SimpleNamespace(repo_root=Path("/tmp/repo"))
@@ -338,12 +393,61 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             for name, value in originals.items():
                 setattr(harness_mod, name, value)
 
+    def test_prepare_pr_prints_public_scaffold(self) -> None:
+        args = argparse.Namespace(
+            title=None,
+            summary="This PR removes private mirror assumptions from the maintainer harness.",
+            change=["Accept only the public upstream package repo"],
+            source_branch=None,
+            exempt=None,
+        )
+        layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
+        originals = {
+            "detect_harness_layout": harness_mod.detect_harness_layout,
+            "load_branch_policy": harness_mod.load_branch_policy,
+            "require_checkout_role": harness_mod.require_checkout_role,
+            "current_branch_name": harness_mod.current_branch_name,
+            "current_commit_subject": harness_mod.current_commit_subject,
+        }
+        out = io.StringIO()
+        try:
+            harness_mod.detect_harness_layout = lambda _start=None: layout
+            harness_mod.load_branch_policy = lambda _checkout_root: SimpleNamespace(
+                default_dev_branch="v4.29.0",
+                required_backport_branches=("v4.28.0",),
+            )
+            harness_mod.require_checkout_role = lambda *_args, **_kwargs: None
+            harness_mod.current_branch_name = lambda _checkout_root: "fix/public-pr-scaffold"
+            harness_mod.current_commit_subject = lambda _checkout_root: "fix: tighten public PR scaffolds"
+            with redirect_stdout(out):
+                self.assertEqual(harness_mod.command_prepare_pr(args), 0)
+        finally:
+            for name, value in originals.items():
+                setattr(harness_mod, name, value)
+
+        output = out.getvalue()
+        self.assertIn("repository=leanprover/verso-blueprint", output)
+        self.assertIn("base=v4.29.0", output)
+        self.assertIn("head=fix/public-pr-scaffold", output)
+        self.assertIn("draft=true", output)
+        self.assertIn("## PR Title\nfix: tighten public PR scaffolds", output)
+        self.assertIn("## PR Body", output)
+        self.assertIn("This PR removes private mirror assumptions from the maintainer harness.", output)
+        self.assertIn("- Accept only the public upstream package repo", output)
+        self.assertIn("Backport v4.28.0: pending", output)
+        self.assertNotIn("## Backports", output)
+        self.assertNotIn("## Validation", output)
+        self.assertNotIn("## Coordination", output)
+        self.assertNotIn("## Risks", output)
+        self.assertNotIn("Worktree:", output)
+        self.assertNotIn("Write scope:", output)
+
     def test_prepare_backport_pr_prints_standardized_scaffold(self) -> None:
         args = argparse.Namespace(
             release="v4.28.0",
             all_required=False,
             main_pr=11,
-            main_title="fix(backports): require draft plans and base-aware retire",
+            main_title="fix: require draft plans and base-aware retire",
             source_branch="fix/backport-discipline",
         )
         layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
@@ -371,13 +475,17 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 setattr(harness_mod, name, value)
 
         output = out.getvalue()
+        self.assertIn("## Local Backport Plan", output)
+        self.assertIn("repository=leanprover/verso-blueprint", output)
         self.assertIn("default_dev_branch=v4.29.0", output)
         self.assertIn("backport_release=v4.28.0", output)
         self.assertIn("paired_worktree=backport-v428-backport-discipline", output)
         self.assertIn("paired_branch=fix/backport-v428-backport-discipline", output)
-        self.assertIn("paired_title=[backport v4.28.0] fix(backports): require draft plans and base-aware retire", output)
+        self.assertIn("paired_title=[backport v4.28.0] fix: require draft plans and base-aware retire", output)
         self.assertIn("source_commits=abc123,def456", output)
         self.assertIn("git cherry-pick -x abc123 def456", output)
+        self.assertIn("## PR Title\n[backport v4.28.0] fix: require draft plans and base-aware retire", output)
+        self.assertIn("## PR Body", output)
         self.assertIn("Primary review: #11", output)
         self.assertIn("Keep review comments on #11 unless this backport diverges materially.", output)
 
@@ -386,7 +494,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             release=None,
             all_required=True,
             main_pr=11,
-            main_title="fix(backports): require draft plans and base-aware retire",
+            main_title="fix: require draft plans and base-aware retire",
             source_branch="fix/backport-discipline",
         )
         layout = SimpleNamespace(package_root=Path("/tmp/worktree"))

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -345,7 +345,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             project_dir = Path(tmp)
             lakefile = project_dir / "lakefile.lean"
             lakefile.write_text(
-                'require VersoBlueprint from git "https://github.com/ejgallego/verso-blueprint.git"@"v1.2.3"\n',
+                'require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint.git"@"v1.2.3"\n',
                 encoding="utf-8",
             )
 
@@ -353,7 +353,19 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
 
             text = lakefile.read_text(encoding="utf-8")
             self.assertIn('require VersoBlueprint from "', text)
-            self.assertNotIn('from git "https://github.com/ejgallego/verso-blueprint.git"', text)
+            self.assertNotIn('from git "https://github.com/leanprover/verso-blueprint.git"', text)
+
+    def test_rewrite_local_blueprint_dependency_rejects_unofficial_source(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            lakefile = project_dir / "lakefile.lean"
+            lakefile.write_text(
+                'require VersoBlueprint from git "https://github.com/example/verso-blueprint.git"@"v1.2.3"\n',
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(SystemExit, "approved `VersoBlueprint` Git source"):
+                rewrite_local_blueprint_dependency(project_dir, PACKAGE_ROOT)
 
     def test_rewrite_local_blueprint_dependency_rejects_unexpected_require_shape(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -372,7 +384,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             project_dir = Path(tmp)
             lakefile = project_dir / "lakefile.lean"
             lakefile.write_text(
-                'require VersoBlueprint from git "https://github.com/ejgallego/verso-blueprint.git"@"old-ref"\n',
+                'require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint.git"@"old-ref"\n',
                 encoding="utf-8",
             )
 
@@ -382,7 +394,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             self.assertEqual(previous_ref, "old-ref")
             self.assertEqual(
                 lakefile.read_text(encoding="utf-8").strip(),
-                'require VersoBlueprint from git "https://github.com/ejgallego/verso-blueprint.git"@"v1.2.3"',
+                'require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint.git"@"v1.2.3"',
             )
 
     def test_default_reference_bump_branch_shortens_commit_hash(self) -> None:
@@ -865,7 +877,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertTrue(result.committed)
         self.assertTrue(result.pushed)
         self.assertEqual(seen["pathspec"], ".")
-        self.assertEqual(seen["message"], "chore(deps): bump VersoBlueprint to v1.2.3")
+        self.assertEqual(seen["message"], "chore: bump VersoBlueprint to v1.2.3")
         self.assertEqual(seen["branch"], "chore/bump-verso-blueprint-v1-2-3")
 
     def test_bump_reference_project_can_generate_review_output(self) -> None:

--- a/tests/harness/test_harness_entrypoints.py
+++ b/tests/harness/test_harness_entrypoints.py
@@ -24,6 +24,7 @@ class HarnessEntrypointSmokeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("create-worktree", result.stdout)
         self.assertIn("prepare-backports", result.stdout)
+        self.assertIn("prepare-pr", result.stdout)
         self.assertIn("prepare-backport-pr", result.stdout)
         self.assertIn("bump-toolchain", result.stdout)
         self.assertIn("land-release", result.stdout)


### PR DESCRIPTION
## Summary
Backport #15 to `v4.28.0`.

## Primary Review
- Primary review: #15
- Keep review comments on #15 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.28.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.