### PR TITLE
[backport v4.28.0] fix(inline): filter generated Lean declarations

### DIFF
--- a/src/VersoBlueprint/Lean.lean
+++ b/src/VersoBlueprint/Lean.lean
@@ -148,15 +148,21 @@ private def findDeclCommand? (fileMap : FileMap) (cmdAnalyses : Array CmdAnalysi
   let declPos := fileMap.ofPosition declRanges.selectionRange.pos
   return cmdAnalyses.findRev? (fun cmd => commandOwnsPos cmd declPos)
 
-private def getDefinedDeclsImpl (fileMap : FileMap) (before after : Environment) (cmdAnalyses : Array CmdAnalysis) :
+/- `sourceBackedDeclNames` comes from `Highlighted.definedNames`. SubVerso marks those tokens
+using Lean's declaration ranges for source syntax, so generated constants that only inherit a
+command range but have no definition token in the source are excluded here. -/
+private def getDefinedDeclsImpl (fileMap : FileMap) (before after : Environment)
+    (cmdAnalyses : Array CmdAnalysis) (sourceBackedDeclNames : NameSet) :
     DocElabM (Array LiterateDef × Array LiterateThm) := do
   let mut defs := #[]
   let mut theorems := #[]
-  for (name, info) in after.constants do
+  for name in sourceBackedDeclNames.toArray do
     if (before.find? name).isSome then
       continue
     if name.isInternalOrNum || name.hasMacroScopes then
       continue
+    let some info := after.find? name
+      | continue
     let baseStatus := Data.ConstantInfo.blueprintProvedStatus info
     let hasTypeGap := baseStatus.hasTypeGap
     let hasProofGap := baseStatus.hasProofGap
@@ -219,9 +225,10 @@ private def getDefinedDeclsImpl (fileMap : FileMap) (before after : Environment)
     (a.commandIndex == b.commandIndex && a.name.toString < b.name.toString)
   pure (defs.qsort cmpDef, theorems.qsort cmpThm)
 
-private def getDefinedDecls (fileMap : FileMap) (before after : Environment) (cmdAnalyses : Array CmdAnalysis) :=
+private def getDefinedDecls (fileMap : FileMap) (before after : Environment)
+    (cmdAnalyses : Array CmdAnalysis) (sourceBackedDeclNames : NameSet) :=
   Profile.withDocElab "lean" "getDefinedDecls" <|
-    getDefinedDeclsImpl fileMap before after cmdAnalyses
+    getDefinedDeclsImpl fileMap before after cmdAnalyses sourceBackedDeclNames
 
 -- Needs to improve
 private partial def collectSorryRefs (stx : Syntax) : Array Syntax :=
@@ -370,7 +377,7 @@ def elabCommands (config : LeanBlockConfig) (str : StrLit) : DocElabM ElabComman
     let block ← toHighlightedLeanBlock config.show hls str
     let (definedDefs, definedTheorems) ←
       if shouldAnalyze then
-        getDefinedDecls cctx.fileMap envBefore cmdState.env cmdAnalyses
+        getDefinedDecls cctx.fileMap envBefore cmdState.env cmdAnalyses hls.definedNames
       else
         pure (#[], #[])
     pure { block, definedDefs, definedTheorems }

--- a/tests/VersoBlueprintTests/BlueprintInlinePrecision.lean
+++ b/tests/VersoBlueprintTests/BlueprintInlinePrecision.lean
@@ -55,4 +55,70 @@ theorem inline_main_complete : True := by
         !nodeLocalProofFormalized external node &&
         helperProofGapOnly
 
+#docs (Manual) inlineGeneratedDeclsDoc "Inline Generated Decls" :=
+:::::::
+:::definition "inline.generated.filtered"
+Inline Lean code should report only source-backed declarations.
+:::
+
+```lean "inline.generated.filtered"
+structure SourceFilteredStructure where
+  alpha : Nat
+  beta : alpha = alpha
+
+inductive SourceFilteredStage where
+  | initial
+  | followup (_ : Nat)
+```
+:::::::
+
+private def literateDeclNamesFor? (label : Name) : CoreM (Option (Array String)) := do
+  let state := Informal.Environment.informalExt.getState (← getEnv)
+  match state.data.get? label with
+  | none => pure none
+  | some node =>
+    match node.code with
+    | some (.literate code) =>
+      pure <| some <|
+        (code.definedDefs.map (·.name.toString)) ++
+        (code.definedTheorems.map (·.name.toString))
+    | _ => pure none
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show CoreM Bool from do
+    let some names ← literateDeclNamesFor? (Name.mkSimple "inline.generated.filtered")
+      | pure false
+    let expectedSuffixes := #[
+      "SourceFilteredStructure",
+      "SourceFilteredStructure.alpha",
+      "SourceFilteredStructure.beta",
+      "SourceFilteredStage",
+      "SourceFilteredStage.initial",
+      "SourceFilteredStage.followup"
+    ]
+    let hasExactlySourceDecls :=
+      names.size == expectedSuffixes.size &&
+        expectedSuffixes.all (fun suffix => names.any (fun name => name.endsWith suffix))
+    let generatedFragments := #[
+      ".casesOn",
+      ".ctorElim",
+      ".ctorElimType",
+      ".ctorIdx",
+      ".elim",
+      ".inj",
+      ".injEq",
+      ".mk",
+      ".noConfusion",
+      ".noConfusionType",
+      ".rec",
+      ".recOn",
+      ".sizeOf_spec"
+    ]
+    let noGeneratedDecls :=
+      names.all fun name =>
+        !generatedFragments.any (fun fragment => name.contains fragment)
+    pure (hasExactlySourceDecls && noGeneratedDecls)
+
 end Verso.VersoBlueprintTests.BlueprintInlinePrecision


### PR DESCRIPTION
## Summary
Backport #52 to `v4.28.0`.

## Primary Review
- Primary review: #52
- Keep review comments on #52 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.28.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- The source-backed filtering patch is unchanged.
- `v4.28.0` already differs from default-dev in nearby `blueprintProvedStatus` opaque-handling context, so #52 documents the automated patch-id check as exempt while this paired PR remains available for release review.