### PR TITLE
[backport v4.28.0] refactor(rust): share code panel rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,14 @@
 - Before opening a paired backport PR, run
   `python3 -m scripts.blueprint_harness prepare-backport-pr <release> --main-pr <pr>`
   and use the emitted paired title/body scaffold.
+- `Backport <release>: pending` placeholders from `prepare-pr` are only
+  acceptable while the default-development PR is draft. Before marking a
+  default-development PR ready for review, replace every pending backport line
+  with either `Backport <release>: #<pr>` or
+  `Backport <release>: exempt: <reason>`.
+- For changes that need paired backports, open the paired backport PRs before
+  the default-development PR leaves draft, then wait for the paired-backport CI
+  check to pass before merging.
 - Do not hand-roll PR descriptions from local status notes or validation
   transcripts. Keep routine validation details in local/final reports unless
   they change review risk or CI cannot show them.

--- a/src/VersoBlueprint/Informal/Block/Common.lean
+++ b/src/VersoBlueprint/Informal/Block/Common.lean
@@ -104,18 +104,25 @@ structure CodePanelHeader where
   number? : Option String := none
 deriving Repr, Inhabited
 
-def codePanelHeader (data : BlockData) (numberText : String) : CodePanelHeader :=
+def codePanelHeaderFor (languageName : String) (data : BlockData) (numberText : String) :
+    CodePanelHeader :=
   match data.kind with
-  | .proof => { caption := "Lean code for proof" }
+  | .proof => { caption := s!"{languageName} code for proof" }
   | .statement nodeKind =>
     {
-      caption := s!"Lean code for {nodeKind}"
+      caption := s!"{languageName} code for {nodeKind}"
       number? := some numberText
     }
 
-def fallbackCodePanelHeader : CodePanelHeader := {
-  caption := "Lean code"
+def fallbackCodePanelHeaderFor (languageName : String) : CodePanelHeader := {
+  caption := s!"{languageName} code"
 }
+
+def codePanelHeader (data : BlockData) (numberText : String) : CodePanelHeader :=
+  codePanelHeaderFor "Lean" data numberText
+
+def fallbackCodePanelHeader : CodePanelHeader :=
+  fallbackCodePanelHeaderFor "Lean"
 
 register_option verso.blueprint.foldProofs : Bool := {
   defValue := true

--- a/src/VersoBlueprint/Informal/RustBlock.lean
+++ b/src/VersoBlueprint/Informal/RustBlock.lean
@@ -11,7 +11,7 @@ import VersoBlueprint.Informal.Block.Common
 import VersoBlueprint.Informal.Block.Store
 import VersoBlueprint.Informal.Code
 import VersoBlueprint.Profiling
-import VersoBlueprint.Rust
+import VersoBlueprint.Informal.RustPanel
 import VersoBlueprint.TraversalIndex
 
 open Verso Doc Elab
@@ -51,15 +51,10 @@ block_extension Block.informalRustCode (data : Informal.Rust.InlineCodeData) whe
         match Informal.TraversalIndex.Nodes.data? s cdata.label with
         | some b =>
           let b := b.withResolvedNumbering s (numberedPartPrefix? ctxt)
-          let caption :=
-            match b.kind with
-            | .proof => "Rust code for proof"
-            | .statement nodeKind => s!"Rust code for {nodeKind}"
-          { (codePanelHeader b (b.displayNumber s)) with caption }
-        | none => { fallbackCodePanelHeader with caption := "Rust code" }
-      let body := Informal.Rust.highlightHtml cdata.raw
-      pure <| mkCodePanel panelHeader s!"Rust code for {cdata.label}" .empty body attrs
-        (folded := cdata.foldCodeBlock)
+          Informal.Rust.codePanelHeader b (b.displayNumber s)
+        | none => Informal.Rust.fallbackCodePanelHeader
+      pure <| Informal.Rust.renderRawCodePanel panelHeader s!"Rust code for {cdata.label}" cdata.raw
+        attrs (folded := cdata.foldCodeBlock)
 
 private def rustImpl : CodeBlockExpanderOf Informal.CodeConfig
   | cfg, contents => do

--- a/src/VersoBlueprint/Informal/RustPanel.lean
+++ b/src/VersoBlueprint/Informal/RustPanel.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoBlueprint.Informal.Block.Common
+import VersoBlueprint.Rust
+
+namespace Informal.Rust
+
+open Verso.Output.Html
+
+def codePanelHeader (data : BlockData) (numberText : String) : CodePanelHeader :=
+  Informal.codePanelHeaderFor "Rust" data numberText
+
+def fallbackCodePanelHeader : CodePanelHeader :=
+  Informal.fallbackCodePanelHeaderFor "Rust"
+
+def renderCodePanel
+    (header : CodePanelHeader) (summaryTitle : String) (body : Verso.Output.Html)
+    (attrs : Array (String × String) := #[]) (folded : Bool := false) :
+    Verso.Output.Html :=
+  mkCodePanel header summaryTitle .empty body attrs (folded := folded)
+
+def renderRawCodePanel
+    (header : CodePanelHeader) (summaryTitle raw : String)
+    (attrs : Array (String × String) := #[]) (folded : Bool := false) :
+    Verso.Output.Html :=
+  renderCodePanel header summaryTitle (highlightHtml raw) attrs (folded := folded)
+
+end Informal.Rust


### PR DESCRIPTION
## Summary
Backport #57 to `v4.28.0`.

## Primary Review
- Primary review: #57
- Keep review comments on #57 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.28.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.