### PR TITLE
feat: add foreign language reference data model

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -40,6 +40,7 @@ lean_lib VersoBlueprintTests where
     `VersoBlueprintTests.BlueprintImportedDuplicates.Reexport,
     `VersoBlueprintTests.BlueprintImportedDuplicates.Transitive,
     `VersoBlueprintTests.BlueprintExternalHeadingStatus,
+    `VersoBlueprintTests.BlueprintForeignRefs,
     `VersoBlueprintTests.BlueprintGraft,
     `VersoBlueprintTests.BlueprintGraph,
     `VersoBlueprintTests.BlueprintHeaderExtras,

--- a/src/VersoBlueprint/Data.lean
+++ b/src/VersoBlueprint/Data.lean
@@ -490,6 +490,125 @@ structure RustInlineCode where
   raw : String
 deriving Repr, Inhabited, DecidableEq, ToJson, FromJson, Quote
 
+/--
+A foreign language whose declarations may be associated with Blueprint nodes.
+
+The current surface is intentionally small: Rocq and Rust are the first target
+languages for language-server lookup experiments.
+-/
+inductive ForeignLanguage where
+  | rocq
+  | rust
+deriving Repr, Inhabited, DecidableEq, BEq, ToJson, FromJson, Quote
+
+def ForeignLanguage.key : ForeignLanguage → String
+  | .rocq => "rocq"
+  | .rust => "rust"
+
+def ForeignLanguage.displayName : ForeignLanguage → String
+  | .rocq => "Rocq"
+  | .rust => "Rust"
+
+def ForeignLanguage.defaultCommand : ForeignLanguage → String
+  | .rocq => "coq-lsp"
+  | .rust => "rust-analyzer"
+
+def ForeignLanguage.languageId : ForeignLanguage → String
+  | .rocq => "coq"
+  | .rust => "rust"
+
+def ForeignLanguage.sourceExtension : ForeignLanguage → String
+  | .rocq => "v"
+  | .rust => "rs"
+
+/-- Result category for a single foreign-language reference lookup. -/
+inductive ForeignLookupStatus where
+  /-- The language server returned a definition location. -/
+  | resolved
+  /-- The language server was available but returned no definition location. -/
+  | unresolved
+  /-- The lookup could not run, for example because a language server is missing. -/
+  | unavailable
+  /-- The lookup ran but failed unexpectedly. -/
+  | failed
+deriving Repr, Inhabited, DecidableEq, BEq, ToJson, FromJson, Quote
+
+def ForeignLookupStatus.isWarning : ForeignLookupStatus → Bool
+  | .resolved => false
+  | .unresolved | .unavailable | .failed => true
+
+def ForeignLookupStatus.label : ForeignLookupStatus → String
+  | .resolved => "resolved"
+  | .unresolved => "unresolved"
+  | .unavailable => "unavailable"
+  | .failed => "failed"
+
+/-- Zero-based LSP-style source position. -/
+structure ForeignPosition where
+  line : Nat
+  character : Nat
+deriving Repr, Inhabited, DecidableEq, BEq, ToJson, FromJson, Quote
+
+/-- Zero-based LSP-style source range. -/
+structure ForeignRange where
+  start : ForeignPosition
+  stop : ForeignPosition
+deriving Repr, Inhabited, DecidableEq, BEq, ToJson, FromJson, Quote
+
+/-- Diagnostic emitted while checking a foreign-language prelude or lookup file. -/
+structure ForeignDiagnostic where
+  message : String
+  range? : Option ForeignRange := none
+deriving Repr, Inhabited, DecidableEq, BEq, ToJson, FromJson, Quote
+
+/--
+Snapshot for one written foreign-language reference attached to a node.
+
+The written field preserves the spelling from the Blueprint source. The
+optional target and source fields are filled only when lookup succeeds.
+-/
+structure ForeignRef where
+  written : String
+  status : ForeignLookupStatus := .unresolved
+  targetUri? : Option String := none
+  targetRange? : Option ForeignRange := none
+  sourceHref? : Option String := none
+  sourceSnippet? : Option String := none
+  message? : Option String := none
+deriving Repr, Inhabited, DecidableEq, BEq, ToJson, FromJson, Quote
+
+def ForeignRef.hasWarning (ref : ForeignRef) : Bool :=
+  ref.status.isWarning
+
+/--
+All foreign-language lookup data for one language attached to a Blueprint node.
+
+The command, root, and synthetic URI fields record the lookup context used to
+produce the snapshot. They are renderable diagnostics, not process handles.
+-/
+structure ForeignAttachment where
+  language : ForeignLanguage
+  command : String
+  root : String
+  syntheticUri : String
+  preludeDiagnostics : Array ForeignDiagnostic := #[]
+  refs : Array ForeignRef := #[]
+deriving Repr, Inhabited, DecidableEq, BEq, ToJson, FromJson, Quote
+
+def ForeignAttachment.hasResolved (attachment : ForeignAttachment) : Bool :=
+  attachment.refs.any (fun ref => ref.status == .resolved)
+
+def ForeignAttachment.hasWarning (attachment : ForeignAttachment) : Bool :=
+  !attachment.preludeDiagnostics.isEmpty || attachment.refs.any (·.hasWarning)
+
+def mergeForeignAttachments
+    (current incoming : Array ForeignAttachment) : Array ForeignAttachment :=
+  incoming.foldl (init := current) fun acc attachment =>
+    if acc.any (fun existing => existing.language == attachment.language) then
+      acc
+    else
+      acc.push attachment
+
 inductive CodeRef where
   /-
   Blueprint code references can currently come from two sources:
@@ -558,6 +677,7 @@ structure Node where
   leanCode : Array CodeRef := #[]
   rustCode : Option RustInlineCode := none -- Informal object associated Rust code
   externalMarkup : ExternalMarkupSet := {} -- Raw external markup keyed by language and slot
+  foreignRefs : Array ForeignAttachment := #[] -- Foreign-language reference snapshots
   parent : Option Parent := none -- Optional parent group for summaries/graphs
   priority : Option String := none -- Optional author-provided triage hint
   owner : Option AuthorId := none
@@ -740,6 +860,18 @@ private def mergeExternalMarkup (label : Label)
   else
     return current.insert incoming
 
+private def mergeForeignRefs (label : Label)
+    (current incoming : Array ForeignAttachment) : m (Array ForeignAttachment) := do
+  if incoming.isEmpty then
+    return current
+  let mut acc := current
+  for attachment in incoming do
+    if acc.any (fun existing => existing.language == attachment.language) then
+      logError m!"Label {label} already has associated {attachment.language.displayName} references"
+    else
+      acc := acc.push attachment
+  return acc
+
 def Data.registerCodeRef (data : Data) (label : Label) (codeRef : CodeRef) : m Data := do
   match data.get? label with
   | none =>
@@ -750,7 +882,7 @@ def Data.registerCodeRef (data : Data) (label : Label) (codeRef : CodeRef) : m D
 def Data.register (data : Data) (label : Label) (kind : InProgressKind) (payload : InformalData)
     (codeHint : Option CodeRef := none) (parent : Option Parent := none) (priority : Option String := none)
     (owner : Option AuthorId := none) (tags : Array String := #[]) (effort : Option String := none)
-    (prUrl : Option String := none) : m Data := do
+    (prUrl : Option String := none) (foreignRefs : Array ForeignAttachment := #[]) : m Data := do
   let applyHints (node : Node) : m Node := do
     let node :=
       match codeHint with
@@ -762,7 +894,8 @@ def Data.register (data : Data) (label : Label) (kind : InProgressKind) (payload
     let effort ← mergeEffort label node.effort effort
     let prUrl ← mergePrUrl label node.prUrl prUrl
     let tags := mergeTags node.tags tags
-    return { node with parent, priority, owner, tags, effort, prUrl }
+    let foreignRefs ← mergeForeignRefs label node.foreignRefs foreignRefs
+    return { node with parent, priority, owner, tags, effort, prUrl, foreignRefs }
   let nextCount := data.nextCount
   match data.get? label, kind with
   -- First statement for a fresh label.

--- a/src/VersoBlueprint/Environment.lean
+++ b/src/VersoBlueprint/Environment.lean
@@ -32,6 +32,7 @@ structure InProgress where
   tags : Array String := #[]
   effort : Option String := none
   prUrl : Option String := none
+  foreignRefs : Array ForeignAttachment := #[]
   deps : Array UseRef := #[]
   previewBlocks : Array (Verso.Doc.Block Verso.Genre.Manual) := #[]
   elabStx : Array Syntax := #[]
@@ -273,13 +274,17 @@ def checkLabelAndNesting (label : Label) (kind : Data.InProgressKind) : m Bool :
 def push (label : Label) (kind : Data.InProgressKind)
     (codeHint : Option CodeRef := none) (parent : Option Parent := none) (priority : Option String := none)
     (owner : Option AuthorId := none) (tags : Array String := #[]) (effort : Option String := none)
-    (prUrl : Option String := none) (useRefs : Array UseRef := #[]) : m Bool := do
+    (prUrl : Option String := none) (useRefs : Array UseRef := #[])
+    (foreignRefs : Array ForeignAttachment := #[]) : m Bool := do
   reportImportedConflicts
   let ok ← checkLabelAndNesting label kind
   if !ok then
     return false
   modify fun data =>
-    let pdata := { label, kind, codeHint, parent, priority, owner, tags, effort, prUrl, deps := useRefs }
+    let pdata := {
+      label, kind, codeHint, parent, priority, owner, tags, effort, prUrl, foreignRefs,
+      deps := useRefs
+    }
     { data with stack := pdata :: data.stack }
   return true
 
@@ -315,6 +320,7 @@ def pop (ref : Syntax) : m Nat := do
         }
         let data ← state.data.register
           cur.label cur.kind payload cur.codeHint cur.parent cur.priority cur.owner cur.tags cur.effort cur.prUrl
+          cur.foreignRefs
         return { state.commitDataForLabel cur.label data with stack }
   let state := informalExt.getState (← getEnv)
   match label? with

--- a/src/VersoBlueprint/Informal/Block/Model.lean
+++ b/src/VersoBlueprint/Informal/Block/Model.lean
@@ -204,6 +204,7 @@ structure BlockData where
   effort : Option String := none
   priority : Option String := none
   prUrl : Option String := none
+  foreignRefs : Array Data.ForeignAttachment := #[]
 deriving FromJson, ToJson, Quote
 
 /--
@@ -238,6 +239,7 @@ structure StoredBlockData where
   effort : Option String := none
   priority : Option String := none
   prUrl : Option String := none
+  foreignRefs : Array Data.ForeignAttachment := #[]
 deriving FromJson, ToJson, Quote
 
 def BlockData.toStoredData (data : BlockData) : StoredBlockData := {
@@ -261,6 +263,7 @@ def BlockData.toStoredData (data : BlockData) : StoredBlockData := {
   effort := data.effort
   priority := data.priority
   prUrl := data.prUrl
+  foreignRefs := data.foreignRefs
 }
 
 def StoredBlockData.toBlockData (data : StoredBlockData)
@@ -286,6 +289,7 @@ def StoredBlockData.toBlockData (data : StoredBlockData)
   effort := data.effort
   priority := data.priority
   prUrl := data.prUrl
+  foreignRefs := data.foreignRefs
 }
 
 def BlockData.statementDeps (data : BlockData) : Array Data.Label :=

--- a/src/VersoBlueprint/Informal/Block/Store.lean
+++ b/src/VersoBlueprint/Informal/Block/Store.lean
@@ -161,6 +161,7 @@ def mergeStoredBlockData (existing incoming : StoredBlockData) : StoredBlockData
       effort := existing.effort <|> incoming.effort
       priority := existing.priority <|> incoming.priority
       prUrl := existing.prUrl <|> incoming.prUrl
+      foreignRefs := Data.mergeForeignAttachments existing.foreignRefs incoming.foreignRefs
   }
 
 /--

--- a/tests/VersoBlueprintTests/Blueprint.lean
+++ b/tests/VersoBlueprintTests/Blueprint.lean
@@ -12,6 +12,7 @@ import VersoBlueprintTests.BlueprintCodeRenderMatrix
 import VersoBlueprintTests.BlueprintImportedDuplicates.Direct
 import VersoBlueprintTests.BlueprintImportedDuplicates.Transitive
 import VersoBlueprintTests.BlueprintExternalHeadingStatus
+import VersoBlueprintTests.BlueprintForeignRefs
 import VersoBlueprintTests.BlueprintGraft
 import VersoBlueprintTests.BlueprintGraph
 import VersoBlueprintTests.BlueprintHeaderExtras

--- a/tests/VersoBlueprintTests/BlueprintForeignRefs.lean
+++ b/tests/VersoBlueprintTests/BlueprintForeignRefs.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoBlueprintTests.Blueprint.Support
+
+namespace Verso.VersoBlueprintTests.BlueprintForeignRefs
+
+open Lean
+open Informal
+
+private def rustTargetRange : Data.ForeignRange := {
+  start := { line := 12, character := 4 }
+  stop := { line := 12, character := 16 }
+}
+
+private def resolvedRustRef : Data.ForeignRef := {
+  written := "collatz_step"
+  status := .resolved
+  targetUri? := some "file:///tmp/vbp-rust/src/lib.rs"
+  targetRange? := some rustTargetRange
+  sourceHref? := some "file:///tmp/vbp-rust/src/lib.rs#L13"
+  sourceSnippet? := some "pub fn collatz_step(n: u64) -> u64 { n + 1 }"
+}
+
+private def unresolvedRustRef : Data.ForeignRef := {
+  written := "collatz_typo"
+  status := .unresolved
+  message? := some "language server did not return a definition location"
+}
+
+private def rustAttachment : Data.ForeignAttachment := {
+  language := .rust
+  command := "rust-analyzer"
+  root := "/tmp/vbp-rust"
+  syntheticUri := "file:///tmp/vbp-rust/.verso-blueprint-foreign/Blueprint.rust.rs"
+  refs := #[resolvedRustRef, unresolvedRustRef]
+}
+
+private def rocqAttachment : Data.ForeignAttachment := {
+  language := .rocq
+  command := "coq-lsp"
+  root := "/tmp/vbp-rocq"
+  syntheticUri := "file:///tmp/vbp-rocq/.verso-blueprint-foreign/Blueprint.rocq.v"
+  preludeDiagnostics := #[
+    {
+      message := "Unknown logical path"
+      range? := some {
+        start := { line := 0, character := 0 }
+        stop := { line := 0, character := 6 }
+      }
+    }
+  ]
+  refs := #[
+    {
+      written := "def1"
+      status := .failed
+      message? := some "prelude diagnostics prevented lookup"
+    }
+  ]
+}
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  Data.ForeignLanguage.rust.key == "rust" &&
+    Data.ForeignLanguage.rust.displayName == "Rust" &&
+    Data.ForeignLanguage.rust.defaultCommand == "rust-analyzer" &&
+    Data.ForeignLanguage.rust.languageId == "rust" &&
+    Data.ForeignLanguage.rust.sourceExtension == "rs" &&
+    Data.ForeignLanguage.rocq.key == "rocq" &&
+    Data.ForeignLanguage.rocq.displayName == "Rocq" &&
+    Data.ForeignLanguage.rocq.defaultCommand == "coq-lsp" &&
+    Data.ForeignLanguage.rocq.languageId == "coq" &&
+    Data.ForeignLanguage.rocq.sourceExtension == "v"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  Data.ForeignLookupStatus.resolved.label == "resolved" &&
+    !Data.ForeignLookupStatus.resolved.isWarning &&
+    Data.ForeignLookupStatus.unresolved.isWarning &&
+    Data.ForeignLookupStatus.unavailable.isWarning &&
+    Data.ForeignLookupStatus.failed.isWarning
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  rustAttachment.hasResolved &&
+    rustAttachment.hasWarning &&
+    resolvedRustRef.hasWarning == false &&
+    unresolvedRustRef.hasWarning &&
+    !rocqAttachment.hasResolved &&
+    rocqAttachment.hasWarning
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  match fromJson? (toJson rustAttachment) with
+  | .ok decoded => decoded == rustAttachment
+  | .error _ => false
+
+private def foreignBlockData : BlockData := {
+  kind := .statement .definition
+  label := Name.mkSimple "foreign.model"
+  count := 1
+  foreignRefs := #[rustAttachment]
+}
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  foreignBlockData.toStoredData.toBlockData.foreignRefs == #[rustAttachment]
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  let existing : StoredBlockData := {
+    kind := .statement .definition
+    label := Name.mkSimple "foreign.existing"
+    count := 1
+    foreignRefs := #[rocqAttachment]
+  }
+  let incoming : StoredBlockData := {
+    kind := .statement .definition
+    label := Name.mkSimple "foreign.existing"
+    count := 1
+    foreignRefs := #[rustAttachment]
+  }
+  let emptyExisting := { existing with foreignRefs := #[] }
+  (mergeStoredBlockData emptyExisting incoming).foreignRefs == #[rustAttachment] &&
+    (mergeStoredBlockData existing incoming).foreignRefs == #[rocqAttachment, rustAttachment] &&
+    (mergeStoredBlockData existing { incoming with foreignRefs := #[rocqAttachment] }).foreignRefs == #[rocqAttachment]
+
+end Verso.VersoBlueprintTests.BlueprintForeignRefs


### PR DESCRIPTION
This PR adds the persisted data model for Rocq/Rust foreign-language references so later renderers and LSP lookup code can share one serialized attachment shape.

Backport v4.31.0: pending
Backport v4.30.0: pending