### PR TITLE
feat(harness): support lean run generation path

### DIFF
--- a/.github/workflows/blueprint-pages.yml
+++ b/.github/workflows/blueprint-pages.yml
@@ -60,13 +60,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            .lake/build/bin
             .lake/build/lib
             .lake/build/ir
-          key: ${{ runner.os }}-lean-build-v1-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.lean', '.gitmodules', '*.lean', '**/*.lean', 'scripts/ci-pages.sh') }}
+          key: ${{ runner.os }}-lean-build-v2-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.lean', '.gitmodules', '*.lean', '**/*.lean', 'scripts/ci-pages.sh') }}
           restore-keys: |
-            ${{ runner.os }}-lean-build-v1-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.lean', '.gitmodules') }}-
-            ${{ runner.os }}-lean-build-v1-
+            ${{ runner.os }}-lean-build-v2-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.lean', '.gitmodules') }}-
+            ${{ runner.os }}-lean-build-v2-
       - if: ${{ inputs.harness_enabled }}
         name: Restore formalization Lean build cache
         uses: actions/cache@v4

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Today a Blueprint project usually owns three things:
 
 - chapter modules containing the mathematical content
 - a Blueprint top-level file that assembles chapters and rendered overview pages
-- a site-generation executable that resolves forward references, computes
-  metadata, and writes the generated output under `_out/`
+- a generator entry point that resolves forward references, computes metadata,
+  and writes the generated output under `_out/`
 
 `verso-blueprint` provides the Blueprint directives, rendering commands, preview
 runtime, and support library code. The starter layout in

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -12,7 +12,7 @@ A Blueprint project usually has three moving parts:
 
 1. one or more chapter modules with the mathematical content
 2. one Blueprint top-level file that assembles the document
-3. one site-generation executable that renders the site
+3. one generator entry point that renders the site
 
 Many older examples call the top-level file `Contents.lean`. In this doc set we
 refer to it as the Blueprint top-level file because the role matters more than
@@ -58,7 +58,8 @@ Its key files are:
   unfinished open problem
 - `ProjectTemplate/Blueprint.lean`: the Blueprint top-level file
 - `ProjectTemplateMain.lean`: the generator entry point
-- `lakefile.lean`: package configuration, including the generator executable
+- `lakefile.lean`: package configuration, including the optional generator
+  executable
 
 The template is intentionally small. It is meant to teach the shape of a
 Blueprint project before you scale it up.
@@ -120,10 +121,10 @@ grouped projects expose the current graph views through the rendered page's
 
 The entry point in
 [project_template/ProjectTemplateMain.lean](../project_template/ProjectTemplateMain.lean)
-is the executable you run to generate the site.
+is the `main` function you run to generate the site.
 
-In this guide, we assume that executable is named `blueprint-gen`, because that
-keeps the examples short and easy to follow:
+The included CI script first builds the project's Lean library artifacts, then
+runs the generator file through Lean:
 
 ```bash
 lake update
@@ -132,8 +133,22 @@ lake update
 
 Run `lake update` once after copying the template. After that, run
 `./scripts/ci-pages.sh` whenever you want the same local build-and-render check
-that the included GitHub Pages workflow uses. If you only want to regenerate
-the site manually, `lake exe blueprint-gen --output _out/site` still works.
+that the included GitHub Pages workflow uses. Internally that script uses:
+
+```bash
+lake build ProjectTemplate
+lake env lean --run ProjectTemplateMain.lean --output _out/site
+```
+
+This path avoids building the generator executable and its transitive native
+artifacts, which is usually the better tradeoff for CI and Mathlib-heavy
+projects. If you repeatedly run the same generator locally and want a compiled
+executable, the `blueprint-gen` executable declared in `lakefile.lean` still
+supports:
+
+```bash
+lake exe blueprint-gen --output _out/site
+```
 
 ## What to change first
 
@@ -143,8 +158,8 @@ After copying the template:
 2. change the document title in the Blueprint top-level file
 3. replace the addition, multiplication, and Collatz chapters with your own
    first chapters
-4. keep the generator executable and top-level file structure until your project
-   is stable
+4. keep the generator entry point and top-level file structure until your
+   project is stable
 
 ## What to read next
 

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -591,6 +591,10 @@ The harness is now project-driven rather than hardcoded to one project.
   outside this repository
 - external entries should declare release-specific refs under `targets` plus
   the build and generation commands needed after checkout
+- prefer a build command that targets only the Lean library or formalization
+  artifacts needed by the document, followed by a `lake env lean --run ...`
+  generation command; do not build the generator executable unless that native
+  executable is the behavior under review
 - the harness currently rewrites the cloned `lakefile.lean` dependency line so
   external test projects exercise the local `VersoBlueprint` checkout instead
   of the committed upstream dependency
@@ -616,11 +620,16 @@ Minimal external catalog entry shape:
       "ref": "0123456789abcdef0123456789abcdef01234567"
     }
   ],
-  "build_command": ["lake", "build"],
-  "generate_command": ["lake", "exe", "blueprint-gen", "--output", "{output_dir}"],
+  "build_command": ["lake", "build", "SomeUserProject"],
+  "generate_command": ["lake", "env", "lean", "--run", "SomeUserProjectMain.lean", "--output", "{output_dir}"],
   "site_subdir": "html-multi"
 }
 ```
+
+The `lean --run` form is intentionally the catalog default for reference
+projects. It still requires the imported Lean modules to have been built first,
+but it avoids Lake's executable build path and the transitive native compilation
+cost that can dominate Mathlib-heavy projects.
 
 That override policy is now the default maintainer behavior: the external
 projects keep their committed dependency pointed at an approved upstream repo,

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -20,7 +20,7 @@ If you are starting a first project, read
 - [Groups, Authors, and Metadata](#groups-authors-and-metadata)
 - [Rendering Surface](#rendering-surface)
 - [Metadata Export and Preview Manifest](#metadata-export-and-preview-manifest)
-- [The Generator Executable](#the-generator-executable)
+- [The Generator Entry Point](#the-generator-entry-point)
 - [Blueprint Options](#blueprint-options)
 - [Experimental Widget](#experimental-widget)
 - [Current Limits](#current-limits)
@@ -31,7 +31,7 @@ A Blueprint project usually owns three things:
 
 - chapter modules containing the mathematical content
 - a Blueprint top-level file that assembles the document
-- a generator executable that renders the site
+- a generator entry point that renders the site
 
 The Blueprint top-level file is often called `Contents.lean` in existing
 projects, but the filename is not special. What matters is that one module
@@ -89,7 +89,7 @@ The role of each file is:
   intentionally unfinished open problem
 - `ProjectTemplate/Blueprint.lean`: the Blueprint top-level file
 - `ProjectTemplateMain.lean`: the renderer entry point
-- `lakefile.lean`: the package definition and the generator executable
+- `lakefile.lean`: the package definition and optional generator executable
 
 ## The Blueprint Top-Level File
 
@@ -555,12 +555,13 @@ for:
 - metadata export for other tools
 - inspection and debugging
 
-Useful inspection flags on a Blueprint executable:
+After building the relevant Lean targets, useful inspection flags on a
+Blueprint generator are:
 
 ```bash
-lake exe <generator> --dump-schema
-lake exe <generator> --dump-manifest
-lake exe <generator> --help
+lake env lean --run <GeneratorMain>.lean --dump-schema
+lake env lean --run <GeneratorMain>.lean --dump-manifest
+lake env lean --run <GeneratorMain>.lean --help
 ```
 
 - `--dump-schema` prints the JSON Schema for the manifest
@@ -569,12 +570,12 @@ lake exe <generator> --help
 - `--help` includes these manifest-related flags alongside the usual rendering
   options
 
-## The Generator Executable
+## The Generator Entry Point
 
-Blueprint projects normally expose a small generator executable.
+Blueprint projects normally expose a small generator `main` function.
 
-In the commands below, `<generator>` stands for whatever executable name the
-project chooses.
+In the commands below, `<GeneratorMain>.lean` stands for the Lean file that
+defines the generator `main`, such as `ProjectTemplateMain.lean`.
 
 Minimal example:
 
@@ -599,10 +600,31 @@ Blueprint-specific rendered surfaces, applies Blueprint's shared preview and
 public-xref emission policy, and keeps downstream projects from needing to
 remember those dependencies manually.
 
-Typical usage:
+Recommended CI usage builds the Lean library or formalization targets needed by
+the document, then runs the generator file directly:
 
 ```bash
-lake exe <generator> --output _out/site
+lake build <library-or-formalization-target>
+lake env lean --run <GeneratorMain>.lean --output _out/site
+```
+
+That path still checks the Blueprint document and writes the same HTML output,
+but it does not force Lake to compile the generator executable and its
+transitive native artifacts. In Mathlib-heavy projects this is often faster for
+cold CI jobs, even though the interpreted generator step itself can be a little
+slower than a compiled executable.
+
+Projects may also declare a `lean_exe` for repeated local runs:
+
+```lean
+lean_exe «blueprint-gen» where
+  root := `ProjectTemplateMain
+```
+
+Then the compiled-executable path remains available:
+
+```bash
+lake exe blueprint-gen --output _out/site
 ```
 
 ## Blueprint Options

--- a/project_template/.github/workflows/blueprint-pages.yml
+++ b/project_template/.github/workflows/blueprint-pages.yml
@@ -60,13 +60,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            .lake/build/bin
             .lake/build/lib
             .lake/build/ir
-          key: ${{ runner.os }}-lean-build-v1-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.lean', '.gitmodules', '*.lean', '**/*.lean', 'scripts/ci-pages.sh') }}
+          key: ${{ runner.os }}-lean-build-v2-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.lean', '.gitmodules', '*.lean', '**/*.lean', 'scripts/ci-pages.sh') }}
           restore-keys: |
-            ${{ runner.os }}-lean-build-v1-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.lean', '.gitmodules') }}-
-            ${{ runner.os }}-lean-build-v1-
+            ${{ runner.os }}-lean-build-v2-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.lean', '.gitmodules') }}-
+            ${{ runner.os }}-lean-build-v2-
       - if: ${{ inputs.harness_enabled }}
         name: Restore formalization Lean build cache
         uses: actions/cache@v4

--- a/project_template/README.md
+++ b/project_template/README.md
@@ -11,7 +11,7 @@ project that already has the right moving parts:
 - a GitHub Pages workflow under `.github/workflows/`
 - chapter files with real Blueprint blocks
 - a Blueprint top-level file
-- a `blueprint-gen` executable
+- a generator entry point, plus an optional `blueprint-gen` executable
 - a local CI script for build-and-render checks
 - rendered graph and summary pages
 
@@ -46,7 +46,8 @@ The important files are:
   the intentionally unfinished conjecture
 - `ProjectTemplate/Blueprint.lean`: the Blueprint top-level file
 - `ProjectTemplateMain.lean`: the rendering entry point
-- `lakefile.lean`: the package definition and the `blueprint-gen` executable
+- `lakefile.lean`: the package definition and optional `blueprint-gen`
+  executable
 - `.github/workflows/blueprint-pages.yml`: copyable reusable Pages workflow
   used by the template
 - `.github/workflows/pages.yml`: thin caller into the local reusable workflow
@@ -70,7 +71,7 @@ The important files are:
 
 1. Copy this folder into a new repository.
 2. Rename `ProjectTemplate` to your project name.
-3. Keep the `blueprint-gen` executable and top-level file structure.
+3. Keep the generator entry point and top-level file structure.
 4. Replace the addition, multiplication, and Collatz chapters with your own
    content.
 
@@ -83,8 +84,18 @@ lake update
 
 Run `lake update` once after copying the template. After that, use
 `./scripts/ci-pages.sh` whenever you want the same local build-and-render check
-that the included GitHub Pages workflow runs. If you only want to regenerate
-the site manually, `lake exe blueprint-gen --output _out/site` still works.
+that the included GitHub Pages workflow runs. The script builds the Lean library
+artifacts and then runs the generator file directly:
+
+```bash
+lake build ProjectTemplate
+lake env lean --run ProjectTemplateMain.lean --output _out/site
+```
+
+This avoids compiling a generator executable and its transitive native artifacts,
+which is especially helpful in cold CI jobs and Mathlib-heavy projects. If you
+want a compiled executable for repeated local runs,
+`lake exe blueprint-gen --output _out/site` still works.
 
 ## GitHub Pages
 

--- a/project_template/scripts/ci-pages.sh
+++ b/project_template/scripts/ci-pages.sh
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-lake build
-lake exe blueprint-gen --output _out/site
+lake build ProjectTemplate
+lake env lean --run ProjectTemplateMain.lean --output _out/site
 
 test -f _out/site/html-multi/index.html
 test -f _out/site/html-multi/-verso-data/blueprint-preview-manifest.json

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,9 +3,12 @@
 This directory contains repository-local maintainer tooling for
 `verso-blueprint`.
 
-For package-facing usage, the preferred entry point is still
-`lake exe blueprint-gen`, not the Python harness here. Start with the
-top-level [`README.md`](../README.md) and [`doc/MANUAL.md`](../doc/MANUAL.md).
+For package-facing usage, use the project's Blueprint generator entry point,
+not the Python harness here. CI and Mathlib-heavy projects should prefer
+`lake env lean --run <GeneratorMain>.lean --output ...` after building the
+needed Lean library artifacts; `lake exe blueprint-gen` remains available for
+projects that want a compiled generator executable. Start with the top-level
+[`README.md`](../README.md) and [`doc/MANUAL.md`](../doc/MANUAL.md).
 
 For repository maintenance, the canonical workflow document is
 [`doc/MAINTAINER_GUIDE.md`](../doc/MAINTAINER_GUIDE.md). This README is

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -16,7 +16,6 @@ if str(PACKAGE_ROOT) not in sys.path:
 
 from scripts.blueprint_harness_paths import (
     canonical_test_blueprint_output_dir,
-    canonical_test_blueprint_package_dir,
     default_test_blueprint_site_dir,
 )
 
@@ -74,19 +73,18 @@ def load_redirects(site_dir: str | Path):
 
 
 def build_test_blueprint_site(name: str) -> Path:
-    package_dir = canonical_test_blueprint_package_dir(name, Path(__file__))
     output_dir = canonical_test_blueprint_output_dir(name, Path(__file__))
     output_dir.parent.mkdir(parents=True, exist_ok=True)
     subprocess.run(
         [
-            str(PACKAGE_ROOT / "scripts" / "lean-low-priority"),
-            "lake",
-            "exe",
-            "blueprint-gen",
-            "--output",
+            sys.executable,
+            "-m",
+            "scripts.blueprint_test_blueprints",
+            "generate",
+            name,
             str(output_dir),
         ],
-        cwd=package_dir,
+        cwd=PACKAGE_ROOT,
         check=True,
     )
     return output_dir / "html-multi"

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -32,8 +32,8 @@
           "release": "v4.29.0"
         }
       ],
-      "build_command": ["lake", "build"],
-      "generate_command": ["lake", "exe", "blueprint-gen", "--output", "{output_dir}"],
+      "build_command": ["lake", "build", "ProjectTemplate"],
+      "generate_command": ["lake", "env", "lean", "--run", "ProjectTemplateMain.lean", "--output", "{output_dir}"],
       "site_subdir": "html-multi"
     },
     {
@@ -50,8 +50,8 @@
           "ref": "070e0c6d7bb205c89270cb1b60e5cf3cf431af28"
         }
       ],
-      "build_command": ["lake", "build"],
-      "generate_command": ["lake", "exe", "blueprint-gen", "--output", "{output_dir}"],
+      "build_command": ["lake", "build", "Contents"],
+      "generate_command": ["lake", "env", "lean", "--run", "Main.lean", "--output", "{output_dir}"],
       "site_subdir": "html-multi"
     },
     {
@@ -68,8 +68,8 @@
           "ref": "ac4f16b7fc8d6b3a5bd7ed9d8dff37eff6ff0e8b"
         }
       ],
-      "build_command": ["lake", "build"],
-      "generate_command": ["lake", "exe", "blueprint-gen", "--output", "{output_dir}"],
+      "build_command": ["lake", "build", "SpherePackingBlueprint"],
+      "generate_command": ["lake", "env", "lean", "--run", "SpherePackingBlueprintMain.lean", "--output", "{output_dir}"],
       "site_subdir": "html-multi"
     },
     {
@@ -86,8 +86,8 @@
           "ref": "ad4cffd681b6234e9ab30b19adb69c92b962ff34"
         }
       ],
-      "build_command": ["lake", "build", "blueprint-gen"],
-      "generate_command": ["lake", "exe", "blueprint-gen", "--output", "{output_dir}"],
+      "build_command": ["lake", "build", "FLTBlueprint"],
+      "generate_command": ["lake", "env", "lean", "--run", "FLTBlueprintMain.lean", "--output", "{output_dir}"],
       "site_subdir": "html-multi"
     },
     {
@@ -104,8 +104,8 @@
           "ref": "1fda7a4581e55dca27209f060a90179b0a1a2f32"
         }
       ],
-      "build_command": ["lake", "build", "blueprint-gen"],
-      "generate_command": ["lake", "exe", "blueprint-gen", "--output", "{output_dir}"],
+      "build_command": ["lake", "build", "AlgebraicCombinatoricsBlueprint"],
+      "generate_command": ["lake", "env", "lean", "--run", "BlueprintMain.lean", "--output", "{output_dir}"],
       "site_subdir": "html-multi"
     }
   ]

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -63,6 +63,27 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             capture_output=True,
         ).stdout.strip()
 
+    def assert_resolved_projects_match_manifest(self, release_id: str) -> None:
+        catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
+        release = resolve_release_target(catalog, release_id, PACKAGE_ROOT)
+        projects = resolve_projects_for_release(catalog, release.release_id, None)
+
+        expected_projects: list[str] = []
+        expected_refs: dict[str, str | None] = {}
+        for project in catalog.projects:
+            target = next((target for target in project.targets if target.release == release.release_id), None)
+            if target is None:
+                continue
+            expected_projects.append(project.project_id)
+            expected_refs[project.project_id] = target.ref
+
+        self.assertEqual([project.project_id for project in projects], expected_projects)
+        for project in projects:
+            self.assertEqual(project.selected_release, release.release_id)
+            expected_ref = expected_refs[project.project_id]
+            if expected_ref is not None:
+                self.assertEqual(project.ref, expected_ref)
+
     def test_default_manifest_contains_current_external_projects(self) -> None:
         manifest = default_project_manifest(PACKAGE_ROOT)
         catalog = load_project_catalog(manifest)
@@ -76,18 +97,25 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertTrue(projects[0].in_repo_project)
         self.assertTrue(projects[0].in_repo_command_project)
         self.assertEqual(projects[0].project_root, "project_template")
-        self.assertEqual(projects[0].generate_command, ("lake", "exe", "blueprint-gen", "--output", "{output_dir}"))
+        self.assertEqual(projects[0].build_command, ("lake", "build", "ProjectTemplate"))
+        self.assertEqual(
+            projects[0].generate_command,
+            ("lake", "env", "lean", "--run", "ProjectTemplateMain.lean", "--output", "{output_dir}"),
+        )
         self.assertEqual([target.release for target in projects[0].targets], ["v4.28.0", "v4.29.0"])
         self.assertTrue(projects[1].git_checkout)
         self.assertEqual(projects[1].repository, "https://github.com/ejgallego/verso-noperthedron.git")
         self.assertEqual([target.release for target in projects[1].targets], ["v4.29.0"])
-        self.assertEqual(projects[1].targets[0].ref, "47f28af5e6d3edf0de439b7de9c3f121e14e4707")
+        self.assertEqual(projects[1].build_command, ("lake", "build", "Contents"))
+        self.assertEqual(
+            projects[1].generate_command,
+            ("lake", "env", "lean", "--run", "Main.lean", "--output", "{output_dir}"),
+        )
         self.assertEqual(projects[1].browser_tests_path, None)
         self.assertEqual(projects[1].panel_regression_script, None)
         self.assertEqual(projects[3].repository, "https://github.com/ejgallego/verso-flt.git")
         self.assertEqual(projects[4].repository, "https://github.com/ejgallego/verso-algebraic-combinatorics.git")
         self.assertEqual([target.release for target in projects[4].targets], ["v4.28.0"])
-        self.assertEqual(projects[4].targets[0].ref, "6506b992702a6e47a29d90d504f9e55eb65e13e9")
 
     def test_reference_pages_workflow_stages_every_manifest_project(self) -> None:
         catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
@@ -110,66 +138,26 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
         matrix = deploy_project_matrix(catalog.release_targets, catalog)
 
+        expected_entries = []
+        for release in catalog.release_targets:
+            if not release.deploy_pages:
+                continue
+            for project in resolve_projects_for_release(catalog, release.release_id, None):
+                expected_entries.append(
+                    {
+                        "release_id": release.release_id,
+                        "toolchain": release.toolchain,
+                        "verso_ref": release.verso_ref,
+                        "branch": release.branch,
+                        "project_id": project.project_id,
+                        "artifact_name": f"reference-blueprints-release-{release.release_id}__project__{project.project_id}",
+                        "artifact_path": f"_out/reference-blueprints/{release.release_id}/{project.project_id}",
+                    }
+                )
+
         self.assertEqual(
             matrix,
-            {
-                "include": [
-                    {
-                        "release_id": "v4.28.0",
-                        "toolchain": "v4.28.0",
-                        "verso_ref": "v4.28.0",
-                        "branch": "v4.28.0",
-                        "project_id": "project-template",
-                        "artifact_name": "reference-blueprints-release-v4.28.0__project__project-template",
-                        "artifact_path": "_out/reference-blueprints/v4.28.0/project-template",
-                    },
-                    {
-                        "release_id": "v4.28.0",
-                        "toolchain": "v4.28.0",
-                        "verso_ref": "v4.28.0",
-                        "branch": "v4.28.0",
-                        "project_id": "spherepackingblueprint",
-                        "artifact_name": "reference-blueprints-release-v4.28.0__project__spherepackingblueprint",
-                        "artifact_path": "_out/reference-blueprints/v4.28.0/spherepackingblueprint",
-                    },
-                    {
-                        "release_id": "v4.28.0",
-                        "toolchain": "v4.28.0",
-                        "verso_ref": "v4.28.0",
-                        "branch": "v4.28.0",
-                        "project_id": "verso-flt",
-                        "artifact_name": "reference-blueprints-release-v4.28.0__project__verso-flt",
-                        "artifact_path": "_out/reference-blueprints/v4.28.0/verso-flt",
-                    },
-                    {
-                        "release_id": "v4.28.0",
-                        "toolchain": "v4.28.0",
-                        "verso_ref": "v4.28.0",
-                        "branch": "v4.28.0",
-                        "project_id": "algebraic-combinatorics",
-                        "artifact_name": "reference-blueprints-release-v4.28.0__project__algebraic-combinatorics",
-                        "artifact_path": "_out/reference-blueprints/v4.28.0/algebraic-combinatorics",
-                    },
-                    {
-                        "release_id": "v4.29.0",
-                        "toolchain": "v4.29.0",
-                        "verso_ref": "v4.29.0",
-                        "branch": "v4.29.0",
-                        "project_id": "project-template",
-                        "artifact_name": "reference-blueprints-release-v4.29.0__project__project-template",
-                        "artifact_path": "_out/reference-blueprints/v4.29.0/project-template",
-                    },
-                    {
-                        "release_id": "v4.29.0",
-                        "toolchain": "v4.29.0",
-                        "verso_ref": "v4.29.0",
-                        "branch": "v4.29.0",
-                        "project_id": "noperthedron",
-                        "artifact_name": "reference-blueprints-release-v4.29.0__project__noperthedron",
-                        "artifact_path": "_out/reference-blueprints/v4.29.0/noperthedron",
-                    },
-                ]
-            },
+            {"include": expected_entries},
         )
 
     def test_git_checkout_project_is_supported(self) -> None:
@@ -258,29 +246,10 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(projects[0].generate_command, ("lake", "exe", "blueprint-gen", "--output", "{output_dir}"))
 
     def test_resolve_projects_for_release_filters_to_matching_targets(self) -> None:
-        catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
-
-        release = resolve_release_target(catalog, "v4.29.0", PACKAGE_ROOT)
-        projects = resolve_projects_for_release(catalog, release.release_id, None)
-
-        self.assertEqual([project.project_id for project in projects], ["project-template", "noperthedron"])
-        self.assertEqual(projects[1].selected_release, "v4.29.0")
-        self.assertEqual(projects[1].ref, "47f28af5e6d3edf0de439b7de9c3f121e14e4707")
+        self.assert_resolved_projects_match_manifest("v4.29.0")
 
     def test_resolve_projects_for_older_release_uses_matching_targets(self) -> None:
-        catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
-
-        release = resolve_release_target(catalog, "v4.28.0", PACKAGE_ROOT)
-        projects = resolve_projects_for_release(catalog, release.release_id, None)
-
-        self.assertEqual(
-            [project.project_id for project in projects],
-            ["project-template", "spherepackingblueprint", "verso-flt", "algebraic-combinatorics"],
-        )
-        self.assertEqual(projects[1].selected_release, "v4.28.0")
-        self.assertEqual(projects[1].ref, "4346c148b91c3a0d1060a0413176e8290a3e0839")
-        self.assertEqual(projects[2].ref, "1d4f671ee5aa6169bd263384d52d97b8957d2d15")
-        self.assertEqual(projects[3].ref, "6506b992702a6e47a29d90d504f9e55eb65e13e9")
+        self.assert_resolved_projects_match_manifest("v4.28.0")
 
     def test_duplicate_project_ids_are_rejected(self) -> None:
         manifest_data = {

--- a/tests/harness/test_blueprint_test_blueprints.py
+++ b/tests/harness/test_blueprint_test_blueprints.py
@@ -45,6 +45,11 @@ class StandaloneTestBlueprintTests(unittest.TestCase):
             ("preview", "runtime", "browser", "graph", "summary", "relationships"),
         )
         self.assertEqual(fixture.project_root, "tests/test_blueprints/preview_runtime_showcase")
+        self.assertEqual(fixture.build_command, ("lake", "build", "PreviewRuntimeShowcase"))
+        self.assertEqual(
+            fixture.generate_command,
+            ("lake", "env", "lean", "--run", "PreviewRuntimeShowcaseMain.lean", "--output", "{output_dir}"),
+        )
         self.assertEqual(fixture.browser_tests_path, "tests/browser")
         self.assertEqual(
             fixture.panel_regression_script,

--- a/tests/harness/test_blueprints.json
+++ b/tests/harness/test_blueprints.json
@@ -18,8 +18,8 @@
       "summary": "Standalone browser-regression showcase with summary, graph, panel, and inline preview pages.",
       "tags": ["preview", "runtime", "browser", "graph", "summary", "relationships"],
       "project_root": "tests/test_blueprints/preview_runtime_showcase",
-      "build_command": ["lake", "build"],
-      "generate_command": ["lake", "exe", "blueprint-gen", "--output", "{output_dir}"],
+      "build_command": ["lake", "build", "PreviewRuntimeShowcase"],
+      "generate_command": ["lake", "env", "lean", "--run", "PreviewRuntimeShowcaseMain.lean", "--output", "{output_dir}"],
       "validation": {
         "panel_regression_script": "tests/harness/preview_runtime_showcase/check_blueprint_code_panels.py",
         "browser_tests_path": "tests/browser"


### PR DESCRIPTION
This PR documents and wires the alternative `lake env lean --run` Blueprint generation path for CI and harness generation, while keeping compiled generator executables available for repeated local runs.

Backport v4.28.0: exempt: paired #28 has release-line-specific harness manifest assertions