### PR TITLE
fix(deps): inherit Verso through Blueprint

### DIFF
--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -208,16 +208,18 @@ python3 -m scripts.blueprint_harness sync-root-lake
 python3 -m scripts.blueprint_reference_harness sync
 ```
 
-To bump the package Lean toolchain and pin the matching `verso` release or
-release candidate in the root package plus the tracked in-repo fixtures:
+To bump the Lean toolchain for the root package plus the tracked in-repo
+fixtures, and pin the matching `verso` release or release candidate in the root
+package:
 
 ```bash
 python3 -m scripts.blueprint_harness bump-toolchain 4.30-rc2
 python3 -m scripts.blueprint_harness bump-toolchain v4.29.0 --skip-validation
 ```
 
-That command rewrites the managed `lean-toolchain` and `require verso` pins,
-refreshes the committed manifests for the root package, `project_template`, and
+That command rewrites the managed `lean-toolchain` files, rewrites the root
+package's direct `require verso` pin, refreshes the committed manifests for the
+root package, `project_template`, and
 `tests/test_blueprints/preview_runtime_showcase/`, and by default runs the same
 build/test validation pass that maintainers would otherwise do manually. Release
 candidates use the official short RC name, for example `4.30-rc2`; the harness
@@ -237,8 +239,9 @@ python3 -m scripts.blueprint_harness start-release-line 4.30-rc2
 
 Run this from the new local branch, for example `v4.30.0`. The command:
 
-- rewrites the managed root, `project_template`, and preview-showcase
-  `lean-toolchain`, `verso` pins, and committed manifests
+- rewrites the managed `lean-toolchain` files, the root `verso` pin, and the
+  committed manifests for the root package, `project_template`, and the
+  preview showcase
 - updates `branch-policy.json` so the new branch is the default-development
   line and the previous default-development branch becomes a required backport
   target

--- a/project_template/README.md
+++ b/project_template/README.md
@@ -108,12 +108,6 @@ It also includes `.github/workflows/blueprint-pages.yml`.
 Depending on your repository or organization settings, you may still need to
 enable GitHub Pages with GitHub Actions as the publishing source once.
 
-## About dependencies
-
-The template currently pins `verso` and `verso-blueprint` from Git. Replace
-those refs with release tags when you move to a released version. The template
-does not need a direct Mathlib dependency.
-
 ## Next step
 
 Continue with [doc/GETTING_STARTED.md](../doc/GETTING_STARTED.md).

--- a/project_template/lake-manifest.json
+++ b/project_template/lake-manifest.json
@@ -16,7 +16,7 @@
    "name": "verso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "v4.30.0-rc2",
-   "inherited": false,
+   "inherited": true,
    "configFile": "lakefile.lean"},
   {"url": "https://github.com/leanprover-community/ProofWidgets4",
    "type": "git",

--- a/project_template/lakefile.lean
+++ b/project_template/lakefile.lean
@@ -1,7 +1,6 @@
 import Lake
 open Lake DSL
 
-require verso from git "https://github.com/leanprover/verso"@"v4.30.0-rc2"
 require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint"@"main"
 
 package ProjectTemplate where

--- a/scripts/blueprint_harness_toolchains.py
+++ b/scripts/blueprint_harness_toolchains.py
@@ -140,7 +140,8 @@ def bump_toolchain_checkout(
 
     for project_dir in managed_toolchain_project_dirs(package_root):
         rewrite_lean_toolchain(project_dir / "lean-toolchain", lean_ref)
-        rewrite_pinned_verso_dependency(project_dir, selected_verso_ref)
+
+    rewrite_pinned_verso_dependency(package_root, selected_verso_ref)
 
     for project_dir in managed_toolchain_project_dirs(package_root):
         refresh_managed_manifest(package_root, project_dir)

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -940,20 +940,30 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             self.assertEqual(seen["package_root"], layout.package_root)
             self.assertEqual(lakefile.read_text(encoding="utf-8"), OFFICIAL_BLUEPRINT_REQUIRE + "\n")
 
-    def test_project_template_manifest_keeps_verso_and_subverso_in_sync_with_root_without_mathlib(self) -> None:
-        root_manifest = json.loads((PACKAGE_ROOT / "lake-manifest.json").read_text(encoding="utf-8"))
-        template_manifest = json.loads((PACKAGE_ROOT / "project_template" / "lake-manifest.json").read_text(encoding="utf-8"))
+    def test_child_manifests_inherit_verso_and_subverso_from_root_without_mathlib(self) -> None:
+        root_manifest_path = PACKAGE_ROOT / "lake-manifest.json"
+        child_manifest_paths = [
+            PACKAGE_ROOT / "project_template" / "lake-manifest.json",
+            PACKAGE_ROOT / "tests" / "test_blueprints" / "preview_runtime_showcase" / "lake-manifest.json",
+        ]
+        root_manifest = json.loads(root_manifest_path.read_text(encoding="utf-8"))
+        child_manifests = [json.loads(path.read_text(encoding="utf-8")) for path in child_manifest_paths]
 
-        def package_rev(manifest_data: dict, package_name: str) -> str:
-            package = next(entry for entry in manifest_data["packages"] if entry["name"] == package_name)
-            rev = package.get("rev")
-            self.assertIsInstance(rev, str)
-            return rev
+        def package_entry(manifest_data: dict, package_name: str) -> dict:
+            return next(entry for entry in manifest_data["packages"] if entry["name"] == package_name)
 
-        self.assertEqual(package_rev(template_manifest, "verso"), package_rev(root_manifest, "verso"))
-        self.assertEqual(package_rev(template_manifest, "subverso"), package_rev(root_manifest, "subverso"))
+        root_verso = package_entry(root_manifest, "verso")
+        for child_manifest in child_manifests:
+            child_verso = package_entry(child_manifest, "verso")
+            self.assertTrue(child_verso["inherited"])
+            if root_verso.get("rev") is not None:
+                self.assertEqual(child_verso.get("rev"), root_verso.get("rev"))
+            self.assertEqual(
+                package_entry(child_manifest, "subverso").get("rev"),
+                package_entry(root_manifest, "subverso").get("rev"),
+            )
+            self.assertNotIn("mathlib", {entry["name"] for entry in child_manifest["packages"]})
         self.assertNotIn("mathlib", {entry["name"] for entry in root_manifest["packages"]})
-        self.assertNotIn("mathlib", {entry["name"] for entry in template_manifest["packages"]})
 
     def test_clone_git_project_checks_out_commit_ref_without_branch_name(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/harness/test_blueprint_harness_toolchains.py
+++ b/tests/harness/test_blueprint_harness_toolchains.py
@@ -38,7 +38,7 @@ class BlueprintHarnessToolchainTests(unittest.TestCase):
             self.assertEqual(previous_ref, "main")
             self.assertIn('require verso from git "https://github.com/leanprover/verso"@"v4.29.0"', lakefile.read_text(encoding="utf-8"))
 
-    def test_bump_toolchain_checkout_updates_managed_files_and_restores_template_dependency(self) -> None:
+    def test_bump_toolchain_checkout_updates_managed_files_and_preserves_inherited_dependencies(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             package_root = Path(tmp)
             root_lakefile = "\n".join(
@@ -54,7 +54,6 @@ class BlueprintHarnessToolchainTests(unittest.TestCase):
                 [
                     "import Lake",
                     "open Lake DSL",
-                    'require verso from git "https://github.com/leanprover/verso"@"main"',
                     'require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint"@"main"',
                     "",
                 ]
@@ -63,7 +62,6 @@ class BlueprintHarnessToolchainTests(unittest.TestCase):
                 [
                     "import Lake",
                     "open Lake DSL",
-                    'require verso from git "https://github.com/leanprover/verso"@"main"',
                     'require VersoBlueprint from "../../../"',
                     "",
                 ]
@@ -111,16 +109,21 @@ class BlueprintHarnessToolchainTests(unittest.TestCase):
             )
             self.assertIn('require verso from git "https://github.com/leanprover/verso"@"v4.29.0"', (package_root / "lakefile.lean").read_text(encoding="utf-8"))
             template_text = (package_root / "project_template" / "lakefile.lean").read_text(encoding="utf-8")
-            self.assertIn('require verso from git "https://github.com/leanprover/verso"@"v4.29.0"', template_text)
+            self.assertNotIn("require verso", template_text)
             self.assertIn(
                 'require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint"@"main"',
                 template_text,
             )
+            preview_text = (
+                package_root / "tests" / "test_blueprints" / "preview_runtime_showcase" / "lakefile.lean"
+            ).read_text(encoding="utf-8")
             self.assertIn(
-                'require verso from git "https://github.com/leanprover/verso"@"v4.29.0"',
-                (package_root / "tests" / "test_blueprints" / "preview_runtime_showcase" / "lakefile.lean").read_text(
-                    encoding="utf-8"
-                ),
+                'require VersoBlueprint from "../../../"',
+                preview_text,
+            )
+            self.assertNotIn(
+                "require verso",
+                preview_text,
             )
             expected_script = str(package_root / "scripts" / "lean-low-priority")
             self.assertEqual(
@@ -140,13 +143,9 @@ class BlueprintHarnessToolchainTests(unittest.TestCase):
             package_root = Path(tmp)
             root_lakefile = 'require verso from git "https://github.com/leanprover/verso"@"v4.29.0"\n'
             template_lakefile = (
-                'require verso from git "https://github.com/leanprover/verso"@"v4.29.0"\n'
                 'require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint"@"main"\n'
             )
-            preview_lakefile = (
-                'require verso from git "https://github.com/leanprover/verso"@"v4.29.0"\n'
-                'require VersoBlueprint from "../../../"\n'
-            )
+            preview_lakefile = 'require VersoBlueprint from "../../../"\n'
 
             self.write(package_root / "lean-toolchain", "leanprover/lean4:v4.29.0")
             self.write(package_root / "lakefile.lean", root_lakefile)
@@ -198,7 +197,6 @@ class BlueprintHarnessToolchainTests(unittest.TestCase):
             self.write(package_root / "project_template" / "lean-toolchain", "leanprover/lean4:v4.29.0-rc6\n")
             self.write(
                 package_root / "project_template" / "lakefile.lean",
-                'require verso from git "https://github.com/leanprover/verso"@"main"\n'
                 'require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint"@"main"\n',
             )
             self.write(
@@ -207,7 +205,6 @@ class BlueprintHarnessToolchainTests(unittest.TestCase):
             )
             self.write(
                 package_root / "tests" / "test_blueprints" / "preview_runtime_showcase" / "lakefile.lean",
-                'require verso from git "https://github.com/leanprover/verso"@"main"\n'
                 'require VersoBlueprint from "../../../"\n',
             )
 

--- a/tests/test_blueprints/preview_runtime_showcase/lake-manifest.json
+++ b/tests/test_blueprints/preview_runtime_showcase/lake-manifest.json
@@ -16,7 +16,7 @@
    "name": "verso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "v4.30.0-rc2",
-   "inherited": false,
+   "inherited": true,
    "configFile": "lakefile.lean"},
   {"url": "https://github.com/leanprover-community/ProofWidgets4",
    "type": "git",

--- a/tests/test_blueprints/preview_runtime_showcase/lakefile.lean
+++ b/tests/test_blueprints/preview_runtime_showcase/lakefile.lean
@@ -1,7 +1,6 @@
 import Lake
 open Lake DSL
 
-require verso from git "https://github.com/leanprover/verso"@"v4.30.0-rc2"
 require VersoBlueprint from "../../../"
 
 package PreviewRuntimeShowcase where


### PR DESCRIPTION
This PR removes direct Verso pins from Blueprint consumer packages in this repo: the starter template and preview runtime showcase now inherit Verso through VersoBlueprint. The toolchain bump helper now only rewrites the root package's direct Verso pin.

Backport v4.29.0: #58
Backport v4.28.0: #59