### PR TITLE
fix(pages): use relative reference index links

### DIFF
--- a/scripts/prepare_reference_blueprints_pages.py
+++ b/scripts/prepare_reference_blueprints_pages.py
@@ -29,12 +29,12 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def html_link(project_id: str, *, release: str | None = None) -> str:
+def html_link(project_id: str, *, release: str | None = None, prefix: str = "reference-blueprints/") -> str:
     label = html.escape(project_id)
     if release is None:
-        href = f"reference-blueprints/{label}/"
+        href = f"{prefix}{label}/"
     else:
-        href = f"reference-blueprints/{html.escape(release)}/{label}/"
+        href = f"{prefix}{html.escape(release)}/{label}/"
     return f'<li><a href="{href}">{label}</a></li>'
 
 
@@ -44,15 +44,15 @@ def html_test_link(slug: str) -> str:
     return f'<li><a href="{href}">{label}</a></li>'
 
 
-def html_release_link(release: str) -> str:
+def html_release_link(release: str, *, prefix: str = "reference-blueprints/") -> str:
     label = html.escape(release)
-    href = f"reference-blueprints/{label}/"
+    href = f"{prefix}{label}/"
     return f'<li><a href="{href}">{label}</a></li>'
 
 
 def write_reference_index(reference_root: Path, release_projects: dict[str | None, list[str]]) -> None:
     if None in release_projects:
-        items = [html_link(project_id) for project_id in release_projects[None]]
+        items = [html_link(project_id, prefix="") for project_id in release_projects[None]]
         body = [
             "<!doctype html>",
             "<html lang=\"en\">",
@@ -83,7 +83,7 @@ def write_reference_index(reference_root: Path, release_projects: dict[str | Non
             "<body>",
             f"<h1>Reference Blueprints {html.escape(release)}</h1>",
             "<ul>",
-            *[html_link(project_id, release=release) for project_id in projects],
+            *[html_link(project_id, prefix="") for project_id in projects],
             "</ul>",
             "</body>",
             "</html>",
@@ -99,7 +99,7 @@ def write_reference_index(reference_root: Path, release_projects: dict[str | Non
         "<body>",
         "<h1>Reference Blueprint Releases</h1>",
         "<ul>",
-        *[html_release_link(release) for release in sorted(release_projects)],
+        *[html_release_link(release, prefix="") for release in sorted(release_projects)],
         "</ul>",
         "</body>",
         "</html>",

--- a/tests/harness/test_prepare_reference_blueprints_pages.py
+++ b/tests/harness/test_prepare_reference_blueprints_pages.py
@@ -84,6 +84,11 @@ class PrepareReferenceBlueprintPagesTests(unittest.TestCase):
             self.assertIn("test-blueprints/", landing_index)
             self.assertIn("test-blueprints/preview_runtime_showcase/html-multi/", landing_index)
 
+            reference_index = (output_root / "reference-blueprints" / "index.html").read_text(encoding="utf-8")
+            self.assertIn('href="project-template/"', reference_index)
+            self.assertIn('href="noperthedron/"', reference_index)
+            self.assertNotIn("reference-blueprints/project-template/", reference_index)
+
     def test_prepare_pages_stages_release_namespaced_reference_blueprints(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
@@ -139,9 +144,17 @@ class PrepareReferenceBlueprintPagesTests(unittest.TestCase):
             )
 
             release_index = (output_root / "reference-blueprints" / "index.html").read_text(encoding="utf-8")
-            self.assertIn("reference-blueprints/v4.28.0/", release_index)
-            self.assertIn("reference-blueprints/v4.29.0/", release_index)
+            self.assertIn('href="v4.28.0/"', release_index)
+            self.assertIn('href="v4.29.0/"', release_index)
+            self.assertNotIn("reference-blueprints/v4.28.0/", release_index)
             self.assertFalse((output_root / "reference-blueprints" / "project-template").exists())
+
+            release_project_index = (
+                output_root / "reference-blueprints" / "v4.29.0" / "index.html"
+            ).read_text(encoding="utf-8")
+            self.assertIn('href="project-template/"', release_project_index)
+            self.assertIn('href="noperthedron/"', release_project_index)
+            self.assertNotIn("reference-blueprints/v4.29.0/noperthedron/", release_project_index)
 
             alias_index = (output_root / "reference-blueprints" / "noperthedron" / "index.html").read_text(
                 encoding="utf-8"


### PR DESCRIPTION
This PR fixes the generated reference-blueprint indexes so nested index pages use links relative to their own directory instead of repeating the `reference-blueprints/` prefix.

Backport v4.29.0: exempt: public Pages deploy assembles the combined site from the default-development checkout
Backport v4.28.0: exempt: public Pages deploy assembles the combined site from the default-development checkout