### PR TITLE
chore(harness): consolidate reference project catalog

### DIFF
--- a/.github/workflows/reference-blueprints-deploy.yml
+++ b/.github/workflows/reference-blueprints-deploy.yml
@@ -51,8 +51,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.resolve-deploy-releases.outputs.deployable_project_matrix) }}
-    env:
-      BP_REFERENCE_CHECKOUT_MODE: shared
     steps:
       - uses: actions/checkout@v4
         with:
@@ -66,6 +64,22 @@ jobs:
           echo "branch=${{ matrix.branch }}"
           echo "project_id=${{ matrix.project_id }}"
           echo "hash=${{ matrix.hash }}"
+          echo "reference_cache_key=${{ matrix.reference_cache_key }}"
+      - name: Write deploy project manifest
+        env:
+          BP_PROJECT_ID: ${{ matrix.project_id }}
+          BP_DEPLOY_PROJECT_MANIFEST: ${{ toJSON(matrix.project_manifest) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path("_out/deploy-projects") / (os.environ["BP_PROJECT_ID"] + ".json")
+          path.parent.mkdir(parents=True, exist_ok=True)
+          manifest = json.loads(os.environ["BP_DEPLOY_PROJECT_MANIFEST"])
+          path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+          PY
       - name: Install elan
         run: |
           curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
@@ -88,6 +102,15 @@ jobs:
           key: ${{ runner.os }}-reference-deploy-lake-deps-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-${{ matrix.release_id }}
           restore-keys: |
             ${{ runner.os }}-reference-deploy-lake-deps-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-
+      - name: Restore external reference dependency cache
+        if: ${{ matrix.reference_cache_key != '' }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            .worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/packages
+          key: ${{ runner.os }}-reference-deploy-deps-v1-${{ matrix.reference_cache_key }}
+          restore-keys: |
+            ${{ runner.os }}-reference-deploy-deps-v1-${{ matrix.project_id }}-
       - name: Show tool versions
         run: |
           lean --version
@@ -96,6 +119,7 @@ jobs:
       - name: Generate release reference blueprints
         run: |
           python3 -m scripts.blueprint_reference_harness generate \
+            --manifest _out/deploy-projects/${{ matrix.project_id }}.json \
             --release ${{ matrix.release_id }} \
             --project ${{ matrix.project_id }} \
             --allow-local-build \

--- a/.github/workflows/reference-blueprints.yml
+++ b/.github/workflows/reference-blueprints.yml
@@ -38,8 +38,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.resolve-reference-release.outputs.reference_matrix) }}
-    env:
-      BP_REFERENCE_CHECKOUT_MODE: shared
     steps:
       - uses: actions/checkout@v4
       - name: Show resolved release target
@@ -50,6 +48,7 @@ jobs:
           echo "verso_ref=${{ needs.resolve-reference-release.outputs.verso_ref }}"
           echo "blueprint=${{ matrix.project_id }}"
           echo "hash=${{ matrix.hash }}"
+          echo "reference_cache_key=${{ matrix.reference_cache_key }}"
       - name: Install elan
         run: |
           curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
@@ -72,6 +71,15 @@ jobs:
           key: ${{ runner.os }}-lake-deps-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}
           restore-keys: |
             ${{ runner.os }}-lake-deps-
+      - name: Restore external reference dependency cache
+        if: ${{ matrix.reference_cache_key != '' }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            .worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/packages
+          key: ${{ runner.os }}-reference-deps-v1-${{ matrix.reference_cache_key }}
+          restore-keys: |
+            ${{ runner.os }}-reference-deps-v1-${{ matrix.project_id }}-
       - name: Show tool versions
         run: |
           lean --version

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -296,8 +296,8 @@ python3 -m scripts.blueprint_harness paths
 `paths` prints the canonical worktree-aware output, cache, and checkout
 locations used by the harness.
 
-It also prints the shared reference blueprint cache root and the current
-checkout's local clone root.
+It also prints the shared reference checkout cache root, dependency package
+cache root, and the current checkout's local clone root.
 
 To generate local test-blueprint fixtures, run:
 
@@ -442,13 +442,15 @@ The harness is worktree-aware:
 - in a linked worktree it writes artifacts to `_out/<worktree>/...`
 - by default it prefers reusing the root checkout's prepared package `.lake`
   artifacts and binaries
-- it also keeps shared warmed reference blueprint caches under
-  `.worktrees/_reference-blueprints/cache/`
-- those shared reference caches are the source of project-specific dependency
-  state, including warmed Mathlib builds for external projects that pin their
-  own Mathlib versions
+- it also keeps shared warmed reference dependency package caches under
+  `.worktrees/_reference-blueprints/deps/<source-ref-key>/packages`
+- those shared caches are keyed by external repository, project root, and
+  selected project ref; they preserve expensive pinned dependency state such as
+  Mathlib package builds, not generated Blueprint site artifacts
+- disposable source checkouts for those refs live separately under
+  `.worktrees/_reference-blueprints/cache/<source-ref-key>/`
 - each checkout uses its own local reference blueprint clones under
-  `.worktrees/_reference-blueprints/by-worktree/<checkout>/`
+  `.worktrees/_reference-blueprints/by-worktree/<checkout>/<source-ref-key>/`
 - the reference CLI avoids local `lake build` and `lake test` in a linked
   worktree by default to avoid unnecessary dependency rebuilds
 
@@ -459,7 +461,7 @@ python3 -m scripts.blueprint_harness create-worktree <name> --lightweight
 ```
 
 When you do want to refresh a linked worktree from the root checkout and shared
-reference cache, prefer:
+reference dependency cache, prefer:
 
 ```bash
 python3 -m scripts.blueprint_harness sync-root-lake
@@ -527,11 +529,17 @@ python3 -m scripts.blueprint_harness worktree-retire <name> --dry-run
 - the default validation catalog mixes in-repo projects with external reference
   blueprints; the larger published reference blueprints live in external
   repositories
-- the harness warms shared reference blueprint checkouts once under
-  `.worktrees/_reference-blueprints/cache/`
+- the harness warms shared reference dependency packages under
+  `.worktrees/_reference-blueprints/deps/<source-ref-key>/packages`
+- the cache key is derived from the external repository URL, project root, and
+  selected project ref, so one project can keep separate caches for different
+  Lean/mathlib release pins
+- disposable source checkouts for those keyed refs live under
+  `.worktrees/_reference-blueprints/cache/<source-ref-key>/`
 - each checkout gets its own local clone under
-  `.worktrees/_reference-blueprints/by-worktree/<checkout>/`, seeded from the
-  shared cache so transitive build artifacts stay warm across worktrees
+  `.worktrees/_reference-blueprints/by-worktree/<checkout>/<source-ref-key>/`,
+  seeded from the dependency package cache so transitive build artifacts stay
+  warm across worktrees
 - editable reference-project clones live separately under
   `.worktrees/_reference-blueprints/edit/<checkout>/` and are not touched by
   `sync`, `generate`, or `prune`
@@ -590,30 +598,37 @@ template-owned CI path.
 pushes to release branches named like `v4.29.0`, and manual dispatch, it:
 
 - resolves the current branch's release target from `tests/harness/projects.json`
-- filters the flat `reference_blueprints` list by that release target's
-  toolchain and builds only the matching reference blueprints
+- builds only project targets for that release that set
+  `publish_reference: true`
 - builds the local `test-blueprints/` artifact set, including
   `preview_runtime_showcase`
 - stages a branch-local site artifact under `_site/` only when the selected
   release target has `deploy_pages: true`
 - uploads that assembled site as a normal workflow artifact
-- uses the shared reference-checkout mode in CI to avoid duplicating warmed
-  `.lake/` trees on the GitHub runner
+- generates external references from per-job local clones seeded by the keyed
+  dependency cache
+- restores and saves external reference dependency caches by the same
+  repository/project-root/ref key used locally, caching only the external
+  project's `.lake/packages/` tree rather than the source checkout or generated
+  Blueprint site's own build output
 
 `reference-blueprints-deploy.yml` is the deployment workflow. It runs after a
 successful `reference-blueprints.yml` run on a release branch named like
 `v4.29.0`, checks out the repository default-development branch as the source
 of truth for deployment policy, resolves every release target with
-`deploy_pages: true`, filters the flat `reference_blueprints` list by that
-release target's toolchain, rebuilds those selected blueprints in isolation,
-and assembles one combined GitHub Pages artifact. Each `reference_blueprints`
-entry is the simple published-reference tuple: `blueprint`, `hash`, and
-`toolchain`; the detailed `projects` entries only describe how to build the
-selected blueprint.
+`deploy_pages: true`, selects project targets marked `publish_reference: true`,
+rebuilds those selected blueprints in isolation, and assembles one combined
+GitHub Pages artifact. The per-project target entry is the source of truth for
+the project id, release, pinned ref, and publication flag. For each deploy
+matrix entry, the workflow writes a small one-project manifest from that
+default-development catalog and passes it to the release-branch harness with
+`--manifest`; the deploy job therefore does not rely on stale branch-local
+`projects.json` refs.
 
 At the moment that means:
 
-- `v4.30.0` deploys Pages for `noperthedron` and `verso-flt`
+- `v4.30.0` deploys Pages for `noperthedron`, `verso-flt`, and
+  `verso-carleson`
 - `v4.29.0` deploys Pages for `spherepackingblueprint`
 - `v4.28.0` also deploys Pages for `algebraic-combinatorics`
 
@@ -654,11 +669,10 @@ The harness is now project-driven rather than hardcoded to one project.
 - the default catalog is declared in `tests/harness/projects.json`
 - catalog entries can also describe ephemeral `git_checkout` projects hosted
   outside this repository
-- the flat top-level `reference_blueprints` list selects the release-facing
-  validation set with one `(blueprint, hash, toolchain)` entry per published
-  reference blueprint
 - external `projects` entries declare the repository plus the build and
   generation commands needed after checkout
+- each project target owns its release ref, and `publish_reference: true` marks
+  the target as part of the release-facing published catalog
 - prefer a build command that targets only the Lean library or formalization
   artifacts needed by the document, followed by a `lake env lean --run ...`
   generation command; do not build the generator executable unless that native
@@ -676,13 +690,6 @@ Minimal external catalog entry shape:
 
 ```json
 {
-  "reference_blueprints": [
-    {
-      "blueprint": "some-user-project",
-      "hash": "0123456789abcdef0123456789abcdef01234567",
-      "toolchain": "v4.29.0"
-    }
-  ],
   "projects": [
     {
       "id": "some-user-project",
@@ -694,7 +701,8 @@ Minimal external catalog entry shape:
       "targets": [
         {
           "release": "v4.29.0",
-          "ref": "0123456789abcdef0123456789abcdef01234567"
+          "ref": "0123456789abcdef0123456789abcdef01234567",
+          "publish_reference": true
         }
       ],
       "build_command": ["lake", "build", "SomeUserProject"],

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -159,8 +159,8 @@ Work:
 2. keep linked worktree metadata local under `.worktrees/`
 3. keep shell wrappers thin; keep Python harness modules as the source of truth
    for orchestration, path logic, release checks, and project catalogs
-4. keep the project catalog explicit and small, with reference blueprints plus
-   opt-in ephemeral GitHub checkout coverage
+4. keep the project catalog explicit and small, with published reference
+   targets plus opt-in ephemeral GitHub checkout coverage
 5. validate both root-checkout and linked-worktree flows end to end
 6. stabilize output-path conventions for generation, static checks, browser
    checks, and published reference catalogs

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -61,6 +61,7 @@ python3 -m scripts.blueprint_test_blueprints list-json
 Reference blueprints and test blueprints are distinct artifact families:
 
 - reference blueprints are the release-facing validation catalog selected from
+  `publish_reference: true` project targets in
   [`tests/harness/projects.json`](../tests/harness/projects.json)
 - test blueprints are local rendering/browser fixtures selected from
   [`tests/VersoBlueprintTests/TestBlueprintRegistry.lean`](../tests/VersoBlueprintTests/TestBlueprintRegistry.lean)
@@ -98,10 +99,12 @@ script map, not a second command reference.
   Shared argparse helper functions used by the harness CLIs.
 - `blueprint_harness_projects.py`
   Project-manifest loader and schema checks for
-  [`tests/harness/projects.json`](../tests/harness/projects.json).
+  [`tests/harness/projects.json`](../tests/harness/projects.json), including
+  the external reference dependency-cache key.
 - `blueprint_harness_references.py`
-  Reference-blueprint checkout, editable-clone setup, local override, cache
-  warm-up, and prune helpers shared by the reference CLI.
+  Reference-blueprint checkout, editable-clone setup, local override,
+  dependency-package cache warm-up, and prune helpers shared by the reference
+  CLI.
 - `blueprint_harness_utils.py`
   Shared process-launch helpers used by the harness modules.
 - `blueprint_harness_validation.py`

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -35,14 +35,14 @@ from scripts.blueprint_harness_paths import (
     detect_harness_layout,
 )
 from scripts.blueprint_harness_projects import (
-    HarnessProject,
     load_project_catalog as load_project_catalog_manifest,
-    load_projects_manifest,
     resolve_manifest_path,
     resolve_projects_for_release,
+    resolve_release_projects,
     resolve_release_target,
 )
 from scripts.blueprint_harness_references import (
+    reference_dependency_cache_keys,
     reference_prune_plan,
     sync_reference_blueprints,
 )
@@ -69,12 +69,6 @@ class RefSyncStatus:
     upstream_oid: str | None
     relationship: str
 
-
-def load_project_catalog(manifest_path: Path) -> list[HarnessProject]:
-    try:
-        return load_projects_manifest(manifest_path)
-    except (FileNotFoundError, ValueError) as err:
-        raise SystemExit(f"[blueprint-harness] {err}") from err
 
 def sync_root_worktree_lake(layout) -> None:
     if not layout.in_linked_worktree:
@@ -274,10 +268,6 @@ def resolve_create_worktree_base(layout, requested_base: str | None) -> str:
                 f"`--base {status.upstream_ref}` explicitly."
             )
     return requested_base
-
-
-def ref_merged_into_main(repo_root: Path, ref: str) -> bool:
-    return is_ancestor(repo_root, ref, preferred_main_ref(repo_root))
 
 
 def preferred_worktree_base_ref(path: Path) -> str:
@@ -601,7 +591,11 @@ def command_create_worktree(args: argparse.Namespace) -> int:
         sync_root_worktree_lake(new_layout)
     if not skip_reference_sync:
         manifest_path = resolve_manifest_path(None, new_layout.package_root)
-        projects = load_project_catalog(manifest_path)
+        try:
+            catalog = load_project_catalog_manifest(manifest_path)
+            _release_target, projects = resolve_release_projects(catalog, None, new_layout.package_root, None)
+        except (FileNotFoundError, ValueError) as err:
+            raise SystemExit(f"[blueprint-harness] {err}") from err
         sync_reference_blueprints(new_layout, projects, warm_build=True, prepare_local_checkout=True)
     if any(value is not None for value in (args.owner, args.priority, args.summary, args.status, args.scope)) or args.lock:
         update_worktree_record(
@@ -1029,7 +1023,8 @@ def command_paths(args: argparse.Namespace) -> int:
     print(f"reference_output_root={layout.reference_output_root}")
     print(f"test_blueprint_output_root={layout.test_blueprint_output_root}")
     print(f"preview_runtime_showcase_test_site={canonical_test_blueprint_site_dir('preview_runtime_showcase', Path(__file__))}")
-    print(f"reference_cache_root={layout.reference_project_cache_root}")
+    print(f"reference_source_cache_root={layout.reference_source_cache_root}")
+    print(f"reference_dependency_cache_root={layout.reference_dependency_cache_root}")
     print(f"reference_checkout_root={layout.reference_project_checkout_root}")
     print(f"reference_edit_root={layout.reference_project_edit_root}")
     for project in projects:
@@ -1095,17 +1090,21 @@ def command_worktree_retire(args: argparse.Namespace) -> int:
         run(["git", "branch", "-d", branch], cwd=layout.repo_root)
 
     manifest_path = resolve_manifest_path(None, layout.package_root)
-    projects = load_project_catalog(manifest_path)
+    try:
+        projects = load_project_catalog_manifest(manifest_path).projects
+    except (FileNotFoundError, ValueError) as err:
+        raise SystemExit(f"[blueprint-harness] {err}") from err
     active_names = {
         root_checkout_namespace(layout.repo_root) if worktree.root_checkout else worktree.name
         for worktree in git_worktrees(layout.repo_root)
     }
-    project_ids = {project.project_id for project in projects if project.git_checkout}
+    cache_keys = reference_dependency_cache_keys(projects)
     removals = reference_prune_plan(
         active_names,
-        project_ids,
-        layout.reference_project_cache_root,
+        cache_keys,
+        layout.reference_source_cache_root,
         layout.reference_project_root / "by-worktree",
+        layout.reference_dependency_cache_root,
     )
     for stale_path in removals:
         shutil.rmtree(stale_path)

--- a/scripts/blueprint_harness_paths.py
+++ b/scripts/blueprint_harness_paths.py
@@ -30,8 +30,12 @@ class HarnessLayout:
         return self.repo_root / ".worktrees" / "_reference-blueprints"
 
     @property
-    def reference_project_cache_root(self) -> Path:
+    def reference_source_cache_root(self) -> Path:
         return self.reference_project_root / "cache"
+
+    @property
+    def reference_dependency_cache_root(self) -> Path:
+        return self.reference_project_root / "deps"
 
     @property
     def reference_project_checkout_namespace(self) -> str:

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
+import hashlib
 import json
 from pathlib import Path
+import re
 
 from scripts.blueprint_harness_branches import (
     active_release_branch,
@@ -15,6 +17,7 @@ from scripts.blueprint_harness_branches import (
 
 IN_REPO_PROJECT_SOURCE_KIND = "in_repo_project"
 GIT_CHECKOUT_SOURCE_KIND = "git_checkout"
+REFERENCE_CACHE_KEY_DIGEST_LENGTH = 12
 
 
 @dataclass(frozen=True)
@@ -39,13 +42,7 @@ class HarnessReleaseTarget:
 class HarnessProjectTarget:
     release: str
     ref: str | None
-
-
-@dataclass(frozen=True)
-class HarnessReferenceBlueprint:
-    blueprint: str
-    hash: str
-    toolchain: str
+    publish_reference: bool = False
 
 
 @dataclass(frozen=True)
@@ -53,7 +50,6 @@ class HarnessProjectCatalog:
     version: int
     release_targets: tuple[HarnessReleaseTarget, ...]
     projects: tuple["HarnessProject", ...]
-    reference_blueprints: tuple[HarnessReferenceBlueprint, ...] = ()
 
     def release_target(self, release_id: str) -> HarnessReleaseTarget | None:
         for target in self.release_targets:
@@ -101,6 +97,47 @@ class HarnessProject:
             if target.release == release:
                 return target
         return None
+
+
+def _reference_cache_key_slug(value: str, *, max_length: int) -> str:
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip(".-_")
+    return (slug or "unknown")[:max_length].strip(".-_") or "unknown"
+
+
+def _short_reference_cache_ref(ref: str) -> str:
+    if len(ref) == 40 and all(char in "0123456789abcdefABCDEF" for char in ref):
+        return ref[:12]
+    return ref
+
+
+def reference_dependency_cache_key(project: HarnessProject) -> str:
+    """Key dependency cache state for one external project source ref.
+
+    The key intentionally ignores the selected release and local package root:
+    the expensive state being reused is the external project's pinned Lake
+    dependency packages, not the generated Blueprint site or local checkout
+    build output.
+    """
+    if not project.git_checkout:
+        raise ValueError(f"project `{project.project_id}` is not an external git checkout project")
+    if project.repository is None:
+        raise ValueError(f"project `{project.project_id}` is missing repository metadata")
+    if project.ref is None:
+        raise ValueError(f"project `{project.project_id}` is missing selected git ref metadata")
+
+    key_material = json.dumps(
+        {
+            "repository": project.repository,
+            "project_root": project.project_root,
+            "ref": project.ref,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(key_material.encode("utf-8")).hexdigest()[:REFERENCE_CACHE_KEY_DIGEST_LENGTH]
+    project_slug = _reference_cache_key_slug(project.project_id, max_length=48)
+    ref_slug = _reference_cache_key_slug(_short_reference_cache_ref(project.ref), max_length=40)
+    return f"{project_slug}-{ref_slug}-{digest}"
 
 
 def default_project_manifest(package_root: Path) -> Path:
@@ -186,30 +223,6 @@ def _load_release_targets(raw: dict, manifest_path: Path | str) -> tuple[Harness
     return tuple(targets)
 
 
-def _load_reference_blueprints(raw: dict, manifest_path: Path | str) -> tuple[HarnessReferenceBlueprint, ...]:
-    entries = raw.get("reference_blueprints")
-    if entries is None:
-        return ()
-    if not isinstance(entries, list):
-        raise ValueError(f"{manifest_path}: expected top-level `reference_blueprints` list")
-
-    blueprints: list[HarnessReferenceBlueprint] = []
-    seen: set[tuple[str, str]] = set()
-    for index, entry in enumerate(entries, start=1):
-        if not isinstance(entry, dict):
-            raise ValueError(f"{manifest_path}: reference blueprint #{index} must be an object")
-        context = f"{manifest_path}: reference blueprint #{index}"
-        blueprint = _require_string(entry, "blueprint", context=context)
-        commit_hash = _require_string(entry, "hash", context=context)
-        toolchain = normalize_lean_release_ref(_require_string(entry, "toolchain", context=context))
-        key = (blueprint, toolchain)
-        if key in seen:
-            raise ValueError(f"{context}: duplicate reference blueprint `{blueprint}` for toolchain `{toolchain}`")
-        seen.add(key)
-        blueprints.append(HarnessReferenceBlueprint(blueprint=blueprint, hash=commit_hash, toolchain=toolchain))
-    return tuple(blueprints)
-
-
 def _load_project_targets(
     entry: dict,
     *,
@@ -238,10 +251,13 @@ def _load_project_targets(
             raise ValueError(f"{target_context}: git checkout targets must declare `ref`")
         if source_kind == IN_REPO_PROJECT_SOURCE_KIND and ref is not None:
             raise ValueError(f"{target_context}: in-repo project targets must not declare `ref`")
+        if "publish" in raw_target:
+            raise ValueError(f"{target_context}: `publish` is no longer supported; use `publish_reference`")
         targets.append(
             HarnessProjectTarget(
                 release=release,
                 ref=ref,
+                publish_reference=_optional_bool(raw_target, "publish_reference", default=False, context=target_context),
             )
         )
     return tuple(targets)
@@ -250,8 +266,12 @@ def _load_project_targets(
 def load_project_catalog_data(raw: dict, manifest_path: Path | str) -> HarnessProjectCatalog:
     if raw.get("version") != 2:
         raise ValueError(f"{manifest_path}: unsupported manifest version {raw.get('version')!r}")
+    if "reference_blueprints" in raw:
+        raise ValueError(
+            f"{manifest_path}: top-level `reference_blueprints` is no longer supported; "
+            "mark published project targets with `publish_reference`"
+        )
     release_targets = _load_release_targets(raw, manifest_path)
-    reference_blueprints = _load_reference_blueprints(raw, manifest_path)
     release_ids = {target.release_id for target in release_targets}
 
     entries = raw.get("projects")
@@ -360,52 +380,16 @@ def load_project_catalog_data(raw: dict, manifest_path: Path | str) -> HarnessPr
             )
         )
 
-    project_by_id = {project.project_id: project for project in projects}
-    for blueprint in reference_blueprints:
-        project = project_by_id.get(blueprint.blueprint)
-        if project is None:
-            known = ", ".join(sorted(project_by_id))
-            raise ValueError(
-                f"{manifest_path}: reference blueprint `{blueprint.blueprint}` is not a known project; "
-                f"known projects: {known}"
-            )
-        if not project.git_checkout:
-            raise ValueError(f"{manifest_path}: reference blueprint `{blueprint.blueprint}` must be a git checkout project")
-        release = release_branch_from_lean_ref(blueprint.toolchain)
-        target = project.target_for_release(release)
-        if target is None:
-            raise ValueError(
-                f"{manifest_path}: reference blueprint `{blueprint.blueprint}` for toolchain "
-                f"`{blueprint.toolchain}` has no project target for release `{release}`"
-            )
-        if target.ref is not None and target.ref != blueprint.hash:
-            raise ValueError(
-                f"{manifest_path}: reference blueprint `{blueprint.blueprint}` hash `{blueprint.hash}` "
-                f"does not match target ref `{target.ref}` for release `{release}`"
-            )
-
     return HarnessProjectCatalog(
         version=2,
         release_targets=release_targets,
         projects=tuple(projects),
-        reference_blueprints=reference_blueprints,
     )
 
 
 def load_project_catalog(manifest_path: Path) -> HarnessProjectCatalog:
     raw = json.loads(manifest_path.read_text(encoding="utf-8"))
     return load_project_catalog_data(raw, manifest_path)
-
-
-def load_project_catalog_text(text: str, manifest_path: Path | str) -> HarnessProjectCatalog:
-    raw = json.loads(text)
-    if not isinstance(raw, dict):
-        raise ValueError(f"{manifest_path}: expected JSON object")
-    return load_project_catalog_data(raw, manifest_path)
-
-
-def load_projects_manifest(manifest_path: Path) -> list[HarnessProject]:
-    return list(load_project_catalog(manifest_path).projects)
 
 
 def resolve_release_target(catalog: HarnessProjectCatalog, release: str | None, package_root: Path) -> HarnessReleaseTarget:
@@ -421,32 +405,17 @@ def resolve_projects_for_release(
     catalog: HarnessProjectCatalog,
     release: str,
     selected_ids: list[str] | None,
+    *,
+    require_selected_targets: bool = True,
 ) -> list[HarnessProject]:
     by_id = {project.project_id: project for project in catalog.projects}
-    release_target = catalog.release_target(release)
-    if catalog.reference_blueprints and release_target is not None and selected_ids is None:
-        matching = [
-            blueprint
-            for blueprint in catalog.reference_blueprints
-            if blueprint.toolchain == release_target.toolchain
-        ]
-        resolved_from_blueprints: list[HarnessProject] = []
-        for blueprint in matching:
-            project = by_id[blueprint.blueprint]
-            target = project.target_for_release(release)
-            if target is None:
-                raise ValueError(f"project `{project.project_id}` has no target for release `{release}`")
-            resolved_from_blueprints.append(
-                replace(
-                    project,
-                    ref=blueprint.hash,
-                    selected_release=release,
-                )
-            )
-        return resolved_from_blueprints
 
     if selected_ids is None:
-        candidates = list(catalog.projects)
+        candidates = [
+            project
+            for project in catalog.projects
+            if (target := project.target_for_release(release)) is not None and target.publish_reference
+        ]
     else:
         seen: set[str] = set()
         candidates: list[HarnessProject] = []
@@ -462,7 +431,7 @@ def resolve_projects_for_release(
     for project in candidates:
         target = project.target_for_release(release)
         if target is None:
-            if selected_ids is not None:
+            if selected_ids is not None and require_selected_targets:
                 raise ValueError(f"project `{project.project_id}` has no target for release `{release}`")
             continue
         resolved.append(
@@ -473,6 +442,24 @@ def resolve_projects_for_release(
             )
         )
     return resolved
+
+
+def resolve_release_projects(
+    catalog: HarnessProjectCatalog,
+    release: str | None,
+    package_root: Path,
+    selected_ids: list[str] | None,
+    *,
+    require_selected_targets: bool = True,
+) -> tuple[HarnessReleaseTarget, list[HarnessProject]]:
+    release_target = resolve_release_target(catalog, release, package_root)
+    projects = resolve_projects_for_release(
+        catalog,
+        release_target.release_id,
+        selected_ids,
+        require_selected_targets=require_selected_targets,
+    )
+    return release_target, projects
 
 
 def reference_artifact_name(project: HarnessProject) -> str:
@@ -488,7 +475,9 @@ def reference_build_matrix(projects: list[HarnessProject]) -> dict[str, list[dic
         "include": [
             {
                 "project_id": project.project_id,
+                "project_root": project.project_root,
                 "hash": project.ref,
+                "reference_cache_key": reference_dependency_cache_key(project) if project.git_checkout else "",
                 "artifact_name": reference_artifact_name(project),
                 "artifact_path": reference_artifact_path(project),
             }
@@ -513,37 +502,3 @@ def deploy_project_artifact_path(project: HarnessProject) -> str:
     if project.selected_release is None:
         raise ValueError(f"project `{project.project_id}` is missing selected release metadata")
     return f"_out/reference-blueprints/{project.selected_release}/{project.project_id}"
-
-
-def reference_blueprint_ids_for_toolchain(catalog: HarnessProjectCatalog, toolchain: str) -> list[str]:
-    normalized_toolchain = normalize_lean_release_ref(toolchain)
-    return [
-        blueprint.blueprint
-        for blueprint in catalog.reference_blueprints
-        if blueprint.toolchain == normalized_toolchain
-    ]
-
-
-def deploy_project_matrix(
-    release_targets: tuple[HarnessReleaseTarget, ...],
-    catalog: HarnessProjectCatalog,
-) -> dict[str, list[dict[str, object]]]:
-    include: list[dict[str, object]] = []
-    for target in release_targets:
-        if not target.deploy_pages:
-            continue
-        for project in resolve_projects_for_release(catalog, target.release_id, None):
-            include.append(
-                {
-                    "release_id": target.release_id,
-                    "rc": target.rc,
-                    "toolchain": target.toolchain,
-                    "verso_ref": target.verso_ref,
-                    "branch": target.branch,
-                    "project_id": project.project_id,
-                    "hash": project.ref,
-                    "artifact_name": deploy_project_artifact_name(project),
-                    "artifact_path": deploy_project_artifact_path(project),
-                }
-            )
-    return {"include": include}

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import os
 import re
 import shutil
@@ -8,7 +8,7 @@ import subprocess
 from pathlib import Path
 import tomllib
 
-from scripts.blueprint_harness_projects import HarnessProject
+from scripts.blueprint_harness_projects import HarnessProject, reference_dependency_cache_key
 from scripts.blueprint_harness_utils import lean_low_priority_command, rebuild_embedded_asset_owners, run
 
 
@@ -55,20 +55,66 @@ def site_dir_for(project: HarnessProject, output_root: Path) -> Path:
     return output_dir_for(project, output_root) / project.site_subdir
 
 
-def reference_cache_checkout_dir(layout, project: HarnessProject) -> Path:
-    return layout.reference_project_cache_root / project.project_id
+def reference_source_cache_checkout_dir(layout, project: HarnessProject) -> Path:
+    return layout.reference_source_cache_root / reference_dependency_cache_key(project)
+
+
+def reference_dependency_cache_dir(layout, project: HarnessProject) -> Path:
+    return layout.reference_dependency_cache_root / reference_dependency_cache_key(project)
+
+
+def reference_dependency_packages_dir(layout, project: HarnessProject) -> Path:
+    return reference_dependency_cache_dir(layout, project) / "packages"
 
 
 def reference_local_checkout_dir(layout, project: HarnessProject) -> Path:
-    return layout.reference_project_checkout_root / project.project_id
+    return layout.reference_project_checkout_root / reference_dependency_cache_key(project)
 
 
 def reference_edit_checkout_dir(layout, project: HarnessProject) -> Path:
     return layout.reference_project_edit_root / project.project_id
 
 
-def use_shared_reference_checkout() -> bool:
-    return os.getenv("BP_REFERENCE_CHECKOUT_MODE") == "shared"
+def reference_dependency_cache_keys(projects: tuple[HarnessProject, ...] | list[HarnessProject]) -> set[str]:
+    keys: set[str] = set()
+    for project in projects:
+        if not project.git_checkout:
+            continue
+        if project.ref is not None:
+            keys.add(reference_dependency_cache_key(project))
+        for target in project.targets:
+            if target.ref is None:
+                continue
+            keys.add(
+                reference_dependency_cache_key(
+                    replace(project, ref=target.ref, selected_release=target.release)
+                )
+            )
+    return keys
+
+
+def lake_packages_dir(project_dir: Path) -> Path:
+    return project_dir / ".lake" / "packages"
+
+
+def seed_lake_packages_from_dependency_cache(layout, project: HarnessProject, project_dir: Path) -> Path | None:
+    source_packages = reference_dependency_packages_dir(layout, project)
+    if not source_packages.exists():
+        return None
+    destination_packages = lake_packages_dir(project_dir)
+    destination_packages.mkdir(parents=True, exist_ok=True)
+    run(["rsync", "-a", f"{source_packages}/", f"{destination_packages}/"], cwd=layout.package_root)
+    return source_packages
+
+
+def store_lake_packages_in_dependency_cache(layout, project: HarnessProject, project_dir: Path) -> Path | None:
+    source_packages = lake_packages_dir(project_dir)
+    if not source_packages.exists():
+        return None
+    destination_packages = reference_dependency_packages_dir(layout, project)
+    destination_packages.mkdir(parents=True, exist_ok=True)
+    run(["rsync", "-a", "--delete", f"{source_packages}/", f"{destination_packages}/"], cwd=layout.package_root)
+    return destination_packages
 
 
 def short_git_ref(ref: str) -> str:
@@ -466,14 +512,40 @@ def seed_reference_edit_checkout_lake(layout, project: HarnessProject, edit_dir:
     if shutil.which("rsync") is None:
         return None
 
+    local_lake = reference_local_checkout_dir(layout, project) / project.project_root / ".lake"
+    if local_lake.exists():
+        run(
+            ["rsync", "-a", "--delete", f"{local_lake}/", f"{edit_dir / project.project_root / '.lake'}/"],
+            cwd=layout.package_root,
+        )
+        return local_lake
+
+    dependency_packages = reference_dependency_packages_dir(layout, project)
+    if dependency_packages.exists():
+        edit_packages = edit_dir / project.project_root / ".lake" / "packages"
+        edit_packages.mkdir(parents=True, exist_ok=True)
+        run(
+            [
+                "rsync",
+                "-a",
+                "--delete",
+                f"{dependency_packages}/",
+                f"{edit_packages}/",
+            ],
+            cwd=layout.package_root,
+        )
+        return dependency_packages
+
     for source_dir in (
-        reference_local_checkout_dir(layout, project),
-        reference_cache_checkout_dir(layout, project),
+        reference_source_cache_checkout_dir(layout, project),
     ):
-        source_lake = source_dir / ".lake"
+        source_lake = source_dir / project.project_root / ".lake"
         if source_lake.exists():
-            run(["rsync", "-a", "--delete", f"{source_lake}/", f"{edit_dir / '.lake'}/"], cwd=layout.package_root)
-            return source_dir
+            run(
+                ["rsync", "-a", "--delete", f"{source_lake}/", f"{edit_dir / project.project_root / '.lake'}/"],
+                cwd=layout.package_root,
+            )
+            return source_lake
     return None
 
 
@@ -574,15 +646,19 @@ def bump_reference_project(
 
 
 def sync_reference_cache_checkout(layout, project: HarnessProject, *, warm_build: bool) -> Path:
-    cache_dir = reference_cache_checkout_dir(layout, project)
+    cache_dir = reference_source_cache_checkout_dir(layout, project)
     cache_dir.parent.mkdir(parents=True, exist_ok=True)
     if not cache_dir.exists():
+        clone_git_project(project, cache_dir, cwd=layout.package_root)
+    elif not (cache_dir / ".git").exists():
+        shutil.rmtree(cache_dir)
         clone_git_project(project, cache_dir, cwd=layout.package_root)
     else:
         update_git_checkout(project, cache_dir)
     project_dir = cache_dir / project.project_root
     discard_untracked_project_manifest(project_dir)
     bootstrap_reference_checkout(project_dir=project_dir)
+    seed_lake_packages_from_dependency_cache(layout, project, project_dir)
     cache_lakefile = project_dir / "lakefile.lean"
     original_text = cache_lakefile.read_text(encoding="utf-8")
     rewrite_local_blueprint_dependency(project_dir, layout.package_root)
@@ -590,6 +666,7 @@ def sync_reference_cache_checkout(layout, project: HarnessProject, *, warm_build
         run(reference_update_command(layout.package_root, project_dir), cwd=project_dir)
         if warm_build and project.build_command is not None:
             run(lean_low_priority_command(layout.package_root, *project.build_command), cwd=project_dir)
+        store_lake_packages_in_dependency_cache(layout, project, project_dir)
     finally:
         cache_lakefile.write_text(original_text, encoding="utf-8")
     return cache_dir
@@ -604,14 +681,31 @@ def sync_reference_local_checkout(layout, project: HarnessProject, cache_dir: Pa
         update_git_checkout(project, local_dir)
     bootstrap_reference_checkout(project_dir=local_dir / project.project_root)
 
-    cache_lake = cache_dir / ".lake"
-    if cache_lake.exists():
-        # Seed dependency state from the shared cache, but preserve the
-        # worktree-local project's own build products. Those artifacts are
-        # produced after rewriting the reference project to depend on the local
-        # VersoBlueprint checkout, so deleting them defeats the local cache.
+    dependency_packages = reference_dependency_packages_dir(layout, project)
+    if dependency_packages.exists():
+        local_packages = local_dir / project.project_root / ".lake" / "packages"
+        local_packages.mkdir(parents=True, exist_ok=True)
         run(
-            ["rsync", "-a", "--exclude", "/build/", f"{cache_lake}/", f"{local_dir / '.lake'}/"],
+            [
+                "rsync",
+                "-a",
+                f"{dependency_packages}/",
+                f"{local_packages}/",
+            ],
+            cwd=layout.package_root,
+        )
+    else:
+        cache_lake = cache_dir / project.project_root / ".lake"
+        if not cache_lake.exists():
+            return local_dir
+        # Fallback for caches produced before the dedicated dependency-package
+        # cache existed: seed dependency state from the shared checkout, but
+        # preserve the worktree-local project's own build products. Those
+        # artifacts are produced after rewriting the reference project to depend
+        # on the local VersoBlueprint checkout, so deleting them defeats the
+        # local cache.
+        run(
+            ["rsync", "-a", "--exclude", "/build/", f"{cache_lake}/", f"{local_dir / project.project_root / '.lake'}/"],
             cwd=layout.package_root,
         )
     return local_dir
@@ -670,45 +764,25 @@ def generate_in_repo_command_project(layout, output_root: Path, project: Harness
 
 
 def generate_git_project(layout, output_root: Path, project: HarnessProject, *, skip_build: bool) -> None:
-    # Shared cache warm builds run against `layout.repo_root` so linked worktree
-    # validations must skip them here and build only after rewriting the local
-    # checkout dependency to `layout.package_root`.
-    cache_warm_build = (not skip_build) and use_shared_reference_checkout()
     rebuilt = rebuild_embedded_asset_owners(layout.package_root)
     for target in rebuilt:
         print(f"[blueprint-harness] rebuilt embedded-asset owner target: {target}")
-    cache_dir = sync_reference_cache_checkout(layout, project, warm_build=cache_warm_build)
-    checkout_root = cache_dir if use_shared_reference_checkout() else sync_reference_local_checkout(layout, project, cache_dir)
+    cache_dir = sync_reference_cache_checkout(layout, project, warm_build=False)
+    checkout_root = sync_reference_local_checkout(layout, project, cache_dir)
     project_dir = checkout_root / project.project_root
     discard_untracked_project_manifest(project_dir)
     output_dir = output_dir_for(project, output_root)
     output_dir.mkdir(parents=True, exist_ok=True)
-    original_text = (project_dir / "lakefile.lean").read_text(encoding="utf-8") if use_shared_reference_checkout() else None
-    try:
-        bootstrap_reference_checkout(project_dir=project_dir)
-        rewritten_lakefile = rewrite_local_blueprint_dependency(project_dir, layout.package_root)
-        print(f"[blueprint-harness] local package override: rewrote {rewritten_lakefile}")
-        run(reference_update_command(layout.package_root, project_dir), cwd=project_dir)
-        if not skip_build and project.build_command is not None:
-            run(
-                lean_low_priority_command(
-                    layout.package_root,
-                    *format_external_command(
-                        project.build_command,
-                        project=project,
-                        package_root=layout.package_root,
-                        checkout_root=checkout_root,
-                        project_dir=project_dir,
-                        output_dir=output_dir,
-                    ),
-                ),
-                cwd=project_dir,
-            )
+    bootstrap_reference_checkout(project_dir=project_dir)
+    rewritten_lakefile = rewrite_local_blueprint_dependency(project_dir, layout.package_root)
+    print(f"[blueprint-harness] local package override: rewrote {rewritten_lakefile}")
+    run(reference_update_command(layout.package_root, project_dir), cwd=project_dir)
+    if not skip_build and project.build_command is not None:
         run(
             lean_low_priority_command(
                 layout.package_root,
                 *format_external_command(
-                    project.generate_command or (),
+                    project.build_command,
                     project=project,
                     package_root=layout.package_root,
                     checkout_root=checkout_root,
@@ -718,9 +792,20 @@ def generate_git_project(layout, output_root: Path, project: HarnessProject, *, 
             ),
             cwd=project_dir,
         )
-    finally:
-        if original_text is not None:
-            (project_dir / "lakefile.lean").write_text(original_text, encoding="utf-8")
+    run(
+        lean_low_priority_command(
+            layout.package_root,
+            *format_external_command(
+                project.generate_command or (),
+                project=project,
+                package_root=layout.package_root,
+                checkout_root=checkout_root,
+                project_dir=project_dir,
+                output_dir=output_dir,
+            ),
+        ),
+        cwd=project_dir,
+    )
 
 
 def sync_reference_blueprints(layout, projects: list[HarnessProject], *, warm_build: bool, prepare_local_checkout: bool) -> None:
@@ -728,7 +813,7 @@ def sync_reference_blueprints(layout, projects: list[HarnessProject], *, warm_bu
     if not git_projects:
         return
     if shutil.which("rsync") is None:
-        raise SystemExit("[blueprint-harness] `rsync` is required for reference blueprint cache sync.")
+        raise SystemExit("[blueprint-harness] `rsync` is required for reference dependency cache sync.")
     for project in git_projects:
         cache_dir = sync_reference_cache_checkout(layout, project, warm_build=warm_build)
         if prepare_local_checkout:
@@ -736,11 +821,21 @@ def sync_reference_blueprints(layout, projects: list[HarnessProject], *, warm_bu
             print(f"[blueprint-harness] prepared local reference checkout: {local_dir}")
 
 
-def reference_prune_plan(active_worktree_names: set[str], project_ids: set[str], cache_root: Path, checkout_root: Path) -> list[Path]:
+def reference_prune_plan(
+    active_worktree_names: set[str],
+    active_cache_keys: set[str],
+    cache_root: Path,
+    checkout_root: Path,
+    dependency_cache_root: Path | None = None,
+) -> list[Path]:
     removals: list[Path] = []
     if cache_root.exists():
         for path in sorted(child for child in cache_root.iterdir() if child.is_dir()):
-            if path.name not in project_ids:
+            if path.name not in active_cache_keys:
+                removals.append(path)
+    if dependency_cache_root is not None and dependency_cache_root.exists():
+        for path in sorted(child for child in dependency_cache_root.iterdir() if child.is_dir()):
+            if path.name not in active_cache_keys:
                 removals.append(path)
     if checkout_root.exists():
         for namespace_dir in sorted(child for child in checkout_root.iterdir() if child.is_dir()):
@@ -748,6 +843,6 @@ def reference_prune_plan(active_worktree_names: set[str], project_ids: set[str],
                 removals.append(namespace_dir)
                 continue
             for project_dir in sorted(child for child in namespace_dir.iterdir() if child.is_dir()):
-                if project_dir.name not in project_ids:
+                if project_dir.name not in active_cache_keys:
                     removals.append(project_dir)
     return removals

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -26,6 +26,7 @@ from scripts.blueprint_harness_projects import (
     HarnessProjectCatalog,
     load_project_catalog as load_project_catalog_manifest,
     resolve_projects_for_release,
+    resolve_release_projects,
     resolve_release_target,
 )
 from scripts.blueprint_harness_references import (
@@ -37,8 +38,9 @@ from scripts.blueprint_harness_references import (
     output_dir_for,
     prepare_reference_edit_checkout,
     ref_is_commit_hash,
-    reference_cache_checkout_dir,
+    reference_dependency_cache_keys,
     reference_prune_plan,
+    reference_source_cache_checkout_dir,
     site_dir_for,
     sync_reference_blueprints,
 )
@@ -212,7 +214,7 @@ def refresh_reference_status_checkout(checkout_root: Path, project: HarnessProje
 
 
 def ensure_reference_status_checkout(layout, project: HarnessProject) -> Path:
-    checkout_root = reference_cache_checkout_dir(layout, project)
+    checkout_root = reference_source_cache_checkout_dir(layout, project)
     checkout_root.parent.mkdir(parents=True, exist_ok=True)
     if not checkout_root.exists():
         clone_git_project(project, checkout_root, cwd=layout.package_root, shallow=False)
@@ -413,10 +415,21 @@ def select_release_projects(
     release: str | None,
     project_ids: list[str] | None,
     package_root: Path,
+    default_to_published_catalog: bool = True,
 ) -> tuple[str, list[HarnessProject]]:
+    selected_ids = project_ids
+    require_selected_targets = True
+    if project_ids is None and not default_to_published_catalog:
+        selected_ids = [project.project_id for project in catalog.projects]
+        require_selected_targets = False
     try:
-        selected_release = resolve_release_target(catalog, release, package_root)
-        projects = resolve_projects_for_release(catalog, selected_release.release_id, project_ids)
+        selected_release, projects = resolve_release_projects(
+            catalog,
+            release,
+            package_root,
+            selected_ids,
+            require_selected_targets=require_selected_targets,
+        )
     except ValueError as err:
         raise SystemExit(f"[blueprint-reference-harness] {err}") from err
     return selected_release.release_id, projects
@@ -808,10 +821,17 @@ def command_release_status(args: argparse.Namespace) -> int:
 
     print(f"project_manifest={manifest_path}")
     for release_target in releases:
-        projects = resolve_projects_for_release(catalog, release_target.release_id, None)
-        if args.project is not None:
-            allowed = set(args.project)
-            projects = [project for project in projects if project.project_id in allowed]
+        try:
+            projects = resolve_projects_for_release(
+                catalog,
+                release_target.release_id,
+                args.project,
+                require_selected_targets=args.release is not None,
+            )
+        except ValueError as err:
+            raise SystemExit(f"[blueprint-reference-harness] {err}") from err
+        if args.project is not None and not projects:
+            continue
 
         statuses: list[ReferenceProjectStatus] = []
         for project in projects:
@@ -875,7 +895,8 @@ def command_reference_sync(args: argparse.Namespace) -> int:
         prepare_local_checkout=not args.skip_local_checkout,
     )
     print(f"[blueprint-reference-harness] release target: {release_id}")
-    print(f"[blueprint-reference-harness] reference cache root: {layout.reference_project_cache_root}")
+    print(f"[blueprint-reference-harness] reference source cache root: {layout.reference_source_cache_root}")
+    print(f"[blueprint-reference-harness] reference dependency cache root: {layout.reference_dependency_cache_root}")
     print(f"[blueprint-reference-harness] reference checkout root: {layout.reference_project_checkout_root}")
     return 0
 
@@ -884,17 +905,22 @@ def command_reference_edit(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
     manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
     catalog = load_project_catalog(manifest_path)
-    project_map = {project.project_id: project for project in catalog.projects}
-    if args.project not in project_map:
-        known = ", ".join(sorted(project_map))
-        raise SystemExit(f"[blueprint-reference-harness] unknown project `{args.project}`; known projects: {known}")
-    project = project_map[args.project]
+    release_id, projects = select_release_projects(
+        catalog,
+        release=args.release,
+        project_ids=[args.project],
+        package_root=layout.package_root,
+    )
+    project = projects[0]
+    if not project.git_checkout:
+        raise SystemExit(f"[blueprint-reference-harness] project `{project.project_id}` is not an external git checkout project")
     edit_dir, branch, base_ref = prepare_reference_edit_checkout(
         layout,
         project,
         branch=args.branch,
         base_ref=args.base,
     )
+    print(f"[blueprint-reference-harness] release target: {release_id}")
     print(f"[blueprint-reference-harness] editable reference checkout: {edit_dir}")
     print(f"[blueprint-reference-harness] branch: {branch}")
     print(f"[blueprint-reference-harness] base ref: {base_ref}")
@@ -909,24 +935,29 @@ def command_reference_bump_blueprint(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
     manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
     catalog = load_project_catalog(manifest_path)
-    project_map = {project.project_id: project for project in catalog.projects if project.git_checkout}
-    if args.project:
-        seen: set[str] = set()
-        projects: list[HarnessProject] = []
-        for value in args.project:
-            if value not in project_map:
-                known = ", ".join(sorted(project_map))
-                raise SystemExit(f"[blueprint-reference-harness] unknown project `{value}`; known projects: {known}")
-            if value not in seen:
-                projects.append(project_map[value])
-                seen.add(value)
-    else:
-        projects = list(project_map.values())
+    release_id, selected_projects = select_release_projects(
+        catalog,
+        release=args.release,
+        project_ids=args.project,
+        package_root=layout.package_root,
+        default_to_published_catalog=False,
+    )
+    projects: list[HarnessProject] = []
+    for project in selected_projects:
+        if not project.git_checkout:
+            if args.project is not None:
+                raise SystemExit(
+                    f"[blueprint-reference-harness] project `{project.project_id}` is not an external git checkout project"
+                )
+            continue
+        projects.append(project)
+    if not projects:
+        raise SystemExit(f"[blueprint-reference-harness] release target `{release_id}` has no external git checkout projects")
     failures: list[StepFailure] = []
     output_root = layout.artifact_root / "reference-blueprints-edit"
 
     for project in projects:
-        print(f"[blueprint-reference-harness] bumping {project.project_id} to {args.ref}")
+        print(f"[blueprint-reference-harness] bumping {project.project_id} on {release_id} to {args.ref}")
         try:
             result = bump_reference_project(
                 layout,
@@ -983,12 +1014,13 @@ def command_reference_prune(args: argparse.Namespace) -> int:
         root_checkout_namespace(layout.repo_root) if worktree.root_checkout else worktree.name
         for worktree in git_worktrees(layout.repo_root)
     }
-    project_ids = {project.project_id for project in projects if project.git_checkout}
+    cache_keys = reference_dependency_cache_keys(projects)
     removals = reference_prune_plan(
         active_names,
-        project_ids,
-        layout.reference_project_cache_root,
+        cache_keys,
+        layout.reference_source_cache_root,
         layout.reference_project_root / "by-worktree",
+        layout.reference_dependency_cache_root,
     )
     if not removals:
         print("[blueprint-reference-harness] reference prune: no stale cached checkouts found")
@@ -1119,7 +1151,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     sync = subparsers.add_parser(
         "sync",
-        help="Warm shared reference blueprint caches and prepare local clones for the current checkout.",
+        help="Warm shared reference dependency caches and prepare local clones for the current checkout.",
     )
     add_manifest_argument(sync)
     add_project_selection_argument(
@@ -1146,6 +1178,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_manifest_argument(edit)
     edit.add_argument("project", help="External git-checkout project id to open for editing.")
+    edit.add_argument("--release", default=None, help="Release target to edit. Defaults to the current checkout release line.")
     edit.add_argument(
         "--branch",
         default=None,
@@ -1167,6 +1200,7 @@ def build_parser() -> argparse.ArgumentParser:
         bump,
         help_text="Restrict the bump to the selected external project. Repeat to select more.",
     )
+    bump.add_argument("--release", default=None, help="Release target to bump. Defaults to the current checkout release line.")
     bump.add_argument(
         "--ref",
         required=True,
@@ -1211,7 +1245,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     prune = subparsers.add_parser(
         "prune",
-        help="Remove stale harness-managed reference blueprint caches and checkout clones.",
+        help="Remove stale harness-managed reference dependency caches and checkout clones.",
     )
     add_manifest_argument(prune)
     prune.add_argument(

--- a/scripts/emit_reference_deploy_matrix.py
+++ b/scripts/emit_reference_deploy_matrix.py
@@ -2,10 +2,8 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Callable
 import json
 from pathlib import Path
-import subprocess
 import sys
 
 if __package__ in {None, ""}:
@@ -13,14 +11,14 @@ if __package__ in {None, ""}:
 
 from scripts.blueprint_harness_paths import detect_harness_layout
 from scripts.blueprint_harness_projects import (
+    HarnessProject,
     HarnessProjectCatalog,
     HarnessReleaseTarget,
-    default_project_manifest,
     deploy_project_artifact_name,
     deploy_project_artifact_path,
     load_project_catalog,
-    load_project_catalog_text,
-    reference_blueprint_ids_for_toolchain,
+    reference_dependency_cache_key,
+    resolve_manifest_path,
     resolve_projects_for_release,
 )
 
@@ -42,103 +40,95 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def resolve_manifest_path(layout, path_text: str | None) -> Path:
-    if path_text is None:
-        return default_project_manifest(layout.package_root)
-    path = Path(path_text)
-    if path.is_absolute():
-        return path.resolve()
-    return (Path.cwd() / path).resolve()
+def release_target_manifest_entry(target: HarnessReleaseTarget) -> dict[str, object]:
+    entry: dict[str, object] = {
+        "id": target.release_id,
+        "toolchain": target.release_toolchain,
+        "verso_ref": target.release_verso_ref,
+        "branch": target.branch,
+        "deploy_pages": target.deploy_pages,
+    }
+    if target.rc is not None:
+        entry["rc"] = target.rc
+    return entry
 
 
-def manifest_relative_to_package(manifest_path: Path, package_root: Path) -> Path | None:
-    try:
-        return manifest_path.relative_to(package_root)
-    except ValueError:
-        return None
+def project_manifest_entry(project: HarnessProject) -> dict[str, object]:
+    if project.selected_release is None:
+        raise ValueError(f"project `{project.project_id}` is missing selected release metadata")
+
+    source: dict[str, object] = {
+        "kind": project.source_kind,
+        "project_root": project.project_root,
+    }
+    if project.repository is not None:
+        source["repository"] = project.repository
+
+    target: dict[str, object] = {"release": project.selected_release}
+    if project.ref is not None:
+        target["ref"] = project.ref
+
+    entry: dict[str, object] = {
+        "id": project.project_id,
+        "source": source,
+        "targets": [target],
+        "site_subdir": project.site_subdir,
+    }
+    if project.description is not None:
+        entry["description"] = project.description
+    if project.build_target is not None:
+        entry["build_target"] = project.build_target
+    if project.generator is not None:
+        entry["generator"] = project.generator
+    if project.build_command is not None:
+        entry["build_command"] = list(project.build_command)
+    if project.generate_command is not None:
+        entry["generate_command"] = list(project.generate_command)
+    validation: dict[str, object] = {}
+    if project.panel_regression_script is not None:
+        validation["panel_regression_script"] = project.panel_regression_script
+    if project.browser_tests_path is not None:
+        validation["browser_tests_path"] = project.browser_tests_path
+    if validation:
+        entry["validation"] = validation
+    return entry
 
 
-def release_branch_ref_candidates(branch: str) -> tuple[str, ...]:
-    return (f"origin/{branch}", f"refs/remotes/origin/{branch}", branch)
+def deploy_project_manifest(target: HarnessReleaseTarget, project: HarnessProject) -> dict[str, object]:
+    return {
+        "version": 2,
+        "release_targets": [release_target_manifest_entry(target)],
+        "projects": [project_manifest_entry(project)],
+    }
 
 
-def load_branch_project_catalog(
-    *,
-    branch: str,
-    manifest_path: Path,
-    package_root: Path,
-) -> HarnessProjectCatalog:
-    manifest_relpath = manifest_relative_to_package(manifest_path, package_root)
-    if manifest_relpath is None:
-        return load_project_catalog(manifest_path)
-
-    errors: list[str] = []
-    for ref in release_branch_ref_candidates(branch):
-        result = subprocess.run(
-            ["git", "show", f"{ref}:{manifest_relpath.as_posix()}"],
-            cwd=package_root,
-            text=True,
-            capture_output=True,
-            check=False,
-        )
-        if result.returncode == 0:
-            return load_project_catalog_text(result.stdout, f"{ref}:{manifest_relpath.as_posix()}")
-        errors.append(result.stderr.strip() or result.stdout.strip())
-
-    raise ValueError(
-        f"could not load reference project catalog for release branch `{branch}` from `{manifest_relpath}`; "
-        + "; ".join(error for error in errors if error)
-    )
-
-
-def deploy_matrix_from_release_catalogs(
+def deploy_matrix_from_controller_catalog(
     controller_catalog: HarnessProjectCatalog,
     deployable_targets: tuple[HarnessReleaseTarget, ...],
-    catalog_for_target: Callable[[HarnessReleaseTarget], HarnessProjectCatalog],
 ) -> dict[str, list[dict[str, object]]]:
     include: list[dict[str, object]] = []
     for target in deployable_targets:
-        selected_blueprints = [
-            blueprint
-            for blueprint in controller_catalog.reference_blueprints
-            if blueprint.toolchain == target.toolchain
-        ]
-        selected_project_ids = reference_blueprint_ids_for_toolchain(controller_catalog, target.toolchain)
-        expected_hash_by_project = {blueprint.blueprint: blueprint.hash for blueprint in selected_blueprints}
-        if controller_catalog.reference_blueprints and not selected_blueprints:
+        controller_projects = resolve_projects_for_release(controller_catalog, target.release_id, None)
+        if not controller_projects:
             raise ValueError(
-                f"release target `{target.release_id}` has `deploy_pages: true` but no reference "
-                f"blueprints for toolchain `{target.toolchain}`"
+                f"release target `{target.release_id}` has `deploy_pages: true` but no published "
+                "reference project targets"
             )
-        release_catalog = catalog_for_target(target)
-        release_target = release_catalog.release_target(target.release_id)
-        if release_target is None:
-            raise ValueError(
-                f"catalog for branch `{target.branch}` does not define release target `{target.release_id}`"
-            )
-        projects = resolve_projects_for_release(
-            release_catalog,
-            release_target.release_id,
-            selected_project_ids or None,
-        )
-        for project in projects:
-            expected_hash = expected_hash_by_project.get(project.project_id)
-            if expected_hash is not None and project.ref != expected_hash:
-                raise ValueError(
-                    f"reference blueprint `{project.project_id}` for toolchain `{target.toolchain}` resolves "
-                    f"to `{project.ref}` on branch `{target.branch}`, but the deploy catalog declares `{expected_hash}`"
-                )
+        for project in controller_projects:
             include.append(
                 {
-                    "release_id": release_target.release_id,
-                    "rc": release_target.rc,
-                    "toolchain": release_target.toolchain,
-                    "verso_ref": release_target.verso_ref,
-                    "branch": release_target.branch,
+                    "release_id": target.release_id,
+                    "rc": target.rc,
+                    "toolchain": target.toolchain,
+                    "verso_ref": target.verso_ref,
+                    "branch": target.branch,
                     "project_id": project.project_id,
+                    "project_root": project.project_root,
                     "hash": project.ref,
+                    "reference_cache_key": reference_dependency_cache_key(project) if project.git_checkout else "",
                     "artifact_name": deploy_project_artifact_name(project),
                     "artifact_path": deploy_project_artifact_path(project),
+                    "project_manifest": deploy_project_manifest(target, project),
                 }
             )
     return {"include": include}
@@ -146,22 +136,14 @@ def deploy_matrix_from_release_catalogs(
 
 def payload(args: argparse.Namespace) -> dict[str, object]:
     layout = detect_harness_layout(Path(__file__))
-    manifest_path = resolve_manifest_path(layout, args.manifest)
+    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
     catalog = load_project_catalog(manifest_path)
     deployable_targets = tuple(
         target
         for target in catalog.release_targets
         if target.deploy_pages
     )
-    matrix = deploy_matrix_from_release_catalogs(
-        catalog,
-        deployable_targets,
-        lambda target: load_branch_project_catalog(
-            branch=target.branch,
-            manifest_path=manifest_path,
-            package_root=layout.package_root,
-        ),
-    )
+    matrix = deploy_matrix_from_controller_catalog(catalog, deployable_targets)
     deployable_release_count = len({entry["release_id"] for entry in matrix["include"]})
     return {
         "manifest_path": str(manifest_path),

--- a/scripts/emit_reference_release_matrix.py
+++ b/scripts/emit_reference_release_matrix.py
@@ -11,9 +11,9 @@ if __package__ in {None, ""}:
 
 from scripts.blueprint_harness_paths import detect_harness_layout
 from scripts.blueprint_harness_projects import (
-    default_project_manifest,
     load_project_catalog,
     reference_build_matrix,
+    resolve_manifest_path,
     resolve_projects_for_release,
     resolve_release_target,
 )
@@ -41,18 +41,9 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def resolve_manifest_path(layout, path_text: str | None) -> Path:
-    if path_text is None:
-        return default_project_manifest(layout.package_root)
-    path = Path(path_text)
-    if path.is_absolute():
-        return path.resolve()
-    return (Path.cwd() / path).resolve()
-
-
 def payload(args: argparse.Namespace) -> dict[str, object]:
     layout = detect_harness_layout(Path(__file__))
-    manifest_path = resolve_manifest_path(layout, args.manifest)
+    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
     catalog = load_project_catalog(manifest_path)
     release_target = resolve_release_target(catalog, args.release, layout.package_root)
     projects = resolve_projects_for_release(catalog, release_target.release_id, None)

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -24,33 +24,6 @@
       "deploy_pages": true
     }
   ],
-  "reference_blueprints": [
-    {
-      "blueprint": "algebraic-combinatorics",
-      "hash": "6d4c38c71801f2dbd44cb11e84ee1a19ae964726",
-      "toolchain": "v4.28.0"
-    },
-    {
-      "blueprint": "spherepackingblueprint",
-      "hash": "5efe6e8414889b42329b659eb29de6e1f0641c8d",
-      "toolchain": "v4.29.0"
-    },
-    {
-      "blueprint": "noperthedron",
-      "hash": "5ebd8b0c6a53f2f34c8f1335c21f919509074bb6",
-      "toolchain": "v4.30.0-rc2"
-    },
-    {
-      "blueprint": "verso-flt",
-      "hash": "abacaae392d78a655cf8ddfffa442313709784a2",
-      "toolchain": "v4.30.0-rc2"
-    },
-    {
-      "blueprint": "verso-carleson",
-      "hash": "4fc4d7be735816d14c8cf0a10ba630ad73ef857b",
-      "toolchain": "v4.30.0-rc2"
-    }
-  ],
   "projects": [
     {
       "id": "project-template",
@@ -89,7 +62,8 @@
         },
         {
           "release": "v4.30.0",
-          "ref": "5ebd8b0c6a53f2f34c8f1335c21f919509074bb6"
+          "ref": "5ebd8b0c6a53f2f34c8f1335c21f919509074bb6",
+          "publish_reference": true
         }
       ],
       "build_command": ["lake", "build", "Contents"],
@@ -107,7 +81,8 @@
       "targets": [
         {
           "release": "v4.29.0",
-          "ref": "5efe6e8414889b42329b659eb29de6e1f0641c8d"
+          "ref": "5efe6e8414889b42329b659eb29de6e1f0641c8d",
+          "publish_reference": true
         }
       ],
       "build_command": ["lake", "build", "SpherePackingBlueprint"],
@@ -129,7 +104,8 @@
         },
         {
           "release": "v4.30.0",
-          "ref": "abacaae392d78a655cf8ddfffa442313709784a2"
+          "ref": "abacaae392d78a655cf8ddfffa442313709784a2",
+          "publish_reference": true
         }
       ],
       "build_command": ["lake", "build", "FLTBlueprint"],
@@ -147,7 +123,8 @@
       "targets": [
         {
           "release": "v4.30.0",
-          "ref": "4fc4d7be735816d14c8cf0a10ba630ad73ef857b"
+          "ref": "4fc4d7be735816d14c8cf0a10ba630ad73ef857b",
+          "publish_reference": true
         }
       ],
       "build_command": ["lake", "build", "CarlesonBlueprint"],
@@ -165,7 +142,8 @@
       "targets": [
         {
           "release": "v4.28.0",
-          "ref": "6d4c38c71801f2dbd44cb11e84ee1a19ae964726"
+          "ref": "6d4c38c71801f2dbd44cb11e84ee1a19ae964726",
+          "publish_reference": true
         }
       ],
       "build_command": ["lake", "build", "AlgebraicCombinatoricsBlueprint"],

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -191,16 +191,20 @@ class BlueprintHarnessCliTests(unittest.TestCase):
 
     def test_reference_edit_parses_project_branch_and_base(self) -> None:
         parser = reference_harness_mod.build_parser()
-        args = parser.parse_args(["edit", "noperthedron", "--branch", "wip/noperthedron", "--base", "origin/main"])
+        args = parser.parse_args(
+            ["edit", "noperthedron", "--release", "v4.29.0", "--branch", "wip/noperthedron", "--base", "origin/main"]
+        )
         self.assertEqual(args.project, "noperthedron")
+        self.assertEqual(args.release, "v4.29.0")
         self.assertEqual(args.branch, "wip/noperthedron")
         self.assertEqual(args.base, "origin/main")
 
     def test_reference_bump_blueprint_parses_ref_and_push(self) -> None:
         parser = reference_harness_mod.build_parser()
         args = parser.parse_args(
-            ["bump-verso-blueprint", "--project", "noperthedron", "--ref", "v1.2.3", "--push"]
+            ["bump-verso-blueprint", "--release", "v4.29.0", "--project", "noperthedron", "--ref", "v1.2.3", "--push"]
         )
+        self.assertEqual(args.release, "v4.29.0")
         self.assertEqual(args.project, ["noperthedron"])
         self.assertEqual(args.ref, "v1.2.3")
         self.assertTrue(args.push)
@@ -313,6 +317,86 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         finally:
             for name, value in originals.items():
                 setattr(harness_mod, name, value)
+
+    def test_create_worktree_syncs_resolved_release_projects(self) -> None:
+        args = argparse.Namespace(
+            name="demo",
+            branch=None,
+            base=None,
+            skip_sync=True,
+            skip_reference_sync=False,
+            lightweight=False,
+            owner=None,
+            priority=None,
+            summary=None,
+            status=None,
+            scope=None,
+            lock=False,
+        )
+        root_layout = SimpleNamespace(repo_root=Path("/tmp/repo"), package_root=Path("/tmp/repo"))
+        new_layout = SimpleNamespace(
+            repo_root=Path("/tmp/repo"),
+            package_root=Path("/tmp/repo/.worktrees/demo"),
+            artifact_root=Path("/tmp/repo/_out/demo"),
+            in_linked_worktree=True,
+        )
+        project = HarnessProject(
+            project_id="published",
+            source_kind="git_checkout",
+            project_root=".",
+            build_target=None,
+            generator=None,
+            repository="https://github.com/example/published.git",
+            ref="published-ref",
+            build_command=("lake", "build"),
+            generate_command=("lake", "exe", "blueprint-gen"),
+            site_subdir="html-multi",
+            panel_regression_script=None,
+            browser_tests_path=None,
+            description=None,
+            selected_release="v4.30.0",
+        )
+        catalog = SimpleNamespace(projects=())
+        originals = {
+            "detect_harness_layout": harness_mod.detect_harness_layout,
+            "resolve_create_worktree_base": harness_mod.resolve_create_worktree_base,
+            "branch_exists": harness_mod.branch_exists,
+            "run": harness_mod.run,
+            "resolve_manifest_path": harness_mod.resolve_manifest_path,
+            "load_project_catalog_manifest": harness_mod.load_project_catalog_manifest,
+            "resolve_release_projects": harness_mod.resolve_release_projects,
+            "sync_reference_blueprints": harness_mod.sync_reference_blueprints,
+        }
+        seen: dict[str, object] = {}
+        try:
+            harness_mod.detect_harness_layout = lambda start=None: new_layout if start == Path("/tmp/repo/.worktrees/demo") else root_layout
+            harness_mod.resolve_create_worktree_base = lambda _layout, _base: "origin/v4.30.0"
+            harness_mod.branch_exists = lambda _repo_root, _branch: False
+            harness_mod.run = lambda command, *, cwd: seen.setdefault("commands", []).append(command)
+            harness_mod.resolve_manifest_path = lambda _path_text, _package_root: Path("/tmp/projects.json")
+            harness_mod.load_project_catalog_manifest = lambda _manifest_path: catalog
+
+            def fake_resolve(_catalog, release, package_root, selected_ids):
+                seen["resolve_args"] = (_catalog, release, package_root, selected_ids)
+                return SimpleNamespace(release_id="v4.30.0"), [project]
+
+            def fake_sync(_layout, projects, *, warm_build, prepare_local_checkout):
+                seen["sync_args"] = (_layout, projects, warm_build, prepare_local_checkout)
+
+            harness_mod.resolve_release_projects = fake_resolve
+            harness_mod.sync_reference_blueprints = fake_sync
+
+            self.assertEqual(harness_mod.command_create_worktree(args), 0)
+        finally:
+            for name, value in originals.items():
+                setattr(harness_mod, name, value)
+
+        self.assertEqual(
+            seen["commands"],
+            [["git", "worktree", "add", "-b", "feat/demo", "/tmp/repo/.worktrees/demo", "origin/v4.30.0"]],
+        )
+        self.assertEqual(seen["resolve_args"], (catalog, None, new_layout.package_root, None))
+        self.assertEqual(seen["sync_args"], (new_layout, [project], True, True))
 
     def test_main_status_require_sync_returns_nonzero_when_unsynced(self) -> None:
         args = argparse.Namespace(require_sync=True)
@@ -1000,7 +1084,8 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             artifact_root=Path("/tmp/package/_out"),
             reference_output_root=Path("/tmp/package/_out/reference-blueprints"),
             test_blueprint_output_root=Path("/tmp/package/_out/test-blueprints"),
-            reference_project_cache_root=Path("/tmp/repo/.worktrees/_reference-blueprints/cache"),
+            reference_source_cache_root=Path("/tmp/repo/.worktrees/_reference-blueprints/cache"),
+            reference_dependency_cache_root=Path("/tmp/repo/.worktrees/_reference-blueprints/deps"),
             reference_project_checkout_root=Path("/tmp/repo/.worktrees/_reference-blueprints/by-worktree/v4.29.0"),
             reference_project_edit_root=Path("/tmp/repo/.worktrees/_reference-blueprints/edit/v4.29.0"),
         )
@@ -1134,12 +1219,35 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             browser_tests_path=None,
             description=None,
         )
-        args = argparse.Namespace(manifest=None, project="noperthedron", branch="wip/noperthedron", base="origin/main")
+        selected_project = HarnessProject(
+            project_id="noperthedron",
+            source_kind="git_checkout",
+            project_root=".",
+            build_target=None,
+            generator=None,
+            repository="https://github.com/example/noperthedron.git",
+            ref="target-ref",
+            build_command=("lake", "build"),
+            generate_command=("lake", "exe", "blueprint-gen"),
+            site_subdir="html-multi",
+            panel_regression_script=None,
+            browser_tests_path=None,
+            description=None,
+            selected_release="v4.29.0",
+        )
+        args = argparse.Namespace(
+            manifest=None,
+            project="noperthedron",
+            release="v4.29.0",
+            branch="wip/noperthedron",
+            base=None,
+        )
         layout = SimpleNamespace(package_root=Path("/tmp/package"), reference_project_edit_root=Path("/tmp/edit"))
         originals = {
             "detect_harness_layout": reference_harness_mod.detect_harness_layout,
             "resolve_manifest_path": reference_harness_mod.resolve_manifest_path,
             "load_project_catalog": reference_harness_mod.load_project_catalog,
+            "select_release_projects": reference_harness_mod.select_release_projects,
             "prepare_reference_edit_checkout": reference_harness_mod.prepare_reference_edit_checkout,
         }
         seen: dict[str, object] = {}
@@ -1147,13 +1255,16 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             reference_harness_mod.detect_harness_layout = lambda _start=None: layout
             reference_harness_mod.resolve_manifest_path = lambda _path_text, _package_root: Path("/tmp/projects.json")
             reference_harness_mod.load_project_catalog = lambda _manifest_path: SimpleNamespace(projects=(project,))
+            reference_harness_mod.select_release_projects = (
+                lambda _catalog, *, release, project_ids, package_root: ("v4.29.0", [selected_project])
+            )
 
             def fake_prepare(_layout, _project, *, branch, base_ref):
                 seen["layout"] = _layout
                 seen["project"] = _project
                 seen["branch"] = branch
                 seen["base_ref"] = base_ref
-                return Path("/tmp/edit/noperthedron"), branch or "wip/noperthedron", base_ref or "origin/main"
+                return Path("/tmp/edit/noperthedron"), branch or "wip/noperthedron", base_ref or "origin/target-ref"
 
             reference_harness_mod.prepare_reference_edit_checkout = fake_prepare
 
@@ -1163,9 +1274,9 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 setattr(reference_harness_mod, name, value)
 
         self.assertEqual(seen["layout"], layout)
-        self.assertEqual(seen["project"], project)
+        self.assertEqual(seen["project"], selected_project)
         self.assertEqual(seen["branch"], "wip/noperthedron")
-        self.assertEqual(seen["base_ref"], "origin/main")
+        self.assertIsNone(seen["base_ref"])
 
     def test_reference_bump_blueprint_uses_bump_helper(self) -> None:
         project = HarnessProject(
@@ -1186,9 +1297,10 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         args = argparse.Namespace(
             manifest=None,
             project=["noperthedron"],
+            release="v4.29.0",
             ref="v1.2.3",
             branch="chore/bump-verso-blueprint-v1-2-3",
-            base="origin/main",
+            base=None,
             skip_build=False,
             generate=True,
             commit=False,
@@ -1200,6 +1312,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             "detect_harness_layout": reference_harness_mod.detect_harness_layout,
             "resolve_manifest_path": reference_harness_mod.resolve_manifest_path,
             "load_project_catalog": reference_harness_mod.load_project_catalog,
+            "select_release_projects": reference_harness_mod.select_release_projects,
             "bump_reference_project": reference_harness_mod.bump_reference_project,
         }
         seen: dict[str, object] = {}
@@ -1207,6 +1320,12 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             reference_harness_mod.detect_harness_layout = lambda _start=None: layout
             reference_harness_mod.resolve_manifest_path = lambda _path_text, _package_root: Path("/tmp/projects.json")
             reference_harness_mod.load_project_catalog = lambda _manifest_path: SimpleNamespace(projects=(project,))
+
+            def fake_select(_catalog, *, release, project_ids, package_root, default_to_published_catalog=True):
+                seen["default_to_published_catalog"] = default_to_published_catalog
+                return "v4.29.0", [project]
+
+            reference_harness_mod.select_release_projects = fake_select
             seen["selected_values"] = ["noperthedron"]
 
             def fake_bump(
@@ -1237,7 +1356,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 return SimpleNamespace(
                     edit_dir=Path("/tmp/edit/noperthedron"),
                     branch=branch,
-                    base_ref=base_ref,
+                    base_ref=base_ref or "origin/main",
                     previous_ref="old-ref",
                     changed=True,
                     committed=False,
@@ -1255,14 +1374,114 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertEqual(seen["layout"], layout)
         self.assertEqual(seen["project"], project)
         self.assertEqual(seen["selected_values"], ["noperthedron"])
+        self.assertFalse(seen["default_to_published_catalog"])
         self.assertEqual(seen["ref"], "v1.2.3")
         self.assertEqual(seen["branch"], "chore/bump-verso-blueprint-v1-2-3")
-        self.assertEqual(seen["base_ref"], "origin/main")
+        self.assertIsNone(seen["base_ref"])
         self.assertTrue(seen["build_project"])
         self.assertTrue(seen["generate_site"])
         self.assertEqual(seen["output_root"], Path("/tmp/out/reference-blueprints-edit"))
         self.assertFalse(seen["commit"])
         self.assertFalse(seen["push"])
+
+    def test_reference_bump_blueprint_defaults_to_release_git_checkout_targets(self) -> None:
+        def external_project(project_id: str, release: str, ref: str, *, publish: bool = False) -> HarnessProject:
+            return HarnessProject(
+                project_id=project_id,
+                source_kind="git_checkout",
+                project_root=".",
+                build_target=None,
+                generator=None,
+                repository=f"https://github.com/example/{project_id}.git",
+                ref=None,
+                build_command=("lake", "build"),
+                generate_command=("lake", "exe", "blueprint-gen"),
+                site_subdir="html-multi",
+                panel_regression_script=None,
+                browser_tests_path=None,
+                description=None,
+                targets=(HarnessProjectTarget(release=release, ref=ref, publish_reference=publish),),
+            )
+
+        in_repo_project = HarnessProject(
+            project_id="project-template",
+            source_kind=IN_REPO_PROJECT_SOURCE_KIND,
+            project_root="project_template",
+            build_target=None,
+            generator=None,
+            repository=None,
+            ref=None,
+            build_command=None,
+            generate_command=("lake", "exe", "blueprint-gen"),
+            site_subdir="html-multi",
+            panel_regression_script=None,
+            browser_tests_path=None,
+            description=None,
+            targets=(HarnessProjectTarget(release="v4.29.0", ref=None),),
+        )
+        catalog = HarnessProjectCatalog(
+            version=2,
+            release_targets=(
+                HarnessReleaseTarget("v4.28.0", "v4.28.0", "v4.28.0", "v4.28.0", False),
+                HarnessReleaseTarget("v4.29.0", "v4.29.0", "v4.29.0", "v4.29.0", True),
+            ),
+            projects=(
+                external_project("published", "v4.29.0", "published-ref", publish=True),
+                external_project("validation-only", "v4.29.0", "validation-ref"),
+                in_repo_project,
+                external_project("old-release", "v4.28.0", "old-ref"),
+            ),
+        )
+        args = argparse.Namespace(
+            manifest=None,
+            project=None,
+            release="v4.29.0",
+            ref="v1.2.3",
+            branch=None,
+            base=None,
+            skip_build=True,
+            generate=False,
+            commit=False,
+            push=False,
+            commit_message=None,
+        )
+        layout = SimpleNamespace(package_root=Path("/tmp/package"), artifact_root=Path("/tmp/out"))
+        originals = {
+            "detect_harness_layout": reference_harness_mod.detect_harness_layout,
+            "resolve_manifest_path": reference_harness_mod.resolve_manifest_path,
+            "load_project_catalog": reference_harness_mod.load_project_catalog,
+            "bump_reference_project": reference_harness_mod.bump_reference_project,
+        }
+        seen_projects: list[HarnessProject] = []
+        try:
+            reference_harness_mod.detect_harness_layout = lambda _start=None: layout
+            reference_harness_mod.resolve_manifest_path = lambda _path_text, _package_root: Path("/tmp/projects.json")
+            reference_harness_mod.load_project_catalog = lambda _manifest_path: catalog
+
+            def fake_bump(_layout, project, **_kwargs):
+                seen_projects.append(project)
+                return SimpleNamespace(
+                    edit_dir=Path(f"/tmp/edit/{project.project_id}"),
+                    branch="chore/bump-verso-blueprint-v1-2-3",
+                    base_ref="origin/main",
+                    previous_ref="old-ref",
+                    changed=True,
+                    committed=False,
+                    pushed=False,
+                    output_dir=None,
+                )
+
+            reference_harness_mod.bump_reference_project = fake_bump
+
+            self.assertEqual(reference_harness_mod.command_reference_bump_blueprint(args), 0)
+        finally:
+            for name, value in originals.items():
+                setattr(reference_harness_mod, name, value)
+
+        self.assertEqual(
+            [(project.project_id, project.ref) for project in seen_projects],
+            [("published", "published-ref"), ("validation-only", "validation-ref")],
+        )
 
     def test_worktree_retire_supports_detached_merged_worktree(self) -> None:
         args = argparse.Namespace(name="reference-edit", dry_run=False)
@@ -1270,7 +1489,8 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             repo_root=Path("/tmp/repo"),
             package_root=Path("/tmp/package"),
             worktree_name=None,
-            reference_project_cache_root=Path("/tmp/cache"),
+            reference_source_cache_root=Path("/tmp/cache"),
+            reference_dependency_cache_root=Path("/tmp/deps"),
             reference_project_root=Path("/tmp/reference-root"),
         )
         detached = GitWorktree(
@@ -1290,7 +1510,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             "local_release_ref": harness_mod.local_release_ref,
             "run": harness_mod.run,
             "resolve_manifest_path": harness_mod.resolve_manifest_path,
-            "load_project_catalog": harness_mod.load_project_catalog,
+            "load_project_catalog_manifest": harness_mod.load_project_catalog_manifest,
             "git_worktrees": harness_mod.git_worktrees,
             "reference_prune_plan": harness_mod.reference_prune_plan,
         }
@@ -1313,7 +1533,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             harness_mod.local_release_ref = lambda _repo_root: "v4.29.0"
             harness_mod.run = lambda command, *, cwd: commands.append(command)
             harness_mod.resolve_manifest_path = lambda _path_text, _package_root: Path("/tmp/projects.json")
-            harness_mod.load_project_catalog = lambda _manifest_path: []
+            harness_mod.load_project_catalog_manifest = lambda _manifest_path: SimpleNamespace(projects=())
             harness_mod.git_worktrees = lambda _repo_root: []
             harness_mod.reference_prune_plan = lambda *_args, **_kwargs: []
 
@@ -1330,7 +1550,8 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             repo_root=Path("/tmp/repo"),
             package_root=Path("/tmp/package"),
             worktree_name=None,
-            reference_project_cache_root=Path("/tmp/cache"),
+            reference_source_cache_root=Path("/tmp/cache"),
+            reference_dependency_cache_root=Path("/tmp/deps"),
             reference_project_root=Path("/tmp/reference-root"),
         )
         backport = GitWorktree(
@@ -1350,7 +1571,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             "local_release_ref": harness_mod.local_release_ref,
             "run": harness_mod.run,
             "resolve_manifest_path": harness_mod.resolve_manifest_path,
-            "load_project_catalog": harness_mod.load_project_catalog,
+            "load_project_catalog_manifest": harness_mod.load_project_catalog_manifest,
             "git_worktrees": harness_mod.git_worktrees,
             "reference_prune_plan": harness_mod.reference_prune_plan,
         }
@@ -1373,7 +1594,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             harness_mod.local_release_ref = lambda _repo_root: "v4.29.0"
             harness_mod.run = lambda command, *, cwd: commands.append(command)
             harness_mod.resolve_manifest_path = lambda _path_text, _package_root: Path("/tmp/projects.json")
-            harness_mod.load_project_catalog = lambda _manifest_path: []
+            harness_mod.load_project_catalog_manifest = lambda _manifest_path: SimpleNamespace(projects=())
             harness_mod.git_worktrees = lambda _repo_root: []
             harness_mod.reference_prune_plan = lambda *_args, **_kwargs: []
 
@@ -1567,7 +1788,8 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             package_root=Path("/tmp/package"),
             repo_root=Path("/tmp/package"),
             in_linked_worktree=False,
-            reference_project_cache_root=Path("/tmp/cache"),
+            reference_source_cache_root=Path("/tmp/cache"),
+            reference_dependency_cache_root=Path("/tmp/deps"),
             reference_project_checkout_root=Path("/tmp/checkouts"),
         )
         originals = {
@@ -1720,7 +1942,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             panel_regression_script=None,
             browser_tests_path=None,
             description=None,
-            targets=(HarnessProjectTarget(release="v4.29.0", ref="deadbeef"),),
+            targets=(HarnessProjectTarget(release="v4.29.0", ref="deadbeef", publish_reference=True),),
         )
         sphere = HarnessProject(
             project_id="spherepackingblueprint",
@@ -1803,6 +2025,75 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertIn("downstream_pin_drift=0", output)
         self.assertIn("project=noperthedron", output)
         self.assertNotIn("project=spherepackingblueprint", output)
+
+    def test_reference_release_status_project_filter_includes_validation_only_targets(self) -> None:
+        validation_project = HarnessProject(
+            project_id="validation-only",
+            source_kind="git_checkout",
+            project_root=".",
+            build_target=None,
+            generator=None,
+            repository="https://github.com/example/validation-only.git",
+            ref=None,
+            build_command=("lake", "build"),
+            generate_command=("lake", "exe", "blueprint-gen"),
+            site_subdir="html-multi",
+            panel_regression_script=None,
+            browser_tests_path=None,
+            description=None,
+            targets=(HarnessProjectTarget(release="v4.29.0", ref="validation-ref"),),
+        )
+        catalog = HarnessProjectCatalog(
+            version=2,
+            release_targets=(
+                HarnessReleaseTarget("v4.28.0", "v4.28.0", "v4.28.0", "v4.28.0", False),
+                HarnessReleaseTarget("v4.29.0", "v4.29.0", "v4.29.0", "v4.29.0", True),
+            ),
+            projects=(validation_project,),
+        )
+        args = argparse.Namespace(manifest=None, project=["validation-only"], release=None, outdated_only=False)
+        layout = SimpleNamespace(package_root=Path("/tmp/package"), repo_root=Path("/tmp/repo"))
+        originals = {
+            "detect_harness_layout": reference_harness_mod.detect_harness_layout,
+            "resolve_manifest_path": reference_harness_mod.resolve_manifest_path,
+            "load_project_catalog": reference_harness_mod.load_project_catalog,
+            "collect_reference_project_status": reference_harness_mod.collect_reference_project_status,
+        }
+        out = io.StringIO()
+        seen_projects: list[HarnessProject] = []
+        try:
+            reference_harness_mod.detect_harness_layout = lambda _start=None: layout
+            reference_harness_mod.resolve_manifest_path = lambda _path_text, _package_root: Path("/tmp/projects.json")
+            reference_harness_mod.load_project_catalog = lambda _manifest_path: catalog
+
+            def fake_collect(_layout, project, *, blueprint_base_ref=None):
+                seen_projects.append(project)
+                return reference_harness_mod.ReferenceProjectStatus(
+                    project=project,
+                    catalog_ref=project.ref,
+                    project_upstream_ref="origin/main",
+                    project_relationship="in_sync",
+                    project_ahead=0,
+                    project_behind=0,
+                    blueprint_pin=None,
+                    blueprint_relationship=None,
+                    blueprint_ahead=None,
+                    blueprint_behind=None,
+                )
+
+            reference_harness_mod.collect_reference_project_status = fake_collect
+
+            with redirect_stdout(out):
+                self.assertEqual(reference_harness_mod.command_release_status(args), 0)
+        finally:
+            for name, value in originals.items():
+                setattr(reference_harness_mod, name, value)
+
+        output = out.getvalue()
+        self.assertIn("release=v4.29.0", output)
+        self.assertIn("project=validation-only", output)
+        self.assertNotIn("release=v4.28.0", output)
+        self.assertEqual([(project.project_id, project.ref) for project in seen_projects], [("validation-only", "validation-ref")])
 
 
 if __name__ == "__main__":

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 import subprocess
 import tempfile
@@ -9,18 +8,17 @@ from types import SimpleNamespace
 import unittest
 
 from scripts.blueprint_harness_projects import (
-    deploy_project_matrix,
     HarnessProject,
     IN_REPO_PROJECT_SOURCE_KIND,
     default_project_manifest,
     load_project_catalog,
-    load_project_catalog_text,
-    load_projects_manifest,
+    load_project_catalog_data,
     reference_build_matrix,
+    reference_dependency_cache_key,
     resolve_projects_for_release,
     resolve_release_target,
 )
-from scripts.emit_reference_deploy_matrix import deploy_matrix_from_release_catalogs
+from scripts.emit_reference_deploy_matrix import deploy_matrix_from_controller_catalog
 from scripts.blueprint_harness_references import (
     OFFICIAL_BLUEPRINT_REQUIRE,
     bootstrap_reference_checkout,
@@ -36,13 +34,21 @@ from scripts.blueprint_harness_references import (
     rewrite_local_blueprint_dependency,
     rewrite_pinned_blueprint_dependency,
     seed_reference_edit_checkout_lake,
+    seed_lake_packages_from_dependency_cache,
+    store_lake_packages_in_dependency_cache,
     tracked_project_manifest_path,
     update_git_checkout,
-    use_shared_reference_checkout,
 )
 
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_project_catalog_text(text: str, manifest_path: Path | str):
+    raw = json.loads(text)
+    if not isinstance(raw, dict):
+        raise ValueError(f"{manifest_path}: expected JSON object")
+    return load_project_catalog_data(raw, manifest_path)
 
 
 class BlueprintHarnessProjectsTests(unittest.TestCase):
@@ -72,12 +78,15 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
 
         expected_projects: list[str] = []
         expected_refs: dict[str, str | None] = {}
-        if catalog.reference_blueprints:
-            for blueprint in catalog.reference_blueprints:
-                if blueprint.toolchain != release.toolchain:
-                    continue
-                expected_projects.append(blueprint.blueprint)
-                expected_refs[blueprint.blueprint] = blueprint.hash
+        published_targets = [
+            (project, target)
+            for project in catalog.projects
+            if (target := project.target_for_release(release.release_id)) is not None and target.publish_reference
+        ]
+        if published_targets:
+            for project, target in published_targets:
+                expected_projects.append(project.project_id)
+                expected_refs[project.project_id] = target.ref
         else:
             for project in catalog.projects:
                 target = next((target for target in project.targets if target.release == release.release_id), None)
@@ -120,19 +129,11 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(release_430.toolchain, "v4.30.0-rc2")
         self.assertEqual(release_430.verso_ref, "v4.30.0-rc2")
         self.assertTrue(release_430.deploy_pages)
-        self.assertEqual(
-            [(entry.blueprint, entry.hash, entry.toolchain) for entry in catalog.reference_blueprints],
-            [
-                ("algebraic-combinatorics", "6d4c38c71801f2dbd44cb11e84ee1a19ae964726", "v4.28.0"),
-                ("spherepackingblueprint", "5efe6e8414889b42329b659eb29de6e1f0641c8d", "v4.29.0"),
-                ("noperthedron", "5ebd8b0c6a53f2f34c8f1335c21f919509074bb6", "v4.30.0-rc2"),
-                ("verso-flt", "abacaae392d78a655cf8ddfffa442313709784a2", "v4.30.0-rc2"),
-                ("verso-carleson", "4fc4d7be735816d14c8cf0a10ba630ad73ef857b", "v4.30.0-rc2"),
-            ],
-        )
         self.assertTrue(projects[1].git_checkout)
         self.assertEqual(projects[1].repository, "https://github.com/ejgallego/verso-noperthedron.git")
         self.assertEqual([target.release for target in projects[1].targets], ["v4.29.0", "v4.30.0"])
+        self.assertFalse(projects[1].targets[0].publish_reference)
+        self.assertTrue(projects[1].targets[1].publish_reference)
         self.assertEqual(projects[1].build_command, ("lake", "build", "Contents"))
         self.assertEqual(
             projects[1].generate_command,
@@ -142,8 +143,11 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(projects[1].panel_regression_script, None)
         self.assertEqual(projects[3].repository, "https://github.com/ejgallego/verso-flt.git")
         self.assertEqual([target.release for target in projects[3].targets], ["v4.29.0", "v4.30.0"])
+        self.assertFalse(projects[3].targets[0].publish_reference)
+        self.assertTrue(projects[3].targets[1].publish_reference)
         self.assertEqual(projects[4].repository, "https://github.com/ejgallego/verso-carleson.git")
         self.assertEqual([target.release for target in projects[4].targets], ["v4.30.0"])
+        self.assertTrue(projects[4].targets[0].publish_reference)
         self.assertEqual(projects[4].build_command, ("lake", "build", "CarlesonBlueprint"))
         self.assertEqual(
             projects[4].generate_command,
@@ -151,6 +155,115 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         )
         self.assertEqual(projects[5].repository, "https://github.com/ejgallego/verso-algebraic-combinatorics.git")
         self.assertEqual([target.release for target in projects[5].targets], ["v4.28.0"])
+        self.assertTrue(projects[5].targets[0].publish_reference)
+
+    def test_reference_dependency_cache_key_tracks_external_source_identity(self) -> None:
+        base_project = HarnessProject(
+            project_id="external-blueprint",
+            source_kind="git_checkout",
+            project_root="nested/blueprint",
+            build_target=None,
+            generator=None,
+            repository="https://github.com/example/external-blueprint.git",
+            ref="0123456789abcdef0123456789abcdef01234567",
+            build_command=("lake", "build"),
+            generate_command=("lake", "exe", "blueprint-gen"),
+            site_subdir="html-multi",
+            panel_regression_script=None,
+            browser_tests_path=None,
+            description=None,
+            selected_release="v4.29.0",
+        )
+        same_source_other_release = HarnessProject(
+            project_id="external-blueprint",
+            source_kind="git_checkout",
+            project_root="nested/blueprint",
+            build_target=None,
+            generator=None,
+            repository="https://github.com/example/external-blueprint.git",
+            ref="0123456789abcdef0123456789abcdef01234567",
+            build_command=("lake", "build"),
+            generate_command=("lake", "exe", "blueprint-gen"),
+            site_subdir="html-multi",
+            panel_regression_script=None,
+            browser_tests_path=None,
+            description=None,
+            selected_release="v4.30.0",
+        )
+        changed_ref = HarnessProject(
+            project_id="external-blueprint",
+            source_kind="git_checkout",
+            project_root="nested/blueprint",
+            build_target=None,
+            generator=None,
+            repository="https://github.com/example/external-blueprint.git",
+            ref="fedcba9876543210fedcba9876543210fedcba98",
+            build_command=("lake", "build"),
+            generate_command=("lake", "exe", "blueprint-gen"),
+            site_subdir="html-multi",
+            panel_regression_script=None,
+            browser_tests_path=None,
+            description=None,
+            selected_release="v4.29.0",
+        )
+
+        key = reference_dependency_cache_key(base_project)
+
+        self.assertTrue(key.startswith("external-blueprint-0123456789ab-"))
+        self.assertEqual(key, reference_dependency_cache_key(same_source_other_release))
+        self.assertNotEqual(key, reference_dependency_cache_key(changed_ref))
+
+    def test_reference_dependency_package_cache_is_separate_from_checkout_cache(self) -> None:
+        import scripts.blueprint_harness_references as refs_mod
+
+        project = HarnessProject(
+            project_id="external-blueprint",
+            source_kind="git_checkout",
+            project_root="nested/blueprint",
+            build_target=None,
+            generator=None,
+            repository="https://github.com/example/external-blueprint.git",
+            ref="main",
+            build_command=("lake", "build"),
+            generate_command=("lake", "exe", "blueprint-gen"),
+            site_subdir="html-multi",
+            panel_regression_script=None,
+            browser_tests_path=None,
+            description=None,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cache_key = reference_dependency_cache_key(project)
+            dependency_packages = root / "deps" / cache_key / "packages"
+            project_dir = root / "checkout" / "nested" / "blueprint"
+            dependency_packages.mkdir(parents=True)
+            (project_dir / ".lake" / "packages" / "mathlib").mkdir(parents=True)
+            layout = SimpleNamespace(
+                package_root=root / "pkg",
+                reference_dependency_cache_root=root / "deps",
+            )
+            layout.package_root.mkdir()
+
+            original_run = refs_mod.run
+            commands: list[list[str]] = []
+            try:
+                refs_mod.run = lambda command, *, cwd: commands.append(command)
+
+                seeded_from = seed_lake_packages_from_dependency_cache(layout, project, project_dir)
+                stored_to = store_lake_packages_in_dependency_cache(layout, project, project_dir)
+            finally:
+                refs_mod.run = original_run
+
+        self.assertEqual(seeded_from, dependency_packages)
+        self.assertEqual(stored_to, dependency_packages)
+        self.assertEqual(
+            commands,
+            [
+                ["rsync", "-a", f"{dependency_packages}/", f"{project_dir / '.lake' / 'packages'}/"],
+                ["rsync", "-a", "--delete", f"{project_dir / '.lake' / 'packages'}/", f"{dependency_packages}/"],
+            ],
+        )
 
     def test_reference_pages_workflow_stages_every_manifest_project(self) -> None:
         catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
@@ -164,40 +277,19 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertIn("emit_reference_release_matrix.py", workflow_text)
         self.assertIn("pattern: reference-blueprints-*", workflow_text)
         self.assertIn("--project ${{ matrix.project_id }}", workflow_text)
+        self.assertIn("matrix.reference_cache_key", workflow_text)
+        self.assertIn(".worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/packages", workflow_text)
 
         for entry in matrix["include"]:
             self.assertEqual(entry["artifact_name"], f"reference-blueprints-{entry['project_id']}")
             self.assertEqual(entry["artifact_path"], f"_out/reference-blueprints/{entry['project_id']}")
+            self.assertIn("project_root", entry)
+            if entry["hash"] is not None:
+                self.assertTrue(entry["reference_cache_key"])
+            else:
+                self.assertEqual(entry["reference_cache_key"], "")
 
-    def test_deploy_project_matrix_includes_only_deployable_projects(self) -> None:
-        catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
-        matrix = deploy_project_matrix(catalog.release_targets, catalog)
-
-        expected_entries = []
-        for release in catalog.release_targets:
-            if not release.deploy_pages:
-                continue
-            for project in resolve_projects_for_release(catalog, release.release_id, None):
-                expected_entries.append(
-                    {
-                        "release_id": release.release_id,
-                        "rc": release.rc,
-                        "toolchain": release.toolchain,
-                        "verso_ref": release.verso_ref,
-                        "branch": release.branch,
-                        "project_id": project.project_id,
-                        "hash": project.ref,
-                        "artifact_name": f"reference-blueprints-release-{release.release_id}__project__{project.project_id}",
-                        "artifact_path": f"_out/reference-blueprints/{release.release_id}/{project.project_id}",
-                    }
-                )
-
-        self.assertEqual(
-            matrix,
-            {"include": expected_entries},
-        )
-
-    def test_deploy_matrix_uses_controller_reference_blueprints_with_release_branch_catalogs(self) -> None:
+    def test_deploy_matrix_uses_controller_publish_targets_for_generated_manifests(self) -> None:
         controller_catalog = load_project_catalog_text(
             json.dumps(
                 {
@@ -218,23 +310,6 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                             "deploy_pages": True,
                         },
                     ],
-                    "reference_blueprints": [
-                        {
-                            "blueprint": "old-release-project",
-                            "hash": "old-controller-ref",
-                            "toolchain": "v4.28.0",
-                        },
-                        {
-                            "blueprint": "new-release-project",
-                            "hash": "new-controller-ref",
-                            "toolchain": "v4.29.0",
-                        },
-                        {
-                            "blueprint": "new-release-second-project",
-                            "hash": "new-second-controller-ref",
-                            "toolchain": "v4.29.0",
-                        },
-                    ],
                     "projects": [
                         {
                             "id": "old-release-project",
@@ -243,7 +318,13 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                                 "repository": "https://example.com/old-release-project.git",
                                 "project_root": "old-controller",
                             },
-                            "targets": [{"release": "v4.28.0", "ref": "old-controller-ref"}],
+                            "targets": [
+                                {
+                                    "release": "v4.28.0",
+                                    "ref": "old-controller-ref",
+                                    "publish_reference": True,
+                                }
+                            ],
                             "build_command": ["lake", "build"],
                             "generate_command": ["lake", "exe", "blueprint-gen"],
                         },
@@ -265,7 +346,13 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                                 "repository": "https://example.com/new-release-project.git",
                                 "project_root": "new-controller",
                             },
-                            "targets": [{"release": "v4.29.0", "ref": "new-controller-ref"}],
+                            "targets": [
+                                {
+                                    "release": "v4.29.0",
+                                    "ref": "new-controller-ref",
+                                    "publish_reference": True,
+                                }
+                            ],
                             "build_command": ["lake", "build"],
                             "generate_command": ["lake", "exe", "blueprint-gen"],
                         },
@@ -276,7 +363,13 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                                 "repository": "https://example.com/new-release-second-project.git",
                                 "project_root": "new-controller-second",
                             },
-                            "targets": [{"release": "v4.29.0", "ref": "new-second-controller-ref"}],
+                            "targets": [
+                                {
+                                    "release": "v4.29.0",
+                                    "ref": "new-second-controller-ref",
+                                    "publish_reference": True,
+                                }
+                            ],
                             "build_command": ["lake", "build"],
                             "generate_command": ["lake", "exe", "blueprint-gen"],
                         }
@@ -285,102 +378,9 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             ),
             "controller-projects.json",
         )
-        release_catalogs = {
-            "v4.28.0": load_project_catalog_text(
-                json.dumps(
-                    {
-                        "version": 2,
-                        "release_targets": [
-                            {
-                                "id": "v4.28.0",
-                                "toolchain": "v4.28.0",
-                                "verso_ref": "v4.28.0",
-                                "branch": "v4.28.0",
-                                "deploy_pages": True,
-                            }
-                        ],
-                        "projects": [
-                            {
-                                "id": "old-release-older-project",
-                                "source": {
-                                    "kind": IN_REPO_PROJECT_SOURCE_KIND,
-                                    "project_root": "old-older",
-                                },
-                                "targets": [{"release": "v4.28.0"}],
-                                "generate_command": ["lake", "exe", "blueprint-gen"],
-                            },
-                            {
-                                "id": "old-release-project",
-                                "source": {
-                                    "kind": "git_checkout",
-                                    "repository": "https://example.com/old-release-project.git",
-                                    "project_root": "old",
-                                },
-                                "targets": [{"release": "v4.28.0", "ref": "old-controller-ref"}],
-                                "build_command": ["lake", "build"],
-                                "generate_command": ["lake", "exe", "blueprint-gen"],
-                            }
-                        ],
-                    }
-                ),
-                "v4.28.0:projects.json",
-            ),
-            "v4.29.0": load_project_catalog_text(
-                json.dumps(
-                    {
-                        "version": 2,
-                        "release_targets": [
-                            {
-                                "id": "v4.29.0",
-                                "toolchain": "v4.29.0",
-                                "verso_ref": "v4.29.0",
-                                "branch": "v4.29.0",
-                                "deploy_pages": True,
-                            }
-                        ],
-                        "projects": [
-                            {
-                                "id": "new-release-older-project",
-                                "source": {
-                                    "kind": IN_REPO_PROJECT_SOURCE_KIND,
-                                    "project_root": "new-older",
-                                },
-                                "targets": [{"release": "v4.29.0"}],
-                                "generate_command": ["lake", "exe", "blueprint-gen"],
-                            },
-                            {
-                                "id": "new-release-project",
-                                "source": {
-                                    "kind": "git_checkout",
-                                    "repository": "https://example.com/new-release-project.git",
-                                    "project_root": "new",
-                                },
-                                "targets": [{"release": "v4.29.0", "ref": "new-controller-ref"}],
-                                "build_command": ["lake", "build"],
-                                "generate_command": ["lake", "exe", "blueprint-gen"],
-                            },
-                            {
-                                "id": "new-release-second-project",
-                                "source": {
-                                    "kind": "git_checkout",
-                                    "repository": "https://example.com/new-release-second-project.git",
-                                    "project_root": "new-second",
-                                },
-                                "targets": [{"release": "v4.29.0", "ref": "new-second-controller-ref"}],
-                                "build_command": ["lake", "build"],
-                                "generate_command": ["lake", "exe", "blueprint-gen"],
-                            }
-                        ],
-                    }
-                ),
-                "v4.29.0:projects.json",
-            ),
-        }
-
-        matrix = deploy_matrix_from_release_catalogs(
+        matrix = deploy_matrix_from_controller_catalog(
             controller_catalog,
             controller_catalog.release_targets,
-            lambda target: release_catalogs[target.release_id],
         )
 
         self.assertEqual(
@@ -390,6 +390,28 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 ("v4.29.0", "new-release-project"),
                 ("v4.29.0", "new-release-second-project"),
             ],
+        )
+        manifest_by_project = {
+            entry["project_id"]: entry["project_manifest"]
+            for entry in matrix["include"]
+        }
+        matrix_by_project = {
+            entry["project_id"]: entry
+            for entry in matrix["include"]
+        }
+        self.assertEqual(
+            manifest_by_project["old-release-project"]["projects"][0]["targets"],
+            [{"release": "v4.28.0", "ref": "old-controller-ref"}],
+        )
+        self.assertEqual(
+            manifest_by_project["old-release-project"]["projects"][0]["source"]["project_root"],
+            "old-controller",
+        )
+        self.assertEqual(matrix_by_project["old-release-project"]["project_root"], "old-controller")
+        self.assertTrue(matrix_by_project["old-release-project"]["reference_cache_key"].startswith("old-release-project-"))
+        self.assertEqual(
+            manifest_by_project["new-release-project"]["projects"][0]["targets"],
+            [{"release": "v4.29.0", "ref": "new-controller-ref"}],
         )
 
     def test_git_checkout_project_is_supported(self) -> None:
@@ -428,7 +450,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             manifest = Path(tmp) / "projects.json"
             manifest.write_text(json.dumps(manifest_data), encoding="utf-8")
-            projects = load_projects_manifest(manifest)
+            projects = load_project_catalog(manifest).projects
 
         self.assertEqual(len(projects), 1)
         self.assertTrue(projects[0].git_checkout)
@@ -468,7 +490,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             manifest = Path(tmp) / "projects.json"
             manifest.write_text(json.dumps(manifest_data), encoding="utf-8")
-            projects = load_projects_manifest(manifest)
+            projects = load_project_catalog(manifest).projects
 
         self.assertEqual(len(projects), 1)
         self.assertTrue(projects[0].in_repo_project)
@@ -482,6 +504,175 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
 
     def test_resolve_projects_for_older_release_uses_matching_targets(self) -> None:
         self.assert_resolved_projects_match_manifest("v4.28.0")
+
+    def test_publish_reference_targets_select_default_release_catalog(self) -> None:
+        catalog = load_project_catalog_text(
+            json.dumps(
+                {
+                    "version": 2,
+                    "release_targets": [
+                        {
+                            "id": "v4.29.0",
+                            "toolchain": "v4.29.0",
+                            "verso_ref": "v4.29.0",
+                            "branch": "v4.29.0",
+                            "deploy_pages": True,
+                        }
+                    ],
+                    "projects": [
+                        {
+                            "id": "validation-only",
+                            "source": {
+                                "kind": "git_checkout",
+                                "repository": "https://example.com/validation-only.git",
+                                "project_root": ".",
+                            },
+                            "targets": [{"release": "v4.29.0", "ref": "validation-ref"}],
+                            "build_command": ["lake", "build"],
+                            "generate_command": ["lake", "exe", "blueprint-gen"],
+                        },
+                        {
+                            "id": "published",
+                            "source": {
+                                "kind": "git_checkout",
+                                "repository": "https://example.com/published.git",
+                                "project_root": ".",
+                            },
+                            "targets": [
+                                {
+                                    "release": "v4.29.0",
+                                    "ref": "published-ref",
+                                    "publish_reference": True,
+                                }
+                            ],
+                            "build_command": ["lake", "build"],
+                            "generate_command": ["lake", "exe", "blueprint-gen"],
+                        },
+                    ],
+                }
+            ),
+            "projects.json",
+        )
+
+        default_projects = resolve_projects_for_release(catalog, "v4.29.0", None)
+        explicit_projects = resolve_projects_for_release(catalog, "v4.29.0", ["validation-only"])
+
+        self.assertEqual(
+            [(project.project_id, project.ref) for project in default_projects],
+            [("published", "published-ref")],
+        )
+        self.assertEqual(
+            [(project.project_id, project.ref) for project in explicit_projects],
+            [("validation-only", "validation-ref")],
+        )
+
+    def test_release_catalog_defaults_to_empty_without_publish_targets(self) -> None:
+        catalog = load_project_catalog_text(
+            json.dumps(
+                {
+                    "version": 2,
+                    "release_targets": [
+                        {
+                            "id": "v4.29.0",
+                            "toolchain": "v4.29.0",
+                            "verso_ref": "v4.29.0",
+                            "branch": "v4.29.0",
+                            "deploy_pages": True,
+                        }
+                    ],
+                    "projects": [
+                        {
+                            "id": "validation-only",
+                            "source": {
+                                "kind": "git_checkout",
+                                "repository": "https://example.com/validation-only.git",
+                                "project_root": ".",
+                            },
+                            "targets": [{"release": "v4.29.0", "ref": "validation-ref"}],
+                            "build_command": ["lake", "build"],
+                            "generate_command": ["lake", "exe", "blueprint-gen"],
+                        }
+                    ],
+                }
+            ),
+            "projects.json",
+        )
+
+        default_projects = resolve_projects_for_release(catalog, "v4.29.0", None)
+        explicit_projects = resolve_projects_for_release(catalog, "v4.29.0", ["validation-only"])
+
+        self.assertEqual(default_projects, [])
+        self.assertEqual(
+            [(project.project_id, project.ref) for project in explicit_projects],
+            [("validation-only", "validation-ref")],
+        )
+
+    def test_legacy_reference_blueprints_are_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "top-level `reference_blueprints` is no longer supported"):
+            load_project_catalog_text(
+                json.dumps(
+                    {
+                        "version": 2,
+                        "release_targets": [
+                            {
+                                "id": "v4.29.0",
+                                "toolchain": "v4.29.0",
+                                "verso_ref": "v4.29.0",
+                                "branch": "v4.29.0",
+                                "deploy_pages": True,
+                            }
+                        ],
+                        "reference_blueprints": [
+                            {
+                                "blueprint": "published",
+                                "hash": "published-ref",
+                                "toolchain": "v4.29.0",
+                            }
+                        ],
+                        "projects": [],
+                    }
+                ),
+                "legacy-projects.json",
+            )
+
+    def test_legacy_publish_alias_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "`publish` is no longer supported; use `publish_reference`"):
+            load_project_catalog_text(
+                json.dumps(
+                    {
+                        "version": 2,
+                        "release_targets": [
+                            {
+                                "id": "v4.29.0",
+                                "toolchain": "v4.29.0",
+                                "verso_ref": "v4.29.0",
+                                "branch": "v4.29.0",
+                                "deploy_pages": True,
+                            }
+                        ],
+                        "projects": [
+                            {
+                                "id": "published",
+                                "source": {
+                                    "kind": "git_checkout",
+                                    "repository": "https://example.com/published.git",
+                                    "project_root": ".",
+                                },
+                                "targets": [
+                                    {
+                                        "release": "v4.29.0",
+                                        "ref": "published-ref",
+                                        "publish": True,
+                                    }
+                                ],
+                                "build_command": ["lake", "build"],
+                                "generate_command": ["lake", "exe", "blueprint-gen"],
+                            }
+                        ],
+                    }
+                ),
+                "legacy-publish-projects.json",
+            )
 
     def test_duplicate_project_ids_are_rejected(self) -> None:
         manifest_data = {
@@ -517,7 +708,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             manifest = Path(tmp) / "projects.json"
             manifest.write_text(json.dumps(manifest_data), encoding="utf-8")
             with self.assertRaisesRegex(ValueError, "duplicate project id"):
-                load_projects_manifest(manifest)
+                load_project_catalog(manifest)
 
     def test_rewrite_local_blueprint_dependency_replaces_official_git_require(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -692,7 +883,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         project = HarnessProject(
             project_id="external-blueprint",
             source_kind="git_checkout",
-            project_root=".",
+            project_root="nested/blueprint",
             build_target=None,
             generator=None,
             repository="https://github.com/example/external-blueprint.git",
@@ -706,14 +897,17 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            cache_dir = root / "cache" / "external-blueprint"
-            cache_dir.mkdir(parents=True)
-            lakefile = cache_dir / "lakefile.lean"
+            cache_dir = root / "cache" / reference_dependency_cache_key(project)
+            project_dir = cache_dir / "nested" / "blueprint"
+            project_dir.mkdir(parents=True)
+            (cache_dir / ".git").mkdir()
+            lakefile = project_dir / "lakefile.lean"
             lakefile.write_text(OFFICIAL_BLUEPRINT_REQUIRE + "\n", encoding="utf-8")
             layout = SimpleNamespace(
                 package_root=root / "worktree",
                 repo_root=root / "root",
-                reference_project_cache_root=root / "cache",
+                reference_source_cache_root=root / "cache",
+                reference_dependency_cache_root=root / "deps",
             )
             layout.package_root.mkdir()
             layout.repo_root.mkdir()
@@ -811,7 +1005,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         project = HarnessProject(
             project_id="external-blueprint",
             source_kind="git_checkout",
-            project_root=".",
+            project_root="nested/blueprint",
             build_target=None,
             generator=None,
             repository="https://github.com/example/external-blueprint.git",
@@ -924,20 +1118,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             ).stdout.strip()
             self.assertEqual(status, "")
 
-    def test_use_shared_reference_checkout_env_switch(self) -> None:
-        old = os.environ.get("BP_REFERENCE_CHECKOUT_MODE")
-        try:
-            os.environ.pop("BP_REFERENCE_CHECKOUT_MODE", None)
-            self.assertFalse(use_shared_reference_checkout())
-            os.environ["BP_REFERENCE_CHECKOUT_MODE"] = "shared"
-            self.assertTrue(use_shared_reference_checkout())
-        finally:
-            if old is None:
-                os.environ.pop("BP_REFERENCE_CHECKOUT_MODE", None)
-            else:
-                os.environ["BP_REFERENCE_CHECKOUT_MODE"] = old
-
-    def test_generate_git_project_skips_cache_warm_build_for_local_checkout_mode(self) -> None:
+    def test_generate_git_project_uses_local_checkout_without_cache_warm_build(self) -> None:
         import scripts.blueprint_harness_references as refs_mod
 
         project = HarnessProject(
@@ -992,7 +1173,6 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 "rewrite_local_blueprint_dependency": refs_mod.rewrite_local_blueprint_dependency,
                 "reference_update_command": refs_mod.reference_update_command,
                 "run": refs_mod.run,
-                "use_shared_reference_checkout": refs_mod.use_shared_reference_checkout,
             }
             commands: list[list[str]] = []
             warm_build_values: list[bool] = []
@@ -1002,7 +1182,6 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 refs_mod.rewrite_local_blueprint_dependency = lambda _project_dir, _package_root: local_dir / "lakefile.lean"
                 refs_mod.reference_update_command = lambda _package_root, _project_dir: ["lake", "update", "VersoBlueprint"]
                 refs_mod.run = lambda command, *, cwd: commands.append(command)
-                refs_mod.use_shared_reference_checkout = lambda: False
 
                 generate_git_project(layout, output_root, project, skip_build=False)
             finally:
@@ -1079,7 +1258,8 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             package_root=Path("/tmp/package"),
             artifact_root=Path("/tmp/out"),
             reference_project_checkout_root=Path("/tmp/checkouts"),
-            reference_project_cache_root=Path("/tmp/cache"),
+            reference_source_cache_root=Path("/tmp/cache"),
+            reference_dependency_cache_root=Path("/tmp/deps"),
         )
         edit_dir = Path("/tmp/edit/external-blueprint")
         originals = {
@@ -1167,7 +1347,8 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 package_root=root / "pkg",
                 artifact_root=root / "out",
                 reference_project_checkout_root=root / "checkouts",
-                reference_project_cache_root=root / "cache",
+                reference_source_cache_root=root / "cache",
+                reference_dependency_cache_root=root / "deps",
             )
             edit_dir = root / "edit" / "external-blueprint"
             output_root = root / "review"
@@ -1222,7 +1403,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         project = HarnessProject(
             project_id="external-blueprint",
             source_kind="git_checkout",
-            project_root=".",
+            project_root="nested/blueprint",
             build_target=None,
             generator=None,
             repository="https://github.com/example/external-blueprint.git",
@@ -1237,35 +1418,48 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            local_dir = root / "local" / project.project_id
-            cache_dir = root / "cache" / project.project_id
+            cache_key = reference_dependency_cache_key(project)
+            local_dir = root / "local" / cache_key
+            cache_dir = root / "cache" / cache_key
             edit_dir = root / "edit" / project.project_id
-            (local_dir / ".lake" / "packages").mkdir(parents=True)
-            (cache_dir / ".lake" / "packages").mkdir(parents=True)
-            edit_dir.mkdir(parents=True)
+            (local_dir / "nested" / "blueprint" / ".lake" / "packages").mkdir(parents=True)
+            (cache_dir / "nested" / "blueprint" / ".lake" / "packages").mkdir(parents=True)
+            (edit_dir / "nested" / "blueprint").mkdir(parents=True)
             layout = SimpleNamespace(
                 package_root=root / "pkg",
                 reference_project_checkout_root=root / "local",
-                reference_project_cache_root=root / "cache",
+                reference_source_cache_root=root / "cache",
+                reference_dependency_cache_root=root / "deps",
             )
             layout.package_root.mkdir()
 
             originals = {
                 "run": refs_mod.run,
             }
+            original_shutil_which = refs_mod.shutil.which
             commands: list[list[str]] = []
             try:
+                refs_mod.shutil.which = lambda _name: "/usr/bin/rsync"
                 refs_mod.run = lambda command, *, cwd: commands.append(command)
 
                 source = seed_reference_edit_checkout_lake(layout, project, edit_dir)
             finally:
                 for name, value in originals.items():
                     setattr(refs_mod, name, value)
+                refs_mod.shutil.which = original_shutil_which
 
-        self.assertEqual(source, local_dir)
+        self.assertEqual(source, local_dir / "nested" / "blueprint" / ".lake")
         self.assertEqual(
             commands,
-            [["rsync", "-a", "--delete", f"{local_dir / '.lake'}/", f"{edit_dir / '.lake'}/"]],
+            [
+                [
+                    "rsync",
+                    "-a",
+                    "--delete",
+                    f"{local_dir / 'nested' / 'blueprint' / '.lake'}/",
+                    f"{edit_dir / 'nested' / 'blueprint' / '.lake'}/",
+                ]
+            ],
         )
 
     def test_sync_reference_local_checkout_rsyncs_warmed_cache_lake(self) -> None:
@@ -1274,7 +1468,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         project = HarnessProject(
             project_id="external-blueprint",
             source_kind="git_checkout",
-            project_root=".",
+            project_root="nested/blueprint",
             build_target=None,
             generator=None,
             repository="https://github.com/example/external-blueprint.git",
@@ -1289,12 +1483,16 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            cache_dir = root / "cache" / project.project_id
+            cache_key = reference_dependency_cache_key(project)
+            cache_dir = root / "cache" / cache_key
             cache_dir.mkdir(parents=True)
-            (cache_dir / ".lake" / "packages" / "mathlib" / ".lake" / "build").mkdir(parents=True)
+            (cache_dir / "nested" / "blueprint" / ".lake" / "packages" / "mathlib" / ".lake" / "build").mkdir(
+                parents=True
+            )
             layout = SimpleNamespace(
                 package_root=root / "pkg",
                 reference_project_checkout_root=root / "checkouts",
+                reference_dependency_cache_root=root / "deps",
             )
             layout.package_root.mkdir()
 
@@ -1305,7 +1503,12 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             }
             commands: list[list[str]] = []
             try:
-                refs_mod.clone_git_project = lambda _project, destination, *, cwd, source=None, shallow=True: destination.mkdir(parents=True) or destination
+                refs_mod.clone_git_project = (
+                    lambda _project, destination, *, cwd, source=None, shallow=True: (
+                        destination / "nested" / "blueprint"
+                    ).mkdir(parents=True)
+                    or destination
+                )
                 refs_mod.update_git_checkout = lambda _project, _checkout_root: None
                 refs_mod.run = lambda command, *, cwd: commands.append(command)
 
@@ -1314,15 +1517,15 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 for name, value in originals.items():
                     setattr(refs_mod, name, value)
 
-        self.assertEqual(local_dir, root / "checkouts" / project.project_id)
+        self.assertEqual(local_dir, root / "checkouts" / cache_key)
         self.assertIn(
             [
                 "rsync",
                 "-a",
                 "--exclude",
                 "/build/",
-                f"{cache_dir / '.lake'}/",
-                f"{local_dir / '.lake'}/",
+                f"{cache_dir / 'nested' / 'blueprint' / '.lake'}/",
+                f"{local_dir / 'nested' / 'blueprint' / '.lake'}/",
             ],
             commands,
         )
@@ -1333,25 +1536,30 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             cache_root = root / "cache"
+            dependency_cache_root = root / "deps"
             checkout_root = root / "by-worktree"
-            (cache_root / "noperthedron").mkdir(parents=True)
-            (cache_root / "oldproject").mkdir(parents=True)
-            (checkout_root / "v4.29.0" / "noperthedron").mkdir(parents=True)
-            (checkout_root / "v4.29.0" / "oldproject").mkdir(parents=True)
-            (checkout_root / "stale-worktree" / "noperthedron").mkdir(parents=True)
+            (cache_root / "noperthedron-ref-active").mkdir(parents=True)
+            (cache_root / "oldproject-ref-stale").mkdir(parents=True)
+            (dependency_cache_root / "noperthedron-ref-active").mkdir(parents=True)
+            (dependency_cache_root / "oldproject-ref-stale").mkdir(parents=True)
+            (checkout_root / "v4.29.0" / "noperthedron-ref-active").mkdir(parents=True)
+            (checkout_root / "v4.29.0" / "oldproject-ref-stale").mkdir(parents=True)
+            (checkout_root / "stale-worktree" / "noperthedron-ref-active").mkdir(parents=True)
 
             removals = reference_prune_plan(
                 {"v4.29.0", "cleanup-automation"},
-                {"noperthedron"},
+                {"noperthedron-ref-active"},
                 cache_root,
                 checkout_root,
+                dependency_cache_root,
             )
 
             self.assertEqual(
                 {path.relative_to(root).as_posix() for path in removals},
                 {
-                    "cache/oldproject",
-                    "by-worktree/v4.29.0/oldproject",
+                    "cache/oldproject-ref-stale",
+                    "deps/oldproject-ref-stale",
+                    "by-worktree/v4.29.0/oldproject-ref-stale",
                     "by-worktree/stale-worktree",
                 },
             )


### PR DESCRIPTION
This PR consolidates reference-blueprint metadata into release-specific project targets, removes the legacy top-level `reference_blueprints` list, and keys external dependency caches by source/ref so release validation reuses pinned upstream libraries without hidden checkout modes.

Backport v4.29.0: pending
Backport v4.28.0: pending
