### PR TITLE
feat(render): configure block folding

### DIFF
--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -350,7 +350,7 @@ the operational detail that is easier to read in prose.
 | Index | Role | Functional map | Value description |
 | --- | --- | --- | --- |
 | `Nodes` | semantic domain | informal label -> `StoredBlockData` plus node anchor ids | Lightweight semantic node metadata: kind, parent/group, numbering caches, declared dependencies, ownership, tags, effort, priority, and PR URL. It deliberately excludes code/render payloads. |
-| `InlineCode` | internal index | informal label -> `InlineCodeData` plus code-panel anchor ids | Inline/literate Lean code data for a node: declared definitions/theorems, command ordering, proof-folding setting, and the code panel destination. |
+| `InlineCode` | internal index | informal label -> `InlineCodeData` plus code-panel anchor ids | Inline/literate Lean code data for a node: declared definitions/theorems, command ordering, proof/code folding settings, and the code panel destination. |
 | `Groups` | semantic domain | group label -> `GroupBlockData` | Declared group metadata for a parent/group label, currently its display header. Group membership itself is stored on `Nodes` through each node's `parent`. |
 | `TraversalPreviews` | runtime cache | `(informal label, preview facet)` -> `PreviewCache.Entry` plus preview anchor ids | Statement/proof preview blocks captured during traversal for hovers and the shared preview manifest. |
 | `LeanCodePreviews` | runtime cache | Lean declaration name -> `LeanCodePreview.Entry` plus declaration-preview anchor ids | Preview payloads for Lean declaration links, either from inline code blocks or external declaration snapshots. |

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -634,7 +634,8 @@ that elaborates the Blueprint chapter or document:
 
 ```lean
 set_option verso.blueprint.numbering global
-set_option verso.blueprint.foldProofs true
+set_option verso.blueprint.foldProofBlocks true
+set_option verso.blueprint.foldCodeBlocks false
 ```
 
 Current options:
@@ -647,6 +648,12 @@ Current options:
 - `verso.blueprint.foldProofs`
   - default: `true`
   - folds proof bodies in rendered Lean code panels after `by`
+- `verso.blueprint.foldProofBlocks`
+  - default: `false`
+  - renders proof blocks as collapsed disclosure blocks
+- `verso.blueprint.foldCodeBlocks`
+  - default: `false`
+  - renders Lean, Rust, and external code panels as collapsed disclosure blocks
 - `verso.blueprint.trimTeXLabelPrefix`
   - default: `false`
   - trims TeX-style label prefixes when deriving Lean names

--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -618,7 +618,7 @@ private def renderStatementMetadataPanel (data : BlockData) : Output.Html :=
 
 private def renderInformalBlock (data : BlockData) (numberText : String) (attrs : Array (String × String))
     (codeEntry : Output.Html) (groupEntry? : Option Output.Html) (usedByEntry : Output.Html)
-    (content : Array Output.Html) : Output.Html :=
+    (content : Array Output.Html) (folded : Bool := false) : Output.Html :=
   open Verso.Output.Html in
   let style := blockKindRenderStyle data
   let labelText := s!"{data.label}"
@@ -634,16 +634,28 @@ private def renderInformalBlock (data : BlockData) (numberText : String) (attrs 
     match data.kind with
     | .proof => .empty
     | .statement _ => renderStatementMetadataPanel data
-  {{
-    <div class={{wrapperClass}} title={{labelText}} {{attrs}}>
-      <div class={{headingClass}}>
-        {{titleRow}}
-        {{extras}}
+  if folded then
+    {{
+      <details class={{wrapperClass}} title={{labelText}} {{attrs}}>
+        <summary class={{headingClass}}>
+          {{titleRow}}
+          {{extras}}
+        </summary>
+        {{metadataPanel}}
+        <div class={{contentClass}}> {{ content }} </div>
+      </details>
+    }}
+  else
+    {{
+      <div class={{wrapperClass}} title={{labelText}} {{attrs}}>
+        <div class={{headingClass}}>
+          {{titleRow}}
+          {{extras}}
+        </div>
+        {{metadataPanel}}
+        <div class={{contentClass}}> {{ content }} </div>
       </div>
-      {{metadataPanel}}
-      <div class={{contentClass}}> {{ content }} </div>
-    </div>
-  }}
+    }}
 
 private def externalDeclsOfBlock (blockData : BlockData) : Array Data.ExternalRef :=
   match blockData.kind, blockData.codeData with
@@ -847,14 +859,20 @@ block_extension Block.informal (data : BlockData) where
                 decls
                 getDeclHref
                 getDeclAnchorAttrs
+                (folded := data.foldCodeBlock)
           | _, _ => none
         let externalPanel := (externalParts?.map (·.externalCodePanel)).getD .empty
         let content := (← blocks.mapM goB)
         let codeEntry := (headingParts?.map (·.codeEntry)).getD .empty
         let groupEntry ← renderGroupEntry relatedPanelContext data
         let usedByEntry ← renderUsedByEntry relatedPanelContext data
+        let foldInformalBlock :=
+          match data.kind with
+          | .proof => data.foldProofBlock
+          | .statement _ => false
         let informalBlock :=
           renderInformalBlock data (data.displayNumber s) attrs codeEntry groupEntry usedByEntry content
+            (folded := foldInformalBlock)
         return .seq #[informalBlock, externalPanel]
 
 private def expanderImpl (kind : Data.NodeKind) (isProof : Bool := false) : DirectiveExpanderOf Config
@@ -976,13 +994,16 @@ private def expanderImpl (kind : Data.NodeKind) (isProof : Bool := false) : Dire
       match owner with
       | some owner => Environment.getAuthor? owner
       | none => pure none
+    let opts ← getOptions
     let data : BlockData := {
       kind := blockKind
       codeData
       label
+      foldProofBlock := verso.blueprint.foldProofBlocks.get opts
+      foldCodeBlock := verso.blueprint.foldCodeBlocks.get opts
       parent := node?.bind (·.parent)
       count
-      numberingMode := numberingMode (← getOptions)
+      numberingMode := numberingMode opts
       statementDeps
       proofDeps
       owner

--- a/src/VersoBlueprint/Informal/Block/Assets.lean
+++ b/src/VersoBlueprint/Informal/Block/Assets.lean
@@ -1150,6 +1150,14 @@ span[class$="_thmlabel"]::after {
   content: "";
 }
 
+details.bp_kind_proof_wrapper > summary.bp_heading {
+  cursor: pointer;
+}
+
+details.bp_kind_proof_wrapper > summary.bp_heading::marker {
+  color: var(--bp-color-text-faint);
+}
+
 .bp_wrapper.bp_style_plain .bp_heading,
 div.theorem-style-plain div[class$="_thmheading"] {
   font-style: normal;

--- a/src/VersoBlueprint/Informal/Block/Common.lean
+++ b/src/VersoBlueprint/Informal/Block/Common.lean
@@ -122,6 +122,16 @@ register_option verso.blueprint.foldProofs : Bool := {
   descr := "Enable proof folding in VersoBlueprint Lean code blocks (hide text after `by` behind a toggle)"
 }
 
+register_option verso.blueprint.foldProofBlocks : Bool := {
+  defValue := false
+  descr := "Render VersoBlueprint proof blocks as collapsed details blocks"
+}
+
+register_option verso.blueprint.foldCodeBlocks : Bool := {
+  defValue := false
+  descr := "Render VersoBlueprint Lean, Rust, and external code panels as collapsed details blocks"
+}
+
 def provedStatusHasSorry (status : Data.ProvedStatus) : Bool :=
   status.isIncomplete
 
@@ -152,8 +162,11 @@ def externalCodeEntryTitle (found total missing withGaps : Nat) : String :=
 def mkCodePanel
     (header : CodePanelHeader) (summaryTitle : String)
     (progressBar body : Output.Html)
-    (attrs : Array (String × String) := #[]) : Output.Html :=
+    (attrs : Array (String × String) := #[])
+    (folded : Bool := false) : Output.Html :=
   open Verso.Output.Html in
+  let attrs :=
+    if folded then attrs else attrs.push ("open", "open")
   {{
     <div class="bp_wrapper bp_code_panel_wrapper">
       <details class="bp_code_block bp_code_panel" {{attrs}}>

--- a/src/VersoBlueprint/Informal/Block/Model.lean
+++ b/src/VersoBlueprint/Informal/Block/Model.lean
@@ -61,6 +61,7 @@ structure InlineCodeData where
   label : Data.Label
   definedDefs : Array CodeDeclData := #[]
   definedTheorems : Array CodeDeclData := #[]
+  foldCodeBlock : Bool := false
   foldProofs : Bool := true
 deriving Repr, Inhabited, FromJson, ToJson, Quote
 
@@ -105,6 +106,8 @@ structure BlockData where
   /-- Optional code hint used for statement blocks (`.proof` always ignores this). -/
   codeData : Option BlockCodeData := none
   label : Data.Label
+  foldProofBlock : Bool := false
+  foldCodeBlock : Bool := false
   parent : Option Data.Parent := none
   count : Nat
   numberingMode : NumberingMode := .sub

--- a/src/VersoBlueprint/Informal/Code.lean
+++ b/src/VersoBlueprint/Informal/Code.lean
@@ -46,7 +46,7 @@ private partial def previewCodeBlocks
 block_extension Block.informalCode (data : InlineCodeData) where
   data := toJson data
   traverse id data _contents := do
-    let .ok cdata@{ label, definedDefs := _, definedTheorems := _, foldProofs := _ } := fromJson? (α := InlineCodeData) data
+    let .ok cdata@{ label, definedDefs := _, definedTheorems := _, foldCodeBlock := _, foldProofs := _ } := fromJson? (α := InlineCodeData) data
       | logError s!"Malformed data: {data}"
         pure none
     if let .some _d := Informal.TraversalIndex.InlineCode.object? (← get) label then
@@ -76,7 +76,7 @@ block_extension Block.informalCode (data : InlineCodeData) where
     open Verso.Doc.Html in
     open Verso.Output.Html in
     some <| fun _goI goB id data blocks => do
-      let .ok { label, definedDefs, definedTheorems, foldProofs } := fromJson? (α := InlineCodeData) data
+      let .ok { label, definedDefs, definedTheorems, foldCodeBlock, foldProofs } := fromJson? (α := InlineCodeData) data
         | HtmlT.logError s!"Malformed data: {data}"
           pure .empty
       let s ← HtmlT.state
@@ -93,12 +93,13 @@ block_extension Block.informalCode (data : InlineCodeData) where
       let panelSummary :=
         renderPanelIndicator label
           {
-            source := some (.inline { label, definedDefs, definedTheorems, foldProofs })
+            source := some (.inline { label, definedDefs, definedTheorems, foldCodeBlock, foldProofs })
           }
           getDeclHref
       let panelAttrs := attrs.push ("data-bp-proof-fold", if foldProofs then "on" else "off")
       let panelBody := .seq (← blocks.mapM goB)
       pure <| mkCodePanel panelHeader panelSummary.summaryTitle panelSummary.indicator panelBody panelAttrs
+        (folded := foldCodeBlock)
 
 structure CodeConfig where
   label : Data.Label
@@ -172,6 +173,7 @@ private def leanImpl : CodeBlockExpanderOf CodeConfig
       label := cfg.label
       definedDefs
       definedTheorems
+      foldCodeBlock := verso.blueprint.foldCodeBlocks.get (← getOptions)
       foldProofs := verso.blueprint.foldProofs.get (← getOptions)
     }
     let codeRef ← getRef

--- a/src/VersoBlueprint/Informal/ExternalCode.lean
+++ b/src/VersoBlueprint/Informal/ExternalCode.lean
@@ -316,7 +316,8 @@ This function only renders optional external code panel body for `(lean := ...)`
 def renderParts (panelHeader : CodePanelHeader)
     (summaryTitle : String) (indicator : Output.Html)
     (externalDecls : Array Data.ExternalRef) (getDeclHref : Name → Option String)
-    (getDeclAnchorAttrs : Data.ExternalRef → Array (String × String) := fun _ => #[]) : RenderParts :=
+    (getDeclAnchorAttrs : Data.ExternalRef → Array (String × String) := fun _ => #[])
+    (folded : Bool := false) : RenderParts :=
   open Verso.Output.Html in
   if externalDecls.isEmpty then
     {}
@@ -335,6 +336,7 @@ def renderParts (panelHeader : CodePanelHeader)
         {{<ul class="bp_code_hover_list bp_external_decl_list">
             {{.seq <| linkedDecls.map (renderExternalDeclRow ∘ externalDeclRowData)}}
           </ul>}}
+        (folded := folded)
     { externalCodePanel }
 
 end ExternalCode

--- a/src/VersoBlueprint/Informal/RustBlock.lean
+++ b/src/VersoBlueprint/Informal/RustBlock.lean
@@ -59,12 +59,14 @@ block_extension Block.informalRustCode (data : Informal.Rust.InlineCodeData) whe
         | none => { fallbackCodePanelHeader with caption := "Rust code" }
       let body := Informal.Rust.highlightHtml cdata.raw
       pure <| mkCodePanel panelHeader s!"Rust code for {cdata.label}" .empty body attrs
+        (folded := cdata.foldCodeBlock)
 
 private def rustImpl : CodeBlockExpanderOf Informal.CodeConfig
   | cfg, contents => do
     let data : Informal.Rust.InlineCodeData := {
       label := cfg.label
       raw := contents.getString
+      foldCodeBlock := verso.blueprint.foldCodeBlocks.get (← getOptions)
     }
     Environment.registerRustCode cfg.label { raw := contents.getString }
     ``(Block.other (Block.informalRustCode $(quote data)) #[])

--- a/src/VersoBlueprint/Rust.lean
+++ b/src/VersoBlueprint/Rust.lean
@@ -18,11 +18,12 @@ def informalRustCodeDomain : Name := Resolve.informalRustCodeDomainName
 structure InlineCodeData where
   label : Data.Label
   raw : String
+  foldCodeBlock : Bool := false
 deriving Repr, Inhabited, DecidableEq, ToJson, FromJson
 
 open Syntax in
 instance : Quote InlineCodeData where
-  quote data := mkCApp ``InlineCodeData.mk #[quote data.label, quote data.raw]
+  quote data := mkCApp ``InlineCodeData.mk #[quote data.label, quote data.raw, quote data.foldCodeBlock]
 
 def css : String := r##"
 .bp_rust_code {

--- a/src/VersoBlueprint/StyleSwitcher.lean
+++ b/src/VersoBlueprint/StyleSwitcher.lean
@@ -418,7 +418,7 @@ private def jsTemplate : String := r##"(function () {
   }
 
   function openDetailsAncestors(elem) {
-    let cur = elem && elem.parentElement;
+    let cur = elem;
     while (cur) {
       if (cur.tagName === "DETAILS") {
         cur.setAttribute("open", "open");

--- a/src/VersoBlueprint/TraversalIndex.lean
+++ b/src/VersoBlueprint/TraversalIndex.lean
@@ -110,7 +110,7 @@ def spec : StoreSpec := {
   name := Resolve.informalCodeDomainName
   kind := .internalIndex
   key := "informal label"
-  value := "InlineCodeData plus code-panel anchor ids"
+  value := "InlineCodeData plus code-panel anchor ids and folding settings"
   summary := "Traversal-local index for Blueprint code-panel sources keyed by informal label."
 }
 

--- a/tests/VersoBlueprintTests/Blueprint.lean
+++ b/tests/VersoBlueprintTests/Blueprint.lean
@@ -5,6 +5,7 @@ Author: Emilio J. Gallego Arias
 -/
 
 import VersoBlueprintTests.BlueprintAttribute
+import VersoBlueprintTests.BlueprintBlockFolding
 import VersoBlueprintTests.BlueprintCodeRenderMatrix
 import VersoBlueprintTests.BlueprintImportedDuplicates.Direct
 import VersoBlueprintTests.BlueprintImportedDuplicates.Transitive

--- a/tests/VersoBlueprintTests/BlueprintBlockFolding.lean
+++ b/tests/VersoBlueprintTests/BlueprintBlockFolding.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoBlueprintTests.Blueprint.Support
+
+namespace Verso.VersoBlueprintTests.BlueprintBlockFolding
+
+open Verso
+open Verso.Genre.Manual
+open Informal
+open Verso.VersoBlueprintTests.Blueprint.Support
+
+private def manualImpls : ExtensionImpls := extension_impls%
+
+set_option doc.verso true
+
+#docs (Genre.Manual) defaultProofBlockDoc "Default Proof Block" :=
+:::::::
+:::definition "folding.default.proof"
+Default proof statement.
+:::
+
+:::proof "folding.default.proof"
+Default proof body.
+:::
+:::::::
+
+set_option verso.blueprint.foldProofBlocks true
+
+#docs (Genre.Manual) foldedProofBlockDoc "Folded Proof Block" :=
+:::::::
+:::definition "folding.folded.proof"
+Folded proof statement.
+:::
+
+:::proof "folding.folded.proof"
+Folded proof body.
+:::
+:::::::
+
+set_option verso.blueprint.foldProofBlocks false
+
+#docs (Genre.Manual) defaultCodeBlockDoc "Default Code Block" :=
+:::::::
+```lean "folding.default.lean"
+def defaultCodeBlockWitness : Nat := 1
+```
+:::::::
+
+#docs (Genre.Manual) openCodeBlockDoc "Open Code Blocks" :=
+:::::::
+```lean "folding.open.lean"
+def openCodeBlockWitness : Nat := 1
+```
+
+```rust "folding.open.rust"
+pub fn open_rust_block() -> i32 {
+    1
+}
+```
+:::::::
+
+set_option verso.blueprint.foldCodeBlocks true
+
+#docs (Genre.Manual) foldedCodeBlockDoc "Folded Code Blocks" :=
+:::::::
+```lean "folding.folded.lean"
+def foldedCodeBlockWitness : Nat := 1
+```
+:::::::
+
+set_option verso.blueprint.foldCodeBlocks false
+
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let out ← renderManualDocHtmlString manualImpls defaultProofBlockDoc
+  pure <|
+    hasSubstr out "<div class=\"bp_wrapper bp_kind_proof_wrapper" &&
+    !hasSubstr out "<details class=\"bp_wrapper bp_kind_proof_wrapper" &&
+    hasSubstr out "Default proof body."
+
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let out ← renderManualDocHtmlString manualImpls foldedProofBlockDoc
+  pure <|
+    hasSubstr out "<details class=\"bp_wrapper bp_kind_proof_wrapper" &&
+    hasSubstr out "<summary class=\"bp_heading bp_kind_proof_heading" &&
+    hasSubstr out "Folded proof body."
+
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let out ← renderManualDocHtmlString manualImpls defaultCodeBlockDoc
+  pure <|
+    hasSubstr out "class=\"bp_code_block bp_code_panel\"" &&
+    hasSubstr out "data-bp-proof-fold=\"on\"" &&
+    hasSubstr out "open=\"open\""
+
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let out ← renderManualDocHtmlString manualImpls openCodeBlockDoc
+  pure <|
+    countSubstr out "class=\"bp_code_block bp_code_panel\"" == 2 &&
+    countSubstr out "open=\"open\"" == 2 &&
+    hasSubstr out "openCodeBlockWitness" &&
+    hasSubstr out "open_rust_block"
+
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let out ← renderManualDocHtmlString manualImpls foldedCodeBlockDoc
+  pure <|
+    hasSubstr out "class=\"bp_code_block bp_code_panel\"" &&
+    hasSubstr out "foldedCodeBlockWitness" &&
+    !hasSubstr out "open=\"open\""
+
+end Verso.VersoBlueprintTests.BlueprintBlockFolding


### PR DESCRIPTION
This PR lets Blueprint projects configure whether rendered proof blocks and code panels start open or folded while keeping Lean proof-body folding as a separate option.

- Adds `verso.blueprint.foldProofBlocks` for folding rendered proof blocks.
- Adds `verso.blueprint.foldCodeBlocks` for folding Lean, Rust, and external code panels, defaulting to open panels.
- Documents the options and adds regression coverage for default and opt-in folding behavior.

Backport v4.28.0: #32