### PR TITLE
fix(summary): reduce renderer compile time

### DIFF
--- a/src/VersoBlueprint/Commands/Summary.lean
+++ b/src/VersoBlueprint/Commands/Summary.lean
@@ -9,6 +9,7 @@ import Lean.Elab.Command
 import Verso
 import VersoManual
 import VersoBlueprint.Commands.Common
+import VersoBlueprint.Commands.Summary.Data
 import VersoBlueprint.Data
 import VersoBlueprint.ProvedStatus
 import VersoBlueprint.Environment
@@ -32,386 +33,6 @@ register_option verso.blueprint.summary.debugDiagnostics : Bool := {
   defValue := false
   descr := "Show maintainer diagnostics such as external declaration render failures in blueprint summaries"
 }
-
-structure SorryItem where
-  label : Name
-  kind : String
-  decl : Name
-  isTheorem : Bool := false
-  status : Data.ProvedStatus := .proved
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote SorryItem where
-  quote s := mkCApp ``SorryItem.mk #[quote s.label, quote s.kind, quote s.decl, quote s.isTheorem, quote s.status]
-
-structure MissingLeanDeclItem where
-  label : Name
-  kind : String
-  written : Name
-  canonical : Name
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote MissingLeanDeclItem where
-  quote s := mkCApp ``MissingLeanDeclItem.mk #[quote s.label, quote s.kind, quote s.written, quote s.canonical]
-
-structure RenderFailureItem where
-  label : Name
-  kind : String
-  written : Name
-  canonical : Name
-  message : String
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote RenderFailureItem where
-  quote s := mkCApp ``RenderFailureItem.mk #[quote s.label, quote s.kind, quote s.written, quote s.canonical, quote s.message]
-
-structure IndexItem where
-  label : Name
-  kind : String
-  leanObjects : List Name := []
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote IndexItem where
-  quote s := mkCApp ``IndexItem.mk #[quote s.label, quote s.kind, quote s.leanObjects]
-
-abbrev PendingInformalItem := IndexItem
-
-structure ParentTheoremGroup where
-  parent : Name
-  header : String := ""
-  entries : List IndexItem := []
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote ParentTheoremGroup where
-  quote s := mkCApp ``ParentTheoremGroup.mk #[quote s.parent, quote s.header, quote s.entries]
-
-structure EntryStatusCounts where
-  completed : Nat := 0
-  completedDepsNo : Nat := 0
-  withSorries : Nat := 0
-  noProof : Nat := 0
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote EntryStatusCounts where
-  quote s := mkCApp ``EntryStatusCounts.mk
-    #[
-      quote s.completed,
-      quote s.completedDepsNo,
-      quote s.withSorries,
-      quote s.noProof
-    ]
-
-structure PriorityItem where
-  label : Name
-  kind : String
-  stage : String
-  priority : Option String := none
-  ownerDisplayName : Option String := none
-  effort : Option String := none
-  prUrl : Option String := none
-  tags : List String := []
-  statementStatus : String
-  proofStatus : String := ""
-  directUses : Nat := 0
-  downstreamUses : Nat := 0
-  leanObjects : List Name := []
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote PriorityItem where
-  quote s := mkCApp ``PriorityItem.mk
-    #[
-      quote s.label,
-      quote s.kind,
-      quote s.stage,
-      quote s.priority,
-      quote s.ownerDisplayName,
-      quote s.effort,
-      quote s.prUrl,
-      quote s.tags,
-      quote s.statementStatus,
-      quote s.proofStatus,
-      quote s.directUses,
-      quote s.downstreamUses,
-      quote s.leanObjects
-    ]
-
-structure UsageItem where
-  label : Name
-  kind : String
-  statementUses : Nat := 0
-  proofUses : Nat := 0
-  directUses : Nat := 0
-  downstreamUses : Nat := 0
-  leanObjects : List Name := []
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote UsageItem where
-  quote s := mkCApp ``UsageItem.mk
-    #[
-      quote s.label,
-      quote s.kind,
-      quote s.statementUses,
-      quote s.proofUses,
-      quote s.directUses,
-      quote s.downstreamUses,
-      quote s.leanObjects
-    ]
-
-structure GroupHealthItem where
-  parent : Name
-  header : String := ""
-  totalEntries : Nat := 0
-  closedEntries : Nat := 0
-  localOnlyEntries : Nat := 0
-  readyEntries : Nat := 0
-  blockedEntries : Nat := 0
-  incompleteLeanEntries : Nat := 0
-  unlockScore : Nat := 0
-  nextPriority? : Option PriorityItem := none
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote GroupHealthItem where
-  quote s := mkCApp ``GroupHealthItem.mk
-    #[
-      quote s.parent,
-      quote s.header,
-      quote s.totalEntries,
-      quote s.closedEntries,
-      quote s.localOnlyEntries,
-      quote s.readyEntries,
-      quote s.blockedEntries,
-      quote s.incompleteLeanEntries,
-      quote s.unlockScore,
-      quote s.nextPriority?
-    ]
-
-structure CoverageSplit where
-  informalOnly : Nat := 0
-  readyToFormalize : Nat := 0
-  formalizedWithoutAncestors : Nat := 0
-  fullyClosed : Nat := 0
-  blockedOrIncomplete : Nat := 0
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote CoverageSplit where
-  quote s := mkCApp ``CoverageSplit.mk
-    #[
-      quote s.informalOnly,
-      quote s.readyToFormalize,
-      quote s.formalizedWithoutAncestors,
-      quote s.fullyClosed,
-      quote s.blockedOrIncomplete
-    ]
-
-structure DependencyLoadItem where
-  label : Name
-  kind : String
-  statementDeps : Nat := 0
-  proofDeps : Nat := 0
-  totalDeps : Nat := 0
-  directUses : Nat := 0
-  downstreamUses : Nat := 0
-  leanObjects : List Name := []
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote DependencyLoadItem where
-  quote s := mkCApp ``DependencyLoadItem.mk
-    #[
-      quote s.label,
-      quote s.kind,
-      quote s.statementDeps,
-      quote s.proofDeps,
-      quote s.totalDeps,
-      quote s.directUses,
-      quote s.downstreamUses,
-      quote s.leanObjects
-    ]
-
-structure DebtHotspotItem where
-  parent : Name
-  header : String := ""
-  affectedEntries : Nat := 0
-  incompleteDecls : Nat := 0
-  missingDecls : Nat := 0
-  totalDebt : Nat := 0
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote DebtHotspotItem where
-  quote s := mkCApp ``DebtHotspotItem.mk
-    #[
-      quote s.parent,
-      quote s.header,
-      quote s.affectedEntries,
-      quote s.incompleteDecls,
-      quote s.missingDecls,
-      quote s.totalDebt
-    ]
-
-structure OwnerRollupItem where
-  owner : Name
-  displayName : String := ""
-  totalEntries : Nat := 0
-  actionableEntries : Nat := 0
-  quickWins : Nat := 0
-  linkedPrs : Nat := 0
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote OwnerRollupItem where
-  quote s := mkCApp ``OwnerRollupItem.mk
-    #[
-      quote s.owner,
-      quote s.displayName,
-      quote s.totalEntries,
-      quote s.actionableEntries,
-      quote s.quickWins,
-      quote s.linkedPrs
-    ]
-
-structure TagRollupItem where
-  tag : String
-  totalEntries : Nat := 0
-  actionableEntries : Nat := 0
-  quickWins : Nat := 0
-  linkedPrs : Nat := 0
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote TagRollupItem where
-  quote s := mkCApp ``TagRollupItem.mk
-    #[
-      quote s.tag,
-      quote s.totalEntries,
-      quote s.actionableEntries,
-      quote s.quickWins,
-      quote s.linkedPrs
-    ]
-
-structure MetadataEntryItem where
-  label : Name
-  kind : String
-  ownerDisplayName : Option String := none
-  effort : Option String := none
-  priority : Option String := none
-  prUrl : Option String := none
-  tags : List String := []
-  leanObjects : List Name := []
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote MetadataEntryItem where
-  quote s := mkCApp ``MetadataEntryItem.mk
-    #[
-      quote s.label,
-      quote s.kind,
-      quote s.ownerDisplayName,
-      quote s.effort,
-      quote s.priority,
-      quote s.prUrl,
-      quote s.tags,
-      quote s.leanObjects
-    ]
-
-structure Summary where
-  showDebugDiagnostics : Bool := false
-  totalEntries : Nat := 0
-  definitions : Nat := 0
-  lemmas : Nat := 0
-  theorems : Nat := 0
-  corollaries : Nat := 0
-  axioms : Nat := 0
-  leanOnlyEntries : Nat := 0
-  informalOnlyEntries : Nat := 0
-  totalStatus : EntryStatusCounts := {}
-  definitionStatus : EntryStatusCounts := {}
-  lemmaStatus : EntryStatusCounts := {}
-  theoremStatus : EntryStatusCounts := {}
-  corollaryStatus : EntryStatusCounts := {}
-  axiomStatus : EntryStatusCounts := {}
-  pendingInformalEntries : List PendingInformalItem := []
-  leanDecls : Nat := 0
-  sorries : Nat := 0
-  sorryDetails : List SorryItem := []
-  missingLeanDecls : List MissingLeanDeclItem := []
-  renderFailures : List RenderFailureItem := []
-  definitionIndex : List IndexItem := []
-  theoremLikeIndex : List IndexItem := []
-  axiomIndex : List IndexItem := []
-  theoremLikeByParent : List ParentTheoremGroup := []
-  topPriorities : List PriorityItem := []
-  mostUsed : List UsageItem := []
-  groupHealth : List GroupHealthItem := []
-  coverageSplit : CoverageSplit := {}
-  heaviestPrerequisites : List DependencyLoadItem := []
-  noPrerequisites : List IndexItem := []
-  noDependents : List IndexItem := []
-  proofDebtHotspots : List DebtHotspotItem := []
-  quickWins : List PriorityItem := []
-  ownerRollups : List OwnerRollupItem := []
-  tagRollups : List TagRollupItem := []
-  linkedPrs : List MetadataEntryItem := []
-  missingOwners : List MetadataEntryItem := []
-  missingEffort : List MetadataEntryItem := []
-  untaggedEntries : List MetadataEntryItem := []
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote Summary where
-  quote s := mkCApp ``Summary.mk
-    #[
-      quote s.showDebugDiagnostics,
-      quote s.totalEntries,
-      quote s.definitions,
-      quote s.lemmas,
-      quote s.theorems,
-      quote s.corollaries,
-      quote s.axioms,
-      quote s.leanOnlyEntries,
-      quote s.informalOnlyEntries,
-      quote s.totalStatus,
-      quote s.definitionStatus,
-      quote s.lemmaStatus,
-      quote s.theoremStatus,
-      quote s.corollaryStatus,
-      quote s.axiomStatus,
-      quote s.pendingInformalEntries,
-      quote s.leanDecls,
-      quote s.sorries,
-      quote s.sorryDetails,
-      quote s.missingLeanDecls,
-      quote s.renderFailures,
-      quote s.definitionIndex,
-      quote s.theoremLikeIndex,
-      quote s.axiomIndex,
-      quote s.theoremLikeByParent,
-      quote s.topPriorities,
-      quote s.mostUsed,
-      quote s.groupHealth,
-      quote s.coverageSplit,
-      quote s.heaviestPrerequisites,
-      quote s.noPrerequisites,
-      quote s.noDependents,
-      quote s.proofDebtHotspots,
-      quote s.quickWins,
-      quote s.ownerRollups,
-      quote s.tagRollups,
-      quote s.linkedPrs,
-      quote s.missingOwners,
-      quote s.missingEffort,
-      quote s.untaggedEntries
-    ]
 
 structure EntryStatusFlags where
   completed : Bool := false
@@ -665,6 +286,15 @@ private def metadataEntryItem (state : Environment.State) (label : Name) (node :
     tags := node.tags.toList
     leanObjects := nodeLeanObjects node
   }
+
+private def collectMetadataEntries (state : Environment.State) (entries : Array (Name × Data.Node))
+    (keep : Data.Node → Bool) : List MetadataEntryItem :=
+  let items := entries.foldl (init := #[]) fun acc (label, node) =>
+    if keep node then
+      acc.push (metadataEntryItem state label node)
+    else
+      acc
+  (sortMetadataEntryItems items).toList
 
 private def priorityItem? (state : Environment.State) (external : Informal.Graph.ExternalCodeStatus)
     (usageMap : NameMap UsageCounts) (reverseMap : NameMap (Array Name))
@@ -1076,33 +706,13 @@ def buildSummary : CoreM Summary := do
         }
     (sortTagRollupItems (rollups.toArray.map fun pair => pair.2)).toList
   let linkedPrs : List MetadataEntryItem :=
-    let items := entries.foldl (init := #[]) fun acc (label, node) =>
-      if node.prUrl.isSome then
-        acc.push (metadataEntryItem state label node)
-      else
-        acc
-    (sortMetadataEntryItems items).toList
+    collectMetadataEntries state entries fun node => node.prUrl.isSome
   let missingOwners : List MetadataEntryItem :=
-    let items := entries.foldl (init := #[]) fun acc (label, node) =>
-      if node.owner.isNone then
-        acc.push (metadataEntryItem state label node)
-      else
-        acc
-    (sortMetadataEntryItems items).toList
+    collectMetadataEntries state entries fun node => node.owner.isNone
   let missingEffort : List MetadataEntryItem :=
-    let items := entries.foldl (init := #[]) fun acc (label, node) =>
-      if node.effort.isNone then
-        acc.push (metadataEntryItem state label node)
-      else
-        acc
-    (sortMetadataEntryItems items).toList
+    collectMetadataEntries state entries fun node => node.effort.isNone
   let untaggedEntries : List MetadataEntryItem :=
-    let items := entries.foldl (init := #[]) fun acc (label, node) =>
-      if node.tags.isEmpty then
-        acc.push (metadataEntryItem state label node)
-      else
-        acc
-    (sortMetadataEntryItems items).toList
+    collectMetadataEntries state entries fun node => node.tags.isEmpty
   return {
     summary with
       showDebugDiagnostics,
@@ -1190,782 +800,929 @@ def summaryPreviewJs : String := r##"(function () {
   }
 })();"##
 
+open Verso Doc Html Genre Manual
+open Verso.Output.Html
+open Verso.Multi (AllRemotes)
+
+private abbrev SummaryHtmlM := HtmlT Manual (ReaderT AllRemotes (ReaderT ExtensionImpls IO))
+
+private structure SummaryHtmlContext where
+  entryHref? : Name → Option String
+  declHref? : Name → Name → Option String
+  previewLookupKey? : Name → Option String
+
+private structure SummaryRows where
+  pendingInformalRows : Array Output.Html := #[]
+  sorryRows : Array Output.Html := #[]
+  missingRows : Array Output.Html := #[]
+  renderFailureRows : Array Output.Html := #[]
+  topPriorityRows : Array Output.Html := #[]
+  quickWinRows : Array Output.Html := #[]
+  statementUsedItems : Array UsageItem := #[]
+  proofUsedItems : Array UsageItem := #[]
+  statementUsedRows : Array Output.Html := #[]
+  proofUsedRows : Array Output.Html := #[]
+  heaviestPrerequisiteRows : Array Output.Html := #[]
+  noPrerequisiteRows : Array Output.Html := #[]
+  noDependentRows : Array Output.Html := #[]
+  proofDebtHotspotRows : Array Output.Html := #[]
+  ownerRollupRows : Array Output.Html := #[]
+  tagRollupRows : Array Output.Html := #[]
+  linkedPrRows : Array Output.Html := #[]
+  missingOwnerRows : Array Output.Html := #[]
+  missingEffortRows : Array Output.Html := #[]
+  untaggedRows : Array Output.Html := #[]
+  groupHealthRows : Array Output.Html := #[]
+  definitionRows : Array Output.Html := #[]
+  theoremLikeRows : Array Output.Html := #[]
+  axiomRows : Array Output.Html := #[]
+  theoremLikeByParentRows : Array Output.Html := #[]
+  blockerCount : Nat := 0
+  blockerRows : Array Output.Html := #[]
+
+private def summaryRenderLeanDeclLink (target : Name) (node : Output.Html)
+    (href? : Option String) (linkTitle? : Option String := Option.none) : Output.Html :=
+  match href? with
+  | some href =>
+    Informal.LeanCodeLink.renderResolved
+      target node "" (some href) linkTitle?
+      (previewTitle := Informal.LeanCodePreview.title target)
+  | Option.none => node
+
+private def SummaryHtmlContext.entryRef (ctx : SummaryHtmlContext) (label : Name) : Output.Html :=
+  let previewLookupKey? := ctx.previewLookupKey? label
+  let previewLabel? : Option Name := previewLookupKey?.map (fun _ => label)
+  let labelNode : Output.Html :=
+    match ctx.entryHref? label with
+    | Option.some href => {{ <a href={{href}}> <code>s!"{label}"</code> </a> }}
+    | Option.none => {{ <code>s!"{label}"</code> }}
+  Informal.HoverRender.summaryPreviewWrap labelNode previewLabel? previewLookupKey?
+
+private def SummaryHtmlContext.declItems (ctx : SummaryHtmlContext) (label : Name)
+    (decls : List Name) : Array Output.Html :=
+  decls.toArray.map fun decl =>
+    let declNode := summaryRenderLeanDeclLink decl {{<code>s!"{decl}"</code>}} (ctx.declHref? label decl)
+    {{ <li>{{declNode}}</li> }}
+
+private def summaryBadge (text : String) (className : String := "bp_summary_badge") : Output.Html :=
+  {{ <span class={{className}}>s!"{text}"</span> }}
+
+private def summaryBadgeRow (badges : Array Output.Html) : Output.Html :=
+  if badges.isEmpty then
+    .empty
+  else
+    {{ <div class="bp_summary_badge_row">{{badges}}</div> }}
+
+private def summaryMetadataBadges (metadata : MetadataPresentation) : Array Output.Html :=
+  metadata.summaryBadgeSpecs.map fun badge =>
+    summaryBadge badge.text <|
+      if badge.warning then
+        "bp_summary_badge bp_summary_badge_warn"
+      else
+        "bp_summary_badge"
+
+private def summaryMetadataActionLinks (metadata : MetadataPresentation) : Array Output.Html :=
+  metadata.summaryActionLinks.map fun action =>
+    {{ <a class="bp_code_link" href={{action.href}}>{{.text true action.label}}</a> }}
+
+private def summaryActionLinksRow (actionLinks : Array Output.Html) : Output.Html :=
+  if Array.isEmpty actionLinks then
+    .empty
+  else
+    {{<div class="bp_summary_item_actions">"Links: " {{(actionLinks.toList.intersperse {{<span class="bp_summary_sep">" | "</span>}}).toArray}}</div>}}
+
+private def summaryCard (label value : String) (status? : Option String := Option.none)
+    (className : String := "bp_summary_card") : Output.Html :=
+  let statusNode : Output.Html :=
+    match status? with
+    | Option.some status => {{<span class="bp_summary_status">{{.text true status}}</span>}}
+    | Option.none => .empty
+  {{ <div class={{className}}>
+      <span class="bp_summary_label">{{.text true label}}</span>
+      <span class="bp_summary_value">{{.text true value}}</span>
+      {{statusNode}}
+    </div> }}
+
+private def summaryOptionalCard (visible : Bool) (label value : String)
+    (status? : Option String := Option.none) (className : String := "bp_summary_card") :
+    Output.Html :=
+  if visible then
+    summaryCard label value status? className
+  else
+    .empty
+
+private def summaryWarnCard (label value : String) (status? : Option String := Option.none) :
+    Output.Html :=
+  summaryCard label value status? "bp_summary_card bp_summary_card_warn"
+
+private def summaryOptionalWarnCard (visible : Bool) (label value : String)
+    (status? : Option String := Option.none) : Output.Html :=
+  if visible then
+    summaryWarnCard label value status?
+  else
+    .empty
+
+private def summaryCapRows (rows : Array Output.Html) (noun : String) : Array Output.Html :=
+  let visible := (rows.toList.take triageVisibleLimit).toArray
+  let hidden := (rows.toList.drop triageVisibleLimit).toArray
+  if hidden.isEmpty then
+    visible
+  else
+    visible.push {{
+      <li class="bp_summary_item bp_summary_item_nested">
+        <details class="bp_summary_nested">
+          <summary>s!"Show all {hidden.size} more {noun}"</summary>
+          <ul class="bp_summary_list">
+            {{hidden}}
+          </ul>
+        </details>
+      </li>
+    }}
+
+private def summaryDetailsList (title : String) (rows : Array Output.Html)
+    (className : String := "bp_summary_subsection") (open? : Bool := false) : Output.Html :=
+  if open? then
+    {{ <details class={{className}} open>
+        <summary>{{.text true title}}</summary>
+        <ul class="bp_summary_list">
+          {{rows}}
+        </ul>
+      </details> }}
+  else
+    {{ <details class={{className}}>
+        <summary>{{.text true title}}</summary>
+        <ul class="bp_summary_list">
+          {{rows}}
+        </ul>
+      </details> }}
+
+private def summaryOptionalDetailsList (visible : Bool) (title : String) (rows : Array Output.Html)
+    (className : String := "bp_summary_subsection") (open? : Bool := false) : Output.Html :=
+  if visible then
+    summaryDetailsList title rows className open?
+  else
+    .empty
+
+private def summaryCappedDetailsList (title : String) (rows : Array Output.Html) (noun : String)
+    (className : String := "bp_summary_subsection") (open? : Bool := false) : Output.Html :=
+  summaryDetailsList title (summaryCapRows rows noun) className open?
+
+private def summaryOptionalCappedDetailsList (visible : Bool) (title : String)
+    (rows : Array Output.Html) (noun : String) (className : String := "bp_summary_subsection")
+    (open? : Bool := false) : Output.Html :=
+  summaryOptionalDetailsList visible title (summaryCapRows rows noun) className open?
+
+private def SummaryHtmlContext.associatedDecls (ctx : SummaryHtmlContext) (label : Name)
+    (leanObjects : List Name) : Output.Html :=
+  if leanObjects.isEmpty then
+    .empty
+  else
+    {{<details class="bp_summary_decls"><summary>s!"Associated lean decls ({leanObjects.length})"</summary><ul class="bp_summary_decl_list">{{ctx.declItems label leanObjects}}</ul></details>}}
+
+private def SummaryHtmlContext.leanRow (ctx : SummaryHtmlContext) (label : Name) (kind : String)
+    (leanObjects : List Name) : Output.Html :=
+  let entryRef := ctx.entryRef label
+  {{ <li class="bp_summary_item">
+      <div class="bp_summary_item_top">
+        <span class="bp_summary_item_head">{{entryRef}}</span>
+        <span class="bp_summary_item_meta">s!"({kind})"</span>
+      </div>
+      {{ctx.associatedDecls label leanObjects}}
+    </li> }}
+
+private def SummaryHtmlContext.leanRows (ctx : SummaryHtmlContext) (items : List IndexItem) :
+    Array Output.Html :=
+  items.toArray.map fun item => ctx.leanRow item.label item.kind item.leanObjects
+
+private def SummaryHtmlContext.sorryRow (ctx : SummaryHtmlContext) (item : SorryItem) :
+    SummaryHtmlM Output.Html := do
+  let entryRef := ctx.entryRef item.label
+  let declLink :=
+    summaryRenderLeanDeclLink item.decl {{<code>s!"{item.decl}"</code>}} (ctx.declHref? item.label item.decl)
+  let statusInfo ←
+    match item.status with
+    | .missing =>
+      pure ("missing", "Missing declaration: ", "bp_summary_badge bp_summary_badge_error",
+        item.status.sorryLocationText, "n/a")
+    | .axiomLike =>
+      pure ("axiom-like", "Axiom-like declaration: ", "bp_summary_badge bp_summary_badge_warn",
+        item.status.sorryLocationText, "n/a")
+    | .containsSorry _ =>
+      let (typeSorryRefs, proofSorryRefs) := item.status.sorryRefCounts
+      let sorryRefs := typeSorryRefs + proofSorryRefs
+      let refsTxt := if sorryRefs > 0 then toString sorryRefs else "unknown"
+      pure ("contains sorry", "Declaration with sorry: ", "bp_summary_badge bp_summary_badge_warn",
+        item.status.sorryLocationText, refsTxt)
+    | .proved =>
+      HtmlT.logError s!"Unexpected proved status in summary sorry details for {item.decl}"
+      pure ("proved", "Declaration: ", "bp_summary_badge", "proved", "0")
+  let (statusLabel, declPrefix, badgeClass, whereTxt, refsTxt) := statusInfo
+  pure {{ <li class="bp_summary_item">
+            <div class="bp_summary_item_top">
+              <span class="bp_summary_item_head">{{entryRef}}</span>
+              <span class="bp_summary_item_meta">s!"({item.kind})"</span>
+            </div>
+            <div class="bp_summary_item_body">
+              {{.text true declPrefix}} {{declLink}} " "
+              <span class={{badgeClass}}>
+                s!"[{if item.isTheorem then "theorem/lemma" else "definition"}; {statusLabel}; {whereTxt}; refs: {refsTxt}]"
+              </span>
+            </div>
+          </li> }}
+
+private def SummaryHtmlContext.externalDeclNode (ctx : SummaryHtmlContext) (label written canonical : Name) :
+    Output.Html :=
+  let canonicalNode : Output.Html :=
+    summaryRenderLeanDeclLink
+      canonical
+      {{<code>s!"{canonical}"</code>}}
+      (ctx.declHref? label canonical)
+  if written == canonical then
+    canonicalNode
+  else
+    {{ <span> <code>s!"{written}"</code> " (resolved as " {{canonicalNode}} ")" </span> }}
+
+private def SummaryHtmlContext.externalDeclIssueRow (ctx : SummaryHtmlContext) (label : Name)
+    (kind : String) (written canonical : Name) (bodyPrefix badgeText badgeClass : String)
+    (actions : Output.Html := .empty) : Output.Html :=
+  let entryRef := ctx.entryRef label
+  let declNode := ctx.externalDeclNode label written canonical
+  {{ <li class="bp_summary_item">
+      <div class="bp_summary_item_top">
+        <span class="bp_summary_item_head">{{entryRef}}</span>
+        <span class="bp_summary_item_meta">s!"({kind})"</span>
+      </div>
+      <div class="bp_summary_item_body">
+        {{.text true bodyPrefix}} {{declNode}} " "
+        <span class={{badgeClass}}>{{.text true badgeText}}</span>
+      </div>
+      {{actions}}
+    </li> }}
+
+private def SummaryHtmlContext.missingRow (ctx : SummaryHtmlContext) (item : MissingLeanDeclItem) :
+    Output.Html :=
+  ctx.externalDeclIssueRow item.label item.kind item.written item.canonical
+    "Missing external Lean declaration: " "[missing declaration]" "bp_summary_badge bp_summary_badge_error"
+
+private def SummaryHtmlContext.renderFailureRow (ctx : SummaryHtmlContext) (item : RenderFailureItem) :
+    Output.Html :=
+  ctx.externalDeclIssueRow item.label item.kind item.written item.canonical
+    "External render failed for " "[render failure]" "bp_summary_badge bp_summary_badge_warn"
+    {{<div class="bp_summary_item_actions"><code>{{.text true item.message}}</code></div>}}
+
+private def SummaryHtmlContext.priorityRow (ctx : SummaryHtmlContext) (item : PriorityItem) :
+    Output.Html :=
+  let entryRef := ctx.entryRef item.label
+  let metadata := metadataPresentationOfPriorityItem item
+  let metadataBadges := summaryMetadataBadges metadata
+  let proofBadges : Array Output.Html :=
+    if item.proofStatus.isEmpty then
+      #[]
+    else
+      #[summaryBadge s!"proof: {item.proofStatus}"]
+  let actionLinks := summaryMetadataActionLinks metadata
+  let badges :=
+    metadataBadges ++ #[
+      summaryBadge s!"stage: {item.stage}",
+      summaryBadge s!"statement: {item.statementStatus}",
+      summaryBadge s!"direct uses: {item.directUses}",
+      summaryBadge s!"downstream unlocks: {item.downstreamUses}"
+    ] ++ proofBadges
+  {{ <li class="bp_summary_item">
+      <div class="bp_summary_item_top">
+        <span class="bp_summary_item_head">{{entryRef}}</span>
+        <span class="bp_summary_item_meta">s!"({item.kind})"</span>
+      </div>
+      <div class="bp_summary_item_body">s!"Ready for {item.stage} work."</div>
+      {{summaryBadgeRow badges}}
+      {{ctx.associatedDecls item.label item.leanObjects}}
+      {{summaryActionLinksRow actionLinks}}
+    </li> }}
+
+private def SummaryHtmlContext.usageRow (ctx : SummaryHtmlContext) (item : UsageItem)
+    (bodyText primaryLabel secondaryLabel : String) (primaryCount secondaryCount : Nat) : Output.Html :=
+  let entryRef := ctx.entryRef item.label
+  let badges :=
+    #[
+      summaryBadge s!"{primaryLabel}: {primaryCount}" "bp_summary_badge bp_summary_badge_warn",
+      summaryBadge s!"{secondaryLabel}: {secondaryCount}",
+      summaryBadge s!"direct uses: {item.directUses}",
+      summaryBadge s!"downstream unlocks: {item.downstreamUses}"
+    ]
+  {{ <li class="bp_summary_item">
+      <div class="bp_summary_item_top">
+        <span class="bp_summary_item_head">{{entryRef}}</span>
+        <span class="bp_summary_item_meta">s!"({item.kind})"</span>
+      </div>
+      <div class="bp_summary_item_body">{{.text true bodyText}}</div>
+      {{summaryBadgeRow badges}}
+      {{ctx.associatedDecls item.label item.leanObjects}}
+    </li> }}
+
+private def SummaryHtmlContext.dependencyLoadRow (ctx : SummaryHtmlContext)
+    (item : DependencyLoadItem) : Output.Html :=
+  let entryRef := ctx.entryRef item.label
+  let badges :=
+    #[
+      summaryBadge s!"total deps: {item.totalDeps}" "bp_summary_badge bp_summary_badge_warn",
+      summaryBadge s!"statement deps: {item.statementDeps}",
+      summaryBadge s!"proof deps: {item.proofDeps}",
+      summaryBadge s!"direct uses: {item.directUses}",
+      summaryBadge s!"downstream unlocks: {item.downstreamUses}"
+    ]
+  {{ <li class="bp_summary_item">
+      <div class="bp_summary_item_top">
+        <span class="bp_summary_item_head">{{entryRef}}</span>
+        <span class="bp_summary_item_meta">s!"({item.kind})"</span>
+      </div>
+      <div class="bp_summary_item_body">"Prerequisite fan-in measured from the current statement/proof dependency graph."</div>
+      {{summaryBadgeRow badges}}
+      {{ctx.associatedDecls item.label item.leanObjects}}
+    </li> }}
+
+private def summaryProofDebtHotspotRow (item : DebtHotspotItem) : Output.Html :=
+  let badges :=
+    #[
+      summaryBadge s!"affected entries: {item.affectedEntries}" "bp_summary_badge bp_summary_badge_warn",
+      summaryBadge s!"incomplete decls: {item.incompleteDecls}",
+      summaryBadge s!"missing decls: {item.missingDecls}",
+      summaryBadge s!"total debt: {item.totalDebt}"
+    ]
+  {{ <li class="bp_summary_item">
+      <div class="bp_summary_item_top">
+        <span class="bp_summary_item_head">{{.text true item.header}}</span>
+        <span class="bp_summary_item_meta"><code>s!"{item.parent}"</code></span>
+      </div>
+      <div class="bp_summary_item_body">"Grouped proof/code debt derived from the current incomplete-declaration snapshots."</div>
+      {{summaryBadgeRow badges}}
+    </li> }}
+
+private def summaryRollupBadges (totalEntries actionableEntries quickWins linkedPrs : Nat) :
+    Array Output.Html :=
+  #[
+    summaryBadge s!"entries: {totalEntries}",
+    summaryBadge s!"actionable: {actionableEntries}" "bp_summary_badge bp_summary_badge_warn",
+    summaryBadge s!"quick wins: {quickWins}",
+    summaryBadge s!"linked PRs: {linkedPrs}"
+  ]
+
+private def summaryOwnerRollupRow (item : OwnerRollupItem) : Output.Html :=
+  let badges :=
+    summaryRollupBadges item.totalEntries item.actionableEntries item.quickWins item.linkedPrs
+  {{ <li class="bp_summary_item">
+      <div class="bp_summary_item_top">
+        <span class="bp_summary_item_head">{{.text true item.displayName}}</span>
+        <span class="bp_summary_item_meta"><code>s!"{item.owner}"</code></span>
+      </div>
+      {{summaryBadgeRow badges}}
+    </li> }}
+
+private def summaryTagRollupRow (item : TagRollupItem) : Output.Html :=
+  let badges :=
+    summaryRollupBadges item.totalEntries item.actionableEntries item.quickWins item.linkedPrs
+  {{ <li class="bp_summary_item">
+      <div class="bp_summary_item_top">
+        <span class="bp_summary_item_head">{{summaryBadge s!"tag: {item.tag}" "bp_summary_badge bp_summary_badge_warn"}}</span>
+      </div>
+      {{summaryBadgeRow badges}}
+    </li> }}
+
+private def SummaryHtmlContext.metadataEntryRow (ctx : SummaryHtmlContext) (item : MetadataEntryItem)
+    (bodyText : String) : Output.Html :=
+  let entryRef := ctx.entryRef item.label
+  let metadata := metadataPresentationOfMetadataEntryItem item
+  let badges := summaryMetadataBadges metadata
+  let actionLinks := summaryMetadataActionLinks metadata
+  {{ <li class="bp_summary_item">
+      <div class="bp_summary_item_top">
+        <span class="bp_summary_item_head">{{entryRef}}</span>
+        <span class="bp_summary_item_meta">s!"({item.kind})"</span>
+      </div>
+      <div class="bp_summary_item_body">{{.text true bodyText}}</div>
+      {{summaryBadgeRow badges}}
+      {{ctx.associatedDecls item.label item.leanObjects}}
+      {{summaryActionLinksRow actionLinks}}
+    </li> }}
+
+private def SummaryHtmlContext.metadataEntryRows (ctx : SummaryHtmlContext)
+    (items : List MetadataEntryItem) (bodyText : String) : Array Output.Html :=
+  items.toArray.map fun item => ctx.metadataEntryRow item bodyText
+
+private def SummaryHtmlContext.groupHealthRow (ctx : SummaryHtmlContext) (item : GroupHealthItem) :
+    Output.Html :=
+  let badges :=
+    #[
+      summaryBadge s!"total: {item.totalEntries}",
+      summaryBadge s!"closed: {item.closedEntries}",
+      summaryBadge s!"local-only: {item.localOnlyEntries}",
+      summaryBadge s!"ready: {item.readyEntries}" "bp_summary_badge bp_summary_badge_warn",
+      summaryBadge s!"blocked: {item.blockedEntries}",
+      summaryBadge s!"incomplete Lean: {item.incompleteLeanEntries}",
+      summaryBadge s!"unlock score: {item.unlockScore}"
+    ]
+  match item.nextPriority? with
+  | Option.none =>
+    {{ <li class="bp_summary_item">
+        <div class="bp_summary_item_top">
+          <span class="bp_summary_item_head">{{.text true item.header}}</span>
+          <span class="bp_summary_item_meta"><code>s!"{item.parent}"</code></span>
+        </div>
+        <div class="bp_summary_item_body">"Grouped view over entries sharing the same parent."</div>
+        {{summaryBadgeRow badges}}
+        <div class="bp_summary_item_actions">"Next: no ready child currently unlocks downstream work."</div>
+      </li> }}
+  | Option.some next =>
+    let nextRef := ctx.entryRef next.label
+    let priorityBadges : Array Output.Html :=
+      match next.priority with
+      | Option.some priority => #[summaryBadge s!"priority: {priority}" "bp_summary_badge bp_summary_badge_warn"]
+      | Option.none => #[]
+    {{ <li class="bp_summary_item">
+        <div class="bp_summary_item_top">
+          <span class="bp_summary_item_head">{{.text true item.header}}</span>
+          <span class="bp_summary_item_meta"><code>s!"{item.parent}"</code></span>
+        </div>
+        <div class="bp_summary_item_body">"Grouped view over entries sharing the same parent."</div>
+        {{summaryBadgeRow badges}}
+        <div class="bp_summary_item_actions">
+          "Next: " {{nextRef}} " "
+          {{priorityBadges ++ #[
+            summaryBadge s!"stage: {next.stage}",
+            summaryBadge s!"downstream unlocks: {next.downstreamUses}"
+          ]}}
+        </div>
+      </li> }}
+
+private def SummaryHtmlContext.theoremLikeParentGroup (ctx : SummaryHtmlContext)
+    (group : ParentTheoremGroup) : Output.Html :=
+  let rows := ctx.leanRows group.entries
+  {{ <details class="bp_summary_subsection">
+      <summary>s!"{group.header} ({group.entries.length})"</summary>
+      <ul class="bp_summary_list">
+        {{if rows.isEmpty then {{<li class="bp_summary_empty">"No theorem/lemma/corollary entries in this parent group."</li>}} else rows}}
+      </ul>
+    </details> }}
+
+-- Keep the large summary renderer in small top-level pieces; compiling it as
+-- one generated `block_extension` descriptor is disproportionately expensive.
+private def SummaryRows.render (ctx : SummaryHtmlContext) (data : Summary) : SummaryHtmlM SummaryRows := do
+  let pendingInformalRows := ctx.leanRows data.pendingInformalEntries
+  let sorryRows ← data.sorryDetails.toArray.mapM ctx.sorryRow
+  let missingRows := data.missingLeanDecls.toArray.map ctx.missingRow
+  let renderFailureRows := data.renderFailures.toArray.map ctx.renderFailureRow
+  let topPriorityRows := data.topPriorities.toArray.map ctx.priorityRow
+  let quickWinRows := data.quickWins.toArray.map ctx.priorityRow
+  let statementUsedItems :=
+    sortUsageItemsByAxis
+      (data.mostUsed.toArray.filter fun item => item.statementUses > 0)
+      (fun item => item.statementUses)
+  let proofUsedItems :=
+    sortUsageItemsByAxis
+      (data.mostUsed.toArray.filter fun item => item.proofUses > 0)
+      (fun item => item.proofUses)
+  let statementUsedRows :=
+    statementUsedItems.map fun item =>
+      ctx.usageRow item
+        "Reverse dependencies recorded in statement dependencies."
+        "statement uses"
+        "proof uses"
+        item.statementUses
+        item.proofUses
+  let proofUsedRows :=
+    proofUsedItems.map fun item =>
+      ctx.usageRow item
+        "Reverse dependencies recorded in proof dependencies."
+        "proof uses"
+        "statement uses"
+        item.proofUses
+        item.statementUses
+  let heaviestPrerequisiteRows := data.heaviestPrerequisites.toArray.map ctx.dependencyLoadRow
+  let noPrerequisiteRows := ctx.leanRows data.noPrerequisites
+  let noDependentRows := ctx.leanRows data.noDependents
+  let proofDebtHotspotRows := data.proofDebtHotspots.toArray.map summaryProofDebtHotspotRow
+  let ownerRollupRows := data.ownerRollups.toArray.map summaryOwnerRollupRow
+  let tagRollupRows := data.tagRollups.toArray.map summaryTagRollupRow
+  let linkedPrRows := ctx.metadataEntryRows data.linkedPrs "Entry already linked to a review PR."
+  let missingOwnerRows := ctx.metadataEntryRows data.missingOwners "Missing owner metadata."
+  let missingEffortRows := ctx.metadataEntryRows data.missingEffort "Missing effort metadata."
+  let untaggedRows := ctx.metadataEntryRows data.untaggedEntries "Missing tag metadata."
+  let groupHealthRows := data.groupHealth.toArray.map ctx.groupHealthRow
+  let definitionRows := ctx.leanRows data.definitionIndex
+  let theoremLikeRows := ctx.leanRows data.theoremLikeIndex
+  let axiomRows := ctx.leanRows data.axiomIndex
+  let theoremLikeByParentRows := data.theoremLikeByParent.toArray.map ctx.theoremLikeParentGroup
+  let blockerCount := data.missingLeanDecls.length + data.sorryDetails.length
+  let blockerRows := missingRows ++ sorryRows
+  pure {
+    pendingInformalRows,
+    sorryRows,
+    missingRows,
+    renderFailureRows,
+    topPriorityRows,
+    quickWinRows,
+    statementUsedItems,
+    proofUsedItems,
+    statementUsedRows,
+    proofUsedRows,
+    heaviestPrerequisiteRows,
+    noPrerequisiteRows,
+    noDependentRows,
+    proofDebtHotspotRows,
+    ownerRollupRows,
+    tagRollupRows,
+    linkedPrRows,
+    missingOwnerRows,
+    missingEffortRows,
+    untaggedRows,
+    groupHealthRows,
+    definitionRows,
+    theoremLikeRows,
+    axiomRows,
+    theoremLikeByParentRows,
+    blockerCount,
+    blockerRows
+  }
+
+private def summaryOverviewSection (data : Summary) (rows : SummaryRows) : Output.Html :=
+  let showBlockers := rows.blockerCount > 0
+  let showPendingInformal := !rows.pendingInformalRows.isEmpty
+  let showQuickWins := !rows.quickWinRows.isEmpty
+  {{ <details class="bp_summary_section" open>
+      <summary>"Overview"</summary>
+      <div class="bp_summary_grid">
+        {{summaryCard "Total entries" (toString data.totalEntries) (Option.some (statusCountsText data.totalStatus))}}
+        {{summaryCard
+            "Ready now"
+            (toString data.coverageSplit.readyToFormalize)
+            (Option.some "Entries whose next formalization step is currently unblocked.")}}
+        {{summaryCard
+            "Fully closed"
+            (toString data.coverageSplit.fullyClosed)
+            (Option.some "Local code and prerequisite closure are both complete.")}}
+        {{summaryCard
+            "Actionable priorities"
+            (toString data.topPriorities.length)
+            (Option.some "Entries ready now and already unlocking downstream work.")}}
+        {{summaryOptionalWarnCard
+            showBlockers
+            "Current blockers"
+            (toString rows.blockerCount)
+            (Option.some "Missing external or incomplete Lean declarations.")}}
+        {{summaryOptionalCard
+            showPendingInformal
+            "Missing informal coverage"
+            (toString data.pendingInformalEntries.length)
+            (Option.some "Entries with Lean code but missing an informal statement or proof block.")}}
+        {{summaryOptionalCard
+            showQuickWins
+            "Quick wins"
+            (toString data.quickWins.length)
+            (Option.some "Actionable entries with `high` priority and `small` effort.")}}
+      </div>
+      {{if data.totalEntries == 0 then
+          {{<p class="bp_summary_empty">"No blueprint entries were registered in the current document."</p>}}
+        else .empty}}
+      {{summaryOptionalCappedDetailsList
+          (!rows.topPriorityRows.isEmpty)
+          s!"Ready next ({data.topPriorities.length})"
+          rows.topPriorityRows
+          "priorities"
+          "bp_summary_subsection"
+          true}}
+      {{summaryOptionalDetailsList
+          showBlockers
+          s!"Current blockers ({rows.blockerCount})"
+          rows.blockerRows
+          "bp_summary_subsection bp_summary_subsection_warn"
+          true}}
+      {{summaryOptionalDetailsList
+          showPendingInformal
+          s!"Missing informal coverage ({data.pendingInformalEntries.length})"
+          rows.pendingInformalRows}}
+    </details> }}
+
+private def summaryEntryIndexSection (data : Summary) (rows : SummaryRows) : Output.Html :=
+  let showDefinitionCard := data.definitions > 0
+  let showLemmaCard := data.lemmas > 0
+  let showTheoremCard := data.theorems > 0
+  let showCorollaryCard := data.corollaries > 0
+  let showAxiomCard := data.axioms > 0
+  let showLeanOnlyCard := data.leanOnlyEntries > 0
+  let showInformalOnlyCard := data.informalOnlyEntries > 0
+  let showDefinitionIndex := !rows.definitionRows.isEmpty
+  let showTheoremLikeIndex := !rows.theoremLikeRows.isEmpty
+  let showAxiomIndex := !rows.axiomRows.isEmpty
+  let showTheoremLikeByParent := !rows.theoremLikeByParentRows.isEmpty
+  if !(showDefinitionIndex || showTheoremLikeIndex || showAxiomIndex) then
+    .empty
+  else
+    {{ <details class="bp_summary_section">
+        <summary>s!"Entry index ({data.totalEntries})"</summary>
+        <div class="bp_summary_grid">
+          {{summaryOptionalCard
+              showDefinitionCard
+              "Definitions"
+              (toString data.definitions)
+              (Option.some (statusCountsText data.definitionStatus))}}
+          {{summaryOptionalCard showLemmaCard "Lemmas" (toString data.lemmas) (Option.some (statusCountsText data.lemmaStatus))}}
+          {{summaryOptionalCard showTheoremCard "Theorems" (toString data.theorems) (Option.some (statusCountsText data.theoremStatus))}}
+          {{summaryOptionalCard
+              showCorollaryCard
+              "Corollaries"
+              (toString data.corollaries)
+              (Option.some (statusCountsText data.corollaryStatus))}}
+          {{summaryOptionalWarnCard
+              showAxiomCard
+              "Axiom-like entries"
+              (toString data.axioms)
+              (Option.some (statusCountsText data.axiomStatus))}}
+          {{summaryOptionalCard showLeanOnlyCard "Lean-only entries" (toString data.leanOnlyEntries)}}
+          {{summaryOptionalCard showInformalOnlyCard "Informal-only entries" (toString data.informalOnlyEntries)}}
+        </div>
+        {{summaryOptionalDetailsList showDefinitionIndex s!"Definition Index ({data.definitionIndex.length})" rows.definitionRows}}
+        {{if showTheoremLikeIndex then
+            {{<details class="bp_summary_subsection">
+              <summary>s!"Theorem / Lemma / Corollary Index ({data.theoremLikeIndex.length})"</summary>
+              <ul class="bp_summary_list">
+                {{rows.theoremLikeRows}}
+              </ul>
+              {{if showTheoremLikeByParent then
+                  {{<details class="bp_summary_nested">
+                    <summary>s!"By parent groups ({data.theoremLikeByParent.length})"</summary>
+                    {{rows.theoremLikeByParentRows}}
+                  </details>}}
+                else .empty}}
+            </details>}}
+        else .empty}}
+        {{summaryOptionalDetailsList
+            showAxiomIndex
+            s!"Axiom-like Index ({data.axiomIndex.length})"
+            rows.axiomRows
+            "bp_summary_subsection bp_summary_subsection_warn"}}
+      </details> }}
+
+private def summaryDependencyInsightsSection (rows : SummaryRows) : Output.Html :=
+  if rows.statementUsedRows.isEmpty && rows.proofUsedRows.isEmpty && rows.groupHealthRows.isEmpty then
+    .empty
+  else
+    {{ <details class="bp_summary_section">
+        <summary>"Dependency insights"</summary>
+        <div class="bp_summary_grid">
+          {{summaryOptionalCard
+              (!rows.statementUsedRows.isEmpty)
+              "Statement-used entries"
+              (toString rows.statementUsedItems.size)
+              (Option.some "Entries reused in statement dependencies.")}}
+          {{summaryOptionalCard
+              (!rows.proofUsedRows.isEmpty)
+              "Proof-used entries"
+              (toString rows.proofUsedItems.size)
+              (Option.some "Entries reused in proof-only dependencies.")}}
+          {{summaryOptionalCard
+              (!rows.groupHealthRows.isEmpty)
+              "Tracked parent groups"
+              (toString rows.groupHealthRows.size)
+              (Option.some "Grouped health rollups for parents with more than one child entry.")}}
+        </div>
+        {{summaryOptionalCappedDetailsList
+            (!rows.statementUsedRows.isEmpty)
+            s!"Most used in statements ({rows.statementUsedItems.size})"
+            rows.statementUsedRows
+            "statement-used entries"}}
+        {{summaryOptionalCappedDetailsList
+            (!rows.proofUsedRows.isEmpty)
+            s!"Most used in proofs ({rows.proofUsedItems.size})"
+            rows.proofUsedRows
+            "proof-used entries"}}
+        {{summaryOptionalCappedDetailsList
+            (!rows.groupHealthRows.isEmpty)
+            s!"Group health ({rows.groupHealthRows.size})"
+            rows.groupHealthRows
+            "groups"}}
+      </details> }}
+
+private def summaryMetadataSection (data : Summary) (rows : SummaryRows) : Output.Html :=
+  let showQuickWins := !rows.quickWinRows.isEmpty
+  let showOwnerRollups := !rows.ownerRollupRows.isEmpty
+  let showTagRollups := !rows.tagRollupRows.isEmpty
+  let showLinkedPrs := !rows.linkedPrRows.isEmpty
+  let showMetadataAudit :=
+    !rows.missingOwnerRows.isEmpty || !rows.missingEffortRows.isEmpty || !rows.untaggedRows.isEmpty
+  let showMetadataCards := showQuickWins || showOwnerRollups || showTagRollups || showLinkedPrs
+  if !(showMetadataCards || showMetadataAudit) then
+    .empty
+  else
+    {{ <details class="bp_summary_section">
+        <summary>"Metadata"</summary>
+        {{if showMetadataCards then
+            {{<div class="bp_summary_grid">
+              {{summaryOptionalCard
+                  showQuickWins
+                  "Quick wins"
+                  (toString data.quickWins.length)
+                  (Option.some "Actionable entries with `high` priority and `small` effort.")}}
+              {{summaryOptionalCard
+                  showOwnerRollups
+                  "Owners in use"
+                  (toString data.ownerRollups.length)
+                  (Option.some "Distinct owners referenced by the current blueprint entries.")}}
+              {{summaryOptionalCard
+                  showTagRollups
+                  "Tags in use"
+                  (toString data.tagRollups.length)
+                  (Option.some "Distinct tags currently attached to blueprint entries.")}}
+              {{summaryOptionalCard
+                  showLinkedPrs
+                  "Linked PRs"
+                  (toString data.linkedPrs.length)
+                  (Option.some "Entries already linked to a review URL.")}}
+            </div>}}
+          else .empty}}
+        {{summaryOptionalCappedDetailsList
+            showQuickWins
+            s!"Quick wins ({data.quickWins.length})"
+            rows.quickWinRows
+            "quick wins"}}
+        {{summaryOptionalCappedDetailsList
+            showOwnerRollups
+            s!"Owner rollups ({data.ownerRollups.length})"
+            rows.ownerRollupRows
+            "owners"}}
+        {{summaryOptionalCappedDetailsList
+            showTagRollups
+            s!"Tag rollups ({data.tagRollups.length})"
+            rows.tagRollupRows
+            "tags"}}
+        {{summaryOptionalCappedDetailsList
+            showLinkedPrs
+            s!"Linked PRs ({data.linkedPrs.length})"
+            rows.linkedPrRows
+            "linked PR entries"}}
+        {{if showMetadataAudit then
+            {{<details class="bp_summary_subsection bp_summary_subsection_warn">
+              <summary>"Metadata audit"</summary>
+              <div class="bp_summary_grid">
+                {{summaryOptionalWarnCard
+                    (!rows.missingOwnerRows.isEmpty)
+                    "Missing owner"
+                    (toString data.missingOwners.length)}}
+                {{summaryOptionalWarnCard
+                    (!rows.missingEffortRows.isEmpty)
+                    "Missing effort"
+                    (toString data.missingEffort.length)}}
+                {{summaryOptionalWarnCard
+                    (!rows.untaggedRows.isEmpty)
+                    "Untagged"
+                    (toString data.untaggedEntries.length)}}
+              </div>
+              {{summaryOptionalCappedDetailsList
+                  (!rows.missingOwnerRows.isEmpty)
+                  s!"Missing owner ({data.missingOwners.length})"
+                  rows.missingOwnerRows
+                  "entries missing owner"
+                  "bp_summary_nested"}}
+              {{summaryOptionalCappedDetailsList
+                  (!rows.missingEffortRows.isEmpty)
+                  s!"Missing effort ({data.missingEffort.length})"
+                  rows.missingEffortRows
+                  "entries missing effort"
+                  "bp_summary_nested"}}
+              {{summaryOptionalCappedDetailsList
+                  (!rows.untaggedRows.isEmpty)
+                  s!"Untagged ({data.untaggedEntries.length})"
+                  rows.untaggedRows
+                  "untagged entries"
+                  "bp_summary_nested"}}
+            </details>}}
+          else .empty}}
+      </details> }}
+
+private def summaryDiagnosticsSection (data : Summary) (rows : SummaryRows) : Output.Html :=
+  if !(data.showDebugDiagnostics && !rows.renderFailureRows.isEmpty) then
+    .empty
+  else
+    {{ <details class="bp_summary_section">
+        <summary>"Maintainer diagnostics"</summary>
+        <div class="bp_summary_grid">
+          {{summaryWarnCard
+              "Render failures"
+              (toString data.renderFailures.length)
+              (Option.some "External declarations that checked in Lean but failed HTML rendering.")}}
+        </div>
+        {{summaryCappedDetailsList
+            s!"Render failures ({data.renderFailures.length})"
+            rows.renderFailureRows
+            "render-failure entries"
+            "bp_summary_subsection bp_summary_subsection_warn"}}
+      </details> }}
+
+private def summaryStructureSection (data : Summary) (rows : SummaryRows) : Output.Html :=
+  let showHeaviestPrerequisites := !rows.heaviestPrerequisiteRows.isEmpty
+  let showNoPrerequisites := !rows.noPrerequisiteRows.isEmpty
+  let showNoDependents := !rows.noDependentRows.isEmpty
+  let showProofDebtHotspots := !rows.proofDebtHotspotRows.isEmpty
+  let showStructureCards :=
+    data.coverageSplit.informalOnly > 0 ||
+    data.coverageSplit.readyToFormalize > 0 ||
+    data.coverageSplit.formalizedWithoutAncestors > 0 ||
+    data.coverageSplit.fullyClosed > 0 ||
+    data.coverageSplit.blockedOrIncomplete > 0
+  if !(showStructureCards || showHeaviestPrerequisites || showNoPrerequisites ||
+      showNoDependents || showProofDebtHotspots) then
+    .empty
+  else
+    {{ <details class="bp_summary_section">
+        <summary>"Structure and coverage"</summary>
+        <div class="bp_summary_grid">
+          {{summaryOptionalCard
+              (data.coverageSplit.informalOnly > 0)
+              "Informal-only"
+              (toString data.coverageSplit.informalOnly)
+              (Option.some "Statements with no associated Lean code yet.")}}
+          {{summaryOptionalCard
+              (data.coverageSplit.readyToFormalize > 0)
+              "Ready to formalize"
+              (toString data.coverageSplit.readyToFormalize)
+              (Option.some "Entries whose next step is currently unblocked.")}}
+          {{summaryOptionalCard
+              (data.coverageSplit.formalizedWithoutAncestors > 0)
+              "Formalized, ancestors open"
+              (toString data.coverageSplit.formalizedWithoutAncestors)
+              (Option.some "Local Lean work is done, but prerequisite closure is still open.")}}
+          {{summaryOptionalCard
+              (data.coverageSplit.fullyClosed > 0)
+              "Fully closed"
+              (toString data.coverageSplit.fullyClosed)
+              (Option.some "Local code and ancestor closure are both complete.")}}
+          {{summaryOptionalWarnCard
+              (data.coverageSplit.blockedOrIncomplete > 0)
+              "Blocked or incomplete"
+              (toString data.coverageSplit.blockedOrIncomplete)
+              (Option.some "Entries not covered by the highlighted readiness buckets above.")}}
+        </div>
+        {{summaryOptionalCappedDetailsList
+            showHeaviestPrerequisites
+            s!"Heaviest prerequisites ({data.heaviestPrerequisites.length})"
+            rows.heaviestPrerequisiteRows
+            "heaviest-prerequisite entries"}}
+        {{summaryOptionalCappedDetailsList
+            showNoPrerequisites
+            s!"No prerequisites ({data.noPrerequisites.length})"
+            rows.noPrerequisiteRows
+            "entries without prerequisites"}}
+        {{summaryOptionalCappedDetailsList
+            showNoDependents
+            s!"No dependents ({data.noDependents.length})"
+            rows.noDependentRows
+            "entries without dependents"}}
+        {{summaryOptionalCappedDetailsList
+            showProofDebtHotspots
+            s!"Proof debt hotspots ({data.proofDebtHotspots.length})"
+            rows.proofDebtHotspotRows
+            "proof-debt hotspots"
+            "bp_summary_subsection bp_summary_subsection_warn"}}
+      </details> }}
+
+private def summaryBlockToHtml : BlockToHtml Manual (ReaderT AllRemotes (ReaderT ExtensionImpls IO)) :=
+  fun _goI _goB _id json _blocks => do
+    let .ok data := fromJson? (α := Summary) json
+      | HtmlT.logError "Malformed data in Block.summary.toHtml"
+        pure .empty
+    let s ← HtmlT.state
+    let previewLookupKeys := (data.previewLabels).foldl (init := ({} : Lean.NameMap String)) fun keys label =>
+      match Informal.PreviewSource.traversalLookupKey? s label with
+      | some key => keys.insert label key
+      | Option.none => keys
+    let ctx : SummaryHtmlContext := {
+      entryHref? := fun label => Informal.TraversalIndex.Nodes.href? s label
+      declHref? := fun label decl =>
+        match Resolve.resolveRenderedExternalDeclHref? s label decl with
+        | Option.some href => Option.some href
+        | Option.none => Resolve.resolveInlineLeanDeclHref? s decl
+      previewLookupKey? := fun label => previewLookupKeys.get? label
+    }
+    let previewUi := Informal.HoverRender.summaryPreviewUi
+    let rows ← SummaryRows.render ctx data
+    pure {{
+      <div class="bp_summary">
+        {{previewUi.store}}
+        {{previewUi.panel}}
+        {{summaryOverviewSection data rows}}
+        {{summaryEntryIndexSection data rows}}
+        {{summaryDependencyInsightsSection rows}}
+        {{summaryMetadataSection data rows}}
+        {{summaryDiagnosticsSection data rows}}
+        {{summaryStructureSection data rows}}
+      </div>
+    }}
+
 open Verso Doc Elab Genre Manual in
 block_extension Block.summary (summary : Summary) where
   data := toJson summary
   traverse _id _data _contents := do
     return none
   toTeX := none
-  toHtml :=
-    open Verso.Doc.Html in
-    open Verso.Output.Html in
-    some <| fun _goI _goB _id data _blocks => do
-      let .ok data := fromJson? (α := Summary) data
-        | HtmlT.logError "Malformed data in Block.summary.toHtml"
-          pure .empty
-      let s ← HtmlT.state
-      let getEntryHref (label : Name) : Option String :=
-        Informal.TraversalIndex.Nodes.href? s label
-      let getDeclHref (label : Name) (decl : Name) : Option String :=
-        match Resolve.resolveRenderedExternalDeclHref? s label decl with
-        | Option.some href => Option.some href
-        | Option.none => Resolve.resolveInlineLeanDeclHref? s decl
-      let renderLeanDeclLink (target : Name) (node : Output.Html)
-          (href? : Option String) (linkTitle? : Option String := Option.none) : Output.Html :=
-        match href? with
-        | some href =>
-          Informal.LeanCodeLink.renderResolved
-            target node "" (some href) linkTitle?
-            (previewTitle := Informal.LeanCodePreview.title target)
-        | Option.none => node
-      let previewLookupKeys := (data.previewLabels).foldl (init := ({} : Lean.NameMap String)) fun keys label =>
-        match Informal.PreviewSource.traversalLookupKey? s label with
-        | some key => keys.insert label key
-        | Option.none => keys
-      let previewUi := Informal.HoverRender.summaryPreviewUi
-      let mkEntryRef (label : Name) := do
-        let previewLookupKey? := previewLookupKeys.get? label
-        let previewLabel? : Option Name := previewLookupKey?.map (fun _ => label)
-        let labelNode : Output.Html :=
-          match getEntryHref label with
-          | Option.some href => {{ <a href={{href}}> <code>s!"{label}"</code> </a> }}
-          | Option.none => {{ <code>s!"{label}"</code> }}
-        pure (Informal.HoverRender.summaryPreviewWrap labelNode previewLabel? previewLookupKey?)
-      let mkDeclItems (label : Name) (decls : List Name) :=
-        decls.toArray.map fun decl =>
-          let declNode := renderLeanDeclLink decl {{<code>s!"{decl}"</code>}} (getDeclHref label decl)
-          {{ <li>{{declNode}}</li> }}
-      let mkBadge (text : String) (className : String := "bp_summary_badge") : Output.Html :=
-        {{ <span class={{className}}>s!"{text}"</span> }}
-      let mkBadgeRow (badges : Array Output.Html) : Output.Html :=
-        if badges.isEmpty then
-          .empty
-        else
-          {{ <div class="bp_summary_badge_row">{{badges}}</div> }}
-      let mkMetadataBadges (metadata : MetadataPresentation) : Array Output.Html :=
-        metadata.summaryBadgeSpecs.map fun badge =>
-          mkBadge badge.text <|
-            if badge.warning then
-              "bp_summary_badge bp_summary_badge_warn"
-            else
-              "bp_summary_badge"
-      let mkMetadataActionLinks (metadata : MetadataPresentation) : Array Output.Html :=
-        metadata.summaryActionLinks.map fun action =>
-          {{ <a class="bp_code_link" href={{action.href}}>{{.text true action.label}}</a> }}
-      let capRows (rows : Array Output.Html) (noun : String) : Array Output.Html :=
-        let visible := (rows.toList.take triageVisibleLimit).toArray
-        let hidden := (rows.toList.drop triageVisibleLimit).toArray
-        if hidden.isEmpty then
-          visible
-        else
-          visible.push {{
-            <li class="bp_summary_item bp_summary_item_nested">
-              <details class="bp_summary_nested">
-                <summary>s!"Show all {hidden.size} more {noun}"</summary>
-                <ul class="bp_summary_list">
-                  {{hidden}}
-                </ul>
-              </details>
-            </li>
-          }}
-      let mkLeanRow (label : Name) (kind : String) (leanObjects : List Name) := do
-        let entryRef ← mkEntryRef label
-        let associatedDecls := !leanObjects.isEmpty
-        pure {{ <li class="bp_summary_item">
-                  <div class="bp_summary_item_top">
-                    <span class="bp_summary_item_head">{{entryRef}}</span>
-                    <span class="bp_summary_item_meta">s!"({kind})"</span>
-                  </div>
-                  {{if associatedDecls then
-                     {{<details class="bp_summary_decls"><summary>s!"Associated lean decls ({leanObjects.length})"</summary><ul class="bp_summary_decl_list">{{mkDeclItems label leanObjects}}</ul></details>}}
-                    else
-                     .empty}}
-                </li> }}
-      let pendingInformalRows ←
-        data.pendingInformalEntries.toArray.mapM fun item =>
-          mkLeanRow item.label item.kind item.leanObjects
-      let sorryRows ←
-        data.sorryDetails.toArray.mapM fun item => do
-          let entryRef ← mkEntryRef item.label
-          let declLink :=
-            renderLeanDeclLink item.decl {{<code>s!"{item.decl}"</code>}} (getDeclHref item.label item.decl)
-          let statusInfo ←
-            match item.status with
-            | .missing =>
-              pure ("missing", "Missing declaration: ", "bp_summary_badge bp_summary_badge_error",
-                item.status.sorryLocationText, "n/a")
-            | .axiomLike =>
-              pure ("axiom-like", "Axiom-like declaration: ", "bp_summary_badge bp_summary_badge_warn",
-                item.status.sorryLocationText, "n/a")
-            | .containsSorry _ =>
-              let (typeSorryRefs, proofSorryRefs) := item.status.sorryRefCounts
-              let sorryRefs := typeSorryRefs + proofSorryRefs
-              let refsTxt := if sorryRefs > 0 then toString sorryRefs else "unknown"
-              pure ("contains sorry", "Declaration with sorry: ", "bp_summary_badge bp_summary_badge_warn",
-                item.status.sorryLocationText, refsTxt)
-            | .proved =>
-              HtmlT.logError s!"Unexpected proved status in summary sorry details for {item.decl}"
-              pure ("proved", "Declaration: ", "bp_summary_badge", "proved", "0")
-          let (statusLabel, declPrefix, badgeClass, whereTxt, refsTxt) := statusInfo
-          pure {{ <li class="bp_summary_item">
-                    <div class="bp_summary_item_top">
-                      <span class="bp_summary_item_head">{{entryRef}}</span>
-                      <span class="bp_summary_item_meta">s!"({item.kind})"</span>
-                    </div>
-                    <div class="bp_summary_item_body">
-                      {{.text true declPrefix}} {{declLink}} " "
-                      <span class={{badgeClass}}>
-                        s!"[{if item.isTheorem then "theorem/lemma" else "definition"}; {statusLabel}; {whereTxt}; refs: {refsTxt}]"
-                      </span>
-                    </div>
-                  </li> }}
-      let missingRows ←
-        data.missingLeanDecls.toArray.mapM fun item => do
-          let entryRef ← mkEntryRef item.label
-          let canonicalNode : Output.Html :=
-            renderLeanDeclLink
-              item.canonical
-              {{<code>s!"{item.canonical}"</code>}}
-              (getDeclHref item.label item.canonical)
-          let declNode : Output.Html :=
-            if item.written == item.canonical then
-              canonicalNode
-            else
-              {{ <span> <code>s!"{item.written}"</code> " (resolved as " {{canonicalNode}} ")" </span> }}
-          pure {{ <li class="bp_summary_item">
-                    <div class="bp_summary_item_top">
-                      <span class="bp_summary_item_head">{{entryRef}}</span>
-                      <span class="bp_summary_item_meta">s!"({item.kind})"</span>
-                    </div>
-                    <div class="bp_summary_item_body">
-                      "Missing external Lean declaration: " {{declNode}} " "
-                      <span class="bp_summary_badge bp_summary_badge_error">"[missing declaration]"</span>
-                    </div>
-                  </li> }}
-      let renderFailureRows ←
-        data.renderFailures.toArray.mapM fun item => do
-          let entryRef ← mkEntryRef item.label
-          let canonicalNode : Output.Html :=
-            renderLeanDeclLink
-              item.canonical
-              {{<code>s!"{item.canonical}"</code>}}
-              (getDeclHref item.label item.canonical)
-          let declNode : Output.Html :=
-            if item.written == item.canonical then
-              canonicalNode
-            else
-              {{ <span> <code>s!"{item.written}"</code> " (resolved as " {{canonicalNode}} ")" </span> }}
-          pure {{ <li class="bp_summary_item">
-                    <div class="bp_summary_item_top">
-                      <span class="bp_summary_item_head">{{entryRef}}</span>
-                      <span class="bp_summary_item_meta">s!"({item.kind})"</span>
-                    </div>
-                    <div class="bp_summary_item_body">
-                      "External render failed for " {{declNode}} " "
-                      <span class="bp_summary_badge bp_summary_badge_warn">"[render failure]"</span>
-                    </div>
-                    <div class="bp_summary_item_actions"><code>{{.text true item.message}}</code></div>
-                  </li> }}
-      let mkPriorityRow (item : PriorityItem) := do
-        let entryRef ← mkEntryRef item.label
-        let associatedDecls := !item.leanObjects.isEmpty
-        let metadata := metadataPresentationOfPriorityItem item
-        let metadataBadges := mkMetadataBadges metadata
-        let proofBadges : Array Output.Html :=
-          if item.proofStatus.isEmpty then
-            #[]
-          else
-            #[mkBadge s!"proof: {item.proofStatus}"]
-        let actionLinks := mkMetadataActionLinks metadata
-        let badges :=
-          metadataBadges ++ #[
-            mkBadge s!"stage: {item.stage}",
-            mkBadge s!"statement: {item.statementStatus}",
-            mkBadge s!"direct uses: {item.directUses}",
-            mkBadge s!"downstream unlocks: {item.downstreamUses}"
-          ] ++ proofBadges
-        pure {{
-          <li class="bp_summary_item">
-            <div class="bp_summary_item_top">
-              <span class="bp_summary_item_head">{{entryRef}}</span>
-              <span class="bp_summary_item_meta">s!"({item.kind})"</span>
-            </div>
-            <div class="bp_summary_item_body">s!"Ready for {item.stage} work."</div>
-            {{mkBadgeRow badges}}
-            {{if associatedDecls then
-               {{<details class="bp_summary_decls"><summary>s!"Associated lean decls ({item.leanObjects.length})"</summary><ul class="bp_summary_decl_list">{{mkDeclItems item.label item.leanObjects}}</ul></details>}}
-              else
-               .empty}}
-            {{if Array.isEmpty actionLinks then
-               .empty
-              else
-               {{<div class="bp_summary_item_actions">"Links: " {{(actionLinks.toList.intersperse {{<span class="bp_summary_sep">" | "</span>}}).toArray}}</div>}}}}
-          </li>
-        }}
-      let topPriorityRows ←
-        data.topPriorities.toArray.mapM mkPriorityRow
-      let quickWinRows ←
-        data.quickWins.toArray.mapM mkPriorityRow
-      let statementUsedItems :=
-        sortUsageItemsByAxis
-          (data.mostUsed.toArray.filter fun item => item.statementUses > 0)
-          (fun item => item.statementUses)
-      let proofUsedItems :=
-        sortUsageItemsByAxis
-          (data.mostUsed.toArray.filter fun item => item.proofUses > 0)
-          (fun item => item.proofUses)
-      let mkUsageRow (item : UsageItem) (bodyText primaryLabel secondaryLabel : String)
-          (primaryCount secondaryCount : Nat) := do
-          let entryRef ← mkEntryRef item.label
-          let associatedDecls := !item.leanObjects.isEmpty
-          let badges :=
-            #[
-              mkBadge s!"{primaryLabel}: {primaryCount}" "bp_summary_badge bp_summary_badge_warn",
-              mkBadge s!"{secondaryLabel}: {secondaryCount}",
-              mkBadge s!"direct uses: {item.directUses}",
-              mkBadge s!"downstream unlocks: {item.downstreamUses}"
-            ]
-          pure {{
-            <li class="bp_summary_item">
-              <div class="bp_summary_item_top">
-                <span class="bp_summary_item_head">{{entryRef}}</span>
-                <span class="bp_summary_item_meta">s!"({item.kind})"</span>
-              </div>
-              <div class="bp_summary_item_body">{{.text true bodyText}}</div>
-              {{mkBadgeRow badges}}
-              {{if associatedDecls then
-                 {{<details class="bp_summary_decls"><summary>s!"Associated lean decls ({item.leanObjects.length})"</summary><ul class="bp_summary_decl_list">{{mkDeclItems item.label item.leanObjects}}</ul></details>}}
-                else
-                 .empty}}
-            </li>
-          }}
-      let statementUsedRows ←
-        statementUsedItems.mapM fun item =>
-          mkUsageRow item
-            "Reverse dependencies recorded in statement dependencies."
-            "statement uses"
-            "proof uses"
-            item.statementUses
-            item.proofUses
-      let proofUsedRows ←
-        proofUsedItems.mapM fun item =>
-          mkUsageRow item
-            "Reverse dependencies recorded in proof dependencies."
-            "proof uses"
-            "statement uses"
-            item.proofUses
-            item.statementUses
-      let heaviestPrerequisiteRows ←
-        data.heaviestPrerequisites.toArray.mapM fun item => do
-          let entryRef ← mkEntryRef item.label
-          let associatedDecls := !item.leanObjects.isEmpty
-          let badges :=
-            #[
-              mkBadge s!"total deps: {item.totalDeps}" "bp_summary_badge bp_summary_badge_warn",
-              mkBadge s!"statement deps: {item.statementDeps}",
-              mkBadge s!"proof deps: {item.proofDeps}",
-              mkBadge s!"direct uses: {item.directUses}",
-              mkBadge s!"downstream unlocks: {item.downstreamUses}"
-            ]
-          pure {{
-            <li class="bp_summary_item">
-              <div class="bp_summary_item_top">
-                <span class="bp_summary_item_head">{{entryRef}}</span>
-                <span class="bp_summary_item_meta">s!"({item.kind})"</span>
-              </div>
-              <div class="bp_summary_item_body">"Prerequisite fan-in measured from the current statement/proof dependency graph."</div>
-              {{mkBadgeRow badges}}
-              {{if associatedDecls then
-                 {{<details class="bp_summary_decls"><summary>s!"Associated lean decls ({item.leanObjects.length})"</summary><ul class="bp_summary_decl_list">{{mkDeclItems item.label item.leanObjects}}</ul></details>}}
-                else
-                 .empty}}
-            </li>
-          }}
-      let noPrerequisiteRows ←
-        data.noPrerequisites.toArray.mapM fun item =>
-          mkLeanRow item.label item.kind item.leanObjects
-      let noDependentRows ←
-        data.noDependents.toArray.mapM fun item =>
-          mkLeanRow item.label item.kind item.leanObjects
-      let proofDebtHotspotRows :=
-        data.proofDebtHotspots.toArray.map fun item =>
-          let badges :=
-            #[
-              mkBadge s!"affected entries: {item.affectedEntries}" "bp_summary_badge bp_summary_badge_warn",
-              mkBadge s!"incomplete decls: {item.incompleteDecls}",
-              mkBadge s!"missing decls: {item.missingDecls}",
-              mkBadge s!"total debt: {item.totalDebt}"
-            ]
-          {{
-            <li class="bp_summary_item">
-              <div class="bp_summary_item_top">
-                <span class="bp_summary_item_head">{{.text true item.header}}</span>
-                <span class="bp_summary_item_meta"><code>s!"{item.parent}"</code></span>
-              </div>
-              <div class="bp_summary_item_body">"Grouped proof/code debt derived from the current incomplete-declaration snapshots."</div>
-              {{mkBadgeRow badges}}
-            </li>
-          }}
-      let ownerRollupRows :=
-        data.ownerRollups.toArray.map fun item =>
-          let badges :=
-            #[
-              mkBadge s!"entries: {item.totalEntries}",
-              mkBadge s!"actionable: {item.actionableEntries}" "bp_summary_badge bp_summary_badge_warn",
-              mkBadge s!"quick wins: {item.quickWins}",
-              mkBadge s!"linked PRs: {item.linkedPrs}"
-            ]
-          {{
-            <li class="bp_summary_item">
-              <div class="bp_summary_item_top">
-                <span class="bp_summary_item_head">{{.text true item.displayName}}</span>
-                <span class="bp_summary_item_meta"><code>s!"{item.owner}"</code></span>
-              </div>
-              {{mkBadgeRow badges}}
-            </li>
-          }}
-      let tagRollupRows :=
-        data.tagRollups.toArray.map fun item =>
-          let badges :=
-            #[
-              mkBadge s!"entries: {item.totalEntries}",
-              mkBadge s!"actionable: {item.actionableEntries}" "bp_summary_badge bp_summary_badge_warn",
-              mkBadge s!"quick wins: {item.quickWins}",
-              mkBadge s!"linked PRs: {item.linkedPrs}"
-            ]
-          {{
-            <li class="bp_summary_item">
-              <div class="bp_summary_item_top">
-                <span class="bp_summary_item_head">{{mkBadge s!"tag: {item.tag}" "bp_summary_badge bp_summary_badge_warn"}}</span>
-              </div>
-              {{mkBadgeRow badges}}
-            </li>
-          }}
-      let mkMetadataEntryRow (item : MetadataEntryItem) (bodyText : String) := do
-        let entryRef ← mkEntryRef item.label
-        let associatedDecls := !item.leanObjects.isEmpty
-        let metadata := metadataPresentationOfMetadataEntryItem item
-        let badges := mkMetadataBadges metadata
-        let actionLinks := mkMetadataActionLinks metadata
-        pure {{
-          <li class="bp_summary_item">
-            <div class="bp_summary_item_top">
-              <span class="bp_summary_item_head">{{entryRef}}</span>
-              <span class="bp_summary_item_meta">s!"({item.kind})"</span>
-            </div>
-            <div class="bp_summary_item_body">{{.text true bodyText}}</div>
-            {{mkBadgeRow badges}}
-            {{if associatedDecls then
-               {{<details class="bp_summary_decls"><summary>s!"Associated lean decls ({item.leanObjects.length})"</summary><ul class="bp_summary_decl_list">{{mkDeclItems item.label item.leanObjects}}</ul></details>}}
-              else
-               .empty}}
-            {{if Array.isEmpty actionLinks then
-               .empty
-              else
-               {{<div class="bp_summary_item_actions">"Links: " {{(actionLinks.toList.intersperse {{<span class="bp_summary_sep">" | "</span>}}).toArray}}</div>}}}}
-          </li>
-        }}
-      let linkedPrRows ←
-        data.linkedPrs.toArray.mapM fun item =>
-          mkMetadataEntryRow item "Entry already linked to a review PR."
-      let missingOwnerRows ←
-        data.missingOwners.toArray.mapM fun item =>
-          mkMetadataEntryRow item "Missing owner metadata."
-      let missingEffortRows ←
-        data.missingEffort.toArray.mapM fun item =>
-          mkMetadataEntryRow item "Missing effort metadata."
-      let untaggedRows ←
-        data.untaggedEntries.toArray.mapM fun item =>
-          mkMetadataEntryRow item "Missing tag metadata."
-      let groupHealthRows ←
-        data.groupHealth.toArray.mapM fun item => do
-          let badges :=
-            #[
-              mkBadge s!"total: {item.totalEntries}",
-              mkBadge s!"closed: {item.closedEntries}",
-              mkBadge s!"local-only: {item.localOnlyEntries}",
-              mkBadge s!"ready: {item.readyEntries}" "bp_summary_badge bp_summary_badge_warn",
-              mkBadge s!"blocked: {item.blockedEntries}",
-              mkBadge s!"incomplete Lean: {item.incompleteLeanEntries}",
-              mkBadge s!"unlock score: {item.unlockScore}"
-            ]
-          match item.nextPriority? with
-          | Option.none =>
-            pure {{
-              <li class="bp_summary_item">
-                <div class="bp_summary_item_top">
-                  <span class="bp_summary_item_head">{{.text true item.header}}</span>
-                  <span class="bp_summary_item_meta"><code>s!"{item.parent}"</code></span>
-                </div>
-                <div class="bp_summary_item_body">"Grouped view over entries sharing the same parent."</div>
-                {{mkBadgeRow badges}}
-                <div class="bp_summary_item_actions">"Next: no ready child currently unlocks downstream work."</div>
-              </li>
-            }}
-          | Option.some next =>
-            let nextRef ← mkEntryRef next.label
-            let priorityBadges : Array Output.Html :=
-              match next.priority with
-              | Option.some priority => #[mkBadge s!"priority: {priority}" "bp_summary_badge bp_summary_badge_warn"]
-              | Option.none => #[]
-            pure {{
-              <li class="bp_summary_item">
-                <div class="bp_summary_item_top">
-                  <span class="bp_summary_item_head">{{.text true item.header}}</span>
-                  <span class="bp_summary_item_meta"><code>s!"{item.parent}"</code></span>
-                </div>
-                <div class="bp_summary_item_body">"Grouped view over entries sharing the same parent."</div>
-                {{mkBadgeRow badges}}
-                <div class="bp_summary_item_actions">
-                  "Next: " {{nextRef}} " "
-                  {{priorityBadges ++ #[
-                    mkBadge s!"stage: {next.stage}",
-                    mkBadge s!"downstream unlocks: {next.downstreamUses}"
-                  ]}}
-                </div>
-              </li>
-            }}
-      let definitionRows ←
-        data.definitionIndex.toArray.mapM fun item =>
-          mkLeanRow item.label item.kind item.leanObjects
-      let theoremLikeRows ←
-        data.theoremLikeIndex.toArray.mapM fun item =>
-          mkLeanRow item.label item.kind item.leanObjects
-      let axiomRows ←
-        data.axiomIndex.toArray.mapM fun item =>
-          mkLeanRow item.label item.kind item.leanObjects
-      let theoremLikeByParentRows ←
-        data.theoremLikeByParent.toArray.mapM fun group => do
-          let rows ← group.entries.toArray.mapM fun item =>
-            mkLeanRow item.label item.kind item.leanObjects
-          pure {{
-            <details class="bp_summary_subsection">
-              <summary>s!"{group.header} ({group.entries.length})"</summary>
-              <ul class="bp_summary_list">
-                {{if rows.isEmpty then {{<li class="bp_summary_empty">"No theorem/lemma/corollary entries in this parent group."</li>}} else rows}}
-              </ul>
-            </details>
-          }}
-      let blockerCount := data.missingLeanDecls.length + data.sorryDetails.length
-      let blockerRows := missingRows ++ sorryRows
-      let showDefinitionCard := data.definitions > 0
-      let showLemmaCard := data.lemmas > 0
-      let showTheoremCard := data.theorems > 0
-      let showCorollaryCard := data.corollaries > 0
-      let showAxiomCard := data.axioms > 0
-      let showLeanOnlyCard := data.leanOnlyEntries > 0
-      let showInformalOnlyCard := data.informalOnlyEntries > 0
-      let showDefinitionIndex := !definitionRows.isEmpty
-      let showTheoremLikeIndex := !theoremLikeRows.isEmpty
-      let showAxiomIndex := !axiomRows.isEmpty
-      let showTheoremLikeByParent := !theoremLikeByParentRows.isEmpty
-      let showPendingInformal := !pendingInformalRows.isEmpty
-      let showBlockers := blockerCount > 0
-      let showQuickWins := !quickWinRows.isEmpty
-      let showOwnerRollups := !ownerRollupRows.isEmpty
-      let showTagRollups := !tagRollupRows.isEmpty
-      let showLinkedPrs := !linkedPrRows.isEmpty
-      let showMetadataAudit :=
-        !missingOwnerRows.isEmpty || !missingEffortRows.isEmpty || !untaggedRows.isEmpty
-      let showMetadataCards := showQuickWins || showOwnerRollups || showTagRollups || showLinkedPrs
-      let showMetadataSection := showMetadataCards || showMetadataAudit
-      let showDiagnosticsSection := data.showDebugDiagnostics && !renderFailureRows.isEmpty
-      let showEntryIndexSection := showDefinitionIndex || showTheoremLikeIndex || showAxiomIndex
-      let showDependencyInsightsSection :=
-        !statementUsedRows.isEmpty || !proofUsedRows.isEmpty || !groupHealthRows.isEmpty
-      let showHeaviestPrerequisites := !heaviestPrerequisiteRows.isEmpty
-      let showNoPrerequisites := !noPrerequisiteRows.isEmpty
-      let showNoDependents := !noDependentRows.isEmpty
-      let showProofDebtHotspots := !proofDebtHotspotRows.isEmpty
-      let showStructureCards :=
-        data.coverageSplit.informalOnly > 0 ||
-        data.coverageSplit.readyToFormalize > 0 ||
-        data.coverageSplit.formalizedWithoutAncestors > 0 ||
-        data.coverageSplit.fullyClosed > 0 ||
-        data.coverageSplit.blockedOrIncomplete > 0
-      let showStructureSection :=
-        showStructureCards || showHeaviestPrerequisites || showNoPrerequisites ||
-        showNoDependents || showProofDebtHotspots
-      return {{
-        <div class="bp_summary">
-          {{previewUi.store}}
-          {{previewUi.panel}}
-          <details class="bp_summary_section" open>
-            <summary>"Overview"</summary>
-            <div class="bp_summary_grid">
-              <div class="bp_summary_card"><span class="bp_summary_label">"Total entries"</span><span class="bp_summary_value">s!"{data.totalEntries}"</span><span class="bp_summary_status">{{.text true (statusCountsText data.totalStatus)}}</span></div>
-              <div class="bp_summary_card"><span class="bp_summary_label">"Ready now"</span><span class="bp_summary_value">s!"{data.coverageSplit.readyToFormalize}"</span><span class="bp_summary_status">"Entries whose next formalization step is currently unblocked."</span></div>
-              <div class="bp_summary_card"><span class="bp_summary_label">"Fully closed"</span><span class="bp_summary_value">s!"{data.coverageSplit.fullyClosed}"</span><span class="bp_summary_status">"Local code and prerequisite closure are both complete."</span></div>
-              <div class="bp_summary_card"><span class="bp_summary_label">"Actionable priorities"</span><span class="bp_summary_value">s!"{data.topPriorities.length}"</span><span class="bp_summary_status">"Entries ready now and already unlocking downstream work."</span></div>
-              {{if showBlockers then
-                  {{<div class="bp_summary_card bp_summary_card_warn"><span class="bp_summary_label">"Current blockers"</span><span class="bp_summary_value">s!"{blockerCount}"</span><span class="bp_summary_status">"Missing external or incomplete Lean declarations."</span></div>}}
-                else .empty}}
-              {{if showPendingInformal then
-                  {{<div class="bp_summary_card"><span class="bp_summary_label">"Missing informal coverage"</span><span class="bp_summary_value">s!"{data.pendingInformalEntries.length}"</span><span class="bp_summary_status">"Entries with Lean code but missing an informal statement or proof block."</span></div>}}
-                else .empty}}
-              {{if showQuickWins then
-                  {{<div class="bp_summary_card"><span class="bp_summary_label">"Quick wins"</span><span class="bp_summary_value">s!"{data.quickWins.length}"</span><span class="bp_summary_status">"Actionable entries with `high` priority and `small` effort."</span></div>}}
-                else .empty}}
-            </div>
-            {{if data.totalEntries == 0 then
-                {{<p class="bp_summary_empty">"No blueprint entries were registered in the current document."</p>}}
-              else .empty}}
-            {{if !topPriorityRows.isEmpty then
-                {{<details class="bp_summary_subsection" open>
-                  <summary>s!"Ready next ({data.topPriorities.length})"</summary>
-                  <ul class="bp_summary_list">
-                    {{capRows topPriorityRows "priorities"}}
-                  </ul>
-                </details>}}
-              else .empty}}
-            {{if showBlockers then
-                {{<details class="bp_summary_subsection bp_summary_subsection_warn" open>
-                  <summary>s!"Current blockers ({blockerCount})"</summary>
-                  <ul class="bp_summary_list">
-                    {{blockerRows}}
-                  </ul>
-                </details>}}
-              else .empty}}
-            {{if showPendingInformal then
-                {{<details class="bp_summary_subsection">
-                  <summary>s!"Missing informal coverage ({data.pendingInformalEntries.length})"</summary>
-                  <ul class="bp_summary_list">
-                    {{pendingInformalRows}}
-                  </ul>
-                </details>}}
-              else .empty}}
-          </details>
-          {{if showEntryIndexSection then
-              {{<details class="bp_summary_section">
-                <summary>s!"Entry index ({data.totalEntries})"</summary>
-                <div class="bp_summary_grid">
-                  {{if showDefinitionCard then
-                      {{<div class="bp_summary_card"><span class="bp_summary_label">"Definitions"</span><span class="bp_summary_value">s!"{data.definitions}"</span><span class="bp_summary_status">{{.text true (statusCountsText data.definitionStatus)}}</span></div>}}
-                    else .empty}}
-                  {{if showLemmaCard then
-                      {{<div class="bp_summary_card"><span class="bp_summary_label">"Lemmas"</span><span class="bp_summary_value">s!"{data.lemmas}"</span><span class="bp_summary_status">{{.text true (statusCountsText data.lemmaStatus)}}</span></div>}}
-                    else .empty}}
-                  {{if showTheoremCard then
-                      {{<div class="bp_summary_card"><span class="bp_summary_label">"Theorems"</span><span class="bp_summary_value">s!"{data.theorems}"</span><span class="bp_summary_status">{{.text true (statusCountsText data.theoremStatus)}}</span></div>}}
-                    else .empty}}
-                  {{if showCorollaryCard then
-                      {{<div class="bp_summary_card"><span class="bp_summary_label">"Corollaries"</span><span class="bp_summary_value">s!"{data.corollaries}"</span><span class="bp_summary_status">{{.text true (statusCountsText data.corollaryStatus)}}</span></div>}}
-                    else .empty}}
-                  {{if showAxiomCard then
-                      {{<div class="bp_summary_card bp_summary_card_warn"><span class="bp_summary_label">"Axiom-like entries"</span><span class="bp_summary_value">s!"{data.axioms}"</span><span class="bp_summary_status">{{.text true (statusCountsText data.axiomStatus)}}</span></div>}}
-                    else .empty}}
-                  {{if showLeanOnlyCard then
-                      {{<div class="bp_summary_card"><span class="bp_summary_label">"Lean-only entries"</span><span class="bp_summary_value">s!"{data.leanOnlyEntries}"</span></div>}}
-                    else .empty}}
-                  {{if showInformalOnlyCard then
-                      {{<div class="bp_summary_card"><span class="bp_summary_label">"Informal-only entries"</span><span class="bp_summary_value">s!"{data.informalOnlyEntries}"</span></div>}}
-                    else .empty}}
-                </div>
-                {{if showDefinitionIndex then
-                    {{<details class="bp_summary_subsection">
-                      <summary>s!"Definition Index ({data.definitionIndex.length})"</summary>
-                      <ul class="bp_summary_list">
-                        {{definitionRows}}
-                      </ul>
-                    </details>}}
-                  else .empty}}
-                {{if showTheoremLikeIndex then
-                    {{<details class="bp_summary_subsection">
-                      <summary>s!"Theorem / Lemma / Corollary Index ({data.theoremLikeIndex.length})"</summary>
-                      <ul class="bp_summary_list">
-                        {{theoremLikeRows}}
-                      </ul>
-                      {{if showTheoremLikeByParent then
-                          {{<details class="bp_summary_nested"><summary>s!"By parent groups ({data.theoremLikeByParent.length})"</summary>{{theoremLikeByParentRows}}</details>}}
-                        else .empty}}
-                    </details>}}
-                else .empty}}
-                {{if showAxiomIndex then
-                    {{<details class="bp_summary_subsection bp_summary_subsection_warn">
-                      <summary>s!"Axiom-like Index ({data.axiomIndex.length})"</summary>
-                      <ul class="bp_summary_list">
-                        {{axiomRows}}
-                      </ul>
-                    </details>}}
-                  else .empty}}
-              </details>}}
-            else .empty}}
-          {{if showDependencyInsightsSection then
-              {{<details class="bp_summary_section">
-            <summary>"Dependency insights"</summary>
-            <div class="bp_summary_grid">
-              {{if !statementUsedRows.isEmpty then
-                  {{<div class="bp_summary_card"><span class="bp_summary_label">"Statement-used entries"</span><span class="bp_summary_value">s!"{statementUsedItems.size}"</span><span class="bp_summary_status">"Entries reused in statement dependencies."</span></div>}}
-                else .empty}}
-              {{if !proofUsedRows.isEmpty then
-                  {{<div class="bp_summary_card"><span class="bp_summary_label">"Proof-used entries"</span><span class="bp_summary_value">s!"{proofUsedItems.size}"</span><span class="bp_summary_status">"Entries reused in proof-only dependencies."</span></div>}}
-                else .empty}}
-              {{if !groupHealthRows.isEmpty then
-                  {{<div class="bp_summary_card"><span class="bp_summary_label">"Tracked parent groups"</span><span class="bp_summary_value">s!"{data.groupHealth.length}"</span><span class="bp_summary_status">"Grouped health rollups for parents with more than one child entry."</span></div>}}
-                else .empty}}
-            </div>
-            {{if !statementUsedRows.isEmpty then
-                {{<details class="bp_summary_subsection">
-                  <summary>s!"Most used in statements ({statementUsedItems.size})"</summary>
-                  <ul class="bp_summary_list">
-                    {{capRows statementUsedRows "statement-used entries"}}
-                  </ul>
-                </details>}}
-              else .empty}}
-            {{if !proofUsedRows.isEmpty then
-                {{<details class="bp_summary_subsection">
-                  <summary>s!"Most used in proofs ({proofUsedItems.size})"</summary>
-                  <ul class="bp_summary_list">
-                    {{capRows proofUsedRows "proof-used entries"}}
-                  </ul>
-                </details>}}
-              else .empty}}
-            {{if !groupHealthRows.isEmpty then
-                {{<details class="bp_summary_subsection">
-                  <summary>s!"Group health ({data.groupHealth.length})"</summary>
-                  <ul class="bp_summary_list">
-                    {{capRows groupHealthRows "groups"}}
-                  </ul>
-                </details>}}
-              else .empty}}
-          </details>}}
-            else .empty}}
-          {{if showMetadataSection then
-              {{<details class="bp_summary_section">
-            <summary>"Metadata"</summary>
-            {{if showMetadataCards then
-                {{<div class="bp_summary_grid">
-                  {{if showQuickWins then
-                      {{<div class="bp_summary_card"><span class="bp_summary_label">"Quick wins"</span><span class="bp_summary_value">s!"{data.quickWins.length}"</span><span class="bp_summary_status">"Actionable entries with `high` priority and `small` effort."</span></div>}}
-                    else .empty}}
-                  {{if showOwnerRollups then
-                      {{<div class="bp_summary_card"><span class="bp_summary_label">"Owners in use"</span><span class="bp_summary_value">s!"{data.ownerRollups.length}"</span><span class="bp_summary_status">"Distinct owners referenced by the current blueprint entries."</span></div>}}
-                    else .empty}}
-                  {{if showTagRollups then
-                      {{<div class="bp_summary_card"><span class="bp_summary_label">"Tags in use"</span><span class="bp_summary_value">s!"{data.tagRollups.length}"</span><span class="bp_summary_status">"Distinct tags currently attached to blueprint entries."</span></div>}}
-                    else .empty}}
-                  {{if showLinkedPrs then
-                      {{<div class="bp_summary_card"><span class="bp_summary_label">"Linked PRs"</span><span class="bp_summary_value">s!"{data.linkedPrs.length}"</span><span class="bp_summary_status">"Entries already linked to a review URL."</span></div>}}
-                    else .empty}}
-                </div>}}
-              else .empty}}
-            {{if showQuickWins then
-                {{<details class="bp_summary_subsection">
-                  <summary>s!"Quick wins ({data.quickWins.length})"</summary>
-                  <ul class="bp_summary_list">
-                    {{capRows quickWinRows "quick wins"}}
-                  </ul>
-                </details>}}
-              else .empty}}
-            {{if showOwnerRollups then
-                {{<details class="bp_summary_subsection">
-                  <summary>s!"Owner rollups ({data.ownerRollups.length})"</summary>
-                  <ul class="bp_summary_list">
-                    {{capRows ownerRollupRows "owners"}}
-                  </ul>
-                </details>}}
-              else .empty}}
-            {{if showTagRollups then
-                {{<details class="bp_summary_subsection">
-                  <summary>s!"Tag rollups ({data.tagRollups.length})"</summary>
-                  <ul class="bp_summary_list">
-                    {{capRows tagRollupRows "tags"}}
-                  </ul>
-                </details>}}
-              else .empty}}
-            {{if showLinkedPrs then
-                {{<details class="bp_summary_subsection">
-                  <summary>s!"Linked PRs ({data.linkedPrs.length})"</summary>
-                  <ul class="bp_summary_list">
-                    {{capRows linkedPrRows "linked PR entries"}}
-                  </ul>
-                </details>}}
-              else .empty}}
-            {{if showMetadataAudit then
-                {{<details class="bp_summary_subsection bp_summary_subsection_warn">
-                  <summary>"Metadata audit"</summary>
-                  <div class="bp_summary_grid">
-                    {{if !missingOwnerRows.isEmpty then {{<div class="bp_summary_card bp_summary_card_warn"><span class="bp_summary_label">"Missing owner"</span><span class="bp_summary_value">s!"{data.missingOwners.length}"</span></div>}} else .empty}}
-                    {{if !missingEffortRows.isEmpty then {{<div class="bp_summary_card bp_summary_card_warn"><span class="bp_summary_label">"Missing effort"</span><span class="bp_summary_value">s!"{data.missingEffort.length}"</span></div>}} else .empty}}
-                    {{if !untaggedRows.isEmpty then {{<div class="bp_summary_card bp_summary_card_warn"><span class="bp_summary_label">"Untagged"</span><span class="bp_summary_value">s!"{data.untaggedEntries.length}"</span></div>}} else .empty}}
-                  </div>
-                  {{if !missingOwnerRows.isEmpty then {{<details class="bp_summary_nested"><summary>s!"Missing owner ({data.missingOwners.length})"</summary><ul class="bp_summary_list">{{capRows missingOwnerRows "entries missing owner"}}</ul></details>}} else .empty}}
-                  {{if !missingEffortRows.isEmpty then {{<details class="bp_summary_nested"><summary>s!"Missing effort ({data.missingEffort.length})"</summary><ul class="bp_summary_list">{{capRows missingEffortRows "entries missing effort"}}</ul></details>}} else .empty}}
-                  {{if !untaggedRows.isEmpty then {{<details class="bp_summary_nested"><summary>s!"Untagged ({data.untaggedEntries.length})"</summary><ul class="bp_summary_list">{{capRows untaggedRows "untagged entries"}}</ul></details>}} else .empty}}
-                </details>}}
-              else .empty}}
-          </details>}}
-            else .empty}}
-          {{if showDiagnosticsSection then
-              {{<details class="bp_summary_section">
-            <summary>"Maintainer diagnostics"</summary>
-            <div class="bp_summary_grid">
-              <div class="bp_summary_card bp_summary_card_warn"><span class="bp_summary_label">"Render failures"</span><span class="bp_summary_value">s!"{data.renderFailures.length}"</span><span class="bp_summary_status">"External declarations that checked in Lean but failed HTML rendering."</span></div>
-            </div>
-            <details class="bp_summary_subsection bp_summary_subsection_warn">
-              <summary>s!"Render failures ({data.renderFailures.length})"</summary>
-              <ul class="bp_summary_list">
-                {{capRows renderFailureRows "render-failure entries"}}
-              </ul>
-            </details>
-          </details>}}
-            else .empty}}
-          {{if showStructureSection then
-              {{<details class="bp_summary_section">
-            <summary>"Structure and coverage"</summary>
-            <div class="bp_summary_grid">
-              {{if data.coverageSplit.informalOnly > 0 then
-                  {{<div class="bp_summary_card"><span class="bp_summary_label">"Informal-only"</span><span class="bp_summary_value">s!"{data.coverageSplit.informalOnly}"</span><span class="bp_summary_status">"Statements with no associated Lean code yet."</span></div>}}
-                else .empty}}
-              {{if data.coverageSplit.readyToFormalize > 0 then
-                  {{<div class="bp_summary_card"><span class="bp_summary_label">"Ready to formalize"</span><span class="bp_summary_value">s!"{data.coverageSplit.readyToFormalize}"</span><span class="bp_summary_status">"Entries whose next step is currently unblocked."</span></div>}}
-                else .empty}}
-              {{if data.coverageSplit.formalizedWithoutAncestors > 0 then
-                  {{<div class="bp_summary_card"><span class="bp_summary_label">"Formalized, ancestors open"</span><span class="bp_summary_value">s!"{data.coverageSplit.formalizedWithoutAncestors}"</span><span class="bp_summary_status">"Local Lean work is done, but prerequisite closure is still open."</span></div>}}
-                else .empty}}
-              {{if data.coverageSplit.fullyClosed > 0 then
-                  {{<div class="bp_summary_card"><span class="bp_summary_label">"Fully closed"</span><span class="bp_summary_value">s!"{data.coverageSplit.fullyClosed}"</span><span class="bp_summary_status">"Local code and ancestor closure are both complete."</span></div>}}
-                else .empty}}
-              {{if data.coverageSplit.blockedOrIncomplete > 0 then
-                  {{<div class="bp_summary_card bp_summary_card_warn"><span class="bp_summary_label">"Blocked or incomplete"</span><span class="bp_summary_value">s!"{data.coverageSplit.blockedOrIncomplete}"</span><span class="bp_summary_status">"Entries not covered by the highlighted readiness buckets above."</span></div>}}
-                else .empty}}
-            </div>
-            {{if showHeaviestPrerequisites then
-                {{<details class="bp_summary_subsection">
-                  <summary>s!"Heaviest prerequisites ({data.heaviestPrerequisites.length})"</summary>
-                  <ul class="bp_summary_list">
-                    {{capRows heaviestPrerequisiteRows "heaviest-prerequisite entries"}}
-                  </ul>
-                </details>}}
-              else .empty}}
-            {{if showNoPrerequisites then
-                {{<details class="bp_summary_subsection">
-                  <summary>s!"No prerequisites ({data.noPrerequisites.length})"</summary>
-                  <ul class="bp_summary_list">
-                    {{capRows noPrerequisiteRows "entries without prerequisites"}}
-                  </ul>
-                </details>}}
-              else .empty}}
-            {{if showNoDependents then
-                {{<details class="bp_summary_subsection">
-                  <summary>s!"No dependents ({data.noDependents.length})"</summary>
-                  <ul class="bp_summary_list">
-                    {{capRows noDependentRows "entries without dependents"}}
-                  </ul>
-                </details>}}
-              else .empty}}
-            {{if showProofDebtHotspots then
-                {{<details class="bp_summary_subsection bp_summary_subsection_warn">
-                  <summary>s!"Proof debt hotspots ({data.proofDebtHotspots.length})"</summary>
-                  <ul class="bp_summary_list">
-                    {{capRows proofDebtHotspotRows "proof-debt hotspots"}}
-                  </ul>
-                </details>}}
-              else .empty}}
-          </details>}}
-            else .empty}}
-        </div>
-      }}
+  toHtml := some summaryBlockToHtml
   extraCss := withPreviewPanelInlinePreviewCssAssets [summaryCss]
   extraJs := withInlinePreviewJsAssets [openTargetDetailsJs] [summaryPreviewJs]
 

--- a/src/VersoBlueprint/Commands/Summary/Data.lean
+++ b/src/VersoBlueprint/Commands/Summary/Data.lean
@@ -1,0 +1,395 @@
+/- 
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import Lean
+import VersoBlueprint.Data
+import VersoBlueprint.ProvedStatus
+
+namespace Informal.Commands
+
+open Lean
+
+structure SorryItem where
+  label : Name
+  kind : String
+  decl : Name
+  isTheorem : Bool := false
+  status : Data.ProvedStatus := .proved
+deriving Inhabited, FromJson, ToJson
+
+open Syntax in
+instance : Quote SorryItem where
+  quote s := mkCApp ``SorryItem.mk #[quote s.label, quote s.kind, quote s.decl, quote s.isTheorem, quote s.status]
+
+structure MissingLeanDeclItem where
+  label : Name
+  kind : String
+  written : Name
+  canonical : Name
+deriving Inhabited, FromJson, ToJson
+
+open Syntax in
+instance : Quote MissingLeanDeclItem where
+  quote s := mkCApp ``MissingLeanDeclItem.mk #[quote s.label, quote s.kind, quote s.written, quote s.canonical]
+
+structure RenderFailureItem where
+  label : Name
+  kind : String
+  written : Name
+  canonical : Name
+  message : String
+deriving Inhabited, FromJson, ToJson
+
+open Syntax in
+instance : Quote RenderFailureItem where
+  quote s := mkCApp ``RenderFailureItem.mk #[quote s.label, quote s.kind, quote s.written, quote s.canonical, quote s.message]
+
+structure IndexItem where
+  label : Name
+  kind : String
+  leanObjects : List Name := []
+deriving Inhabited, FromJson, ToJson
+
+open Syntax in
+instance : Quote IndexItem where
+  quote s := mkCApp ``IndexItem.mk #[quote s.label, quote s.kind, quote s.leanObjects]
+
+abbrev PendingInformalItem := IndexItem
+
+structure ParentTheoremGroup where
+  parent : Name
+  header : String := ""
+  entries : List IndexItem := []
+deriving Inhabited, FromJson, ToJson
+
+open Syntax in
+instance : Quote ParentTheoremGroup where
+  quote s := mkCApp ``ParentTheoremGroup.mk #[quote s.parent, quote s.header, quote s.entries]
+
+structure EntryStatusCounts where
+  completed : Nat := 0
+  completedDepsNo : Nat := 0
+  withSorries : Nat := 0
+  noProof : Nat := 0
+deriving Inhabited, FromJson, ToJson
+
+open Syntax in
+instance : Quote EntryStatusCounts where
+  quote s := mkCApp ``EntryStatusCounts.mk
+    #[
+      quote s.completed,
+      quote s.completedDepsNo,
+      quote s.withSorries,
+      quote s.noProof
+    ]
+
+structure PriorityItem where
+  label : Name
+  kind : String
+  stage : String
+  priority : Option String := none
+  ownerDisplayName : Option String := none
+  effort : Option String := none
+  prUrl : Option String := none
+  tags : List String := []
+  statementStatus : String
+  proofStatus : String := ""
+  directUses : Nat := 0
+  downstreamUses : Nat := 0
+  leanObjects : List Name := []
+deriving Inhabited, FromJson, ToJson
+
+open Syntax in
+instance : Quote PriorityItem where
+  quote s := mkCApp ``PriorityItem.mk
+    #[
+      quote s.label,
+      quote s.kind,
+      quote s.stage,
+      quote s.priority,
+      quote s.ownerDisplayName,
+      quote s.effort,
+      quote s.prUrl,
+      quote s.tags,
+      quote s.statementStatus,
+      quote s.proofStatus,
+      quote s.directUses,
+      quote s.downstreamUses,
+      quote s.leanObjects
+    ]
+
+structure UsageItem where
+  label : Name
+  kind : String
+  statementUses : Nat := 0
+  proofUses : Nat := 0
+  directUses : Nat := 0
+  downstreamUses : Nat := 0
+  leanObjects : List Name := []
+deriving Inhabited, FromJson, ToJson
+
+open Syntax in
+instance : Quote UsageItem where
+  quote s := mkCApp ``UsageItem.mk
+    #[
+      quote s.label,
+      quote s.kind,
+      quote s.statementUses,
+      quote s.proofUses,
+      quote s.directUses,
+      quote s.downstreamUses,
+      quote s.leanObjects
+    ]
+
+structure GroupHealthItem where
+  parent : Name
+  header : String := ""
+  totalEntries : Nat := 0
+  closedEntries : Nat := 0
+  localOnlyEntries : Nat := 0
+  readyEntries : Nat := 0
+  blockedEntries : Nat := 0
+  incompleteLeanEntries : Nat := 0
+  unlockScore : Nat := 0
+  nextPriority? : Option PriorityItem := none
+deriving Inhabited, FromJson, ToJson
+
+open Syntax in
+instance : Quote GroupHealthItem where
+  quote s := mkCApp ``GroupHealthItem.mk
+    #[
+      quote s.parent,
+      quote s.header,
+      quote s.totalEntries,
+      quote s.closedEntries,
+      quote s.localOnlyEntries,
+      quote s.readyEntries,
+      quote s.blockedEntries,
+      quote s.incompleteLeanEntries,
+      quote s.unlockScore,
+      quote s.nextPriority?
+    ]
+
+structure CoverageSplit where
+  informalOnly : Nat := 0
+  readyToFormalize : Nat := 0
+  formalizedWithoutAncestors : Nat := 0
+  fullyClosed : Nat := 0
+  blockedOrIncomplete : Nat := 0
+deriving Inhabited, FromJson, ToJson
+
+open Syntax in
+instance : Quote CoverageSplit where
+  quote s := mkCApp ``CoverageSplit.mk
+    #[
+      quote s.informalOnly,
+      quote s.readyToFormalize,
+      quote s.formalizedWithoutAncestors,
+      quote s.fullyClosed,
+      quote s.blockedOrIncomplete
+    ]
+
+structure DependencyLoadItem where
+  label : Name
+  kind : String
+  statementDeps : Nat := 0
+  proofDeps : Nat := 0
+  totalDeps : Nat := 0
+  directUses : Nat := 0
+  downstreamUses : Nat := 0
+  leanObjects : List Name := []
+deriving Inhabited, FromJson, ToJson
+
+open Syntax in
+instance : Quote DependencyLoadItem where
+  quote s := mkCApp ``DependencyLoadItem.mk
+    #[
+      quote s.label,
+      quote s.kind,
+      quote s.statementDeps,
+      quote s.proofDeps,
+      quote s.totalDeps,
+      quote s.directUses,
+      quote s.downstreamUses,
+      quote s.leanObjects
+    ]
+
+structure DebtHotspotItem where
+  parent : Name
+  header : String := ""
+  affectedEntries : Nat := 0
+  incompleteDecls : Nat := 0
+  missingDecls : Nat := 0
+  totalDebt : Nat := 0
+deriving Inhabited, FromJson, ToJson
+
+open Syntax in
+instance : Quote DebtHotspotItem where
+  quote s := mkCApp ``DebtHotspotItem.mk
+    #[
+      quote s.parent,
+      quote s.header,
+      quote s.affectedEntries,
+      quote s.incompleteDecls,
+      quote s.missingDecls,
+      quote s.totalDebt
+    ]
+
+structure OwnerRollupItem where
+  owner : Name
+  displayName : String := ""
+  totalEntries : Nat := 0
+  actionableEntries : Nat := 0
+  quickWins : Nat := 0
+  linkedPrs : Nat := 0
+deriving Inhabited, FromJson, ToJson
+
+open Syntax in
+instance : Quote OwnerRollupItem where
+  quote s := mkCApp ``OwnerRollupItem.mk
+    #[
+      quote s.owner,
+      quote s.displayName,
+      quote s.totalEntries,
+      quote s.actionableEntries,
+      quote s.quickWins,
+      quote s.linkedPrs
+    ]
+
+structure TagRollupItem where
+  tag : String
+  totalEntries : Nat := 0
+  actionableEntries : Nat := 0
+  quickWins : Nat := 0
+  linkedPrs : Nat := 0
+deriving Inhabited, FromJson, ToJson
+
+open Syntax in
+instance : Quote TagRollupItem where
+  quote s := mkCApp ``TagRollupItem.mk
+    #[
+      quote s.tag,
+      quote s.totalEntries,
+      quote s.actionableEntries,
+      quote s.quickWins,
+      quote s.linkedPrs
+    ]
+
+structure MetadataEntryItem where
+  label : Name
+  kind : String
+  ownerDisplayName : Option String := none
+  effort : Option String := none
+  priority : Option String := none
+  prUrl : Option String := none
+  tags : List String := []
+  leanObjects : List Name := []
+deriving Inhabited, FromJson, ToJson
+
+open Syntax in
+instance : Quote MetadataEntryItem where
+  quote s := mkCApp ``MetadataEntryItem.mk
+    #[
+      quote s.label,
+      quote s.kind,
+      quote s.ownerDisplayName,
+      quote s.effort,
+      quote s.priority,
+      quote s.prUrl,
+      quote s.tags,
+      quote s.leanObjects
+    ]
+
+structure Summary where
+  showDebugDiagnostics : Bool := false
+  totalEntries : Nat := 0
+  definitions : Nat := 0
+  lemmas : Nat := 0
+  theorems : Nat := 0
+  corollaries : Nat := 0
+  axioms : Nat := 0
+  leanOnlyEntries : Nat := 0
+  informalOnlyEntries : Nat := 0
+  totalStatus : EntryStatusCounts := {}
+  definitionStatus : EntryStatusCounts := {}
+  lemmaStatus : EntryStatusCounts := {}
+  theoremStatus : EntryStatusCounts := {}
+  corollaryStatus : EntryStatusCounts := {}
+  axiomStatus : EntryStatusCounts := {}
+  pendingInformalEntries : List PendingInformalItem := []
+  leanDecls : Nat := 0
+  sorries : Nat := 0
+  sorryDetails : List SorryItem := []
+  missingLeanDecls : List MissingLeanDeclItem := []
+  renderFailures : List RenderFailureItem := []
+  definitionIndex : List IndexItem := []
+  theoremLikeIndex : List IndexItem := []
+  axiomIndex : List IndexItem := []
+  theoremLikeByParent : List ParentTheoremGroup := []
+  topPriorities : List PriorityItem := []
+  mostUsed : List UsageItem := []
+  groupHealth : List GroupHealthItem := []
+  coverageSplit : CoverageSplit := {}
+  heaviestPrerequisites : List DependencyLoadItem := []
+  noPrerequisites : List IndexItem := []
+  noDependents : List IndexItem := []
+  proofDebtHotspots : List DebtHotspotItem := []
+  quickWins : List PriorityItem := []
+  ownerRollups : List OwnerRollupItem := []
+  tagRollups : List TagRollupItem := []
+  linkedPrs : List MetadataEntryItem := []
+  missingOwners : List MetadataEntryItem := []
+  missingEffort : List MetadataEntryItem := []
+  untaggedEntries : List MetadataEntryItem := []
+deriving Inhabited, FromJson, ToJson
+
+open Syntax in
+instance : Quote Summary where
+  quote s := mkCApp ``Summary.mk
+    #[
+      quote s.showDebugDiagnostics,
+      quote s.totalEntries,
+      quote s.definitions,
+      quote s.lemmas,
+      quote s.theorems,
+      quote s.corollaries,
+      quote s.axioms,
+      quote s.leanOnlyEntries,
+      quote s.informalOnlyEntries,
+      quote s.totalStatus,
+      quote s.definitionStatus,
+      quote s.lemmaStatus,
+      quote s.theoremStatus,
+      quote s.corollaryStatus,
+      quote s.axiomStatus,
+      quote s.pendingInformalEntries,
+      quote s.leanDecls,
+      quote s.sorries,
+      quote s.sorryDetails,
+      quote s.missingLeanDecls,
+      quote s.renderFailures,
+      quote s.definitionIndex,
+      quote s.theoremLikeIndex,
+      quote s.axiomIndex,
+      quote s.theoremLikeByParent,
+      quote s.topPriorities,
+      quote s.mostUsed,
+      quote s.groupHealth,
+      quote s.coverageSplit,
+      quote s.heaviestPrerequisites,
+      quote s.noPrerequisites,
+      quote s.noDependents,
+      quote s.proofDebtHotspots,
+      quote s.quickWins,
+      quote s.ownerRollups,
+      quote s.tagRollups,
+      quote s.linkedPrs,
+      quote s.missingOwners,
+      quote s.missingEffort,
+      quote s.untaggedEntries
+    ]
+
+end Informal.Commands


### PR DESCRIPTION
This PR splits the Blueprint summary HTML renderer into smaller helper definitions so Lean no longer compiles one large generated block-extension descriptor.

Backport v4.29.0: #47
Backport v4.28.0: #48