### PR TITLE
ci: allow RC reference toolchain override

### DIFF
--- a/.github/workflows/reference-blueprints-deploy.yml
+++ b/.github/workflows/reference-blueprints-deploy.yml
@@ -93,18 +93,20 @@ jobs:
           path: |
             .lake/packages/mathlib
             .lake/packages/verso
-          key: ${{ runner.os }}-reference-deploy-lake-packages-v2-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-${{ matrix.release_id }}
+          key: ${{ runner.os }}-reference-deploy-lake-packages-v2-${{ matrix.toolchain }}-${{ hashFiles('lake-manifest.json') }}-${{ matrix.release_id }}
           restore-keys: |
-            ${{ runner.os }}-reference-deploy-lake-packages-v2-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-
+            ${{ runner.os }}-reference-deploy-lake-packages-v2-${{ matrix.toolchain }}-
+            ${{ runner.os }}-reference-deploy-lake-packages-v2-
       - name: Restore Lake dependency build cache
         uses: actions/cache@v4
         with:
           path: |
             .lake/packages/mathlib/.lake/build
             .lake/packages/verso/.lake/build
-          key: ${{ runner.os }}-reference-deploy-lake-deps-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-${{ matrix.release_id }}
+          key: ${{ runner.os }}-reference-deploy-lake-deps-${{ matrix.toolchain }}-${{ hashFiles('lake-manifest.json') }}-${{ matrix.release_id }}
           restore-keys: |
-            ${{ runner.os }}-reference-deploy-lake-deps-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-
+            ${{ runner.os }}-reference-deploy-lake-deps-${{ matrix.toolchain }}-
+            ${{ runner.os }}-reference-deploy-lake-deps-
       - name: Restore external reference dependency cache
         if: ${{ matrix.reference_cache_key != '' }}
         uses: actions/cache@v4
@@ -125,6 +127,7 @@ jobs:
             --manifest _out/deploy-projects/${{ matrix.project_id }}.json \
             --release ${{ matrix.release_id }} \
             --project ${{ matrix.project_id }} \
+            --allow-unsafe-root-release \
             --allow-local-build \
             --serial \
             _out/reference-blueprints/${{ matrix.release_id }}

--- a/.github/workflows/reference-blueprints.yml
+++ b/.github/workflows/reference-blueprints.yml
@@ -62,8 +62,9 @@ jobs:
           path: |
             .lake/packages/mathlib
             .lake/packages/verso
-          key: ${{ runner.os }}-lake-packages-v2-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}
+          key: ${{ runner.os }}-lake-packages-v2-${{ needs.resolve-reference-release.outputs.toolchain }}-${{ hashFiles('lake-manifest.json') }}
           restore-keys: |
+            ${{ runner.os }}-lake-packages-v2-${{ needs.resolve-reference-release.outputs.toolchain }}-
             ${{ runner.os }}-lake-packages-v2-
       - name: Restore Lake dependency build cache
         uses: actions/cache@v4
@@ -71,8 +72,9 @@ jobs:
           path: |
             .lake/packages/mathlib/.lake/build
             .lake/packages/verso/.lake/build
-          key: ${{ runner.os }}-lake-deps-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}
+          key: ${{ runner.os }}-lake-deps-${{ needs.resolve-reference-release.outputs.toolchain }}-${{ hashFiles('lake-manifest.json') }}
           restore-keys: |
+            ${{ runner.os }}-lake-deps-${{ needs.resolve-reference-release.outputs.toolchain }}-
             ${{ runner.os }}-lake-deps-
       - name: Restore external reference dependency cache
         if: ${{ matrix.reference_cache_key != '' }}
@@ -89,7 +91,7 @@ jobs:
           lake --version
           python3 --version
       - name: Generate reference blueprint
-        run: ./scripts/generate-reference-blueprints.sh --project ${{ matrix.project_id }}
+        run: ./scripts/generate-reference-blueprints.sh --allow-unsafe-root-release --project ${{ matrix.project_id }}
       - name: Upload reference blueprint artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This PR keeps the temporary RC-backed reference-blueprint workflow from tripping the release-root safety guard. The workflow still downgrades the CI checkout `lean-toolchain` for RC reference targets so nested reference checkouts inherit the matching toolchain, then passes `--allow-unsafe-root-release` because that tracked-file change is intentional in the ephemeral CI checkout.

It also keys the workflow caches on the resolved reference toolchain directly, so RC and final runs do not share the same root cache key.

Backport v4.29.0: exempt: this fixes the v4.30.0 RC reference-catalog transition path and is not needed on the v4.29.0 line.