### PR TITLE
[backport v4.28.0] fix(backports): stop mirroring paired PR CI

### DIFF
--- a/.github/workflows/backport-discipline.yml
+++ b/.github/workflows/backport-discipline.yml
@@ -13,8 +13,6 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  checks: read
-  statuses: read
 
 jobs:
   paired-backport:

--- a/scripts/check_backport_pr.py
+++ b/scripts/check_backport_pr.py
@@ -125,7 +125,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--token",
         default=os.environ.get("GITHUB_TOKEN"),
-        help="GitHub token with read access to pull requests and checks. Defaults to GITHUB_TOKEN.",
+        help="GitHub token with read access to pull requests. Defaults to GITHUB_TOKEN.",
     )
     return parser.parse_args()
 

--- a/scripts/check_backport_pr.py
+++ b/scripts/check_backport_pr.py
@@ -88,18 +88,6 @@ class GitHubApi:
             raise BackportCheckError(f"Unexpected pull request payload for #{number}")
         return data
 
-    def check_runs(self, sha: str) -> dict[str, Any]:
-        data = self.get_json(f"/repos/{self.repo_full_name}/commits/{sha}/check-runs")
-        if not isinstance(data, dict):
-            raise BackportCheckError(f"Unexpected check run payload for {sha}")
-        return data
-
-    def combined_status(self, sha: str) -> dict[str, Any]:
-        data = self.get_json(f"/repos/{self.repo_full_name}/commits/{sha}/status")
-        if not isinstance(data, dict):
-            raise BackportCheckError(f"Unexpected combined status payload for {sha}")
-        return data
-
     def pull_request_commits(self, number: int) -> list[PullRequestCommit]:
         commits: list[PullRequestCommit] = []
         page = 1
@@ -289,41 +277,6 @@ def verify_backport_commit_series(api: GitHubApi, source_pr_number: int, backpor
             )
 
 
-def check_runs_state(check_runs: dict[str, Any], combined_status: dict[str, Any]) -> None:
-    failures: list[str] = []
-    pending: list[str] = []
-    seen_run = False
-
-    for run in check_runs.get("check_runs", []):
-        if not isinstance(run, dict):
-            continue
-        seen_run = True
-        name = str(run.get("name") or "<unnamed check>")
-        status = str(run.get("status") or "")
-        conclusion = run.get("conclusion")
-        if status != "completed":
-            pending.append(name)
-            continue
-        if conclusion in {"success", "neutral", "skipped"}:
-            continue
-        failures.append(f"{name} ({conclusion or 'unknown'})")
-
-    state = str(combined_status.get("state") or "")
-    if state in {"failure", "error"}:
-        failures.append(f"combined status ({state})")
-    elif state == "pending":
-        pending.append("combined status")
-
-    if failures:
-        raise BackportCheckError("paired backport PR checks are failing: " + ", ".join(failures))
-    if pending:
-        raise BackportCheckError("paired backport PR checks are still pending: " + ", ".join(pending))
-    if not seen_run and state not in {"success", ""}:
-        raise BackportCheckError(f"paired backport PR has unexpected combined status `{state}`")
-    if not seen_run and state == "":
-        raise BackportCheckError("paired backport PR does not report any check runs yet")
-
-
 def verify_backport_pr(
     api: GitHubApi,
     source_pr_number: int,
@@ -347,15 +300,6 @@ def verify_backport_pr(
         raise BackportCheckError(f"paired backport PR #{entry.pr_number} is closed without merge")
 
     verify_backport_commit_series(api, source_pr_number, entry.pr_number)
-
-    if bool(pr.get("merged")):
-        return
-
-    sha = str(pr.get("head", {}).get("sha") or "")
-    if not sha:
-        raise BackportCheckError(f"paired backport PR #{entry.pr_number} is missing a head SHA")
-
-    check_runs_state(api.check_runs(sha), api.combined_status(sha))
 
 
 def event_pull_request(event: dict[str, Any]) -> dict[str, Any]:
@@ -401,7 +345,7 @@ def run(event_path: str | None, token: str | None) -> int:
             else:
                 print(
                     f"[backport-check] {branch}: paired PR #{entry.pr_number} recorded; "
-                    "ready-state checks will run after ready for review"
+                    "paired PR structure will be verified after ready for review"
                 )
         return 0
 

--- a/tests/harness/test_backport_pr_check.py
+++ b/tests/harness/test_backport_pr_check.py
@@ -28,12 +28,6 @@ class FakeGitHubApi:
     def commit_diff(self, sha: str) -> str:
         return self._commit_diffs[sha]
 
-    def check_runs(self, sha: str) -> dict[str, object]:
-        return {"check_runs": []}
-
-    def combined_status(self, sha: str) -> dict[str, object]:
-        return {"state": "success"}
-
 
 def diff_for(line: str) -> str:
     return (
@@ -82,19 +76,6 @@ Backport v4.26.0: exempt: no longer maintained
     def test_should_enforce_skips_non_default_dev_targets(self) -> None:
         pull_request = {"base": {"ref": "v4.28.0"}, "draft": False}
         self.assertFalse(backport_mod.should_enforce(pull_request, "v4.29.0", ("v4.28.0",)))
-
-    def test_check_runs_state_rejects_pending_and_failing_runs(self) -> None:
-        with self.assertRaisesRegex(backport_mod.BackportCheckError, "pending"):
-            backport_mod.check_runs_state(
-                {"check_runs": [{"name": "CI", "status": "in_progress", "conclusion": None}]},
-                {"state": "pending"},
-            )
-
-        with self.assertRaisesRegex(backport_mod.BackportCheckError, "failing"):
-            backport_mod.check_runs_state(
-                {"check_runs": [{"name": "CI", "status": "completed", "conclusion": "failure"}]},
-                {"state": "failure"},
-            )
 
     def test_run_requires_metadata_for_draft_default_dev_prs(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -193,14 +174,13 @@ Backport v4.26.0: exempt: no longer maintained
         with self.assertRaisesRegex(backport_mod.BackportCheckError, "does not match the patch from source commit"):
             backport_mod.verify_backport_commit_series(api, 11, 13)
 
-    def test_verify_backport_pr_checks_commit_series_before_ci(self) -> None:
+    def test_verify_backport_pr_accepts_structural_match_without_ci_status(self) -> None:
         api = FakeGitHubApi(
             pull_requests={
                 13: {
                     "base": {"ref": "v4.28.0"},
                     "draft": False,
                     "state": "open",
-                    "head": {"sha": "c" * 40},
                 }
             },
             pull_request_commits={


### PR DESCRIPTION
## Summary
Backport #33 to `v4.28.0`.

## Primary Review
- Primary review: #33
- Keep review comments on #33 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.28.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.
