### PR TITLE
feat(harness): label paired backport PRs

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -92,6 +92,8 @@ subjects such as `Update files` or `misc cleanup`.
     need to refresh just the backport plan lines in an existing PR body
   - once it is ready for review, open the paired `v4.28.0` PR
   - use `python3 -m scripts.blueprint_harness prepare-backport-pr v4.28.0 --main-pr <pr>` to scaffold the paired backport PR branch name, title, and body
+  - apply the scaffolded release label, for example `backport-v4.28.0`, to the
+    paired backport PR
   - when several releases are required, use `python3 -m scripts.blueprint_harness prepare-backport-pr --all-required --main-pr <pr>` to emit one scaffold block per release, then let the agent apply the `git cherry-pick -x` series and resolve conflicts in each backport worktree
   - replace each `Backport ...: pending` line with `Backport ...: #<pr>` or
     `Backport ...: exempt: <reason>`

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -187,6 +187,10 @@ python3 -m scripts.blueprint_harness prepare-backport-pr --all-required --main-p
 Use `git cherry-pick -x` for paired backport branches so the paired-backport
 check can verify recorded source SHAs and patch IDs.
 
+Each paired backport PR should carry the scaffolded release label, such as
+`backport-v4.28.0`, so release-specific queues remain visible when several
+maintenance lines are active.
+
 Land reviewed local work from the clean root checkout:
 
 ```bash
@@ -337,8 +341,8 @@ python3 -m scripts.blueprint_harness prepare-backport-pr v4.28.0 --main-pr <pr>
 ```
 
 That helper prints a standardized paired branch name, a title of the form
-`[backport v4.28.0] ...`, and a PR body that points back to the primary
-default-development review.
+`[backport v4.28.0] ...`, a `backport-v4.28.0` release label, and a PR body
+that points back to the primary default-development review.
 
 When several backport releases are required, use:
 
@@ -347,9 +351,9 @@ python3 -m scripts.blueprint_harness prepare-backport-pr --all-required --main-p
 ```
 
 That batch mode emits one scaffold block per required release, including the
-paired worktree name, branch name, and the exact `git cherry-pick -x ...`
-series to apply. An agent can then create each worktree, apply the series, and
-resolve conflicts release by release.
+paired worktree name, branch name, release label, and the exact
+`git cherry-pick -x ...` series to apply. An agent can then create each
+worktree, apply the series, and resolve conflicts release by release.
 
 When populating the paired backport branch itself, use `git cherry-pick -x` so
 each backport commit records `(cherry picked from commit <sha>)`. The

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -537,6 +537,12 @@ def release_marker(release_ref: str) -> str:
     return "v" + re.sub(r"[^A-Za-z0-9]+", "", normalized.removeprefix("v"))
 
 
+def backport_label_for_release(release_ref: str) -> str:
+    normalized = normalize_lean_release_ref(release_ref)
+    label_fragment = re.sub(r"[^A-Za-z0-9._-]+", "-", normalized).strip("-").lower()
+    return f"backport-{label_fragment or 'release'}"
+
+
 def slugify_backport_fragment(text: str) -> str:
     cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", text.strip())
     cleaned = re.sub(r"-{2,}", "-", cleaned).strip("-")
@@ -579,6 +585,7 @@ def print_prepare_backport_pr_scaffold(
     paired_branch = default_backport_branch_name(source_branch, backport_release)
     paired_worktree = default_backport_worktree_name(source_branch, backport_release)
     paired_title = f"[backport {backport_release}] {main_title}"
+    paired_label = backport_label_for_release(backport_release)
 
     print("## Local Backport Plan")
     print()
@@ -589,6 +596,7 @@ def print_prepare_backport_pr_scaffold(
     print(f"paired_worktree={paired_worktree}")
     print(f"paired_branch={paired_branch}")
     print(f"paired_title={paired_title}")
+    print(f"paired_label={paired_label}")
     print(f"source_commits={','.join(source_commits)}")
     print(f"base_ref=origin/{backport_release}")
     print()
@@ -605,6 +613,7 @@ def print_prepare_backport_pr_scaffold(
     print()
     print("## PR Submission Guardrails")
     print("- Use the PR title and body below as the public backport PR metadata.")
+    print(f"- Apply the release label `{paired_label}` to the paired backport PR.")
     print("- Keep review-facing discussion on the default-development PR unless this backport diverges.")
     print("- Do not add routine validation transcripts to the backport PR body; CI is the default validation record.")
     print()

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -138,6 +138,14 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertTrue(args.all_required)
         self.assertEqual(args.main_pr, 11)
 
+    def test_backport_label_for_release_uses_normalized_release_ref(self) -> None:
+        self.assertEqual(harness_mod.backport_label_for_release("v4.28.0"), "backport-v4.28.0")
+        self.assertEqual(
+            harness_mod.backport_label_for_release("leanprover/lean4:v4.28.0"),
+            "backport-v4.28.0",
+        )
+        self.assertEqual(harness_mod.backport_label_for_release("4.28.0"), "backport-v4.28.0")
+
     def test_bump_toolchain_parses_optional_flags(self) -> None:
         parser = build_parser()
         args = parser.parse_args(["bump-toolchain", "4.29.0", "--verso-ref", "v4.29.0", "--skip-validation"])
@@ -507,10 +515,12 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertIn("paired_worktree=backport-v428-backport-discipline", output)
         self.assertIn("paired_branch=fix/backport-v428-backport-discipline", output)
         self.assertIn("paired_title=[backport v4.28.0] fix: require draft plans and base-aware retire", output)
+        self.assertIn("paired_label=backport-v4.28.0", output)
         self.assertIn("source_commits=abc123,def456", output)
         self.assertIn("git cherry-pick -x abc123 def456", output)
         self.assertIn("## PR Submission Guardrails", output)
         self.assertIn("Use the PR title and body below as the public backport PR metadata", output)
+        self.assertIn("Apply the release label `backport-v4.28.0`", output)
         self.assertIn("Keep review-facing discussion on the default-development PR", output)
         self.assertIn("Do not add routine validation transcripts to the backport PR body", output)
         self.assertIn("## PR Title\n[backport v4.28.0] fix: require draft plans and base-aware retire", output)
@@ -553,8 +563,10 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         output = out.getvalue()
         self.assertIn("backport_release=v4.28.0", output)
         self.assertIn("paired_branch=fix/backport-v428-backport-discipline", output)
+        self.assertIn("paired_label=backport-v4.28.0", output)
         self.assertIn("backport_release=v4.27.0", output)
         self.assertIn("paired_branch=fix/backport-v427-backport-discipline", output)
+        self.assertIn("paired_label=backport-v4.27.0", output)
         self.assertIn("\n---\n", output)
 
     def test_land_main_rejects_unsynced_main(self) -> None:


### PR DESCRIPTION
This PR adds release-specific labels to the paired backport PR scaffold so each maintenance-line PR can be tracked in its own queue.

- Emit a normalized paired_label field from prepare-backport-pr
- Document applying the scaffolded backport-vX.Y.Z label to each paired backport PR
- Cover single-release and multi-release scaffold output in harness CLI tests

Backport v4.28.0: #30