### PR TITLE
[backport v4.28.0] fix(graph): preserve interaction and expose layout options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,12 +102,13 @@
 - The Python harness is maintainer tooling for this repository's in-repo
   own tests plus ephemeral checkout validations, not the preferred end-user
   interface.
-- Harnessed artifact-generation flows now detect embedded package assets such
-  as `graph.css`, `graph.js`, `summary.css`, `bibliography.css`, and
-  `static-web/math.js` becoming newer than their owning Lean modules before
-  build steps run. When that happens, the harness refreshes the owner-module
-  mtimes and runs a targeted root `lake build` for those owner modules so
-  downstream generator projects do not silently serve stale embedded assets.
+- Harnessed artifact-generation flows now proactively refresh the owner-module
+  mtimes for embedded package assets such as `graph.css`, `graph.js`,
+  `summary.css`, `bibliography.css`, and `static-web/math.js` before build
+  steps run, remove those owner modules' cached build outputs, and then run a
+  targeted root `lake build` for those owner modules. This keeps downstream
+  generator projects from silently serving stale embedded assets when only the
+  asset files changed.
 - Keep the two generated artifact families distinct:
   - Reference blueprints are the release-facing validation catalog built by
     `./scripts/generate-reference-blueprints.sh`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,12 @@
 - The Python harness is maintainer tooling for this repository's in-repo
   own tests plus ephemeral checkout validations, not the preferred end-user
   interface.
+- Harnessed artifact-generation flows now detect embedded package assets such
+  as `graph.css`, `graph.js`, `summary.css`, `bibliography.css`, and
+  `static-web/math.js` becoming newer than their owning Lean modules before
+  build steps run. When that happens, the harness refreshes the owner-module
+  mtimes and runs a targeted root `lake build` for those owner modules so
+  downstream generator projects do not silently serve stale embedded assets.
 - Keep the two generated artifact families distinct:
   - Reference blueprints are the release-facing validation catalog built by
     `./scripts/generate-reference-blueprints.sh`,

--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ Blueprint can render:
 - associated Rust code panels for labeled inline Rust blocks
 
 The graph page is interactive rather than static: it can expose a view switcher
-for grouped graphs, a legend popover, and the usual Blueprint hover/link
-previews.
+for grouped graphs, a legend popover, a `Graph options` control for direction
+switching, and the usual Blueprint hover/link previews.
 
 Progress is computed automatically from the status of the associated Lean code
 and declarations, so the HTML summary and graph views stay aligned with the

--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ Blueprint can render:
 - math-enabled previews and cross-links
 - associated Rust code panels for labeled inline Rust blocks
 
+The graph page is interactive rather than static: it can expose a view switcher
+for grouped graphs, a legend popover, and the usual Blueprint hover/link
+previews.
+
 Progress is computed automatically from the status of the associated Lean code
 and declarations, so the HTML summary and graph views stay aligned with the
 formal side. In particular, incomplete Lean declarations such as `sorry`

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Blueprint can render:
 
 The graph page is interactive rather than static: it can expose a view switcher
 for grouped graphs, a legend popover, a `Graph options` control for direction
-switching, and the usual Blueprint hover/link previews.
+and component-packing switches, and the usual Blueprint hover/link previews.
 
 Progress is computed automatically from the status of the associated Lean code
 and declarations, so the HTML summary and graph views stay aligned with the

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -112,9 +112,9 @@ The starter template includes:
 - a progress summary with `{blueprint_summary}`
 
 That is the core HTML surface most projects want first. The dependency graph can
-also take `(direction := LR | RL | TB | BT)`, and grouped projects expose the
-current graph views through the rendered page's `View`, `Legend`, and `Graph
-options` controls.
+also take `(direction := LR | RL | TB | BT)` and `(pack := true | false)`, and
+grouped projects expose the current graph views through the rendered page's
+`View`, `Legend`, and `Graph options` controls.
 
 ## Read the generator entry point
 

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -113,7 +113,8 @@ The starter template includes:
 
 That is the core HTML surface most projects want first. The dependency graph can
 also take `(direction := LR | RL | TB | BT)`, and grouped projects expose the
-current graph views through the rendered page's `View` and `Legend` controls.
+current graph views through the rendered page's `View`, `Legend`, and `Graph
+options` controls.
 
 ## Read the generator entry point
 

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -111,7 +111,9 @@ The starter template includes:
 - a dependency graph with `{blueprint_graph}`
 - a progress summary with `{blueprint_summary}`
 
-That is the core HTML surface most projects want first.
+That is the core HTML surface most projects want first. The dependency graph can
+also take `(direction := LR | RL | TB | BT)`, and grouped projects expose the
+current graph views through the rendered page's `View` and `Legend` controls.
 
 ## Read the generator entry point
 

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -462,8 +462,16 @@ The rendered graph page is interactive:
 - a `View` selector switches between the full graph and any derived grouped
   views
 - a `Legend` button opens the current graph legend in a popover
+- a `Graph options` button exposes runtime graph options such as direction
 - when grouped metadata produces multiple children for the same parent, the
   selector includes a synthetic group overview plus one subgraph view per group
+
+The command-side direction and the runtime direction control are compatible:
+
+- `(direction := ...)` chooses the initial graph direction when the page first
+  loads
+- the rendered `Graph options` control lets readers switch among the supported
+  directions without regenerating the site
 
 Group metadata may be used to organize the presentation, but grouping does not
 change dependency edges.

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -451,7 +451,7 @@ or with explicit graph layout options:
 
 ```lean
 {blueprint_graph (direction := LR)}
-{blueprint_graph (direction := LR) (pack := false)}
+{blueprint_graph (direction := LR) (pack := true)}
 ```
 
 Supported directions are `LR`, `RL`, `TB`, and `BT`. When `(direction := ...)`
@@ -459,7 +459,7 @@ is omitted, the command falls back to the
 `verso.blueprint.graph.defaultDirection` option.
 The `(pack := true | false)` option controls Graphviz component packing for
 disconnected graph components. It defaults to
-`verso.blueprint.graph.defaultPack`, which is `true`.
+`verso.blueprint.graph.defaultPack`, which is `false`.
 
 The rendered graph page is interactive:
 
@@ -646,7 +646,7 @@ Current options:
   - sets the fallback graph direction for `blueprint_graph` when
     `(direction := ...)` is omitted
 - `verso.blueprint.graph.defaultPack`
-  - default: `true`
+  - default: `false`
   - sets the fallback Graphviz component packing behavior for
     `blueprint_graph` when `(pack := ...)` is omitted
 - `verso.blueprint.debug.commands`

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -447,31 +447,36 @@ Use it as either:
 {blueprint_graph}
 ```
 
-or with an explicit direction:
+or with explicit graph layout options:
 
 ```lean
 {blueprint_graph (direction := LR)}
+{blueprint_graph (direction := LR) (pack := false)}
 ```
 
 Supported directions are `LR`, `RL`, `TB`, and `BT`. When `(direction := ...)`
 is omitted, the command falls back to the
 `verso.blueprint.graph.defaultDirection` option.
+The `(pack := true | false)` option controls Graphviz component packing for
+disconnected graph components. It defaults to
+`verso.blueprint.graph.defaultPack`, which is `true`.
 
 The rendered graph page is interactive:
 
 - a `View` selector switches between the full graph and any derived grouped
   views
 - a `Legend` button opens the current graph legend in a popover
-- a `Graph options` button exposes runtime graph options such as direction
+- a `Graph options` button exposes runtime graph options such as direction and
+  component packing
 - when grouped metadata produces multiple children for the same parent, the
   selector includes a synthetic group overview plus one subgraph view per group
 
-The command-side direction and the runtime direction control are compatible:
+The command-side options and the runtime graph controls are compatible:
 
 - `(direction := ...)` chooses the initial graph direction when the page first
   loads
 - the rendered `Graph options` control lets readers switch among the supported
-  directions without regenerating the site
+  directions and toggle component packing without regenerating the site
 
 Group metadata may be used to organize the presentation, but grouping does not
 change dependency edges.
@@ -640,6 +645,10 @@ Current options:
   - default: `TB`
   - sets the fallback graph direction for `blueprint_graph` when
     `(direction := ...)` is omitted
+- `verso.blueprint.graph.defaultPack`
+  - default: `true`
+  - sets the fallback Graphviz component packing behavior for
+    `blueprint_graph` when `(pack := ...)` is omitted
 - `verso.blueprint.debug.commands`
   - default: `false`
   - emits debug info logs while elaborating Blueprint graph, summary, and

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -441,6 +441,30 @@ shows an associated Rust code panel below the statement body.
 `blueprint_graph` renders a dependency-oriented view of the current Blueprint
 document.
 
+Use it as either:
+
+```lean
+{blueprint_graph}
+```
+
+or with an explicit direction:
+
+```lean
+{blueprint_graph (direction := LR)}
+```
+
+Supported directions are `LR`, `RL`, `TB`, and `BT`. When `(direction := ...)`
+is omitted, the command falls back to the
+`verso.blueprint.graph.defaultDirection` option.
+
+The rendered graph page is interactive:
+
+- a `View` selector switches between the full graph and any derived grouped
+  views
+- a `Legend` button opens the current graph legend in a popover
+- when grouped metadata produces multiple children for the same parent, the
+  selector includes a synthetic group overview plus one subgraph view per group
+
 Group metadata may be used to organize the presentation, but grouping does not
 change dependency edges.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -97,6 +97,13 @@ From a linked worktree, do not treat `lake build` or `lake test` as the
 default next step. Ordinary `generate` and `validate` runs reuse the current
 worktree `.lake/`; they do not automatically resync it from the root checkout.
 
+The harness now also detects embedded package assets such as `graph.css`,
+`graph.js`, `summary.css`, `bibliography.css`, and `static-web/math.js`
+becoming newer than their owning Lean modules before generator builds run. When
+that happens, it refreshes the owner module mtimes and runs a targeted root
+`lake build` for those owning modules so downstream generated sites do not
+silently serve stale embedded assets.
+
 If you want to refresh the worktree from the root checkout and shared reference
 cache, prefer:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -97,12 +97,13 @@ From a linked worktree, do not treat `lake build` or `lake test` as the
 default next step. Ordinary `generate` and `validate` runs reuse the current
 worktree `.lake/`; they do not automatically resync it from the root checkout.
 
-The harness now also detects embedded package assets such as `graph.css`,
-`graph.js`, `summary.css`, `bibliography.css`, and `static-web/math.js`
-becoming newer than their owning Lean modules before generator builds run. When
-that happens, it refreshes the owner module mtimes and runs a targeted root
-`lake build` for those owning modules so downstream generated sites do not
-silently serve stale embedded assets.
+The harness now proactively refreshes the owner-module mtimes for embedded
+package assets such as `graph.css`, `graph.js`, `summary.css`,
+`bibliography.css`, and `static-web/math.js` before generator builds run, and
+also removes the owner modules' cached build outputs before running a targeted
+root `lake build` for those owning modules. This keeps
+downstream generated sites from silently serving stale embedded assets when
+only the asset files changed.
 
 If you want to refresh the worktree from the root checkout and shared reference
 cache, prefer:

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import tomllib
 
 from scripts.blueprint_harness_projects import HarnessProject
-from scripts.blueprint_harness_utils import lean_low_priority_command, run
+from scripts.blueprint_harness_utils import lean_low_priority_command, rebuild_embedded_asset_owners, run
 
 
 OFFICIAL_BLUEPRINT_REPOSITORY = "leanprover/verso-blueprint"
@@ -647,6 +647,9 @@ def generate_in_repo_command_project(layout, output_root: Path, project: Harness
 
     output_dir = output_dir_for(project, output_root)
     output_dir.mkdir(parents=True, exist_ok=True)
+    rebuilt = rebuild_embedded_asset_owners(layout.package_root)
+    for target in rebuilt:
+        print(f"[blueprint-harness] rebuilt embedded-asset owner target: {target}")
     discard_untracked_project_manifest(project_dir)
     original_manifest = snapshot_tracked_project_manifest(project_dir)
     rewritten_lakefile, original_lakefile_text = maybe_rewrite_in_repo_blueprint_dependency(project_dir, layout.package_root)
@@ -694,6 +697,9 @@ def generate_git_project(layout, output_root: Path, project: HarnessProject, *, 
     # validations must skip them here and build only after rewriting the local
     # checkout dependency to `layout.package_root`.
     cache_warm_build = (not skip_build) and use_shared_reference_checkout()
+    rebuilt = rebuild_embedded_asset_owners(layout.package_root)
+    for target in rebuilt:
+        print(f"[blueprint-harness] rebuilt embedded-asset owner target: {target}")
     cache_dir = sync_reference_cache_checkout(layout, project, warm_build=cache_warm_build)
     checkout_root = cache_dir if use_shared_reference_checkout() else sync_reference_local_checkout(layout, project, cache_dir)
     project_dir = checkout_root / project.project_root

--- a/scripts/blueprint_harness_utils.py
+++ b/scripts/blueprint_harness_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import subprocess
 from pathlib import Path
+import shutil
 
 
 EMBEDDED_ASSET_OWNER_PATHS: tuple[tuple[str, str, str], ...] = (
@@ -49,9 +50,15 @@ def rebuild_embedded_asset_owners(package_root: Path) -> list[str]:
         owner = package_root / owner_rel
         if not asset.exists() or not owner.exists():
             continue
-        if asset.stat().st_mtime_ns <= owner.stat().st_mtime_ns:
-            continue
         os.utime(owner, None)
+        rel_target_stem = Path(*target.split("."))
+        for build_root in (package_root / ".lake" / "build" / "lib" / "lean", package_root / ".lake" / "build" / "ir"):
+            base = build_root / rel_target_stem
+            for artifact in base.parent.glob(base.name + "*"):
+                if artifact.is_dir():
+                    shutil.rmtree(artifact)
+                else:
+                    artifact.unlink()
         if target not in seen_targets:
             touched_targets.append(target)
             seen_targets.add(target)

--- a/scripts/blueprint_harness_utils.py
+++ b/scripts/blueprint_harness_utils.py
@@ -1,7 +1,17 @@
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
+
+
+EMBEDDED_ASSET_OWNER_PATHS: tuple[tuple[str, str, str], ...] = (
+    ("src/VersoBlueprint/Commands/graph.css", "src/VersoBlueprint/Commands/Graph.lean", "VersoBlueprint.Commands.Graph"),
+    ("src/VersoBlueprint/Commands/graph.js", "src/VersoBlueprint/Commands/Graph.lean", "VersoBlueprint.Commands.Graph"),
+    ("src/VersoBlueprint/Commands/summary.css", "src/VersoBlueprint/Commands/Summary.lean", "VersoBlueprint.Commands.Summary"),
+    ("src/VersoBlueprint/Commands/bibliography.css", "src/VersoBlueprint/Commands/Bibliography.lean", "VersoBlueprint.Commands.Bibliography"),
+    ("static-web/math.js", "src/VersoBlueprint/Macros.lean", "VersoBlueprint.Macros"),
+)
 
 
 def format_command(command: list[str]) -> str:
@@ -15,3 +25,36 @@ def run(command: list[str], *, cwd: Path) -> None:
 
 def lean_low_priority_command(package_root: Path, *args: str) -> list[str]:
     return [str(package_root / "scripts" / "lean-low-priority"), *args]
+
+
+def refresh_embedded_asset_owner_mtimes(package_root: Path) -> list[Path]:
+    touched: list[Path] = []
+    for asset_rel, owner_rel, _target in EMBEDDED_ASSET_OWNER_PATHS:
+        asset = package_root / asset_rel
+        owner = package_root / owner_rel
+        if not asset.exists() or not owner.exists():
+            continue
+        if asset.stat().st_mtime_ns <= owner.stat().st_mtime_ns:
+            continue
+        os.utime(owner, None)
+        touched.append(owner)
+    return touched
+
+
+def rebuild_embedded_asset_owners(package_root: Path) -> list[str]:
+    touched_targets: list[str] = []
+    seen_targets: set[str] = set()
+    for asset_rel, owner_rel, target in EMBEDDED_ASSET_OWNER_PATHS:
+        asset = package_root / asset_rel
+        owner = package_root / owner_rel
+        if not asset.exists() or not owner.exists():
+            continue
+        if asset.stat().st_mtime_ns <= owner.stat().st_mtime_ns:
+            continue
+        os.utime(owner, None)
+        if target not in seen_targets:
+            touched_targets.append(target)
+            seen_targets.add(target)
+    if touched_targets:
+        run(lean_low_priority_command(package_root, "lake", "build", *touched_targets), cwd=package_root)
+    return touched_targets

--- a/scripts/blueprint_test_blueprints.py
+++ b/scripts/blueprint_test_blueprints.py
@@ -13,7 +13,7 @@ from scripts.blueprint_harness_references import (
     restore_tracked_project_manifest,
     snapshot_tracked_project_manifest,
 )
-from scripts.blueprint_harness_utils import lean_low_priority_command, run
+from scripts.blueprint_harness_utils import lean_low_priority_command, rebuild_embedded_asset_owners, run
 
 
 TAG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
@@ -197,6 +197,9 @@ def generate_standalone_test_blueprint(package_root: Path, fixture: StandaloneTe
     if not project_dir.exists():
         raise SystemExit(f"[blueprint-test-blueprints] missing project root for `{fixture.slug}`: {project_dir}")
     output_dir.mkdir(parents=True, exist_ok=True)
+    rebuilt = rebuild_embedded_asset_owners(package_root)
+    for target in rebuilt:
+        print(f"[blueprint-harness] rebuilt embedded-asset owner target: {target}")
     original_manifest = snapshot_tracked_project_manifest(project_dir)
     rewritten_lakefile, original_lakefile_text = maybe_rewrite_in_repo_blueprint_dependency(project_dir, package_root)
     try:

--- a/src/VersoBlueprint/Commands/Graph.lean
+++ b/src/VersoBlueprint/Commands/Graph.lean
@@ -60,6 +60,7 @@ def graphDotHeader (rankdir : String) : String :=
   "strict digraph \"\" {\n" ++
   s!"    rankdir={rankdir};\n" ++
   "    bgcolor=\"white\";\n" ++
+  "    pack=true;\n" ++
   "    splines=true;\n" ++
   "    nodesep=0.35;\n" ++
   "    ranksep=0.45;\n" ++

--- a/src/VersoBlueprint/Commands/Graph.lean
+++ b/src/VersoBlueprint/Commands/Graph.lean
@@ -81,7 +81,6 @@ structure GraphRenderVariant where
   key : String
   label : String
   dot : String
-  dotByDirection : Array (String × String) := #[]
   direction : GraphDirection := .TB
   selectOnNodeId : Array (String × String) := #[]
   hoverOnNodeId : Array (String × String) := #[]
@@ -89,12 +88,6 @@ structure GraphRenderVariant where
 deriving Inhabited, ToJson
 
 def allGraphDirections : Array GraphDirection := #[.TB, .LR, .RL, .BT]
-
-def dotsForAllDirections (graph : Graph)
-    (resolveHref : Name → Option String) (resolveGroupTitle : Name → Option String) :
-    Array (String × String) :=
-  allGraphDirections.map fun direction =>
-    (direction.rankdir, graphToDot graph direction resolveHref resolveGroupTitle)
 
 -- Keep this module rebuilt when the embedded graph assets change.
 -- This module owns the embedded graph CSS/JS boundary, so adjacent edits here
@@ -338,7 +331,6 @@ def mkGraphVariants (graphData : GraphBlockData) (resolveHref : Name → Option 
       key := "full"
       label := "Full Graph"
       dot := graphToDot graphData.graph graphData.direction resolveHref resolveGroupTitle
-      dotByDirection := dotsForAllDirections graphData.graph resolveHref resolveGroupTitle
       direction := graphData.direction
       selectOnNodeId := #[]
       hoverOnNodeId := #[]
@@ -351,9 +343,6 @@ def mkGraphVariants (graphData : GraphBlockData) (resolveHref : Name → Option 
       label := "Group View"
       dot := graphToDot (mkParentOverviewGraph graphData.graph parents groupTitles)
         graphData.direction (fun _ => none) (fun _ => none)
-      dotByDirection := dotsForAllDirections
-        (mkParentOverviewGraph graphData.graph parents groupTitles)
-        (fun _ => none) (fun _ => none)
       direction := graphData.direction
       selectOnNodeId := parentVariantRefs
       hoverOnNodeId := parentVariantRefs
@@ -363,7 +352,6 @@ def mkGraphVariants (graphData : GraphBlockData) (resolveHref : Name → Option 
       key := "full"
       label := "Full Graph"
       dot := graphToDot graphData.graph graphData.direction resolveHref resolveGroupTitle
-      dotByDirection := dotsForAllDirections graphData.graph resolveHref resolveGroupTitle
       direction := graphData.direction
       selectOnNodeId := #[]
       hoverOnNodeId := #[]
@@ -377,7 +365,6 @@ def mkGraphVariants (graphData : GraphBlockData) (resolveHref : Name → Option 
         label := title
         dot := graphToDot parentSubgraph
           graphData.direction resolveHref resolveGroupTitle
-        dotByDirection := dotsForAllDirections parentSubgraph resolveHref resolveGroupTitle
         direction := graphData.direction
         selectOnNodeId := #[]
         hoverOnNodeId := #[]
@@ -526,9 +513,11 @@ block_extension Block.graph (graphData : GraphBlockData) where
         | some value => value
         | Option.none => fallbackGraphControlId id "--options"
       let graphDirectionOptions : Array Output.Html :=
-        allGraphDirections.map fun direction => {{
-          <option value={{direction.rankdir}}>{{direction.rankdir}}</option>
-        }}
+        allGraphDirections.map fun direction =>
+          if direction == graphData.direction then
+            {{ <option value={{direction.rankdir}} selected>{{direction.rankdir}}</option> }}
+          else
+            {{ <option value={{direction.rankdir}}>{{direction.rankdir}}</option> }}
       let fallbackDot : String :=
         match graphVariants[0]? with
         | some variant => variant.dot

--- a/src/VersoBlueprint/Commands/Graph.lean
+++ b/src/VersoBlueprint/Commands/Graph.lean
@@ -51,7 +51,7 @@ register_option verso.blueprint.graph.defaultDirection : String := {
 }
 
 register_option verso.blueprint.graph.defaultPack : Bool := {
-  defValue := true
+  defValue := false
   descr := "Default Graphviz component packing for `blueprint_graph` when `(pack := ...)` is omitted"
 }
 
@@ -61,7 +61,7 @@ structure GraphOptions where
   Ask Graphviz to compact disconnected graph components before d3-graphviz fits
   the SVG into the canvas.
   -/
-  pack : Bool := true
+  pack : Bool := false
 deriving Inhabited, BEq, FromJson, ToJson, Quote
 
 structure GraphBlockData where
@@ -81,7 +81,7 @@ instance : FromJson GraphBlockData where
           match v.getObjVal? "direction" with
           | .ok directionJson => fromJson? directionJson
           | .error _ => pure .TB
-        pure { direction, pack := true }
+        pure { direction, pack := false }
     let groupTitles ←
       match v.getObjVal? "groupTitles" with
       | .ok groupTitlesJson => fromJson? groupTitlesJson

--- a/src/VersoBlueprint/Commands/Graph.lean
+++ b/src/VersoBlueprint/Commands/Graph.lean
@@ -50,17 +50,58 @@ register_option verso.blueprint.graph.defaultDirection : String := {
   descr := "Default direction for `blueprint_graph` when `(direction := ...)` is omitted (LR, RL, TB, BT)"
 }
 
+register_option verso.blueprint.graph.defaultPack : Bool := {
+  defValue := true
+  descr := "Default Graphviz component packing for `blueprint_graph` when `(pack := ...)` is omitted"
+}
+
+structure GraphOptions where
+  direction : GraphDirection := .TB
+  /--
+  Ask Graphviz to compact disconnected graph components before d3-graphviz fits
+  the SVG into the canvas.
+  -/
+  pack : Bool := true
+deriving Inhabited, BEq, FromJson, ToJson, Quote
+
 structure GraphBlockData where
   graph : Graph
-  direction : GraphDirection := .TB
+  options : GraphOptions := {}
   groupTitles : Array (Name × String) := #[]
-deriving Inhabited, FromJson, ToJson, Quote
+deriving Inhabited, ToJson, Quote
 
-def graphDotHeader (rankdir : String) : String :=
+instance : FromJson GraphBlockData where
+  fromJson? v := do
+    let graph ← v.getObjVal? "graph" >>= fromJson?
+    let options ←
+      match v.getObjVal? "options" with
+      | .ok optionsJson => fromJson? optionsJson
+      | .error _ =>
+        let direction ←
+          match v.getObjVal? "direction" with
+          | .ok directionJson => fromJson? directionJson
+          | .error _ => pure .TB
+        pure { direction, pack := true }
+    let groupTitles ←
+      match v.getObjVal? "groupTitles" with
+      | .ok groupTitlesJson => fromJson? groupTitlesJson
+      | .error _ => pure #[]
+    pure { graph, options, groupTitles }
+
+def graphPackAttr (pack : Bool) : String :=
+  if pack then "true" else "false"
+
+/-- Common DOT header for rendered Blueprint graphs.
+
+`pack=true` keeps disconnected graph components compact before d3-graphviz fits
+the SVG into the canvas. Without it, sparse multi-component graphs can be
+placed far from the top of the viewport after variant or direction switches.
+-/
+def graphDotHeader (options : GraphOptions := {}) : String :=
   "strict digraph \"\" {\n" ++
-  s!"    rankdir={rankdir};\n" ++
+  s!"    rankdir={options.direction.rankdir};\n" ++
   "    bgcolor=\"white\";\n" ++
-  "    pack=true;\n" ++
+  s!"    pack={graphPackAttr options.pack};\n" ++
   "    splines=true;\n" ++
   "    nodesep=0.35;\n" ++
   "    ranksep=0.45;\n" ++
@@ -69,10 +110,10 @@ def graphDotHeader (rankdir : String) : String :=
   "    graph [fontname=\"Helvetica\"];\n" ++
   "  "
 
-def graphToDot (g : Graph) (direction : GraphDirection := .TB)
+def graphToDot (g : Graph) (options : GraphOptions := {})
     (resolveHref : Name → Option String := fun _ => none)
     (resolveGroupTitle : Name → Option String := fun _ => none) : String :=
-  Informal.Graph.Graph.toDot g (graphDotHeader direction.rankdir)
+  Informal.Graph.Graph.toDot g (graphDotHeader options)
     (groupLabel? := some resolveGroupTitle)
     (refAttrs? := some fun ref =>
     (resolveHref ref).map (fun href => s!"URL=\"{href}\", target=\"_self\""))
@@ -81,7 +122,7 @@ structure GraphRenderVariant where
   key : String
   label : String
   dot : String
-  direction : GraphDirection := .TB
+  options : GraphOptions := {}
   selectOnNodeId : Array (String × String) := #[]
   hoverOnNodeId : Array (String × String) := #[]
   previewKeyByNodeId : Array (String × String) := #[]
@@ -330,8 +371,8 @@ def mkGraphVariants (graphData : GraphBlockData) (resolveHref : Name → Option 
     #[{
       key := "full"
       label := "Full Graph"
-      dot := graphToDot graphData.graph graphData.direction resolveHref resolveGroupTitle
-      direction := graphData.direction
+      dot := graphToDot graphData.graph graphData.options resolveHref resolveGroupTitle
+      options := graphData.options
       selectOnNodeId := #[]
       hoverOnNodeId := #[]
       previewKeyByNodeId := previewKeyByNodeId graphData.graph
@@ -342,8 +383,8 @@ def mkGraphVariants (graphData : GraphBlockData) (resolveHref : Name → Option 
       key := groupVariantKey
       label := "Group View"
       dot := graphToDot (mkParentOverviewGraph graphData.graph parents groupTitles)
-        graphData.direction (fun _ => none) (fun _ => none)
-      direction := graphData.direction
+        graphData.options (fun _ => none) (fun _ => none)
+      options := graphData.options
       selectOnNodeId := parentVariantRefs
       hoverOnNodeId := parentVariantRefs
       previewKeyByNodeId := #[]
@@ -351,8 +392,8 @@ def mkGraphVariants (graphData : GraphBlockData) (resolveHref : Name → Option 
     let fullVariant : GraphRenderVariant := {
       key := "full"
       label := "Full Graph"
-      dot := graphToDot graphData.graph graphData.direction resolveHref resolveGroupTitle
-      direction := graphData.direction
+      dot := graphToDot graphData.graph graphData.options resolveHref resolveGroupTitle
+      options := graphData.options
       selectOnNodeId := #[]
       hoverOnNodeId := #[]
       previewKeyByNodeId := previewKeyByNodeId graphData.graph
@@ -364,8 +405,8 @@ def mkGraphVariants (graphData : GraphBlockData) (resolveHref : Name → Option 
         key := parentVariantKey parent
         label := title
         dot := graphToDot parentSubgraph
-          graphData.direction resolveHref resolveGroupTitle
-        direction := graphData.direction
+          graphData.options resolveHref resolveGroupTitle
+        options := graphData.options
         selectOnNodeId := #[]
         hoverOnNodeId := #[]
         previewKeyByNodeId := previewKeyByNodeId parentSubgraph
@@ -396,10 +437,10 @@ block_extension Block.graph (graphData : GraphBlockData) where
         | .ok gd => pure gd
         | .error _ =>
           match fromJson? (α := Graph) data with
-          | .ok graph => pure { graph, direction := .TB }
+          | .ok graph => pure { graph, options := {}, groupTitles := #[] }
           | .error _ =>
             HtmlT.logError "Malformed data in Block.graph.toHtml"
-            pure { graph := #[], direction := .TB }
+            pure { graph := #[], options := {}, groupTitles := #[] }
       let s ← HtmlT.state
       let resolveHref : Name → Option String := fun ref =>
         Informal.TraversalIndex.Nodes.href? s ref
@@ -498,6 +539,13 @@ block_extension Block.graph (graphData : GraphBlockData) where
             | _ => Option.none with
         | some value => value
         | Option.none => fallbackGraphControlId id "--direction"
+      let graphPackInputId : String :=
+        let attrs := s.htmlId id
+        match attrs.findSome? fun
+            | ("id", value) => some s!"{value}--pack"
+            | _ => Option.none with
+        | some value => value
+        | Option.none => fallbackGraphControlId id "--pack"
       let graphLegendPanelId : String :=
         let attrs := s.htmlId id
         match attrs.findSome? fun
@@ -514,14 +562,17 @@ block_extension Block.graph (graphData : GraphBlockData) where
         | Option.none => fallbackGraphControlId id "--options"
       let graphDirectionOptions : Array Output.Html :=
         allGraphDirections.map fun direction =>
-          if direction == graphData.direction then
+          if direction == graphData.options.direction then
             {{ <option value={{direction.rankdir}} selected>{{direction.rankdir}}</option> }}
           else
             {{ <option value={{direction.rankdir}}>{{direction.rankdir}}</option> }}
+      let graphPackChecked : Array (String × String) :=
+        if graphData.options.pack then #[("checked", "checked")] else #[]
+      let graphPackDefault : String := graphPackAttr graphData.options.pack
       let fallbackDot : String :=
         match graphVariants[0]? with
         | some variant => variant.dot
-        | Option.none => graphToDot graphData.graph graphData.direction resolveHref resolveGroupTitle
+        | Option.none => graphToDot graphData.graph graphData.options resolveHref resolveGroupTitle
       let previewUi := Informal.HoverRender.graphPreviewUi
       let groupHoverUi := Informal.HoverRender.graphGroupPreviewUi
       return {{
@@ -574,13 +625,26 @@ block_extension Block.graph (graphData : GraphBlockData) where
               <select
                 id={{graphDirectionSelectId}}
                 class="bp_graph_controls_select bp_graph_direction_select"
-                data-bp-graph-default-direction={{graphData.direction.rankdir}}
+                data-bp-graph-default-direction={{graphData.options.direction.rankdir}}
               >
                 {{graphDirectionOptions}}
               </select>
+              <label class="bp_graph_option_toggle" for={{graphPackInputId}}>
+                <input
+                  id={{graphPackInputId}}
+                  type="checkbox"
+                  class="bp_graph_pack_input"
+                  data-bp-graph-default-pack={{graphPackDefault}}
+                  {{graphPackChecked}}/>
+                <span>"Pack disconnected components"</span>
+              </label>
             </div>
           </div>
-          <div class="bp_graph_canvas" "data-bp-graph-direction"={{graphData.direction.rankdir}}>
+          <div
+            class="bp_graph_canvas"
+            "data-bp-graph-direction"={{graphData.options.direction.rankdir}}
+            "data-bp-graph-pack"={{graphPackDefault}}
+          >
             <script type="application/json" class="bp-graph-variants">
               {{.text false s!"{graphVariantJson}"}}
             </script>
@@ -625,9 +689,13 @@ instance : FromArgVal GraphDirection Verso.Doc.Elab.PartElabM where
 
 structure BlueprintGraphConfig where
   direction : Option GraphDirection := none
+  pack : Option Bool := none
 
 instance : FromArgs BlueprintGraphConfig Verso.Doc.Elab.PartElabM where
-  fromArgs := BlueprintGraphConfig.mk <$> .named' `direction true
+  fromArgs :=
+    BlueprintGraphConfig.mk <$>
+      .named' `direction true <*>
+      .named' `pack true
 
 def parseGraphDirection (cfg : BlueprintGraphConfig) : Verso.Doc.Elab.PartElabM GraphDirection := do
   match cfg.direction with
@@ -643,8 +711,17 @@ def parseGraphDirection (cfg : BlueprintGraphConfig) : Verso.Doc.Elab.PartElabM 
       pure .TB
   | some direction => pure direction
 
+def parseGraphOptions (cfg : BlueprintGraphConfig) : Verso.Doc.Elab.PartElabM GraphOptions := do
+  let direction ← parseGraphDirection cfg
+  let pack :=
+    cfg.pack.getD <|
+      (← getOptions).get
+        verso.blueprint.graph.defaultPack.name
+        verso.blueprint.graph.defaultPack.defValue
+  pure { direction, pack }
+
 open Verso Doc Elab Syntax in
-def mkGraphPart (stx : Syntax) (endPos : String.Pos.Raw) (direction : GraphDirection := .TB) :
+def mkGraphPart (stx : Syntax) (endPos : String.Pos.Raw) (options : GraphOptions := {}) :
     PartElabM FinishedPart := do
   let titlePreview := "Dependency Graph"
   let titleInlines ← `(inline | "Dependency Graph")
@@ -653,7 +730,7 @@ def mkGraphPart (stx : Syntax) (endPos : String.Pos.Raw) (direction : GraphDirec
   let (graph, groupTitles) ← buildAll
   if verso.blueprint.debug.commands.get (← Lean.getOptions) then
     logInfo m!"Adding {graph.size} nodes"
-  let graphData : GraphBlockData := { graph, direction, groupTitles }
+  let graphData : GraphBlockData := { graph, options, groupTitles }
   let block ← ``(Verso.Doc.Block.other (Informal.Commands.Block.graph $(quote graphData)) #[])
   let subParts := #[]
   pure <| FinishedPart.mk stx expandedTitle titlePreview metadata #[block] subParts endPos
@@ -663,10 +740,10 @@ open Verso Doc Elab Syntax PartElabM in
 public meta def depGraph : PartCommand
   | stx@`(block|command{blueprint_graph $args*}) => do
     let cfg ← Verso.ArgParse.parseThe BlueprintGraphConfig (← parseArgs args)
-    let direction ← parseGraphDirection cfg
+    let options ← parseGraphOptions cfg
     let endPos := stx.getTailPos?.get!
     closePartsUntil 1 endPos
-    addPart (← mkGraphPart stx endPos direction)
+    addPart (← mkGraphPart stx endPos options)
   | _ => (Lean.Elab.throwUnsupportedSyntax : PartElabM Unit)
 
 end Informal.Commands

--- a/src/VersoBlueprint/Commands/Graph.lean
+++ b/src/VersoBlueprint/Commands/Graph.lean
@@ -81,11 +81,20 @@ structure GraphRenderVariant where
   key : String
   label : String
   dot : String
+  dotByDirection : Array (String × String) := #[]
   direction : GraphDirection := .TB
   selectOnNodeId : Array (String × String) := #[]
   hoverOnNodeId : Array (String × String) := #[]
   previewKeyByNodeId : Array (String × String) := #[]
 deriving Inhabited, ToJson
+
+def allGraphDirections : Array GraphDirection := #[.TB, .LR, .RL, .BT]
+
+def dotsForAllDirections (graph : Graph)
+    (resolveHref : Name → Option String) (resolveGroupTitle : Name → Option String) :
+    Array (String × String) :=
+  allGraphDirections.map fun direction =>
+    (direction.rankdir, graphToDot graph direction resolveHref resolveGroupTitle)
 
 -- Keep this module rebuilt when the embedded graph assets change.
 -- This module owns the embedded graph CSS/JS boundary, so adjacent edits here
@@ -329,6 +338,7 @@ def mkGraphVariants (graphData : GraphBlockData) (resolveHref : Name → Option 
       key := "full"
       label := "Full Graph"
       dot := graphToDot graphData.graph graphData.direction resolveHref resolveGroupTitle
+      dotByDirection := dotsForAllDirections graphData.graph resolveHref resolveGroupTitle
       direction := graphData.direction
       selectOnNodeId := #[]
       hoverOnNodeId := #[]
@@ -341,6 +351,9 @@ def mkGraphVariants (graphData : GraphBlockData) (resolveHref : Name → Option 
       label := "Group View"
       dot := graphToDot (mkParentOverviewGraph graphData.graph parents groupTitles)
         graphData.direction (fun _ => none) (fun _ => none)
+      dotByDirection := dotsForAllDirections
+        (mkParentOverviewGraph graphData.graph parents groupTitles)
+        (fun _ => none) (fun _ => none)
       direction := graphData.direction
       selectOnNodeId := parentVariantRefs
       hoverOnNodeId := parentVariantRefs
@@ -350,6 +363,7 @@ def mkGraphVariants (graphData : GraphBlockData) (resolveHref : Name → Option 
       key := "full"
       label := "Full Graph"
       dot := graphToDot graphData.graph graphData.direction resolveHref resolveGroupTitle
+      dotByDirection := dotsForAllDirections graphData.graph resolveHref resolveGroupTitle
       direction := graphData.direction
       selectOnNodeId := #[]
       hoverOnNodeId := #[]
@@ -363,6 +377,7 @@ def mkGraphVariants (graphData : GraphBlockData) (resolveHref : Name → Option 
         label := title
         dot := graphToDot parentSubgraph
           graphData.direction resolveHref resolveGroupTitle
+        dotByDirection := dotsForAllDirections parentSubgraph resolveHref resolveGroupTitle
         direction := graphData.direction
         selectOnNodeId := #[]
         hoverOnNodeId := #[]
@@ -489,6 +504,13 @@ block_extension Block.graph (graphData : GraphBlockData) where
             | _ => Option.none with
         | some value => value
         | Option.none => fallbackGraphControlId id "--view"
+      let graphDirectionSelectId : String :=
+        let attrs := s.htmlId id
+        match attrs.findSome? fun
+            | ("id", value) => some s!"{value}--direction"
+            | _ => Option.none with
+        | some value => value
+        | Option.none => fallbackGraphControlId id "--direction"
       let graphLegendPanelId : String :=
         let attrs := s.htmlId id
         match attrs.findSome? fun
@@ -496,6 +518,17 @@ block_extension Block.graph (graphData : GraphBlockData) where
             | _ => Option.none with
         | some value => value
         | Option.none => fallbackGraphControlId id "--legend"
+      let graphOptionsPanelId : String :=
+        let attrs := s.htmlId id
+        match attrs.findSome? fun
+            | ("id", value) => some s!"{value}--options"
+            | _ => Option.none with
+        | some value => value
+        | Option.none => fallbackGraphControlId id "--options"
+      let graphDirectionOptions : Array Output.Html :=
+        allGraphDirections.map fun direction => {{
+          <option value={{direction.rankdir}}>{{direction.rankdir}}</option>
+        }}
       let fallbackDot : String :=
         match graphVariants[0]? with
         | some variant => variant.dot
@@ -520,6 +553,17 @@ block_extension Block.graph (graphData : GraphBlockData) where
                 {{graphVariantOptions}}
               </select>
             </div>
+            <div class="bp_graph_controls_actions">
+              <button
+                type="button"
+                class="bp_graph_controls_button bp_graph_options_button"
+                aria-haspopup="dialog"
+                aria-expanded="false"
+                aria-controls={{graphOptionsPanelId}}
+              >
+                "Graph options"
+              </button>
+            </div>
           </div>
           <div id={{graphLegendPanelId}} class="bp_graph_legend_popover" hidden>
             <div class="bp_graph_legend_popover_header">
@@ -529,6 +573,22 @@ block_extension Block.graph (graphData : GraphBlockData) where
             <div class="bp_graph_legend_popover_body">
               {{fullLegendHtml}}
               {{groupLegendHtml}}
+            </div>
+          </div>
+          <div id={{graphOptionsPanelId}} class="bp_graph_options_popover" hidden>
+            <div class="bp_graph_options_popover_header">
+              <span class="bp_graph_options_popover_title">"Graph options"</span>
+              <button type="button" class="bp_graph_options_popover_close" aria-label="Close graph options">"Close"</button>
+            </div>
+            <div class="bp_graph_options_popover_body">
+              <label class="bp_graph_controls_label" for={{graphDirectionSelectId}}>"Direction"</label>
+              <select
+                id={{graphDirectionSelectId}}
+                class="bp_graph_controls_select bp_graph_direction_select"
+                data-bp-graph-default-direction={{graphData.direction.rankdir}}
+              >
+                {{graphDirectionOptions}}
+              </select>
             </div>
           </div>
           <div class="bp_graph_canvas" "data-bp-graph-direction"={{graphData.direction.rankdir}}>

--- a/src/VersoBlueprint/Commands/graph.css
+++ b/src/VersoBlueprint/Commands/graph.css
@@ -219,6 +219,28 @@
   justify-self: start;
 }
 
+.bp_graph_option_toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+  color: var(--bp-color-text-strong);
+  font-size: 0.84rem;
+  font-weight: 600;
+  line-height: 1.25;
+  cursor: pointer;
+}
+
+.bp_graph_pack_input {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--bp-color-accent, #0f766e);
+}
+
+.bp_graph_pack_input:focus-visible {
+  outline: 2px solid var(--bp-color-accent, #0f766e);
+  outline-offset: 2px;
+}
+
 .bp_graph_controls_select:focus-visible {
   outline: 2px solid var(--bp-color-accent, #0f766e);
   outline-offset: 2px;

--- a/src/VersoBlueprint/Commands/graph.css
+++ b/src/VersoBlueprint/Commands/graph.css
@@ -430,13 +430,15 @@ html[data-bp-style="modern"] .bp_graph_controls_button {
   border-color: var(--bp-color-modern-border);
 }
 
-html[data-bp-style="modern"] .bp_graph_legend_popover {
+html[data-bp-style="modern"] .bp_graph_legend_popover,
+html[data-bp-style="modern"] .bp_graph_options_popover {
   background: var(--bp-color-surface-modern);
   border: 1px solid var(--bp-color-modern-border);
   border-radius: var(--bp-radius-2xl);
 }
 
-html[data-bp-style="modern"] .bp_graph_legend_popover_header {
+html[data-bp-style="modern"] .bp_graph_legend_popover_header,
+html[data-bp-style="modern"] .bp_graph_options_popover_header {
   border-bottom-color: var(--bp-color-modern-border);
 }
 
@@ -450,7 +452,8 @@ html[data-bp-style="bold"] .bp_graph_controls_button {
   box-shadow: 0 3px 0 rgba(15, 23, 42, 0.14);
 }
 
-html[data-bp-style="bold"] .bp_graph_legend_popover {
+html[data-bp-style="bold"] .bp_graph_legend_popover,
+html[data-bp-style="bold"] .bp_graph_options_popover {
   background:
     radial-gradient(circle at 100% 0%, var(--bp-color-bold-surface-glow-1), transparent 36%),
     radial-gradient(circle at 0% 100%, var(--bp-color-bold-surface-glow-2), transparent 32%),
@@ -460,7 +463,8 @@ html[data-bp-style="bold"] .bp_graph_legend_popover {
   box-shadow: var(--bp-shadow-bold);
 }
 
-html[data-bp-style="bold"] .bp_graph_legend_popover_header {
+html[data-bp-style="bold"] .bp_graph_legend_popover_header,
+html[data-bp-style="bold"] .bp_graph_options_popover_header {
   border-bottom-color: rgba(15, 23, 42, 0.2);
 }
 
@@ -481,6 +485,12 @@ html[data-bp-style="bold"] .bp_graph_legend_swatch {
 
 @media (max-width: 720px) {
   .bp_graph_legend_popover {
+    left: 0;
+    right: 0;
+    width: auto;
+  }
+
+  .bp_graph_options_popover {
     left: 0;
     right: 0;
     width: auto;

--- a/src/VersoBlueprint/Commands/graph.css
+++ b/src/VersoBlueprint/Commands/graph.css
@@ -182,8 +182,8 @@
 }
 
 .bp_graph_controls_primary {
-  flex: 1 1 22rem;
-  min-width: min(100%, 22rem);
+  flex: 1 1 auto;
+  min-width: min(100%, 20rem);
 }
 
 .bp_graph_controls_label {
@@ -194,8 +194,7 @@
 }
 
 .bp_graph_controls_select {
-  flex: 1 1 18rem;
-  min-width: min(28rem, 88vw);
+  min-width: 0;
   max-width: 100%;
   border: 1px solid var(--bp-color-border);
   border-radius: var(--bp-radius-md);
@@ -204,6 +203,20 @@
   padding: 0.35rem 0.55rem;
   font-size: 0.87rem;
   line-height: 1.2;
+}
+
+.bp_graph_view_select {
+  flex: 1 1 clamp(15rem, 30vw, 22rem);
+  width: clamp(15rem, 30vw, 22rem);
+  min-width: min(100%, 15rem);
+}
+
+.bp_graph_direction_select {
+  display: inline-block;
+  width: max-content;
+  min-width: 0;
+  max-width: 100%;
+  justify-self: start;
 }
 
 .bp_graph_controls_select:focus-visible {
@@ -264,8 +277,9 @@
   top: 0;
   right: 0;
   z-index: 26;
-  width: min(18rem, calc(100% - 1.8rem));
-  max-width: 100%;
+  width: fit-content;
+  min-width: 0;
+  max-width: min(18rem, calc(100% - 1.8rem));
   border: 1px solid var(--bp-color-border-soft);
   border-radius: var(--bp-radius-xl);
   background: rgba(255, 255, 255, 0.98);
@@ -352,6 +366,9 @@
   display: grid;
   gap: 0.45rem;
   padding: 0.55rem 0.7rem 0.7rem;
+  justify-items: start;
+  width: max-content;
+  min-width: 0;
 }
 
 .bp_graph_legend_group {

--- a/src/VersoBlueprint/Commands/graph.css
+++ b/src/VersoBlueprint/Commands/graph.css
@@ -240,6 +240,10 @@
   background: var(--bp-color-surface-subtle);
 }
 
+.bp_graph_options_button[aria-expanded="true"] {
+  background: var(--bp-color-surface-subtle);
+}
+
 .bp_graph_legend_popover {
   position: absolute;
   top: 0;
@@ -255,11 +259,43 @@
   backdrop-filter: blur(3px);
 }
 
+.bp_graph_options_popover {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 26;
+  width: min(18rem, calc(100% - 1.8rem));
+  max-width: 100%;
+  border: 1px solid var(--bp-color-border-soft);
+  border-radius: var(--bp-radius-xl);
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow: var(--bp-shadow-lg);
+  overflow: auto;
+  backdrop-filter: blur(3px);
+}
+
 .bp_graph_legend_popover[hidden] {
   display: none;
 }
 
+.bp_graph_options_popover[hidden] {
+  display: none;
+}
+
 .bp_graph_legend_popover_header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.65rem 0.7rem 0.5rem;
+  border-bottom: 1px solid var(--bp-color-border-soft);
+  background: inherit;
+}
+
+.bp_graph_options_popover_header {
   position: sticky;
   top: 0;
   z-index: 1;
@@ -278,6 +314,12 @@
   color: var(--bp-color-text-strong);
 }
 
+.bp_graph_options_popover_title {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--bp-color-text-strong);
+}
+
 .bp_graph_legend_popover_close {
   border: 1px solid var(--bp-color-border);
   border-radius: var(--bp-radius-sm);
@@ -290,7 +332,25 @@
   cursor: pointer;
 }
 
+.bp_graph_options_popover_close {
+  border: 1px solid var(--bp-color-border);
+  border-radius: var(--bp-radius-sm);
+  background: var(--bp-color-surface);
+  color: var(--bp-color-text-strong);
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1;
+  padding: 0.25rem 0.45rem;
+  cursor: pointer;
+}
+
 .bp_graph_legend_popover_body {
+  padding: 0.55rem 0.7rem 0.7rem;
+}
+
+.bp_graph_options_popover_body {
+  display: grid;
+  gap: 0.45rem;
   padding: 0.55rem 0.7rem 0.7rem;
 }
 

--- a/src/VersoBlueprint/Commands/graph.js
+++ b/src/VersoBlueprint/Commands/graph.js
@@ -27,6 +27,33 @@
     return "TB";
   }
 
+  function normalizeGraphPack(rawPack) {
+    if (rawPack === false) return false;
+    if (rawPack === true) return true;
+    const pack = rawPack === null || typeof rawPack === "undefined" ? "" : String(rawPack).trim().toLowerCase();
+    if (pack === "false" || pack === "0" || pack === "no" || pack === "off") {
+      return false;
+    }
+    return true;
+  }
+
+  function normalizeGraphOptions(rawOptions) {
+    const options = rawOptions && typeof rawOptions === "object" ? rawOptions : {};
+    return {
+      direction: normalizeGraphDirection(options.direction),
+      pack: normalizeGraphPack(Object.prototype.hasOwnProperty.call(options, "pack") ? options.pack : true)
+    };
+  }
+
+  function graphPackAttr(pack) {
+    return normalizeGraphPack(pack) ? "true" : "false";
+  }
+
+  function graphOptionsKey(options) {
+    const normalized = normalizeGraphOptions(options);
+    return normalized.direction + "|" + graphPackAttr(normalized.pack);
+  }
+
   function readGraphCanvasFlowBottom(graphRoot) {
     if (!(graphRoot instanceof Element)) return 0;
     const flowContainer = graphRoot.closest(".content-wrapper") || graphRoot.closest("main");
@@ -107,32 +134,41 @@
     const dotTxt = graphContainer.select("script.dot-source").text().trim();
     if (!dotTxt) return [];
     const fallbackDirection = normalizeGraphDirection(graphContainer.attr("data-bp-graph-direction"));
+    const fallbackPack = normalizeGraphPack(graphContainer.attr("data-bp-graph-pack"));
     return [{
       key: "full",
       label: "Full Graph",
       dot: dotTxt,
-      direction: fallbackDirection,
+      options: { direction: fallbackDirection, pack: fallbackPack },
       selectOnNodeId: [],
       hoverOnNodeId: []
     }];
   }
 
-  function dotWithGraphDirection(dot, direction) {
-    const source = String(dot || "").trim();
+  function dotWithGraphAttribute(dot, name, value) {
+    const source = String(dot || "");
     if (!source) return "";
-    const desired = normalizeGraphDirection(direction);
-    const rankdirPattern = /(^\s*rankdir\s*=\s*)(LR|RL|TB|BT)(\s*;)/m;
-    if (rankdirPattern.test(source)) {
-      return source.replace(rankdirPattern, "$1" + desired + "$3");
+    const attrPattern = new RegExp("(^\\s*" + name + "\\s*=\\s*)([^;]+)(\\s*;)", "mi");
+    if (attrPattern.test(source)) {
+      return source.replace(attrPattern, "$1" + value + "$3");
     }
     const openBrace = source.indexOf("{");
     if (openBrace < 0) return source;
-    return source.slice(0, openBrace + 1) + "\n    rankdir=" + desired + ";" + source.slice(openBrace + 1);
+    return source.slice(0, openBrace + 1) + "\n    " + name + "=" + value + ";" + source.slice(openBrace + 1);
   }
 
-  function dotForVariantDirection(variant, direction) {
+  function dotWithGraphOptions(dot, options) {
+    const source = String(dot || "").trim();
+    if (!source) return "";
+    const normalized = normalizeGraphOptions(options);
+    let updated = dotWithGraphAttribute(source, "rankdir", normalized.direction);
+    updated = dotWithGraphAttribute(updated, "pack", graphPackAttr(normalized.pack));
+    return updated;
+  }
+
+  function dotForVariantOptions(variant, options) {
     if (!variant || typeof variant !== "object") return "";
-    return dotWithGraphDirection(variant.dot, direction);
+    return dotWithGraphOptions(variant.dot, options);
   }
 
   function graphNodeLabel(node) {
@@ -167,7 +203,7 @@
       groupHoverShownNodeId: "",
       graphviz: null,
       renderedVariantKey: "",
-      renderedDirectionKey: "",
+      renderedOptionsKey: "",
       canvasAutoHeight: null,
       canvasUserResized: false,
       renderToken: 0,
@@ -238,7 +274,7 @@
       graphState.lastCanvasWidth = 0;
       graphState.lastCanvasHeight = 0;
       graphState.renderedVariantKey = "";
-      graphState.renderedDirectionKey = "";
+      graphState.renderedOptionsKey = "";
     }
   }
 
@@ -733,6 +769,7 @@
         const graphState = ensureGraphBlockState(graphBlock);
         const selector = graphBlock.querySelector(".bp_graph_view_select");
         const directionSelector = graphBlock.querySelector(".bp_graph_direction_select");
+        const packInput = graphBlock.querySelector(".bp_graph_pack_input");
         const previewMap = collectPreviewTemplates(graphBlock);
         const previewPanelNode = graphBlock.querySelector(".bp_graph_preview");
         const previewClose = previewPanelNode
@@ -777,7 +814,11 @@
           const key = String(variant.key || "").trim();
           const label = String(variant.label || key).trim();
           const dot = String(variant.dot || "").trim();
-          const direction = normalizeGraphDirection(variant.direction);
+          const options = normalizeGraphOptions(
+            variant.options && typeof variant.options === "object"
+              ? variant.options
+              : { direction: variant.direction, pack: variant.pack }
+          );
           const selectOnNodeId = Array.isArray(variant.selectOnNodeId) ? variant.selectOnNodeId : [];
           const hoverOnNodeId = Array.isArray(variant.hoverOnNodeId) ? variant.hoverOnNodeId : [];
           const previewKeyByNodeId = Array.isArray(variant.previewKeyByNodeId) ? variant.previewKeyByNodeId : [];
@@ -786,7 +827,7 @@
             key: key,
             label: label || key,
             dot: dot,
-            direction: direction,
+            options: options,
             selectOnNodeId: selectOnNodeId,
             hoverOnNodeId: hoverOnNodeId,
             previewKeyByNodeId: new Map(previewKeyByNodeId)
@@ -809,12 +850,16 @@
           activeKey = selector.value;
         }
         if (selector) selector.value = activeKey;
-        let activeDirection = normalizeGraphDirection(
-          directionSelector
+        let activeOptions = normalizeGraphOptions({
+          direction: directionSelector
             ? directionSelector.getAttribute("data-bp-graph-default-direction")
-            : graphContainer.attr("data-bp-graph-direction")
-        );
-        if (directionSelector) directionSelector.value = activeDirection;
+            : graphContainer.attr("data-bp-graph-direction"),
+          pack: packInput
+            ? packInput.getAttribute("data-bp-graph-default-pack")
+            : graphContainer.attr("data-bp-graph-pack")
+        });
+        if (directionSelector) directionSelector.value = activeOptions.direction;
+        if (packInput) packInput.checked = activeOptions.pack;
         syncLegend(graphBlock, activeKey);
         const legendPopover = bindLegendPopover(graphBlock);
         const optionsPopover = bindOptionsPopover(graphBlock);
@@ -824,8 +869,8 @@
           return variantsByKey.get(activeKey) || fallback;
         };
 
-        const getActiveDirection = function () {
-          return normalizeGraphDirection(activeDirection);
+        const getActiveOptions = function () {
+          return normalizeGraphOptions(activeOptions);
         };
 
         const groupHoverPanel = graphBlock.querySelector(".bp_group_hover_preview");
@@ -854,7 +899,7 @@
               groupHoverGraphviz
                 .width(width)
                 .height(height)
-                .renderDot(dotForVariantDirection(variant, getActiveDirection()));
+                .renderDot(dotForVariantOptions(variant, getActiveOptions()));
             },
             positionPanel: makeGroupPanelPositioner(graphBlock, groupHoverBehavior),
             onHide: function () {
@@ -948,12 +993,29 @@
           renderGraph();
         };
 
-        const switchDirection = function (nextDirection) {
-          const normalized = normalizeGraphDirection(nextDirection);
-          if (normalized === activeDirection) return;
-          activeDirection = normalized;
-          if (directionSelector) directionSelector.value = normalized;
+        const switchGraphOptions = function (nextOptions) {
+          const rawNextOptions = nextOptions && typeof nextOptions === "object" ? nextOptions : {};
+          const normalized = normalizeGraphOptions({
+            direction: Object.prototype.hasOwnProperty.call(rawNextOptions, "direction")
+              ? rawNextOptions.direction
+              : activeOptions.direction,
+            pack: Object.prototype.hasOwnProperty.call(rawNextOptions, "pack")
+              ? rawNextOptions.pack
+              : activeOptions.pack
+          });
+          if (graphOptionsKey(normalized) === graphOptionsKey(activeOptions)) return;
+          activeOptions = normalized;
+          if (directionSelector) directionSelector.value = normalized.direction;
+          if (packInput) packInput.checked = normalized.pack;
           renderGraph();
+        };
+
+        const switchDirection = function (nextDirection) {
+          switchGraphOptions({ direction: nextDirection });
+        };
+
+        const switchPack = function (nextPack) {
+          switchGraphOptions({ pack: nextPack });
         };
 
         const scheduleRender = debounce(function () {
@@ -962,8 +1024,9 @@
 
         function renderGraph() {
           const activeVariant = getActiveVariant();
-          const direction = getActiveDirection();
-          const dot = dotForVariantDirection(activeVariant, direction);
+          const options = getActiveOptions();
+          const optionsKey = graphOptionsKey(options);
+          const dot = dotForVariantOptions(activeVariant, options);
           if (!activeVariant || !dot) return;
           graphState.renderToken += 1;
           const renderToken = graphState.renderToken;
@@ -1000,16 +1063,17 @@
           if (
             (graphState.renderedVariantKey &&
               graphState.renderedVariantKey !== activeVariant.key) ||
-            (graphState.renderedDirectionKey &&
-              graphState.renderedDirectionKey !== direction)
+            (graphState.renderedOptionsKey &&
+              graphState.renderedOptionsKey !== optionsKey)
           ) {
             resetGraphvizForVariant(graphRoot, graphState);
           }
           const gv = graphState.graphviz || graphContainer.graphviz();
           graphState.graphviz = gv;
           graphState.renderedVariantKey = activeVariant.key;
-          graphState.renderedDirectionKey = direction;
-          graphRoot.setAttribute("data-bp-active-direction", direction);
+          graphState.renderedOptionsKey = optionsKey;
+          graphRoot.setAttribute("data-bp-active-direction", options.direction);
+          graphRoot.setAttribute("data-bp-active-pack", graphPackAttr(options.pack));
           gv
             .zoom(true)
             .width(width)
@@ -1033,6 +1097,11 @@
           directionSelector.addEventListener("change", function () {
             switchDirection(directionSelector.value);
             if (optionsPopover) optionsPopover.close();
+          });
+        }
+        if (packInput) {
+          packInput.addEventListener("change", function () {
+            switchPack(packInput.checked);
           });
         }
 

--- a/src/VersoBlueprint/Commands/graph.js
+++ b/src/VersoBlueprint/Commands/graph.js
@@ -111,10 +111,42 @@
       key: "full",
       label: "Full Graph",
       dot: dotTxt,
+      dotByDirection: [[fallbackDirection, dotTxt]],
       direction: fallbackDirection,
       selectOnNodeId: [],
       hoverOnNodeId: []
     }];
+  }
+
+  function dotByDirectionMap(dotByDirection, fallbackDirection, fallbackDot) {
+    const map = new Map();
+    if (Array.isArray(dotByDirection)) {
+      dotByDirection.forEach(function (entry) {
+        if (!Array.isArray(entry) || entry.length < 2) return;
+        const direction = normalizeGraphDirection(entry[0]);
+        const dot = String(entry[1] || "").trim();
+        if (!dot) return;
+        map.set(direction, dot);
+      });
+    }
+    if (fallbackDot) {
+      const normalizedFallback = normalizeGraphDirection(fallbackDirection);
+      if (!map.has(normalizedFallback)) {
+        map.set(normalizedFallback, fallbackDot);
+      }
+    }
+    return map;
+  }
+
+  function dotForVariantDirection(variant, direction) {
+    if (!variant || typeof variant !== "object") return "";
+    const desired = normalizeGraphDirection(direction);
+    const dotMap = variant.dotByDirection instanceof Map ? variant.dotByDirection : null;
+    if (dotMap) {
+      const matched = dotMap.get(desired);
+      if (matched) return matched;
+    }
+    return String(variant.dot || "").trim();
   }
 
   function graphNodeLabel(node) {
@@ -149,6 +181,7 @@
       groupHoverShownNodeId: "",
       graphviz: null,
       renderedVariantKey: "",
+      renderedDirectionKey: "",
       canvasAutoHeight: null,
       canvasUserResized: false,
       renderToken: 0,
@@ -206,6 +239,7 @@
       graphState.lastCanvasWidth = 0;
       graphState.lastCanvasHeight = 0;
       graphState.renderedVariantKey = "";
+      graphState.renderedDirectionKey = "";
     }
   }
 
@@ -608,49 +642,49 @@
     if (groupLegend) groupLegend.hidden = !showGroupLegend;
   }
 
-  function bindLegendPopover(graphBlock) {
-    const legendButton = graphBlock.querySelector(".bp_graph_legend_button");
-    const legendPanel = graphBlock.querySelector(".bp_graph_legend_popover");
-    const legendClose = legendPanel
-      ? legendPanel.querySelector(".bp_graph_legend_popover_close")
+  function bindAnchoredPopover(graphBlock, buttonSelector, panelSelector, closeSelector, boundAttr) {
+    const triggerButton = graphBlock.querySelector(buttonSelector);
+    const popoverPanel = graphBlock.querySelector(panelSelector);
+    const popoverClose = popoverPanel
+      ? popoverPanel.querySelector(closeSelector)
       : null;
-    if (!legendButton || !legendPanel) return null;
+    if (!triggerButton || !popoverPanel) return null;
 
     const position = function () {
       const blockRect = graphBlock.getBoundingClientRect();
-      const buttonRect = legendButton.getBoundingClientRect();
+      const buttonRect = triggerButton.getBoundingClientRect();
       const top = Math.max(0, Math.round(buttonRect.bottom - blockRect.top + 8));
       const right = Math.max(0, Math.round(blockRect.right - buttonRect.right));
-      legendPanel.style.top = top + "px";
-      legendPanel.style.right = right + "px";
+      popoverPanel.style.top = top + "px";
+      popoverPanel.style.right = right + "px";
     };
 
     const setOpen = function (isOpen) {
       if (isOpen) position();
-      legendPanel.hidden = !isOpen;
-      legendButton.setAttribute("aria-expanded", isOpen ? "true" : "false");
+      popoverPanel.hidden = !isOpen;
+      triggerButton.setAttribute("aria-expanded", isOpen ? "true" : "false");
     };
 
     setOpen(false);
-    if (legendButton.getAttribute("data-bp-legend-bound") === "1") {
+    if (triggerButton.getAttribute(boundAttr) === "1") {
       return {
         open: function () { setOpen(true); },
         close: function () { setOpen(false); },
         position: position
       };
     }
-    legendButton.setAttribute("data-bp-legend-bound", "1");
+    triggerButton.setAttribute(boundAttr, "1");
 
-    legendButton.addEventListener("click", function () {
-      setOpen(legendPanel.hidden);
+    triggerButton.addEventListener("click", function () {
+      setOpen(popoverPanel.hidden);
     });
-    if (legendClose) {
-      legendClose.addEventListener("click", function () {
+    if (popoverClose) {
+      popoverClose.addEventListener("click", function () {
         setOpen(false);
       });
     }
     document.addEventListener("pointerdown", function (ev) {
-      if (legendPanel.hidden) return;
+      if (popoverPanel.hidden) return;
       const target = ev.target;
       if (!(target instanceof Node)) return;
       if (graphBlock.contains(target)) return;
@@ -662,6 +696,26 @@
       close: function () { setOpen(false); },
       position: position
     };
+  }
+
+  function bindLegendPopover(graphBlock) {
+    return bindAnchoredPopover(
+      graphBlock,
+      ".bp_graph_legend_button",
+      ".bp_graph_legend_popover",
+      ".bp_graph_legend_popover_close",
+      "data-bp-legend-bound"
+    );
+  }
+
+  function bindOptionsPopover(graphBlock) {
+    return bindAnchoredPopover(
+      graphBlock,
+      ".bp_graph_options_button",
+      ".bp_graph_options_popover",
+      ".bp_graph_options_popover_close",
+      "data-bp-options-bound"
+    );
   }
 
   Promise.resolve()
@@ -679,6 +733,7 @@
         if (graphContainer.empty()) return;
         const graphState = ensureGraphBlockState(graphBlock);
         const selector = graphBlock.querySelector(".bp_graph_view_select");
+        const directionSelector = graphBlock.querySelector(".bp_graph_direction_select");
         const previewMap = collectPreviewTemplates(graphBlock);
         const previewPanelNode = graphBlock.querySelector(".bp_graph_preview");
         const previewClose = previewPanelNode
@@ -724,6 +779,7 @@
           const label = String(variant.label || key).trim();
           const dot = String(variant.dot || "").trim();
           const direction = normalizeGraphDirection(variant.direction);
+          const dotByDirection = dotByDirectionMap(variant.dotByDirection, direction, dot);
           const selectOnNodeId = Array.isArray(variant.selectOnNodeId) ? variant.selectOnNodeId : [];
           const hoverOnNodeId = Array.isArray(variant.hoverOnNodeId) ? variant.hoverOnNodeId : [];
           const previewKeyByNodeId = Array.isArray(variant.previewKeyByNodeId) ? variant.previewKeyByNodeId : [];
@@ -732,6 +788,7 @@
             key: key,
             label: label || key,
             dot: dot,
+            dotByDirection: dotByDirection,
             direction: direction,
             selectOnNodeId: selectOnNodeId,
             hoverOnNodeId: hoverOnNodeId,
@@ -755,12 +812,23 @@
           activeKey = selector.value;
         }
         if (selector) selector.value = activeKey;
+        let activeDirection = normalizeGraphDirection(
+          directionSelector && directionSelector.value
+            ? directionSelector.value
+            : (directionSelector && directionSelector.getAttribute("data-bp-graph-default-direction"))
+        );
+        if (directionSelector) directionSelector.value = activeDirection;
         syncLegend(graphBlock, activeKey);
         const legendPopover = bindLegendPopover(graphBlock);
+        const optionsPopover = bindOptionsPopover(graphBlock);
 
         const getActiveVariant = function () {
           const fallback = variantsByKey.get("full") || variants[0];
           return variantsByKey.get(activeKey) || fallback;
+        };
+
+        const getActiveDirection = function () {
+          return normalizeGraphDirection(activeDirection);
         };
 
         const groupHoverPanel = graphBlock.querySelector(".bp_group_hover_preview");
@@ -789,7 +857,7 @@
               groupHoverGraphviz
                 .width(width)
                 .height(height)
-                .renderDot(variant.dot);
+                .renderDot(dotForVariantDirection(variant, getActiveDirection()));
             },
             positionPanel: makeGroupPanelPositioner(graphBlock, groupHoverBehavior),
             onHide: function () {
@@ -816,6 +884,9 @@
             if (legendPopover && !graphBlock.querySelector(".bp_graph_legend_popover").hidden) {
               legendPopover.position();
             }
+            if (optionsPopover && !graphBlock.querySelector(".bp_graph_options_popover").hidden) {
+              optionsPopover.position();
+            }
             if (
               graphState.previewController &&
               graphState.previewController.behavior &&
@@ -838,6 +909,7 @@
           window.addEventListener("keydown", function (ev) {
             if (ev.key !== "Escape") return;
             if (legendPopover) legendPopover.close();
+            if (optionsPopover) optionsPopover.close();
             if (graphState.groupHoverController) graphState.groupHoverController.hide();
             if (graphState.previewController) graphState.previewController.hide();
           });
@@ -879,13 +951,23 @@
           renderGraph();
         };
 
+        const switchDirection = function (nextDirection) {
+          const normalized = normalizeGraphDirection(nextDirection);
+          if (normalized === activeDirection) return;
+          activeDirection = normalized;
+          if (directionSelector) directionSelector.value = normalized;
+          renderGraph();
+        };
+
         const scheduleRender = debounce(function () {
           renderGraph();
         }, 180);
 
         function renderGraph() {
           const activeVariant = getActiveVariant();
-          if (!activeVariant || !activeVariant.dot) return;
+          const direction = getActiveDirection();
+          const dot = dotForVariantDirection(activeVariant, direction);
+          if (!activeVariant || !dot) return;
           graphState.renderToken += 1;
           const renderToken = graphState.renderToken;
           syncLegend(graphBlock, activeVariant.key);
@@ -919,14 +1001,18 @@
           };
 
           if (
-            graphState.renderedVariantKey &&
-            graphState.renderedVariantKey !== activeVariant.key
+            (graphState.renderedVariantKey &&
+              graphState.renderedVariantKey !== activeVariant.key) ||
+            (graphState.renderedDirectionKey &&
+              graphState.renderedDirectionKey !== direction)
           ) {
             resetGraphvizForVariant(graphRoot, graphState);
           }
           const gv = graphState.graphviz || graphContainer.graphviz();
           graphState.graphviz = gv;
           graphState.renderedVariantKey = activeVariant.key;
+          graphState.renderedDirectionKey = direction;
+          graphRoot.setAttribute("data-bp-active-direction", direction);
           gv
             .zoom(true)
             .width(width)
@@ -935,7 +1021,7 @@
             .on("end", function () {
               finalizeRender();
             });
-          gv.renderDot(activeVariant.dot);
+          gv.renderDot(dot);
           setTimeout(function () {
             finalizeRender();
           }, 120);
@@ -944,6 +1030,12 @@
         if (selector) {
           selector.addEventListener("change", function () {
             switchVariant(selector.value);
+          });
+        }
+        if (directionSelector) {
+          directionSelector.addEventListener("change", function () {
+            switchDirection(directionSelector.value);
+            if (optionsPopover) optionsPopover.close();
           });
         }
 

--- a/src/VersoBlueprint/Commands/graph.js
+++ b/src/VersoBlueprint/Commands/graph.js
@@ -214,6 +214,19 @@
   }
 
   function resetGraphvizForVariant(graphRoot, graphState) {
+    let cachedGraphviz = null;
+    if (graphState && typeof graphState === "object" && graphState.graphviz) {
+      cachedGraphviz = graphState.graphviz;
+    } else if (graphRoot instanceof Element && graphRoot.__graphviz__) {
+      cachedGraphviz = graphRoot.__graphviz__;
+    }
+    // d3-graphviz caches zoom state on the canvas. Destroy the renderer first
+    // so the replacement SVG gets fresh D3 zoom handlers.
+    if (cachedGraphviz && typeof cachedGraphviz.destroy === "function") {
+      cachedGraphviz.destroy();
+    } else if (graphRoot instanceof Element && graphRoot.__graphviz__) {
+      delete graphRoot.__graphviz__;
+    }
     if (graphRoot instanceof Element) {
       graphRoot.querySelectorAll("svg").forEach(function (svg) {
         svg.remove();

--- a/src/VersoBlueprint/Commands/graph.js
+++ b/src/VersoBlueprint/Commands/graph.js
@@ -111,42 +111,28 @@
       key: "full",
       label: "Full Graph",
       dot: dotTxt,
-      dotByDirection: [[fallbackDirection, dotTxt]],
       direction: fallbackDirection,
       selectOnNodeId: [],
       hoverOnNodeId: []
     }];
   }
 
-  function dotByDirectionMap(dotByDirection, fallbackDirection, fallbackDot) {
-    const map = new Map();
-    if (Array.isArray(dotByDirection)) {
-      dotByDirection.forEach(function (entry) {
-        if (!Array.isArray(entry) || entry.length < 2) return;
-        const direction = normalizeGraphDirection(entry[0]);
-        const dot = String(entry[1] || "").trim();
-        if (!dot) return;
-        map.set(direction, dot);
-      });
+  function dotWithGraphDirection(dot, direction) {
+    const source = String(dot || "").trim();
+    if (!source) return "";
+    const desired = normalizeGraphDirection(direction);
+    const rankdirPattern = /(^\s*rankdir\s*=\s*)(LR|RL|TB|BT)(\s*;)/m;
+    if (rankdirPattern.test(source)) {
+      return source.replace(rankdirPattern, "$1" + desired + "$3");
     }
-    if (fallbackDot) {
-      const normalizedFallback = normalizeGraphDirection(fallbackDirection);
-      if (!map.has(normalizedFallback)) {
-        map.set(normalizedFallback, fallbackDot);
-      }
-    }
-    return map;
+    const openBrace = source.indexOf("{");
+    if (openBrace < 0) return source;
+    return source.slice(0, openBrace + 1) + "\n    rankdir=" + desired + ";" + source.slice(openBrace + 1);
   }
 
   function dotForVariantDirection(variant, direction) {
     if (!variant || typeof variant !== "object") return "";
-    const desired = normalizeGraphDirection(direction);
-    const dotMap = variant.dotByDirection instanceof Map ? variant.dotByDirection : null;
-    if (dotMap) {
-      const matched = dotMap.get(desired);
-      if (matched) return matched;
-    }
-    return String(variant.dot || "").trim();
+    return dotWithGraphDirection(variant.dot, direction);
   }
 
   function graphNodeLabel(node) {
@@ -779,7 +765,6 @@
           const label = String(variant.label || key).trim();
           const dot = String(variant.dot || "").trim();
           const direction = normalizeGraphDirection(variant.direction);
-          const dotByDirection = dotByDirectionMap(variant.dotByDirection, direction, dot);
           const selectOnNodeId = Array.isArray(variant.selectOnNodeId) ? variant.selectOnNodeId : [];
           const hoverOnNodeId = Array.isArray(variant.hoverOnNodeId) ? variant.hoverOnNodeId : [];
           const previewKeyByNodeId = Array.isArray(variant.previewKeyByNodeId) ? variant.previewKeyByNodeId : [];
@@ -788,7 +773,6 @@
             key: key,
             label: label || key,
             dot: dot,
-            dotByDirection: dotByDirection,
             direction: direction,
             selectOnNodeId: selectOnNodeId,
             hoverOnNodeId: hoverOnNodeId,
@@ -813,9 +797,9 @@
         }
         if (selector) selector.value = activeKey;
         let activeDirection = normalizeGraphDirection(
-          directionSelector && directionSelector.value
-            ? directionSelector.value
-            : (directionSelector && directionSelector.getAttribute("data-bp-graph-default-direction"))
+          directionSelector
+            ? directionSelector.getAttribute("data-bp-graph-default-direction")
+            : graphContainer.attr("data-bp-graph-direction")
         );
         if (directionSelector) directionSelector.value = activeDirection;
         syncLegend(graphBlock, activeKey);

--- a/src/VersoBlueprint/Commands/graph.js
+++ b/src/VersoBlueprint/Commands/graph.js
@@ -31,6 +31,7 @@
     if (rawPack === false) return false;
     if (rawPack === true) return true;
     const pack = rawPack === null || typeof rawPack === "undefined" ? "" : String(rawPack).trim().toLowerCase();
+    if (pack === "") return false;
     if (pack === "false" || pack === "0" || pack === "no" || pack === "off") {
       return false;
     }
@@ -41,7 +42,7 @@
     const options = rawOptions && typeof rawOptions === "object" ? rawOptions : {};
     return {
       direction: normalizeGraphDirection(options.direction),
-      pack: normalizeGraphPack(Object.prototype.hasOwnProperty.call(options, "pack") ? options.pack : true)
+      pack: normalizeGraphPack(Object.prototype.hasOwnProperty.call(options, "pack") ? options.pack : false)
     };
   }
 

--- a/src/VersoBlueprint/Commands/graph.js
+++ b/src/VersoBlueprint/Commands/graph.js
@@ -148,6 +148,7 @@
       groupHoverShownKey: "",
       groupHoverShownNodeId: "",
       graphviz: null,
+      renderedVariantKey: "",
       canvasAutoHeight: null,
       canvasUserResized: false,
       renderToken: 0,
@@ -191,6 +192,21 @@
       graphState.lastCanvasHeight = nextHeight;
     }
     return true;
+  }
+
+  function resetGraphvizForVariant(graphRoot, graphState) {
+    if (graphRoot instanceof Element) {
+      graphRoot.querySelectorAll("svg").forEach(function (svg) {
+        svg.remove();
+      });
+    }
+    if (graphState && typeof graphState === "object") {
+      graphState.graphviz = null;
+      graphState.renderFinalizedToken = 0;
+      graphState.lastCanvasWidth = 0;
+      graphState.lastCanvasHeight = 0;
+      graphState.renderedVariantKey = "";
+    }
   }
 
   function parsePreviewEntry(entry) {
@@ -902,8 +918,15 @@
             );
           };
 
+          if (
+            graphState.renderedVariantKey &&
+            graphState.renderedVariantKey !== activeVariant.key
+          ) {
+            resetGraphvizForVariant(graphRoot, graphState);
+          }
           const gv = graphState.graphviz || graphContainer.graphviz();
           graphState.graphviz = gv;
+          graphState.renderedVariantKey = activeVariant.key;
           gv
             .zoom(true)
             .width(width)

--- a/tests/VersoBlueprintTests/BlueprintGraph/Groups.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraph/Groups.lean
@@ -92,17 +92,10 @@ def groupedVariants : Array Informal.Commands.GraphRenderVariant :=
   | some variant =>
     let expectedId := graphNodeSvgId `group_alpha
     let expectedLabel := escapeDotString (Informal.Commands.graphParentDisplayLabel groupedGraphTitleMap `group_alpha)
-    let hasDirection (rankdir : String) : Bool :=
-      variant.dotByDirection.any fun (direction, dot) =>
-        direction == rankdir && dot.contains s!"rankdir={rankdir};"
     variant.selectOnNodeId.contains (expectedId, Informal.Commands.parentVariantKey `group_alpha) &&
     variant.hoverOnNodeId.contains (expectedId, Informal.Commands.parentVariantKey `group_alpha) &&
     variant.dot.contains s!"id=\"{expectedId}\"" &&
     variant.dot.contains s!"label=\"{expectedLabel}\"" &&
-    hasDirection "TB" &&
-    hasDirection "LR" &&
-    hasDirection "RL" &&
-    hasDirection "BT" &&
     !variant.dot.contains "label=\"group_alpha\""
 
 /-- info: true -/

--- a/tests/VersoBlueprintTests/BlueprintGraph/Groups.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraph/Groups.lean
@@ -92,10 +92,17 @@ def groupedVariants : Array Informal.Commands.GraphRenderVariant :=
   | some variant =>
     let expectedId := graphNodeSvgId `group_alpha
     let expectedLabel := escapeDotString (Informal.Commands.graphParentDisplayLabel groupedGraphTitleMap `group_alpha)
+    let hasDirection (rankdir : String) : Bool :=
+      variant.dotByDirection.any fun (direction, dot) =>
+        direction == rankdir && dot.contains s!"rankdir={rankdir};"
     variant.selectOnNodeId.contains (expectedId, Informal.Commands.parentVariantKey `group_alpha) &&
     variant.hoverOnNodeId.contains (expectedId, Informal.Commands.parentVariantKey `group_alpha) &&
     variant.dot.contains s!"id=\"{expectedId}\"" &&
     variant.dot.contains s!"label=\"{expectedLabel}\"" &&
+    hasDirection "TB" &&
+    hasDirection "LR" &&
+    hasDirection "RL" &&
+    hasDirection "BT" &&
     !variant.dot.contains "label=\"group_alpha\""
 
 /-- info: true -/

--- a/tests/VersoBlueprintTests/BlueprintGraph/Groups.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraph/Groups.lean
@@ -70,7 +70,7 @@ def groupedOverview : Informal.Commands.Graph :=
 
 def groupedVariants : Array Informal.Commands.GraphRenderVariant :=
   Informal.Commands.mkGraphVariants
-    { graph := groupedGraphInput, options := { direction := .TB }, groupTitles := groupedGraphTitles }
+    { graph := groupedGraphInput, options := { direction := .TB, pack := true }, groupTitles := groupedGraphTitles }
     (fun _ => none)
     groupedGraphTitleMap
 
@@ -101,11 +101,11 @@ def groupedVariants : Array Informal.Commands.GraphRenderVariant :=
 /-- info: true -/
 #guard_msgs in
 #eval
-  Informal.Commands.graphDotHeader { direction := .TB, pack := true } |>.contains "pack=true;"
+  Informal.Commands.graphDotHeader |>.contains "pack=false;"
 
 /-- info: true -/
 #guard_msgs in
 #eval
-  Informal.Commands.graphDotHeader { direction := .TB, pack := false } |>.contains "pack=false;"
+  Informal.Commands.graphDotHeader { direction := .TB, pack := true } |>.contains "pack=true;"
 
 end Verso.VersoBlueprintTests.BlueprintGraph.Groups

--- a/tests/VersoBlueprintTests/BlueprintGraph/Groups.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraph/Groups.lean
@@ -98,4 +98,9 @@ def groupedVariants : Array Informal.Commands.GraphRenderVariant :=
     variant.dot.contains s!"label=\"{expectedLabel}\"" &&
     !variant.dot.contains "label=\"group_alpha\""
 
+/-- info: true -/
+#guard_msgs in
+#eval
+  Informal.Commands.graphDotHeader "TB" |>.contains "pack=true;"
+
 end Verso.VersoBlueprintTests.BlueprintGraph.Groups

--- a/tests/VersoBlueprintTests/BlueprintGraph/Groups.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraph/Groups.lean
@@ -70,7 +70,7 @@ def groupedOverview : Informal.Commands.Graph :=
 
 def groupedVariants : Array Informal.Commands.GraphRenderVariant :=
   Informal.Commands.mkGraphVariants
-    { graph := groupedGraphInput, direction := .TB, groupTitles := groupedGraphTitles }
+    { graph := groupedGraphInput, options := { direction := .TB }, groupTitles := groupedGraphTitles }
     (fun _ => none)
     groupedGraphTitleMap
 
@@ -101,6 +101,11 @@ def groupedVariants : Array Informal.Commands.GraphRenderVariant :=
 /-- info: true -/
 #guard_msgs in
 #eval
-  Informal.Commands.graphDotHeader "TB" |>.contains "pack=true;"
+  Informal.Commands.graphDotHeader { direction := .TB, pack := true } |>.contains "pack=true;"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  Informal.Commands.graphDotHeader { direction := .TB, pack := false } |>.contains "pack=false;"
 
 end Verso.VersoBlueprintTests.BlueprintGraph.Groups

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
@@ -52,9 +52,9 @@ Base statement for an explicit left-to-right graph.
       hasSubstr out "class=\"bp_graph_controls_select bp_graph_direction_select\"" &&
       hasSubstr out "class=\"bp_graph_pack_input\"" &&
       hasSubstr out "data-bp-graph-direction=\"TB\"" &&
-      hasSubstr out "data-bp-graph-pack=\"true\"" &&
-      hasSubstr out "data-bp-graph-default-pack=\"true\"" &&
-      hasSubstr out "\"options\":{\"direction\":\"TB\",\"pack\":true}" &&
+      hasSubstr out "data-bp-graph-pack=\"false\"" &&
+      hasSubstr out "data-bp-graph-default-pack=\"false\"" &&
+      hasSubstr out "\"options\":{\"direction\":\"TB\",\"pack\":false}" &&
       hasSubstr out "data-bp-tex-prelude-id" &&
       !hasSubstr out "data-bp-tex-prelude=\"" &&
       !hasSubstr out "bp_preview_tex_prelude" &&

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
@@ -57,7 +57,9 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
         hasSubstr graphJs "configurePanelCloseButton(previewUtils, groupHoverClose" &&
         hasSubstr graphJs "previewKeyByNodeId: new Map(previewKeyByNodeId)" &&
         hasSubstr graphJs "graphviz: null," &&
+        hasSubstr graphJs "renderedVariantKey: \"\"," &&
         hasSubstr graphJs "renderToken: 0," &&
+        hasSubstr graphJs "function resetGraphvizForVariant(graphRoot, graphState)" &&
         hasSubstr graphJs "const finalizeRender = function () {" &&
         hasSubstr graphJs "if (graphState.renderToken !== renderToken) return;" &&
         hasSubstr graphJs "const gv = graphState.graphviz || graphContainer.graphviz();" &&

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
@@ -8,8 +8,22 @@ import VersoBlueprintTests.BlueprintPreviewWiring.Shared
 
 namespace Verso.VersoBlueprintTests.BlueprintPreviewWiring.Graph
 
+open Verso
+open Verso.Genre.Manual
+open Informal
 open Verso.VersoBlueprintTests.Blueprint.Support
 open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
+
+set_option doc.verso true
+
+#docs (Genre.Manual) lrDirectionGraphDoc "Blueprint LR Direction Graph" :=
+:::::::
+:::definition "def:graph.lr.base"
+Base statement for an explicit left-to-right graph.
+:::
+
+{blueprint_graph (direction := LR)}
+:::::::
 
 /-- info: true -/
 #guard_msgs in
@@ -35,7 +49,7 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
       hasSubstr out "class=\"bp-graph-variants\"" &&
       hasSubstr out "class=\"bp_graph_controls_button bp_graph_options_button\"" &&
       hasSubstr out "class=\"bp_graph_options_popover\"" &&
-      hasSubstr out "class=\"bp_graph_direction_select\"" &&
+      hasSubstr out "class=\"bp_graph_controls_select bp_graph_direction_select\"" &&
       hasSubstr out "data-bp-graph-direction=\"TB\"" &&
       hasSubstr out "\"direction\":\"TB\"" &&
       hasSubstr out "data-bp-tex-prelude-id" &&
@@ -59,13 +73,13 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
         hasSubstr graphJs "configurePanelCloseButton(previewUtils, previewClose" &&
         hasSubstr graphJs "configurePanelCloseButton(previewUtils, groupHoverClose" &&
         hasSubstr graphJs "previewKeyByNodeId: new Map(previewKeyByNodeId)" &&
-        hasSubstr graphJs "dotByDirection: dotByDirectionMap(variant.dotByDirection, direction, dot)" &&
         hasSubstr graphJs "graphviz: null," &&
         hasSubstr graphJs "renderedVariantKey: \"\"," &&
         hasSubstr graphJs "renderedDirectionKey: \"\"," &&
         hasSubstr graphJs "renderToken: 0," &&
-        hasSubstr graphJs "function dotByDirectionMap(dotByDirection, fallbackDirection, fallbackDot)" &&
+        hasSubstr graphJs "function dotWithGraphDirection(dot, direction)" &&
         hasSubstr graphJs "function dotForVariantDirection(variant, direction)" &&
+        hasSubstr graphJs "return dotWithGraphDirection(variant.dot, direction);" &&
         hasSubstr graphJs "function resetGraphvizForVariant(graphRoot, graphState)" &&
         hasSubstr graphJs "function bindOptionsPopover(graphBlock)" &&
         hasSubstr graphJs "const finalizeRender = function () {" &&
@@ -81,6 +95,20 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
         hasSubstr graphJs ".fit(true)" &&
         hasSubstr graphJs "syncLegend(graphBlock, activeKey)"
       | none => false
+    )
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (out, _) ← renderManualDocHtmlStringAndState manualImpls lrDirectionGraphDoc
+    pure (
+      hasSubstr out "data-bp-graph-direction=\"LR\"" &&
+      hasSubstr out "data-bp-graph-default-direction=\"LR\"" &&
+      (hasSubstr out "selected value=\"LR\"" || hasSubstr out "value=\"LR\" selected") &&
+      hasSubstr out "\"direction\":\"LR\"" &&
+      hasSubstr out "rankdir=LR;" &&
+      !hasSubstr out "dotByDirection"
     )
 
 end Verso.VersoBlueprintTests.BlueprintPreviewWiring.Graph

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
@@ -33,6 +33,9 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
       hasSubstr out "class=\"bp_group_hover_preview_graph bp_preview_panel_body\"" &&
       hasSubstr out "aria-label=\"Close group preview\"" &&
       hasSubstr out "class=\"bp-graph-variants\"" &&
+      hasSubstr out "class=\"bp_graph_controls_button bp_graph_options_button\"" &&
+      hasSubstr out "class=\"bp_graph_options_popover\"" &&
+      hasSubstr out "class=\"bp_graph_direction_select\"" &&
       hasSubstr out "data-bp-graph-direction=\"TB\"" &&
       hasSubstr out "\"direction\":\"TB\"" &&
       hasSubstr out "data-bp-tex-prelude-id" &&
@@ -56,13 +59,21 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
         hasSubstr graphJs "configurePanelCloseButton(previewUtils, previewClose" &&
         hasSubstr graphJs "configurePanelCloseButton(previewUtils, groupHoverClose" &&
         hasSubstr graphJs "previewKeyByNodeId: new Map(previewKeyByNodeId)" &&
+        hasSubstr graphJs "dotByDirection: dotByDirectionMap(variant.dotByDirection, direction, dot)" &&
         hasSubstr graphJs "graphviz: null," &&
         hasSubstr graphJs "renderedVariantKey: \"\"," &&
+        hasSubstr graphJs "renderedDirectionKey: \"\"," &&
         hasSubstr graphJs "renderToken: 0," &&
+        hasSubstr graphJs "function dotByDirectionMap(dotByDirection, fallbackDirection, fallbackDot)" &&
+        hasSubstr graphJs "function dotForVariantDirection(variant, direction)" &&
         hasSubstr graphJs "function resetGraphvizForVariant(graphRoot, graphState)" &&
+        hasSubstr graphJs "function bindOptionsPopover(graphBlock)" &&
         hasSubstr graphJs "const finalizeRender = function () {" &&
         hasSubstr graphJs "if (graphState.renderToken !== renderToken) return;" &&
         hasSubstr graphJs "const gv = graphState.graphviz || graphContainer.graphviz();" &&
+        hasSubstr graphJs "const directionSelector = graphBlock.querySelector(\".bp_graph_direction_select\");" &&
+        hasSubstr graphJs "let activeDirection = normalizeGraphDirection(" &&
+        hasSubstr graphJs "switchDirection(directionSelector.value);" &&
         hasSubstr graphJs ".zoom(true)" &&
         hasSubstr graphJs "function normalizeGraphDirection(rawDirection)" &&
         hasSubstr graphJs "layoutGraphCanvas(graphRoot, graphState)" &&

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
@@ -22,7 +22,7 @@ set_option doc.verso true
 Base statement for an explicit left-to-right graph.
 :::
 
-{blueprint_graph (direction := LR)}
+{blueprint_graph (direction := LR) (pack := false)}
 :::::::
 
 /-- info: true -/
@@ -50,8 +50,11 @@ Base statement for an explicit left-to-right graph.
       hasSubstr out "class=\"bp_graph_controls_button bp_graph_options_button\"" &&
       hasSubstr out "class=\"bp_graph_options_popover\"" &&
       hasSubstr out "class=\"bp_graph_controls_select bp_graph_direction_select\"" &&
+      hasSubstr out "class=\"bp_graph_pack_input\"" &&
       hasSubstr out "data-bp-graph-direction=\"TB\"" &&
-      hasSubstr out "\"direction\":\"TB\"" &&
+      hasSubstr out "data-bp-graph-pack=\"true\"" &&
+      hasSubstr out "data-bp-graph-default-pack=\"true\"" &&
+      hasSubstr out "\"options\":{\"direction\":\"TB\",\"pack\":true}" &&
       hasSubstr out "data-bp-tex-prelude-id" &&
       !hasSubstr out "data-bp-tex-prelude=\"" &&
       !hasSubstr out "bp_preview_tex_prelude" &&
@@ -75,21 +78,24 @@ Base statement for an explicit left-to-right graph.
         hasSubstr graphJs "previewKeyByNodeId: new Map(previewKeyByNodeId)" &&
         hasSubstr graphJs "graphviz: null," &&
         hasSubstr graphJs "renderedVariantKey: \"\"," &&
-        hasSubstr graphJs "renderedDirectionKey: \"\"," &&
+        hasSubstr graphJs "renderedOptionsKey: \"\"," &&
         hasSubstr graphJs "renderToken: 0," &&
-        hasSubstr graphJs "function dotWithGraphDirection(dot, direction)" &&
-        hasSubstr graphJs "function dotForVariantDirection(variant, direction)" &&
-        hasSubstr graphJs "return dotWithGraphDirection(variant.dot, direction);" &&
+        hasSubstr graphJs "function dotWithGraphOptions(dot, options)" &&
+        hasSubstr graphJs "function dotForVariantOptions(variant, options)" &&
+        hasSubstr graphJs "return dotWithGraphOptions(variant.dot, options);" &&
         hasSubstr graphJs "function resetGraphvizForVariant(graphRoot, graphState)" &&
         hasSubstr graphJs "function bindOptionsPopover(graphBlock)" &&
         hasSubstr graphJs "const finalizeRender = function () {" &&
         hasSubstr graphJs "if (graphState.renderToken !== renderToken) return;" &&
         hasSubstr graphJs "const gv = graphState.graphviz || graphContainer.graphviz();" &&
         hasSubstr graphJs "const directionSelector = graphBlock.querySelector(\".bp_graph_direction_select\");" &&
-        hasSubstr graphJs "let activeDirection = normalizeGraphDirection(" &&
+        hasSubstr graphJs "const packInput = graphBlock.querySelector(\".bp_graph_pack_input\");" &&
+        hasSubstr graphJs "let activeOptions = normalizeGraphOptions({" &&
         hasSubstr graphJs "switchDirection(directionSelector.value);" &&
+        hasSubstr graphJs "switchPack(packInput.checked);" &&
         hasSubstr graphJs ".zoom(true)" &&
         hasSubstr graphJs "function normalizeGraphDirection(rawDirection)" &&
+        hasSubstr graphJs "function normalizeGraphPack(rawPack)" &&
         hasSubstr graphJs "layoutGraphCanvas(graphRoot, graphState)" &&
         hasSubstr graphJs "if (typeof ResizeObserver === \"function\")" &&
         hasSubstr graphJs ".fit(true)" &&
@@ -104,10 +110,13 @@ Base statement for an explicit left-to-right graph.
     let (out, _) ← renderManualDocHtmlStringAndState manualImpls lrDirectionGraphDoc
     pure (
       hasSubstr out "data-bp-graph-direction=\"LR\"" &&
+      hasSubstr out "data-bp-graph-pack=\"false\"" &&
       hasSubstr out "data-bp-graph-default-direction=\"LR\"" &&
+      hasSubstr out "data-bp-graph-default-pack=\"false\"" &&
       (hasSubstr out "selected value=\"LR\"" || hasSubstr out "value=\"LR\" selected") &&
-      hasSubstr out "\"direction\":\"LR\"" &&
+      hasSubstr out "\"options\":{\"direction\":\"LR\",\"pack\":false}" &&
       hasSubstr out "rankdir=LR;" &&
+      hasSubstr out "pack=false;" &&
       !hasSubstr out "dotByDirection"
     )
 

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -155,7 +155,7 @@ def server(request):
         port = int(port)
 
     proc = subprocess.Popen(
-        ["python", "-m", "http.server", str(port), "--bind", "127.0.0.1"],
+        [sys.executable, "-m", "http.server", str(port), "--bind", "127.0.0.1"],
         cwd=site_dir,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,

--- a/tests/browser/test_graph_layout_runtime.py
+++ b/tests/browser/test_graph_layout_runtime.py
@@ -11,6 +11,70 @@ def wait_for_graph(page: Page):
     )
 
 
+def wait_for_rendered_variant(page: Page, variant: str):
+    page.wait_for_function(
+        """(expectedVariant) => {
+            const block = document.querySelector(".bp_graph_fullwidth");
+            const canvas = document.querySelector(".bp_graph_canvas");
+            const select = document.querySelector(".bp_graph_view_select");
+            const svg = canvas ? canvas.querySelector("svg") : null;
+            const state = block ? block.__bpGraphState : null;
+            return (
+                !!select &&
+                !!svg &&
+                !!state &&
+                select.value === expectedVariant &&
+                state.renderedVariantKey === expectedVariant &&
+                state.renderFinalizedToken === state.renderToken
+            );
+        }""",
+        arg=variant,
+    )
+
+
+def graph_transform(page: Page):
+    return page.evaluate(
+        """() => {
+            const canvas = document.querySelector(".bp_graph_canvas");
+            const svg = canvas ? canvas.querySelector("svg") : null;
+            const graph = svg ? (svg.querySelector("g.graph") || svg.querySelector("g")) : null;
+            return graph ? graph.getAttribute("transform") : null;
+        }"""
+    )
+
+
+def assert_graph_has_zoom_handlers(page: Page):
+    assert page.evaluate(
+        """() => {
+            const svg = document.querySelector(".bp_graph_canvas svg");
+            if (!svg || !Array.isArray(svg.__on) || !svg.__zoom) return false;
+            return svg.__on.some((entry) => entry.type === "mousedown" && entry.name === "zoom");
+        }"""
+    )
+
+
+def assert_graph_can_be_dragged(page: Page):
+    before = graph_transform(page)
+    assert before is not None
+    canvas_box = page.locator(".bp_graph_canvas").first.bounding_box()
+    assert canvas_box is not None
+    center_x = canvas_box["x"] + canvas_box["width"] / 2
+    center_y = canvas_box["y"] + canvas_box["height"] / 2
+    page.mouse.move(center_x, center_y)
+    page.mouse.down()
+    page.mouse.move(center_x + 90, center_y + 36, steps=6)
+    page.mouse.up()
+    page.wait_for_function(
+        """(previousTransform) => {
+            const canvas = document.querySelector(".bp_graph_canvas");
+            const svg = canvas ? canvas.querySelector("svg") : null;
+            const graph = svg ? (svg.querySelector("g.graph") || svg.querySelector("g")) : null;
+            return !!graph && graph.getAttribute("transform") !== previousTransform;
+        }""",
+        arg=before,
+    )
+
+
 def graph_visibility_metrics(page: Page):
     return page.evaluate(
         """() => {
@@ -227,6 +291,22 @@ class TestGraphLayoutRuntime:
                 arg=variant,
             )
             assert_graph_is_well_placed(page)
+
+    def test_graph_remains_interactive_after_variant_switch(self, server: str, page: Page):
+        page.set_viewport_size({"width": 1400, "height": 900})
+        page.goto(f"{server}/Dependency-Graph/")
+        wait_for_graph(page)
+
+        selector = page.locator(".bp_graph_view_select").first
+
+        assert_graph_has_zoom_handlers(page)
+        assert_graph_can_be_dragged(page)
+
+        for variant in ["group", "parent:preview_core", "full"]:
+            selector.select_option(variant)
+            wait_for_rendered_variant(page, variant)
+            assert_graph_has_zoom_handlers(page)
+            assert_graph_can_be_dragged(page)
 
     def test_graph_width_is_css_driven_without_inline_offsets(self, server: str, page: Page):
         page.set_viewport_size({"width": 1400, "height": 900})

--- a/tests/browser/test_graph_layout_runtime.py
+++ b/tests/browser/test_graph_layout_runtime.py
@@ -11,6 +11,32 @@ def wait_for_graph(page: Page):
     )
 
 
+def graph_visibility_metrics(page: Page):
+    return page.evaluate(
+        """() => {
+            const canvas = document.querySelector(".bp_graph_canvas");
+            const svg = canvas ? canvas.querySelector("svg") : null;
+            const graph = svg ? (svg.querySelector("g.graph") || svg.querySelector("g")) : null;
+            if (!canvas || !svg || !graph) return null;
+            const canvasRect = canvas.getBoundingClientRect();
+            const graphRect = graph.getBoundingClientRect();
+            return {
+                canvasTop: canvasRect.top,
+                canvasHeight: canvasRect.height,
+                graphTop: graphRect.top,
+                graphBottom: graphRect.bottom,
+            };
+        }"""
+    )
+
+
+def assert_graph_is_well_placed(page: Page):
+    metrics = graph_visibility_metrics(page)
+    assert metrics is not None
+    assert metrics["graphTop"] < metrics["canvasTop"] + 0.35 * metrics["canvasHeight"]
+    assert metrics["graphBottom"] > metrics["canvasTop"] + 0.5 * metrics["canvasHeight"]
+
+
 class TestGraphLayoutRuntime:
     def test_graph_legend_is_collapsed_by_default_and_tracks_variant_switch(self, server: str, page: Page):
         page.set_viewport_size({"width": 1400, "height": 900})
@@ -108,26 +134,29 @@ class TestGraphLayoutRuntime:
         page.goto(f"{server}/Dependency-Graph/")
         wait_for_graph(page)
 
-        metrics = page.evaluate(
-            """() => {
-                const canvas = document.querySelector(".bp_graph_canvas");
-                const svg = canvas ? canvas.querySelector("svg") : null;
-                const graph = svg ? (svg.querySelector("g.graph") || svg.querySelector("g")) : null;
-                if (!canvas || !svg || !graph) return null;
-                const canvasRect = canvas.getBoundingClientRect();
-                const graphRect = graph.getBoundingClientRect();
-                return {
-                    canvasTop: canvasRect.top,
-                    canvasHeight: canvasRect.height,
-                    graphTop: graphRect.top,
-                    graphBottom: graphRect.bottom,
-                };
-            }"""
-        )
+        assert_graph_is_well_placed(page)
 
-        assert metrics is not None
-        assert metrics["graphTop"] < metrics["canvasTop"] + 0.35 * metrics["canvasHeight"]
-        assert metrics["graphBottom"] > metrics["canvasTop"] + 0.5 * metrics["canvasHeight"]
+    def test_graph_remains_well_placed_after_variant_switch(self, server: str, page: Page):
+        page.set_viewport_size({"width": 1400, "height": 900})
+        page.goto(f"{server}/Dependency-Graph/")
+        wait_for_graph(page)
+
+        selector = page.locator(".bp_graph_view_select").first
+
+        assert_graph_is_well_placed(page)
+
+        for variant in ["group", "parent:preview_core", "parent:preview_group", "full"]:
+            selector.select_option(variant)
+            page.wait_for_function(
+                """(expectedValue) => {
+                    const select = document.querySelector(".bp_graph_view_select");
+                    const canvas = document.querySelector(".bp_graph_canvas");
+                    const svg = canvas ? canvas.querySelector("svg") : null;
+                    return !!select && !!svg && select.value === expectedValue;
+                }""",
+                arg=variant,
+            )
+            assert_graph_is_well_placed(page)
 
     def test_graph_width_is_css_driven_without_inline_offsets(self, server: str, page: Page):
         page.set_viewport_size({"width": 1400, "height": 900})

--- a/tests/browser/test_graph_layout_runtime.py
+++ b/tests/browser/test_graph_layout_runtime.py
@@ -30,6 +30,23 @@ def graph_visibility_metrics(page: Page):
     )
 
 
+def graph_dimensions(page: Page):
+    return page.evaluate(
+        """() => {
+            const canvas = document.querySelector(".bp_graph_canvas");
+            const svg = canvas ? canvas.querySelector("svg") : null;
+            const graph = svg ? (svg.querySelector("g.graph") || svg.querySelector("g")) : null;
+            if (!canvas || !svg || !graph) return null;
+            const graphRect = graph.getBoundingClientRect();
+            return {
+                width: graphRect.width,
+                height: graphRect.height,
+                activeDirection: canvas.getAttribute("data-bp-active-direction") || "",
+            };
+        }"""
+    )
+
+
 def assert_graph_is_well_placed(page: Page):
     metrics = graph_visibility_metrics(page)
     assert metrics is not None
@@ -83,6 +100,59 @@ class TestGraphLayoutRuntime:
                 );
             }"""
         )
+
+    def test_graph_options_popover_switches_direction(self, server: str, page: Page):
+        page.set_viewport_size({"width": 1400, "height": 900})
+        page.goto(f"{server}/Dependency-Graph/")
+        wait_for_graph(page)
+
+        options_button = page.locator(".bp_graph_options_button").first
+        options_panel = page.locator(".bp_graph_options_popover").first
+        direction_selector = page.locator(".bp_graph_direction_select").first
+
+        initial = graph_dimensions(page)
+        assert initial is not None
+        assert initial["activeDirection"] == "TB"
+
+        options_button.click()
+        page.wait_for_function(
+            """() => {
+                const button = document.querySelector(".bp_graph_options_button");
+                const panel = document.querySelector(".bp_graph_options_popover");
+                const select = document.querySelector(".bp_graph_direction_select");
+                return (
+                    !!button &&
+                    !!panel &&
+                    !!select &&
+                    button.getAttribute("aria-expanded") === "true" &&
+                    !panel.hidden &&
+                    select.value === "TB"
+                );
+            }"""
+        )
+
+        direction_selector.select_option("LR")
+        page.wait_for_function(
+            """() => {
+                const canvas = document.querySelector(".bp_graph_canvas");
+                const select = document.querySelector(".bp_graph_direction_select");
+                const panel = document.querySelector(".bp_graph_options_popover");
+                return (
+                    !!canvas &&
+                    !!select &&
+                    !!panel &&
+                    select.value === "LR" &&
+                    canvas.getAttribute("data-bp-active-direction") === "LR" &&
+                    panel.hidden
+                );
+            }"""
+        )
+
+        switched = graph_dimensions(page)
+        assert switched is not None
+        assert switched["activeDirection"] == "LR"
+        assert switched["width"] > switched["height"]
+        assert_graph_is_well_placed(page)
 
     def test_graph_page_does_not_force_extra_vertical_scroll(self, server: str, page: Page):
         page.set_viewport_size({"width": 1400, "height": 900})

--- a/tests/browser/test_graph_layout_runtime.py
+++ b/tests/browser/test_graph_layout_runtime.py
@@ -106,6 +106,7 @@ def graph_dimensions(page: Page):
                 width: graphRect.width,
                 height: graphRect.height,
                 activeDirection: canvas.getAttribute("data-bp-active-direction") || "",
+                activePack: canvas.getAttribute("data-bp-active-pack") || "",
             };
         }"""
     )
@@ -173,10 +174,12 @@ class TestGraphLayoutRuntime:
         options_button = page.locator(".bp_graph_options_button").first
         options_panel = page.locator(".bp_graph_options_popover").first
         direction_selector = page.locator(".bp_graph_direction_select").first
+        pack_input = page.locator(".bp_graph_pack_input").first
 
         initial = graph_dimensions(page)
         assert initial is not None
         assert initial["activeDirection"] == "TB"
+        assert initial["activePack"] == "true"
 
         options_button.click()
         page.wait_for_function(
@@ -184,13 +187,16 @@ class TestGraphLayoutRuntime:
                 const button = document.querySelector(".bp_graph_options_button");
                 const panel = document.querySelector(".bp_graph_options_popover");
                 const select = document.querySelector(".bp_graph_direction_select");
+                const pack = document.querySelector(".bp_graph_pack_input");
                 return (
                     !!button &&
                     !!panel &&
                     !!select &&
+                    !!pack &&
                     button.getAttribute("aria-expanded") === "true" &&
                     !panel.hidden &&
-                    select.value === "TB"
+                    select.value === "TB" &&
+                    pack.checked
                 );
             }"""
         )
@@ -212,9 +218,53 @@ class TestGraphLayoutRuntime:
             }"""
         )
 
+        options_button.click()
+        page.wait_for_function(
+            """() => {
+                const panel = document.querySelector(".bp_graph_options_popover");
+                const pack = document.querySelector(".bp_graph_pack_input");
+                return !!panel && !!pack && !panel.hidden && pack.checked;
+            }"""
+        )
+        pack_input.uncheck()
+        page.wait_for_function(
+            """() => {
+                const block = document.querySelector(".bp_graph_fullwidth");
+                const canvas = document.querySelector(".bp_graph_canvas");
+                const pack = document.querySelector(".bp_graph_pack_input");
+                const state = block ? block.__bpGraphState : null;
+                return (
+                    !!canvas &&
+                    !!pack &&
+                    !!state &&
+                    !pack.checked &&
+                    canvas.getAttribute("data-bp-active-pack") === "false" &&
+                    state.renderFinalizedToken === state.renderToken
+                );
+            }"""
+        )
+        pack_input.check()
+        page.wait_for_function(
+            """() => {
+                const block = document.querySelector(".bp_graph_fullwidth");
+                const canvas = document.querySelector(".bp_graph_canvas");
+                const pack = document.querySelector(".bp_graph_pack_input");
+                const state = block ? block.__bpGraphState : null;
+                return (
+                    !!canvas &&
+                    !!pack &&
+                    !!state &&
+                    pack.checked &&
+                    canvas.getAttribute("data-bp-active-pack") === "true" &&
+                    state.renderFinalizedToken === state.renderToken
+                );
+            }"""
+        )
+
         switched = graph_dimensions(page)
         assert switched is not None
         assert switched["activeDirection"] == "LR"
+        assert switched["activePack"] == "true"
         assert switched["width"] > switched["height"]
         assert_graph_is_well_placed(page)
 

--- a/tests/harness/test_blueprint_harness_utils.py
+++ b/tests/harness/test_blueprint_harness_utils.py
@@ -51,9 +51,15 @@ class TestBlueprintHarnessUtils(unittest.TestCase):
             root = Path(tmp)
             asset = root / "src" / "VersoBlueprint" / "Commands" / "graph.css"
             owner = root / "src" / "VersoBlueprint" / "Commands" / "Graph.lean"
+            cached_olean = root / ".lake" / "build" / "lib" / "lean" / "VersoBlueprint" / "Commands" / "Graph.olean"
+            cached_ir = root / ".lake" / "build" / "ir" / "VersoBlueprint" / "Commands" / "Graph.c"
             owner.parent.mkdir(parents=True, exist_ok=True)
+            cached_olean.parent.mkdir(parents=True, exist_ok=True)
+            cached_ir.parent.mkdir(parents=True, exist_ok=True)
             asset.write_text("/* css */", encoding="utf-8")
             owner.write_text("-- lean", encoding="utf-8")
+            cached_olean.write_text("stale", encoding="utf-8")
+            cached_ir.write_text("stale", encoding="utf-8")
 
             now = time.time()
             os.utime(owner, (now - 10, now - 10))
@@ -68,3 +74,24 @@ class TestBlueprintHarnessUtils(unittest.TestCase):
             self.assertEqual(command[1:3], ["lake", "build"])
             self.assertIn("VersoBlueprint.Commands.Graph", command)
             self.assertEqual(run_mock.call_args.kwargs["cwd"], root)
+            self.assertFalse(cached_olean.exists())
+            self.assertFalse(cached_ir.exists())
+
+    def test_rebuild_embedded_asset_owners_runs_even_when_owner_is_newer(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            asset = root / "src" / "VersoBlueprint" / "Commands" / "graph.css"
+            owner = root / "src" / "VersoBlueprint" / "Commands" / "Graph.lean"
+            owner.parent.mkdir(parents=True, exist_ok=True)
+            asset.write_text("/* css */", encoding="utf-8")
+            owner.write_text("-- lean", encoding="utf-8")
+
+            now = time.time()
+            os.utime(asset, (now - 10, now - 10))
+            os.utime(owner, (now, now))
+
+            with patch("scripts.blueprint_harness_utils.run") as run_mock:
+                rebuilt = rebuild_embedded_asset_owners(root)
+
+            self.assertEqual(rebuilt, ["VersoBlueprint.Commands.Graph"])
+            run_mock.assert_called_once()

--- a/tests/harness/test_blueprint_harness_utils.py
+++ b/tests/harness/test_blueprint_harness_utils.py
@@ -1,0 +1,70 @@
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.blueprint_harness_utils import rebuild_embedded_asset_owners, refresh_embedded_asset_owner_mtimes
+
+
+class TestBlueprintHarnessUtils(unittest.TestCase):
+    def test_refresh_embedded_asset_owner_mtimes_touches_owner_when_asset_is_newer(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            asset = root / "src" / "VersoBlueprint" / "Commands" / "graph.css"
+            owner = root / "src" / "VersoBlueprint" / "Commands" / "Graph.lean"
+            owner.parent.mkdir(parents=True, exist_ok=True)
+            asset.write_text("/* css */", encoding="utf-8")
+            owner.write_text("-- lean", encoding="utf-8")
+
+            now = time.time()
+            os.utime(owner, (now - 10, now - 10))
+            os.utime(asset, (now, now))
+
+            touched = refresh_embedded_asset_owner_mtimes(root)
+
+            self.assertEqual(touched, [owner])
+            self.assertGreaterEqual(owner.stat().st_mtime_ns, asset.stat().st_mtime_ns)
+
+    def test_refresh_embedded_asset_owner_mtimes_skips_owner_when_asset_is_not_newer(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            asset = root / "src" / "VersoBlueprint" / "Commands" / "graph.css"
+            owner = root / "src" / "VersoBlueprint" / "Commands" / "Graph.lean"
+            owner.parent.mkdir(parents=True, exist_ok=True)
+            asset.write_text("/* css */", encoding="utf-8")
+            owner.write_text("-- lean", encoding="utf-8")
+
+            now = time.time()
+            os.utime(asset, (now - 10, now - 10))
+            os.utime(owner, (now, now))
+            original_owner_time = owner.stat().st_mtime_ns
+
+            touched = refresh_embedded_asset_owner_mtimes(root)
+
+            self.assertEqual(touched, [])
+            self.assertEqual(owner.stat().st_mtime_ns, original_owner_time)
+
+    def test_rebuild_embedded_asset_owners_runs_targeted_root_build(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            asset = root / "src" / "VersoBlueprint" / "Commands" / "graph.css"
+            owner = root / "src" / "VersoBlueprint" / "Commands" / "Graph.lean"
+            owner.parent.mkdir(parents=True, exist_ok=True)
+            asset.write_text("/* css */", encoding="utf-8")
+            owner.write_text("-- lean", encoding="utf-8")
+
+            now = time.time()
+            os.utime(owner, (now - 10, now - 10))
+            os.utime(asset, (now, now))
+
+            with patch("scripts.blueprint_harness_utils.run") as run_mock:
+                rebuilt = rebuild_embedded_asset_owners(root)
+
+            self.assertEqual(rebuilt, ["VersoBlueprint.Commands.Graph"])
+            run_mock.assert_called_once()
+            command = run_mock.call_args.kwargs["command"] if "command" in run_mock.call_args.kwargs else run_mock.call_args.args[0]
+            self.assertEqual(command[1:3], ["lake", "build"])
+            self.assertIn("VersoBlueprint.Commands.Graph", command)
+            self.assertEqual(run_mock.call_args.kwargs["cwd"], root)

--- a/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Blueprint.lean
+++ b/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Blueprint.lean
@@ -25,5 +25,5 @@ generator checks can run against a focused, synthetic site.
 {include 0 PreviewRuntimeShowcase.Chapters.PreviewRelationships}
 {include 0 PreviewRuntimeShowcase.Chapters.InlineHoverPreviews}
 
-{blueprint_graph}
+{blueprint_graph (pack := true)}
 {blueprint_summary}


### PR DESCRIPTION
## Summary
Backport #18 to `v4.28.0`.

## Primary Review
- Primary review: #18
- Keep review comments on #18 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.28.0`.
- Includes the graph interaction fix plus the `GraphOptions` / `(pack := true | false)` follow-up from #18.
- Keeps graph command defaults aligned with TeX Blueprint behavior: `direction := TB`, `pack := false`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
