### PR TITLE
[backport v4.29.0] Repair starter template workflow

### DIFF
--- a/project_template/README.md
+++ b/project_template/README.md
@@ -2,8 +2,8 @@
 
 This folder is a copyable starter Blueprint project.
 
-If you want to inspect the current generated output before copying it, see the
-[rendered project template](https://leanprover.github.io/verso-blueprint/reference-blueprints/project-template/).
+To inspect the generated output, copy this folder and run the local workflow
+below; it writes the site to `_out/site/html-multi/`.
 
 The goal is not to show every feature. The goal is to give you one small
 project that already has the right moving parts:

--- a/project_template/lakefile.lean
+++ b/project_template/lakefile.lean
@@ -1,7 +1,7 @@
 import Lake
 open Lake DSL
 
-require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint"@"main"
+require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint"@"v4.29.0"
 
 package ProjectTemplate where
   precompileModules := false

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -14,7 +14,7 @@ from scripts.blueprint_harness_utils import lean_low_priority_command, rebuild_e
 
 OFFICIAL_BLUEPRINT_REPOSITORY = "leanprover/verso-blueprint"
 OFFICIAL_BLUEPRINT_REQUIRE = (
-    f'require VersoBlueprint from git "https://github.com/{OFFICIAL_BLUEPRINT_REPOSITORY}"@"main"'
+    f'require VersoBlueprint from git "https://github.com/{OFFICIAL_BLUEPRINT_REPOSITORY}"@"v4.29.0"'
 )
 OFFICIAL_BLUEPRINT_URL_PATTERNS = (
     rf"https://github\.com/{OFFICIAL_BLUEPRINT_REPOSITORY}(?:\.git)?",

--- a/scripts/blueprint_harness_toolchains.py
+++ b/scripts/blueprint_harness_toolchains.py
@@ -5,8 +5,14 @@ import re
 import subprocess
 from pathlib import Path
 
-from scripts.blueprint_harness_branches import LEAN_TOOLCHAIN_PREFIX, normalize_lean_release_ref
-from scripts.blueprint_harness_references import maybe_rewrite_in_repo_blueprint_dependency
+from scripts.blueprint_harness_branches import (
+    LEAN_TOOLCHAIN_PREFIX,
+    normalize_lean_release_ref,
+)
+from scripts.blueprint_harness_references import (
+    maybe_rewrite_in_repo_blueprint_dependency,
+    rewrite_pinned_blueprint_dependency,
+)
 from scripts.blueprint_harness_utils import lean_low_priority_command, run
 
 
@@ -142,6 +148,10 @@ def bump_toolchain_checkout(
         rewrite_lean_toolchain(project_dir / "lean-toolchain", lean_ref)
 
     rewrite_pinned_verso_dependency(package_root, selected_verso_ref)
+    rewrite_pinned_blueprint_dependency(
+        package_root / "project_template",
+        normalize_lean_release_ref(lean_ref),
+    )
 
     for project_dir in managed_toolchain_project_dirs(package_root):
         refresh_managed_manifest(package_root, project_dir)

--- a/tests/harness/test_blueprint_harness_toolchains.py
+++ b/tests/harness/test_blueprint_harness_toolchains.py
@@ -4,7 +4,12 @@ from pathlib import Path
 import tempfile
 import unittest
 
+from scripts.blueprint_harness_branches import active_release_branch
+from scripts.blueprint_harness_references import OFFICIAL_BLUEPRINT_REQUIRE_PATTERN
 import scripts.blueprint_harness_toolchains as toolchains_mod
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 
 
 class BlueprintHarnessToolchainTests(unittest.TestCase):
@@ -54,7 +59,7 @@ class BlueprintHarnessToolchainTests(unittest.TestCase):
                 [
                     "import Lake",
                     "open Lake DSL",
-                    'require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint"@"main"',
+                    'require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint"@"v4.28.0"',
                     "",
                 ]
             )
@@ -111,7 +116,7 @@ class BlueprintHarnessToolchainTests(unittest.TestCase):
             template_text = (package_root / "project_template" / "lakefile.lean").read_text(encoding="utf-8")
             self.assertNotIn("require verso", template_text)
             self.assertIn(
-                'require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint"@"main"',
+                'require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint"@"v4.29.0"',
                 template_text,
             )
             preview_text = (
@@ -149,7 +154,7 @@ class BlueprintHarnessToolchainTests(unittest.TestCase):
             self.write(package_root / "project_template" / "lean-toolchain", "leanprover/lean4:v4.29.0-rc6\n")
             self.write(
                 package_root / "project_template" / "lakefile.lean",
-                'require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint"@"main"\n',
+                'require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint"@"v4.28.0"\n',
             )
             self.write(
                 package_root / "tests" / "test_blueprints" / "preview_runtime_showcase" / "lean-toolchain",
@@ -167,6 +172,14 @@ class BlueprintHarnessToolchainTests(unittest.TestCase):
                     toolchains_mod.bump_toolchain_checkout(package_root, "v4.29.0", validate=False)
             finally:
                 toolchains_mod.resolve_remote_verso_tag_oid = original
+
+    def test_project_template_blueprint_dependency_tracks_active_release_branch(self) -> None:
+        text = (PACKAGE_ROOT / "project_template" / "lakefile.lean").read_text(encoding="utf-8")
+        match = next(OFFICIAL_BLUEPRINT_REQUIRE_PATTERN.finditer(text), None)
+
+        self.assertIsNotNone(match)
+        assert match is not None
+        self.assertEqual(match.group("ref"), active_release_branch(PACKAGE_ROOT))
 
 
 if __name__ == "__main__":

--- a/tests/harness/test_prepare_reference_blueprints_pages.py
+++ b/tests/harness/test_prepare_reference_blueprints_pages.py
@@ -165,6 +165,12 @@ class PrepareReferenceBlueprintPagesTests(unittest.TestCase):
         self.assertIn("reference-blueprints/v4.30.0/noperthedron/", readme)
         self.assertIn("reference-blueprints/v4.30.0/verso-flt/", readme)
 
+    def test_project_template_readme_does_not_link_unpublished_render(self) -> None:
+        readme = (PACKAGE_ROOT / "project_template" / "README.md").read_text(encoding="utf-8")
+
+        self.assertNotIn("reference-blueprints/project-template/", readme)
+        self.assertIn("_out/site/html-multi/", readme)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Backport #67 to `v4.29.0`.

## Primary Review
- Primary review: #67
- Keep review comments on #67 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.29.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- Release-specific: the starter template `VersoBlueprint` pin targets `v4.29.0`.
- Release-specific: the backport uses the older stable-branch helper shape where `normalize_lean_release_ref` is the available release ref helper.