### PR TITLE
[backport v4.29.0] chore(harness): checkpoint v4.30 reference matrix

### DIFF
--- a/.github/workflows/reference-blueprints-deploy.yml
+++ b/.github/workflows/reference-blueprints-deploy.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.repository.default_branch }}
+          fetch-depth: 0
       - name: Resolve deploy release metadata
         id: resolve
         run: python3 ./scripts/emit_reference_deploy_matrix.py --github-output >> "$GITHUB_OUTPUT"
@@ -63,6 +64,7 @@ jobs:
           echo "verso_ref=${{ matrix.verso_ref }}"
           echo "branch=${{ matrix.branch }}"
           echo "project_id=${{ matrix.project_id }}"
+          echo "hash=${{ matrix.hash }}"
       - name: Install elan
         run: |
           curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y

--- a/.github/workflows/reference-blueprints.yml
+++ b/.github/workflows/reference-blueprints.yml
@@ -46,6 +46,8 @@ jobs:
           echo "release_id=${{ needs.resolve-reference-release.outputs.release_id }}"
           echo "toolchain=${{ needs.resolve-reference-release.outputs.toolchain }}"
           echo "verso_ref=${{ needs.resolve-reference-release.outputs.verso_ref }}"
+          echo "blueprint=${{ matrix.project_id }}"
+          echo "hash=${{ matrix.hash }}"
       - name: Install elan
         run: |
           curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y

--- a/README.md
+++ b/README.md
@@ -34,9 +34,8 @@ Today a Blueprint project usually owns three things:
 `verso-blueprint` provides the Blueprint directives, rendering commands, preview
 runtime, and support library code. The starter layout in
 [project_template/](./project_template/) shows the recommended shape.
-If you want to inspect that starter as a generated site before copying it, see
-the [rendered project template](https://leanprover.github.io/verso-blueprint/reference-blueprints/project-template/).
-For the broader rendered artifact index, including local test fixtures, see the
+For the broader rendered artifact index, including published reference
+blueprints and local test fixtures, see the
 [published rendered artifact index](https://leanprover.github.io/verso-blueprint/).
 
 ## Core Features
@@ -178,14 +177,15 @@ you want to enable it.
 
 The repository also tracks larger reference blueprints.
 
-- [project_template/](./project_template/),
-  [rendered site](https://leanprover.github.io/verso-blueprint/reference-blueprints/project-template/)
-- [`ejgallego/verso-noperthedron`](https://github.com/ejgallego/verso-noperthedron),
-  [rendered site](https://leanprover.github.io/verso-blueprint/reference-blueprints/noperthedron/)
+- [project_template/](./project_template/), the in-repo starter template
+- [`ejgallego/verso-algebraic-combinatorics`](https://github.com/ejgallego/verso-algebraic-combinatorics),
+  [rendered site](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.28.0/algebraic-combinatorics/)
 - [`ejgallego/verso-sphere-packing`](https://github.com/ejgallego/verso-sphere-packing),
-  [rendered site](https://leanprover.github.io/verso-blueprint/reference-blueprints/spherepackingblueprint/)
+  [rendered site](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.29.0/spherepackingblueprint/)
+- [`ejgallego/verso-noperthedron`](https://github.com/ejgallego/verso-noperthedron),
+  [rendered site](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.30.0/noperthedron/)
 - [`ejgallego/verso-flt`](https://github.com/ejgallego/verso-flt),
-  [rendered site](https://leanprover.github.io/verso-blueprint/reference-blueprints/verso-flt/)
+  [rendered site](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.30.0/verso-flt/)
 
 ## Rendered Test Blueprints
 

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -534,8 +534,8 @@ template-owned CI path.
 pushes to release branches named like `v4.29.0`, and manual dispatch, it:
 
 - resolves the current branch's release target from `tests/harness/projects.json`
-- builds only the reference projects that declare compatibility with that
-  release target
+- filters the flat `reference_blueprints` list by that release target's
+  toolchain and builds only the matching reference blueprints
 - builds the local `test-blueprints/` artifact set, including
   `preview_runtime_showcase`
 - stages a branch-local site artifact under `_site/` only when the selected
@@ -548,13 +548,18 @@ pushes to release branches named like `v4.29.0`, and manual dispatch, it:
 successful `reference-blueprints.yml` run on a release branch named like
 `v4.29.0`, checks out the repository default-development branch as the source
 of truth for deployment policy, resolves every release target with
-`deploy_pages: true`, rebuilds each deployable reference slice in isolation,
-and assembles one combined GitHub Pages artifact.
+`deploy_pages: true`, filters the flat `reference_blueprints` list by that
+release target's toolchain, rebuilds those selected blueprints in isolation,
+and assembles one combined GitHub Pages artifact. Each `reference_blueprints`
+entry is the simple published-reference tuple: `blueprint`, `hash`, and
+`toolchain`; the detailed `projects` entries only describe how to build the
+selected blueprint.
 
 At the moment that means:
 
-- `v4.29.0` deploys Pages for its selected reference targets
-- `v4.28.0` also deploys Pages for its selected reference targets
+- `v4.30.0` deploys Pages for `noperthedron` and `verso-flt`
+- `v4.29.0` deploys Pages for `spherepackingblueprint`
+- `v4.28.0` also deploys Pages for `algebraic-combinatorics`
 
 The branch-local site artifact produced by `reference-blueprints.yml` for one
 release includes:
@@ -570,7 +575,7 @@ The combined Pages artifact produced by `reference-blueprints-deploy.yml`
 includes:
 
 - `_site/index.html`
-- `_site/reference-blueprints/<release-id>/<project-id>/` for each deployable
+- `_site/reference-blueprints/<release-id>/<project-id>/` for each selected
   reference target across all deployable release slices
 - `_site/test-blueprints/index.html`
 - `_site/test-blueprints/preview_runtime_showcase/`
@@ -593,8 +598,11 @@ The harness is now project-driven rather than hardcoded to one project.
 - the default catalog is declared in `tests/harness/projects.json`
 - catalog entries can also describe ephemeral `git_checkout` projects hosted
   outside this repository
-- external entries should declare release-specific refs under `targets` plus
-  the build and generation commands needed after checkout
+- the flat top-level `reference_blueprints` list selects the release-facing
+  validation set with one `(blueprint, hash, toolchain)` entry per published
+  reference blueprint
+- external `projects` entries declare the repository plus the build and
+  generation commands needed after checkout
 - prefer a build command that targets only the Lean library or formalization
   artifacts needed by the document, followed by a `lake env lean --run ...`
   generation command; do not build the generator executable unless that native
@@ -612,21 +620,32 @@ Minimal external catalog entry shape:
 
 ```json
 {
-  "id": "some-user-project",
-  "source": {
-    "kind": "git_checkout",
-    "repository": "https://github.com/org/some-user-project.git",
-    "project_root": "."
-  },
-  "targets": [
+  "reference_blueprints": [
     {
-      "release": "v4.29.0",
-      "ref": "0123456789abcdef0123456789abcdef01234567"
+      "blueprint": "some-user-project",
+      "hash": "0123456789abcdef0123456789abcdef01234567",
+      "toolchain": "v4.29.0"
     }
   ],
-  "build_command": ["lake", "build", "SomeUserProject"],
-  "generate_command": ["lake", "env", "lean", "--run", "SomeUserProjectMain.lean", "--output", "{output_dir}"],
-  "site_subdir": "html-multi"
+  "projects": [
+    {
+      "id": "some-user-project",
+      "source": {
+        "kind": "git_checkout",
+        "repository": "https://github.com/org/some-user-project.git",
+        "project_root": "."
+      },
+      "targets": [
+        {
+          "release": "v4.29.0",
+          "ref": "0123456789abcdef0123456789abcdef01234567"
+        }
+      ],
+      "build_command": ["lake", "build", "SomeUserProject"],
+      "generate_command": ["lake", "env", "lean", "--run", "SomeUserProjectMain.lean", "--output", "{output_dir}"],
+      "site_subdir": "html-multi"
+    }
+  ]
 }
 ```
 

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -27,10 +27,18 @@ class HarnessProjectTarget:
 
 
 @dataclass(frozen=True)
+class HarnessReferenceBlueprint:
+    blueprint: str
+    hash: str
+    toolchain: str
+
+
+@dataclass(frozen=True)
 class HarnessProjectCatalog:
     version: int
     release_targets: tuple[HarnessReleaseTarget, ...]
     projects: tuple["HarnessProject", ...]
+    reference_blueprints: tuple[HarnessReferenceBlueprint, ...] = ()
 
     def release_target(self, release_id: str) -> HarnessReleaseTarget | None:
         for target in self.release_targets:
@@ -126,7 +134,7 @@ def _optional_bool(data: dict, key: str, *, default: bool, context: str) -> bool
     return value
 
 
-def _load_release_targets(raw: dict, manifest_path: Path) -> tuple[HarnessReleaseTarget, ...]:
+def _load_release_targets(raw: dict, manifest_path: Path | str) -> tuple[HarnessReleaseTarget, ...]:
     entries = raw.get("release_targets")
     if not isinstance(entries, list) or not entries:
         raise ValueError(f"{manifest_path}: expected non-empty top-level `release_targets` list")
@@ -155,6 +163,30 @@ def _load_release_targets(raw: dict, manifest_path: Path) -> tuple[HarnessReleas
             )
         )
     return tuple(targets)
+
+
+def _load_reference_blueprints(raw: dict, manifest_path: Path | str) -> tuple[HarnessReferenceBlueprint, ...]:
+    entries = raw.get("reference_blueprints")
+    if entries is None:
+        return ()
+    if not isinstance(entries, list):
+        raise ValueError(f"{manifest_path}: expected top-level `reference_blueprints` list")
+
+    blueprints: list[HarnessReferenceBlueprint] = []
+    seen: set[tuple[str, str]] = set()
+    for index, entry in enumerate(entries, start=1):
+        if not isinstance(entry, dict):
+            raise ValueError(f"{manifest_path}: reference blueprint #{index} must be an object")
+        context = f"{manifest_path}: reference blueprint #{index}"
+        blueprint = _require_string(entry, "blueprint", context=context)
+        commit_hash = _require_string(entry, "hash", context=context)
+        toolchain = normalize_lean_release_ref(_require_string(entry, "toolchain", context=context))
+        key = (blueprint, toolchain)
+        if key in seen:
+            raise ValueError(f"{context}: duplicate reference blueprint `{blueprint}` for toolchain `{toolchain}`")
+        seen.add(key)
+        blueprints.append(HarnessReferenceBlueprint(blueprint=blueprint, hash=commit_hash, toolchain=toolchain))
+    return tuple(blueprints)
 
 
 def _load_project_targets(
@@ -194,11 +226,11 @@ def _load_project_targets(
     return tuple(targets)
 
 
-def load_project_catalog(manifest_path: Path) -> HarnessProjectCatalog:
-    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+def load_project_catalog_data(raw: dict, manifest_path: Path | str) -> HarnessProjectCatalog:
     if raw.get("version") != 2:
         raise ValueError(f"{manifest_path}: unsupported manifest version {raw.get('version')!r}")
     release_targets = _load_release_targets(raw, manifest_path)
+    reference_blueprints = _load_reference_blueprints(raw, manifest_path)
     release_ids = {target.release_id for target in release_targets}
 
     entries = raw.get("projects")
@@ -307,7 +339,48 @@ def load_project_catalog(manifest_path: Path) -> HarnessProjectCatalog:
             )
         )
 
-    return HarnessProjectCatalog(version=2, release_targets=release_targets, projects=tuple(projects))
+    project_by_id = {project.project_id: project for project in projects}
+    for blueprint in reference_blueprints:
+        project = project_by_id.get(blueprint.blueprint)
+        if project is None:
+            known = ", ".join(sorted(project_by_id))
+            raise ValueError(
+                f"{manifest_path}: reference blueprint `{blueprint.blueprint}` is not a known project; "
+                f"known projects: {known}"
+            )
+        if not project.git_checkout:
+            raise ValueError(f"{manifest_path}: reference blueprint `{blueprint.blueprint}` must be a git checkout project")
+        release = normalize_lean_release_ref(blueprint.toolchain)
+        target = project.target_for_release(release)
+        if target is None:
+            raise ValueError(
+                f"{manifest_path}: reference blueprint `{blueprint.blueprint}` for toolchain "
+                f"`{blueprint.toolchain}` has no project target for release `{release}`"
+            )
+        if target.ref is not None and target.ref != blueprint.hash:
+            raise ValueError(
+                f"{manifest_path}: reference blueprint `{blueprint.blueprint}` hash `{blueprint.hash}` "
+                f"does not match target ref `{target.ref}` for release `{release}`"
+            )
+
+    return HarnessProjectCatalog(
+        version=2,
+        release_targets=release_targets,
+        projects=tuple(projects),
+        reference_blueprints=reference_blueprints,
+    )
+
+
+def load_project_catalog(manifest_path: Path) -> HarnessProjectCatalog:
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    return load_project_catalog_data(raw, manifest_path)
+
+
+def load_project_catalog_text(text: str, manifest_path: Path | str) -> HarnessProjectCatalog:
+    raw = json.loads(text)
+    if not isinstance(raw, dict):
+        raise ValueError(f"{manifest_path}: expected JSON object")
+    return load_project_catalog_data(raw, manifest_path)
 
 
 def load_projects_manifest(manifest_path: Path) -> list[HarnessProject]:
@@ -329,6 +402,28 @@ def resolve_projects_for_release(
     selected_ids: list[str] | None,
 ) -> list[HarnessProject]:
     by_id = {project.project_id: project for project in catalog.projects}
+    release_target = catalog.release_target(release)
+    if catalog.reference_blueprints and release_target is not None and selected_ids is None:
+        matching = [
+            blueprint
+            for blueprint in catalog.reference_blueprints
+            if blueprint.toolchain == release_target.toolchain
+        ]
+        resolved_from_blueprints: list[HarnessProject] = []
+        for blueprint in matching:
+            project = by_id[blueprint.blueprint]
+            target = project.target_for_release(release)
+            if target is None:
+                raise ValueError(f"project `{project.project_id}` has no target for release `{release}`")
+            resolved_from_blueprints.append(
+                replace(
+                    project,
+                    ref=blueprint.hash,
+                    selected_release=release,
+                )
+            )
+        return resolved_from_blueprints
+
     if selected_ids is None:
         candidates = list(catalog.projects)
     else:
@@ -367,11 +462,12 @@ def reference_artifact_path(project: HarnessProject) -> str:
     return f"_out/reference-blueprints/{project.project_id}"
 
 
-def reference_build_matrix(projects: list[HarnessProject]) -> dict[str, list[dict[str, str]]]:
+def reference_build_matrix(projects: list[HarnessProject]) -> dict[str, list[dict[str, object]]]:
     return {
         "include": [
             {
                 "project_id": project.project_id,
+                "hash": project.ref,
                 "artifact_name": reference_artifact_name(project),
                 "artifact_path": reference_artifact_path(project),
             }
@@ -398,11 +494,20 @@ def deploy_project_artifact_path(project: HarnessProject) -> str:
     return f"_out/reference-blueprints/{project.selected_release}/{project.project_id}"
 
 
+def reference_blueprint_ids_for_toolchain(catalog: HarnessProjectCatalog, toolchain: str) -> list[str]:
+    normalized_toolchain = normalize_lean_release_ref(toolchain)
+    return [
+        blueprint.blueprint
+        for blueprint in catalog.reference_blueprints
+        if blueprint.toolchain == normalized_toolchain
+    ]
+
+
 def deploy_project_matrix(
     release_targets: tuple[HarnessReleaseTarget, ...],
     catalog: HarnessProjectCatalog,
-) -> dict[str, list[dict[str, str]]]:
-    include: list[dict[str, str]] = []
+) -> dict[str, list[dict[str, object]]]:
+    include: list[dict[str, object]] = []
     for target in release_targets:
         if not target.deploy_pages:
             continue
@@ -414,6 +519,7 @@ def deploy_project_matrix(
                     "verso_ref": target.verso_ref,
                     "branch": target.branch,
                     "project_id": project.project_id,
+                    "hash": project.ref,
                     "artifact_name": deploy_project_artifact_name(project),
                     "artifact_path": deploy_project_artifact_path(project),
                 }

--- a/scripts/emit_reference_deploy_matrix.py
+++ b/scripts/emit_reference_deploy_matrix.py
@@ -2,8 +2,10 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Callable
 import json
 from pathlib import Path
+import subprocess
 import sys
 
 if __package__ in {None, ""}:
@@ -11,9 +13,14 @@ if __package__ in {None, ""}:
 
 from scripts.blueprint_harness_paths import detect_harness_layout
 from scripts.blueprint_harness_projects import (
+    HarnessProjectCatalog,
+    HarnessReleaseTarget,
     default_project_manifest,
-    deploy_project_matrix,
+    deploy_project_artifact_name,
+    deploy_project_artifact_path,
     load_project_catalog,
+    load_project_catalog_text,
+    reference_blueprint_ids_for_toolchain,
     resolve_projects_for_release,
 )
 
@@ -44,6 +51,99 @@ def resolve_manifest_path(layout, path_text: str | None) -> Path:
     return (Path.cwd() / path).resolve()
 
 
+def manifest_relative_to_package(manifest_path: Path, package_root: Path) -> Path | None:
+    try:
+        return manifest_path.relative_to(package_root)
+    except ValueError:
+        return None
+
+
+def release_branch_ref_candidates(branch: str) -> tuple[str, ...]:
+    return (f"origin/{branch}", f"refs/remotes/origin/{branch}", branch)
+
+
+def load_branch_project_catalog(
+    *,
+    branch: str,
+    manifest_path: Path,
+    package_root: Path,
+) -> HarnessProjectCatalog:
+    manifest_relpath = manifest_relative_to_package(manifest_path, package_root)
+    if manifest_relpath is None:
+        return load_project_catalog(manifest_path)
+
+    errors: list[str] = []
+    for ref in release_branch_ref_candidates(branch):
+        result = subprocess.run(
+            ["git", "show", f"{ref}:{manifest_relpath.as_posix()}"],
+            cwd=package_root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return load_project_catalog_text(result.stdout, f"{ref}:{manifest_relpath.as_posix()}")
+        errors.append(result.stderr.strip() or result.stdout.strip())
+
+    raise ValueError(
+        f"could not load reference project catalog for release branch `{branch}` from `{manifest_relpath}`; "
+        + "; ".join(error for error in errors if error)
+    )
+
+
+def deploy_matrix_from_release_catalogs(
+    controller_catalog: HarnessProjectCatalog,
+    deployable_targets: tuple[HarnessReleaseTarget, ...],
+    catalog_for_target: Callable[[HarnessReleaseTarget], HarnessProjectCatalog],
+) -> dict[str, list[dict[str, object]]]:
+    include: list[dict[str, object]] = []
+    for target in deployable_targets:
+        selected_blueprints = [
+            blueprint
+            for blueprint in controller_catalog.reference_blueprints
+            if blueprint.toolchain == target.toolchain
+        ]
+        selected_project_ids = reference_blueprint_ids_for_toolchain(controller_catalog, target.toolchain)
+        expected_hash_by_project = {blueprint.blueprint: blueprint.hash for blueprint in selected_blueprints}
+        if controller_catalog.reference_blueprints and not selected_blueprints:
+            raise ValueError(
+                f"release target `{target.release_id}` has `deploy_pages: true` but no reference "
+                f"blueprints for toolchain `{target.toolchain}`"
+            )
+        release_catalog = catalog_for_target(target)
+        release_target = release_catalog.release_target(target.release_id)
+        if release_target is None:
+            raise ValueError(
+                f"catalog for branch `{target.branch}` does not define release target `{target.release_id}`"
+            )
+        projects = resolve_projects_for_release(
+            release_catalog,
+            release_target.release_id,
+            selected_project_ids or None,
+        )
+        for project in projects:
+            expected_hash = expected_hash_by_project.get(project.project_id)
+            if expected_hash is not None and project.ref != expected_hash:
+                raise ValueError(
+                    f"reference blueprint `{project.project_id}` for toolchain `{target.toolchain}` resolves "
+                    f"to `{project.ref}` on branch `{target.branch}`, but the deploy catalog declares `{expected_hash}`"
+                )
+            include.append(
+                {
+                    "release_id": release_target.release_id,
+                    "rc": getattr(release_target, "rc", None),
+                    "toolchain": release_target.toolchain,
+                    "verso_ref": release_target.verso_ref,
+                    "branch": release_target.branch,
+                    "project_id": project.project_id,
+                    "hash": project.ref,
+                    "artifact_name": deploy_project_artifact_name(project),
+                    "artifact_path": deploy_project_artifact_path(project),
+                }
+            )
+    return {"include": include}
+
+
 def payload(args: argparse.Namespace) -> dict[str, object]:
     layout = detect_harness_layout(Path(__file__))
     manifest_path = resolve_manifest_path(layout, args.manifest)
@@ -51,12 +151,21 @@ def payload(args: argparse.Namespace) -> dict[str, object]:
     deployable_targets = tuple(
         target
         for target in catalog.release_targets
-        if target.deploy_pages and resolve_projects_for_release(catalog, target.release_id, None)
+        if target.deploy_pages
     )
-    matrix = deploy_project_matrix(deployable_targets, catalog)
+    matrix = deploy_matrix_from_release_catalogs(
+        catalog,
+        deployable_targets,
+        lambda target: load_branch_project_catalog(
+            branch=target.branch,
+            manifest_path=manifest_path,
+            package_root=layout.package_root,
+        ),
+    )
+    deployable_release_count = len({entry["release_id"] for entry in matrix["include"]})
     return {
         "manifest_path": str(manifest_path),
-        "deployable_release_count": len(deployable_targets),
+        "deployable_release_count": deployable_release_count,
         "deployable_project_count": len(matrix["include"]),
         "deployable_project_matrix": matrix,
     }

--- a/scripts/prepare_reference_blueprints_pages.py
+++ b/scripts/prepare_reference_blueprints_pages.py
@@ -107,6 +107,50 @@ def write_reference_index(reference_root: Path, release_projects: dict[str | Non
     (reference_root / "index.html").write_text("\n".join(body) + "\n", encoding="utf-8")
 
 
+def write_redirect_alias(alias_root: Path, target_href: str, *, label: str) -> None:
+    alias_root.mkdir(parents=True, exist_ok=True)
+    escaped_target = html.escape(target_href, quote=True)
+    escaped_label = html.escape(label)
+    body = [
+        "<!doctype html>",
+        "<html lang=\"en\">",
+        "<meta charset=\"utf-8\">",
+        "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">",
+        f"<meta http-equiv=\"refresh\" content=\"0; url={escaped_target}\">",
+        f"<link rel=\"canonical\" href=\"{escaped_target}\">",
+        f"<title>{escaped_label}</title>",
+        "<body>",
+        f"<p><a href=\"{escaped_target}\">Open {escaped_label}</a></p>",
+        "</body>",
+        "</html>",
+    ]
+    (alias_root / "index.html").write_text("\n".join(body) + "\n", encoding="utf-8")
+
+
+def write_unique_project_aliases(reference_root: Path, release_projects: dict[str | None, list[str]]) -> None:
+    if None in release_projects:
+        return
+
+    releases_by_project: dict[str, list[str]] = {}
+    for release, projects in release_projects.items():
+        assert release is not None
+        for project in projects:
+            releases_by_project.setdefault(project, []).append(release)
+
+    for project, releases in releases_by_project.items():
+        if len(releases) != 1:
+            continue
+        alias_root = reference_root / project
+        if alias_root.exists():
+            continue
+        release = releases[0]
+        write_redirect_alias(
+            alias_root,
+            f"../{release}/{project}/",
+            label=project,
+        )
+
+
 def copy_reference_sites(reference_root: Path, publish_reference_root: Path) -> dict[str | None, list[str]]:
     release_projects: dict[str | None, list[str]] = {}
     children = sorted(path for path in reference_root.iterdir() if path.is_dir())
@@ -151,6 +195,7 @@ def main() -> int:
 
     release_projects = copy_reference_sites(reference_root, publish_reference_root)
     write_reference_index(publish_reference_root, release_projects)
+    write_unique_project_aliases(publish_reference_root, release_projects)
 
     test_blueprints: list[str] = []
     for test_dir in sorted(path for path in test_root.iterdir() if path.is_dir()):

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -16,6 +16,18 @@
       "deploy_pages": true
     }
   ],
+  "reference_blueprints": [
+    {
+      "blueprint": "algebraic-combinatorics",
+      "hash": "6506b992702a6e47a29d90d504f9e55eb65e13e9",
+      "toolchain": "v4.28.0"
+    },
+    {
+      "blueprint": "spherepackingblueprint",
+      "hash": "3aa1a4d2f2952d5c2d7fa1e68ae9a57284149184",
+      "toolchain": "v4.29.0"
+    }
+  ],
   "projects": [
     {
       "id": "project-template",
@@ -101,7 +113,7 @@
       "targets": [
         {
           "release": "v4.28.0",
-          "ref": "1fda7a4581e55dca27209f060a90179b0a1a2f32"
+          "ref": "6506b992702a6e47a29d90d504f9e55eb65e13e9"
         }
       ],
       "build_command": ["lake", "build", "AlgebraicCombinatoricsBlueprint"],

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -14,11 +14,13 @@ from scripts.blueprint_harness_projects import (
     IN_REPO_PROJECT_SOURCE_KIND,
     default_project_manifest,
     load_project_catalog,
+    load_project_catalog_text,
     load_projects_manifest,
     reference_build_matrix,
     resolve_projects_for_release,
     resolve_release_target,
 )
+from scripts.emit_reference_deploy_matrix import deploy_matrix_from_release_catalogs
 from scripts.blueprint_harness_references import (
     OFFICIAL_BLUEPRINT_REQUIRE,
     bootstrap_reference_checkout,
@@ -70,12 +72,19 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
 
         expected_projects: list[str] = []
         expected_refs: dict[str, str | None] = {}
-        for project in catalog.projects:
-            target = next((target for target in project.targets if target.release == release.release_id), None)
-            if target is None:
-                continue
-            expected_projects.append(project.project_id)
-            expected_refs[project.project_id] = target.ref
+        if catalog.reference_blueprints:
+            for blueprint in catalog.reference_blueprints:
+                if blueprint.toolchain != release.toolchain:
+                    continue
+                expected_projects.append(blueprint.blueprint)
+                expected_refs[blueprint.blueprint] = blueprint.hash
+        else:
+            for project in catalog.projects:
+                target = next((target for target in project.targets if target.release == release.release_id), None)
+                if target is None:
+                    continue
+                expected_projects.append(project.project_id)
+                expected_refs[project.project_id] = target.ref
 
         self.assertEqual([project.project_id for project in projects], expected_projects)
         for project in projects:
@@ -103,6 +112,13 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             ("lake", "env", "lean", "--run", "ProjectTemplateMain.lean", "--output", "{output_dir}"),
         )
         self.assertEqual([target.release for target in projects[0].targets], ["v4.28.0", "v4.29.0"])
+        self.assertEqual(
+            [(entry.blueprint, entry.hash, entry.toolchain) for entry in catalog.reference_blueprints],
+            [
+                ("algebraic-combinatorics", "6506b992702a6e47a29d90d504f9e55eb65e13e9", "v4.28.0"),
+                ("spherepackingblueprint", "3aa1a4d2f2952d5c2d7fa1e68ae9a57284149184", "v4.29.0"),
+            ],
+        )
         self.assertTrue(projects[1].git_checkout)
         self.assertEqual(projects[1].repository, "https://github.com/ejgallego/verso-noperthedron.git")
         self.assertEqual([target.release for target in projects[1].targets], ["v4.29.0"])
@@ -150,6 +166,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                         "verso_ref": release.verso_ref,
                         "branch": release.branch,
                         "project_id": project.project_id,
+                        "hash": project.ref,
                         "artifact_name": f"reference-blueprints-release-{release.release_id}__project__{project.project_id}",
                         "artifact_path": f"_out/reference-blueprints/{release.release_id}/{project.project_id}",
                     }
@@ -158,6 +175,201 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(
             matrix,
             {"include": expected_entries},
+        )
+
+    def test_deploy_matrix_uses_controller_reference_blueprints_with_release_branch_catalogs(self) -> None:
+        controller_catalog = load_project_catalog_text(
+            json.dumps(
+                {
+                    "version": 2,
+                    "release_targets": [
+                        {
+                            "id": "v4.28.0",
+                            "toolchain": "v4.28.0",
+                            "verso_ref": "v4.28.0",
+                            "branch": "v4.28.0",
+                            "deploy_pages": True,
+                        },
+                        {
+                            "id": "v4.29.0",
+                            "toolchain": "v4.29.0",
+                            "verso_ref": "v4.29.0",
+                            "branch": "v4.29.0",
+                            "deploy_pages": True,
+                        },
+                    ],
+                    "reference_blueprints": [
+                        {
+                            "blueprint": "old-release-project",
+                            "hash": "old-controller-ref",
+                            "toolchain": "v4.28.0",
+                        },
+                        {
+                            "blueprint": "new-release-project",
+                            "hash": "new-controller-ref",
+                            "toolchain": "v4.29.0",
+                        },
+                        {
+                            "blueprint": "new-release-second-project",
+                            "hash": "new-second-controller-ref",
+                            "toolchain": "v4.29.0",
+                        },
+                    ],
+                    "projects": [
+                        {
+                            "id": "old-release-project",
+                            "source": {
+                                "kind": "git_checkout",
+                                "repository": "https://example.com/old-release-project.git",
+                                "project_root": "old-controller",
+                            },
+                            "targets": [{"release": "v4.28.0", "ref": "old-controller-ref"}],
+                            "build_command": ["lake", "build"],
+                            "generate_command": ["lake", "exe", "blueprint-gen"],
+                        },
+                        {
+                            "id": "new-release-older-project",
+                            "source": {
+                                "kind": "git_checkout",
+                                "repository": "https://example.com/new-release-older-project.git",
+                                "project_root": "new-controller-older",
+                            },
+                            "targets": [{"release": "v4.29.0", "ref": "new-older-controller-ref"}],
+                            "build_command": ["lake", "build"],
+                            "generate_command": ["lake", "exe", "blueprint-gen"],
+                        },
+                        {
+                            "id": "new-release-project",
+                            "source": {
+                                "kind": "git_checkout",
+                                "repository": "https://example.com/new-release-project.git",
+                                "project_root": "new-controller",
+                            },
+                            "targets": [{"release": "v4.29.0", "ref": "new-controller-ref"}],
+                            "build_command": ["lake", "build"],
+                            "generate_command": ["lake", "exe", "blueprint-gen"],
+                        },
+                        {
+                            "id": "new-release-second-project",
+                            "source": {
+                                "kind": "git_checkout",
+                                "repository": "https://example.com/new-release-second-project.git",
+                                "project_root": "new-controller-second",
+                            },
+                            "targets": [{"release": "v4.29.0", "ref": "new-second-controller-ref"}],
+                            "build_command": ["lake", "build"],
+                            "generate_command": ["lake", "exe", "blueprint-gen"],
+                        }
+                    ],
+                }
+            ),
+            "controller-projects.json",
+        )
+        release_catalogs = {
+            "v4.28.0": load_project_catalog_text(
+                json.dumps(
+                    {
+                        "version": 2,
+                        "release_targets": [
+                            {
+                                "id": "v4.28.0",
+                                "toolchain": "v4.28.0",
+                                "verso_ref": "v4.28.0",
+                                "branch": "v4.28.0",
+                                "deploy_pages": True,
+                            }
+                        ],
+                        "projects": [
+                            {
+                                "id": "old-release-older-project",
+                                "source": {
+                                    "kind": IN_REPO_PROJECT_SOURCE_KIND,
+                                    "project_root": "old-older",
+                                },
+                                "targets": [{"release": "v4.28.0"}],
+                                "generate_command": ["lake", "exe", "blueprint-gen"],
+                            },
+                            {
+                                "id": "old-release-project",
+                                "source": {
+                                    "kind": "git_checkout",
+                                    "repository": "https://example.com/old-release-project.git",
+                                    "project_root": "old",
+                                },
+                                "targets": [{"release": "v4.28.0", "ref": "old-controller-ref"}],
+                                "build_command": ["lake", "build"],
+                                "generate_command": ["lake", "exe", "blueprint-gen"],
+                            }
+                        ],
+                    }
+                ),
+                "v4.28.0:projects.json",
+            ),
+            "v4.29.0": load_project_catalog_text(
+                json.dumps(
+                    {
+                        "version": 2,
+                        "release_targets": [
+                            {
+                                "id": "v4.29.0",
+                                "toolchain": "v4.29.0",
+                                "verso_ref": "v4.29.0",
+                                "branch": "v4.29.0",
+                                "deploy_pages": True,
+                            }
+                        ],
+                        "projects": [
+                            {
+                                "id": "new-release-older-project",
+                                "source": {
+                                    "kind": IN_REPO_PROJECT_SOURCE_KIND,
+                                    "project_root": "new-older",
+                                },
+                                "targets": [{"release": "v4.29.0"}],
+                                "generate_command": ["lake", "exe", "blueprint-gen"],
+                            },
+                            {
+                                "id": "new-release-project",
+                                "source": {
+                                    "kind": "git_checkout",
+                                    "repository": "https://example.com/new-release-project.git",
+                                    "project_root": "new",
+                                },
+                                "targets": [{"release": "v4.29.0", "ref": "new-controller-ref"}],
+                                "build_command": ["lake", "build"],
+                                "generate_command": ["lake", "exe", "blueprint-gen"],
+                            },
+                            {
+                                "id": "new-release-second-project",
+                                "source": {
+                                    "kind": "git_checkout",
+                                    "repository": "https://example.com/new-release-second-project.git",
+                                    "project_root": "new-second",
+                                },
+                                "targets": [{"release": "v4.29.0", "ref": "new-second-controller-ref"}],
+                                "build_command": ["lake", "build"],
+                                "generate_command": ["lake", "exe", "blueprint-gen"],
+                            }
+                        ],
+                    }
+                ),
+                "v4.29.0:projects.json",
+            ),
+        }
+
+        matrix = deploy_matrix_from_release_catalogs(
+            controller_catalog,
+            controller_catalog.release_targets,
+            lambda target: release_catalogs[target.release_id],
+        )
+
+        self.assertEqual(
+            [(entry["release_id"], entry["project_id"]) for entry in matrix["include"]],
+            [
+                ("v4.28.0", "old-release-project"),
+                ("v4.29.0", "new-release-project"),
+                ("v4.29.0", "new-release-second-project"),
+            ],
         )
 
     def test_git_checkout_project_is_supported(self) -> None:

--- a/tests/harness/test_prepare_reference_blueprints_pages.py
+++ b/tests/harness/test_prepare_reference_blueprints_pages.py
@@ -141,10 +141,29 @@ class PrepareReferenceBlueprintPagesTests(unittest.TestCase):
             release_index = (output_root / "reference-blueprints" / "index.html").read_text(encoding="utf-8")
             self.assertIn("reference-blueprints/v4.28.0/", release_index)
             self.assertIn("reference-blueprints/v4.29.0/", release_index)
+            self.assertFalse((output_root / "reference-blueprints" / "project-template").exists())
+
+            alias_index = (output_root / "reference-blueprints" / "noperthedron" / "index.html").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn("../v4.29.0/noperthedron/", alias_index)
 
             landing_index = (output_root / "index.html").read_text(encoding="utf-8")
             self.assertIn("reference-blueprints/v4.28.0/", landing_index)
             self.assertIn("reference-blueprints/v4.29.0/", landing_index)
+
+    def test_readme_uses_release_namespaced_reference_links(self) -> None:
+        readme = (PACKAGE_ROOT / "README.md").read_text(encoding="utf-8")
+
+        self.assertNotIn("reference-blueprints/project-template/", readme)
+        self.assertNotIn("reference-blueprints/noperthedron/", readme)
+        self.assertNotIn("reference-blueprints/spherepackingblueprint/", readme)
+        self.assertNotIn("reference-blueprints/verso-flt/", readme)
+
+        self.assertIn("reference-blueprints/v4.28.0/algebraic-combinatorics/", readme)
+        self.assertIn("reference-blueprints/v4.29.0/spherepackingblueprint/", readme)
+        self.assertIn("reference-blueprints/v4.30.0/noperthedron/", readme)
+        self.assertIn("reference-blueprints/v4.30.0/verso-flt/", readme)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Backport #37 to `v4.29.0`.

## Primary Review
- Primary review: #37
- Keep review comments on #37 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.29.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- Resolved the catalog conflict by keeping the v4.29 release-line targets and omitting v4.30-only reference rows.
- Kept the deploy resolver compatible with this release line's older `HarnessReleaseTarget` shape.