### PR TITLE
[backport v4.29.0] feat(informal): add link-only blueprint refs

### DIFF
--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -31,7 +31,8 @@ Examples:
 Those labels are the key to the whole system. They are used to:
 
 - identify nodes in the summary and graph views
-- connect `{uses "addition_spec"}[]` references
+- connect dependency references with `{uses "addition_spec"}[]`
+- point at a node without adding a dependency edge with `{bpref "addition_spec"}[]`
 - attach inline Lean code with a labeled `lean` code block
 - attach raw TeX source for porting with a `tex` code block
 - tag compiled declarations with `@[blueprint "label"]`
@@ -43,8 +44,13 @@ Unlike Lean code references, `{uses "addition_spec"}[]` can refer to a label
 before its final use sites are elaborated. Blueprint resolves those forward
 references when building the document.
 
-If the payload of `{uses "addition_spec"}[]` is empty, Blueprint can generate
-the visible text automatically, for example `Theorem N`.
+Use `uses` when the current Blueprint node mathematically depends on the target
+node. Use `bpref` for prose references that should render as Blueprint links but
+should not affect the graph or dependency summaries.
+
+If the payload of `{uses "addition_spec"}[]` or `{bpref "addition_spec"}[]` is
+empty, Blueprint can generate the visible text automatically, for example
+`Theorem N`.
 
 ## Start from the template
 
@@ -88,6 +94,7 @@ show the most important authoring patterns:
 - definition, theorem, and proof blocks
 - labels that identify nodes
 - a `uses` link to another Blueprint entry
+- a `bpref` link when prose should reference a node without adding a dependency
 - a local Lean code block
 - a statement linked to an existing Lean declaration
 - optional metadata such as `parent`, `owner`, `tags`, `effort`, and `priority`

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -49,7 +49,8 @@ Examples:
 
 These identifiers are used by:
 
-- `{uses "addition_spec"}[]` references
+- `{uses "addition_spec"}[]` dependency references
+- `{bpref "addition_spec"}[]` link-only references
 - labeled inline Lean code blocks
 - labeled inline Rust code blocks
 - `tex` code blocks carrying raw TeX source
@@ -59,9 +60,13 @@ These identifiers are used by:
 
 Choose labels early and treat them as stable project identifiers.
 
-If a role such as `{uses "addition_spec"}[]` or a citation has an empty
-payload, Blueprint can generate the visible text automatically, for example
-`Theorem N`.
+Use `uses` when the current node depends on the target and should add an edge to
+the graph and dependency summaries. Use `bpref` when prose should link to a
+Blueprint node without registering that relationship as a dependency.
+
+If a role such as `{uses "addition_spec"}[]`, `{bpref "addition_spec"}[]`, or a
+citation has an empty payload, Blueprint can generate the visible text
+automatically, for example `Theorem N`.
 
 ## Minimal Project Shape
 
@@ -191,6 +196,7 @@ This example shows the core pattern:
 
 - define an informal mathematical object
 - attach later statements to it with `uses`
+- point to related entries without adding dependencies with `bpref`
 - keep informal proofs close to the statement
 - connect to Lean either locally or through an existing declaration
 

--- a/src/VersoBlueprint/Informal/Uses.lean
+++ b/src/VersoBlueprint/Informal/Uses.lean
@@ -117,19 +117,26 @@ private def Data.Node.toBlockInfo (node : Data.Node) (label : Data.Label) : Bloc
     prUrl := node.prUrl
   }
 
-private def usesImpl : RoleExpanderOf Config
+private def nodeRefImpl (registerDependency : Bool) : RoleExpanderOf Config
   | cfg, contents => do
     let contents ← contents.mapM elabInline
     let label := cfg.label
     let node ← Environment.getNode? label
-    let useRef ← getRef
-    Environment.addDep useRef label
+    if registerDependency then
+      let useRef ← getRef
+      Environment.addDep useRef label
     let data : InlineData := { label, block := node.map (fun n => n.toBlockInfo label) }
     ``(Inline.other (Inline.informal $(quote data)) #[$contents,*])
 
 @[role]
 def uses : RoleExpanderOf Config
   | cfg, contents => do
-    Profile.withDocElab "role" "uses" <| usesImpl cfg contents
+    Profile.withDocElab "role" "uses" <| nodeRefImpl true cfg contents
+
+/-- Reference a Blueprint node without registering a dependency edge. -/
+@[role]
+def bpref : RoleExpanderOf Config
+  | cfg, contents => do
+    Profile.withDocElab "role" "bpref" <| nodeRefImpl false cfg contents
 
 end Informal

--- a/tests/VersoBlueprintTests/BlueprintLinkHover.lean
+++ b/tests/VersoBlueprintTests/BlueprintLinkHover.lean
@@ -9,6 +9,7 @@ import VersoManual.Bibliography
 
 namespace Verso.VersoBlueprintTests.BlueprintLinkHover
 
+open Lean
 open Verso
 open Verso.Genre.Manual
 open Informal
@@ -55,6 +56,17 @@ Using {uses "lem:hover.base"}[] and again {uses "lem:hover.base"}[].
 :::
 :::::::
 
+#docs (Genre.Manual) hoverBprefDoc "Hover Bpref Doc" :=
+:::::::
+:::lemma_ "lem:hover.bpref.target"
+Target lemma for reference-only links.
+:::
+
+:::lemma_ "lem:hover.bpref.source"
+Mention {bpref "lem:hover.bpref.target"}[] without declaring a dependency.
+:::
+:::::::
+
 #docs (Genre.Manual) hoverCiteOnlyDoc "Hover Cite Only Doc" :=
 :::::::
 Cite once {Informal.citet hover.cite (kind := lemma) (index := 3)}[] and cite twice
@@ -90,6 +102,30 @@ Cite once {Informal.citet hover.cite (kind := lemma) (index := 3)}[] and cite tw
           "data-bp-preview-key=\"«lem:hover.base»--statement\"" >= 2 &&
       countSubstr out
           "data-bp-preview-fallback-label=\"«lem:hover.base»\"" >= 2 &&
+      !hasSubstr out "class=\"bp_inline_preview_tpl\""
+    )
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show CoreM Bool from do
+    let state := Informal.Environment.informalExt.getState (← getEnv)
+    match state.data.get? (Name.mkSimple "lem:hover.bpref.source") with
+    | some node =>
+      pure <| node.statement.map (·.deps.isEmpty) |>.getD false
+    | none => pure false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let out ← renderManualDocHtmlString manualImpls hoverBprefDoc
+    pure (
+      countSubstr out "class=\"bp_inline_preview_ref\"" >= 1 &&
+      countSubstr out
+          "data-bp-preview-key=\"«lem:hover.bpref.target»--statement\"" >= 1 &&
+      countSubstr out
+          "data-bp-preview-fallback-label=\"«lem:hover.bpref.target»\"" >= 1 &&
       !hasSubstr out "class=\"bp_inline_preview_tpl\""
     )
 


### PR DESCRIPTION
## Summary
Backport #42 to `v4.29.0`.

## Primary Review
- Primary review: #42
- Keep review comments on #42 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.29.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.