### PR TITLE
feat: add proposition block kind

### DIFF
--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -91,7 +91,7 @@ plus
 [project_template/ProjectTemplate/Chapters/Collatz.lean](../project_template/ProjectTemplate/Chapters/Collatz.lean)
 show the most important authoring patterns:
 
-- definition, theorem, and proof blocks
+- definition, proposition, theorem, and proof blocks
 - labels that identify nodes
 - a `uses` link to another Blueprint entry
 - a `bpref` link when prose should reference a node without adding a dependency

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -205,12 +205,13 @@ This example shows the core pattern:
 Blueprint chapters commonly use:
 
 - `:::definition "label_1"`
-- `:::lemma_ "label_2"`
-- `:::theorem "label_3"`
-- `:::corollary "label_4"`
-- `:::proof "label_3"`
+- `:::proposition "label_2"`
+- `:::lemma_ "label_3"`
+- `:::theorem "label_4"`
+- `:::corollary "label_5"`
+- `:::proof "label_4"`
 
-`:::proof "label_3"` attaches to the earlier statement with the same label.
+`:::proof "label_4"` attaches to the earlier statement with the same label.
 
 ## Connecting Blocks to Lean
 

--- a/project_template/README.md
+++ b/project_template/README.md
@@ -57,7 +57,7 @@ The important files are:
 ## What the template demonstrates
 
 - labels that identify Blueprint nodes
-- `:::definition`, `:::theorem`, and `:::proof`
+- `:::definition`, `:::proposition`, `:::theorem`, and `:::proof`
 - local Lean code attached to a Blueprint label
 - local Rust code attached to a Blueprint label
 - a statement linked to an existing Lean declaration

--- a/src/VersoBlueprint/Cite.lean
+++ b/src/VersoBlueprint/Cite.lean
@@ -99,6 +99,7 @@ inductive CitePartKind where
   | chapter
   | section
   | theorem
+  | proposition
   | lemma
   | corollary
   | page
@@ -111,6 +112,7 @@ def CitePartKind.parse? (s : String) : Option CitePartKind :=
   | "chapter" | "ch" => some .chapter
   | "section" | "sec" => some .section
   | "theorem" | "thm" => some .theorem
+  | "proposition" | "prop" => some .proposition
   | "lemma" | "lem" => some .lemma
   | "corollary" | "cor" => some .corollary
   | "page" | "p" | "pp" => some .page
@@ -122,6 +124,7 @@ def CitePartKind.text : CitePartKind → String
   | .chapter => "Chapter"
   | .section => "Section"
   | .theorem => "Theorem"
+  | .proposition => "Proposition"
   | .lemma => "Lemma"
   | .corollary => "Corollary"
   | .page => "p."

--- a/src/VersoBlueprint/Commands/Summary.lean
+++ b/src/VersoBlueprint/Commands/Summary.lean
@@ -472,6 +472,11 @@ def buildSummary : CoreM Summary := do
             definitions := acc.definitions + 1
             definitionStatus := bumpEntryStatus acc.definitionStatus statusFlags
           }
+        | Data.NodeKind.proposition =>
+          { acc with
+            propositions := acc.propositions + 1
+            propositionStatus := bumpEntryStatus acc.propositionStatus statusFlags
+          }
         | Data.NodeKind.lemma =>
           { acc with
             lemmas := acc.lemmas + 1
@@ -1259,7 +1264,7 @@ private def SummaryHtmlContext.theoremLikeParentGroup (ctx : SummaryHtmlContext)
   {{ <details class="bp_summary_subsection">
       <summary>s!"{group.header} ({group.entries.length})"</summary>
       <ul class="bp_summary_list">
-        {{if rows.isEmpty then {{<li class="bp_summary_empty">"No theorem/lemma/corollary entries in this parent group."</li>}} else rows}}
+        {{if rows.isEmpty then {{<li class="bp_summary_empty">"No theorem/proposition/lemma/corollary entries in this parent group."</li>}} else rows}}
       </ul>
     </details> }}
 
@@ -1403,6 +1408,7 @@ private def summaryOverviewSection (data : Summary) (rows : SummaryRows) : Outpu
 
 private def summaryEntryIndexSection (data : Summary) (rows : SummaryRows) : Output.Html :=
   let showDefinitionCard := data.definitions > 0
+  let showPropositionCard := data.propositions > 0
   let showLemmaCard := data.lemmas > 0
   let showTheoremCard := data.theorems > 0
   let showCorollaryCard := data.corollaries > 0
@@ -1424,6 +1430,11 @@ private def summaryEntryIndexSection (data : Summary) (rows : SummaryRows) : Out
               "Definitions"
               (toString data.definitions)
               (Option.some (statusCountsText data.definitionStatus))}}
+          {{summaryOptionalCard
+              showPropositionCard
+              "Propositions"
+              (toString data.propositions)
+              (Option.some (statusCountsText data.propositionStatus))}}
           {{summaryOptionalCard showLemmaCard "Lemmas" (toString data.lemmas) (Option.some (statusCountsText data.lemmaStatus))}}
           {{summaryOptionalCard showTheoremCard "Theorems" (toString data.theorems) (Option.some (statusCountsText data.theoremStatus))}}
           {{summaryOptionalCard
@@ -1442,7 +1453,7 @@ private def summaryEntryIndexSection (data : Summary) (rows : SummaryRows) : Out
         {{summaryOptionalDetailsList showDefinitionIndex s!"Definition Index ({data.definitionIndex.length})" rows.definitionRows}}
         {{if showTheoremLikeIndex then
             {{<details class="bp_summary_subsection">
-              <summary>s!"Theorem / Lemma / Corollary Index ({data.theoremLikeIndex.length})"</summary>
+              <summary>s!"Theorem / Proposition / Lemma / Corollary Index ({data.theoremLikeIndex.length})"</summary>
               <ul class="bp_summary_list">
                 {{rows.theoremLikeRows}}
               </ul>

--- a/src/VersoBlueprint/Commands/Summary/Data.lean
+++ b/src/VersoBlueprint/Commands/Summary/Data.lean
@@ -307,6 +307,7 @@ structure Summary where
   showDebugDiagnostics : Bool := false
   totalEntries : Nat := 0
   definitions : Nat := 0
+  propositions : Nat := 0
   lemmas : Nat := 0
   theorems : Nat := 0
   corollaries : Nat := 0
@@ -315,6 +316,7 @@ structure Summary where
   informalOnlyEntries : Nat := 0
   totalStatus : EntryStatusCounts := {}
   definitionStatus : EntryStatusCounts := {}
+  propositionStatus : EntryStatusCounts := {}
   lemmaStatus : EntryStatusCounts := {}
   theoremStatus : EntryStatusCounts := {}
   corollaryStatus : EntryStatusCounts := {}
@@ -353,6 +355,7 @@ instance : Quote Summary where
       quote s.showDebugDiagnostics,
       quote s.totalEntries,
       quote s.definitions,
+      quote s.propositions,
       quote s.lemmas,
       quote s.theorems,
       quote s.corollaries,
@@ -361,6 +364,7 @@ instance : Quote Summary where
       quote s.informalOnlyEntries,
       quote s.totalStatus,
       quote s.definitionStatus,
+      quote s.propositionStatus,
       quote s.lemmaStatus,
       quote s.theoremStatus,
       quote s.corollaryStatus,

--- a/src/VersoBlueprint/Data.lean
+++ b/src/VersoBlueprint/Data.lean
@@ -55,6 +55,7 @@ instance : Quote AuthorInfo where
 
 inductive NodeKind where
   | definition
+  | proposition
   | lemma
   | theorem
   | corollary
@@ -63,12 +64,13 @@ deriving Repr, Inhabited, DecidableEq, ToJson, FromJson
 instance : ToString NodeKind where
   toString
     | .definition => "Definition"
+    | .proposition => "Proposition"
     | .lemma => "Lemma"
     | .theorem => "Theorem"
     | .corollary => "Corollary"
 
 def NodeKind.isTheoremLike : NodeKind → Bool
-  | .lemma | .theorem | .corollary => true
+  | .proposition | .lemma | .theorem | .corollary => true
   | .definition => false
 
 inductive InProgressKind where
@@ -80,6 +82,7 @@ open Syntax in
 instance : Quote NodeKind where
   quote
     | .definition => mkCApp ``NodeKind.definition #[]
+    | .proposition => mkCApp ``NodeKind.proposition #[]
     | .lemma => mkCApp ``NodeKind.lemma #[]
     | .theorem => mkCApp ``NodeKind.theorem #[]
     | .corollary => mkCApp ``NodeKind.corollary #[]

--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -808,6 +808,7 @@ private def expander (kind : Data.NodeKind) (isProof : Bool := false) : Directiv
       (expanderImpl kind isProof) cfg contents
 
 @[directive] def «definition» := expander .definition
+@[directive] def «proposition» := expander .proposition
 @[directive] def «lemma_» := expander .lemma
 @[directive] def «theorem» := expander .theorem
 @[directive] def «corollary» := expander .corollary

--- a/src/VersoBlueprint/Informal/Block/Assets.lean
+++ b/src/VersoBlueprint/Informal/Block/Assets.lean
@@ -1333,6 +1333,7 @@ div.theorem_thmcontent {
   border-left: 0.15rem solid black;
 }
 
+.bp_kind_proposition_content,
 div.proposition_thmcontent {
   border-left: 0.15rem solid black;
 }

--- a/src/VersoBlueprint/Informal/Block/Render.lean
+++ b/src/VersoBlueprint/Informal/Block/Render.lean
@@ -47,6 +47,16 @@ private def blockKindRenderStyle (data : BlockData) : BlockKindRenderStyle :=
         labelCss := "definition_thmlabel"
         contentCss := "definition_thmcontent"
       }
+    | .proposition =>
+      {
+        kindText := s!"{nodeKind}"
+        kindCss := "proposition"
+        wrapperCss := "proposition_thmwrapper theorem-style-plain bp_kind_proposition bp_style_plain"
+        headingCss := "proposition_thmheading"
+        captionCss := "proposition_thmcaption"
+        labelCss := "proposition_thmlabel"
+        contentCss := "proposition_thmcontent"
+      }
     | .theorem =>
       {
         kindText := s!"{nodeKind}"

--- a/src/VersoBlueprint/Informal/CodeSummary.lean
+++ b/src/VersoBlueprint/Informal/CodeSummary.lean
@@ -192,6 +192,7 @@ def externalDeclKindText? (decl : Data.ExternalRef) : Option String :=
   else
     match decl.kind with
     | .definition => some "definition"
+    | .proposition => some "proposition"
     | .lemma => some "lemma"
     | .theorem => some "theorem"
     | .corollary => some "corollary"
@@ -199,7 +200,7 @@ def externalDeclKindText? (decl : Data.ExternalRef) : Option String :=
 private def externalSummaryKind (decl : Data.ExternalRef) : DeclSummaryKind :=
   match decl.kind with
   | .definition => .definition
-  | .lemma | .theorem | .corollary => .theoremLike
+  | .proposition | .lemma | .theorem | .corollary => .theoremLike
 
 private def externalDeclHref (decl : Data.ExternalRef) (hrefOf : Name → Option String) : Option String :=
   if decl.present then

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -500,7 +500,7 @@ structure Entry where
   label : Name
   /-- Which preview variant this entry contains; non-block previews use `statement`. -/
   facet : PreviewCache.Facet
-  /-- Kind (definition, lemma, theorem, corollary). -/
+  /-- Kind (definition, proposition, lemma, theorem, corollary). -/
   kind : Option Informal.Data.NodeKind := none
   /-- Resolved display title for this preview entry. -/
   title : String

--- a/src/VersoBlueprint/ProvedStatus.lean
+++ b/src/VersoBlueprint/ProvedStatus.lean
@@ -65,7 +65,7 @@ Theorem-like statements are blocked only by statement gaps.
 def ProvedStatus.blocksStatementCompletion (status : ProvedStatus) (kind : NodeKind) : Bool :=
   match kind with
   | .definition => status.hasTypeGap || status.hasProofGap
-  | .lemma | .theorem | .corollary => status.hasTypeGap
+  | .proposition | .lemma | .theorem | .corollary => status.hasTypeGap
 
 /-- Conservative proof-track blocker predicate. -/
 def ProvedStatus.blocksProofCompletion (status : ProvedStatus) : Bool :=

--- a/src/VersoBlueprint/StyleSwitcher.lean
+++ b/src/VersoBlueprint/StyleSwitcher.lean
@@ -67,6 +67,7 @@ html[data-bp-style="blueprint"] .bp_content {
 }
 
 html[data-bp-style="blueprint"] .bp_kind_theorem_content,
+html[data-bp-style="blueprint"] .bp_kind_proposition_content,
 html[data-bp-style="blueprint"] .bp_kind_lemma_content,
 html[data-bp-style="blueprint"] .bp_kind_corollary_content,
 html[data-bp-style="blueprint"] .bp_kind_proof_content,
@@ -103,6 +104,7 @@ html[data-bp-style="modern"] .bp_content {
 }
 
 html[data-bp-style="modern"] .bp_kind_theorem_content,
+html[data-bp-style="modern"] .bp_kind_proposition_content,
 html[data-bp-style="modern"] .bp_kind_lemma_content,
 html[data-bp-style="modern"] .bp_kind_corollary_content,
 html[data-bp-style="modern"] .bp_kind_proof_content,
@@ -163,6 +165,7 @@ html[data-bp-style="bold"] .bp_content {
 }
 
 html[data-bp-style="bold"] .bp_kind_theorem_content,
+html[data-bp-style="bold"] .bp_kind_proposition_content,
 html[data-bp-style="bold"] .bp_kind_lemma_content,
 html[data-bp-style="bold"] .bp_kind_corollary_content,
 html[data-bp-style="bold"] .bp_kind_proof_content,

--- a/tests/VersoBlueprintTests/BlueprintBlockFolding.lean
+++ b/tests/VersoBlueprintTests/BlueprintBlockFolding.lean
@@ -28,6 +28,13 @@ Default proof body.
 :::
 :::::::
 
+#docs (Genre.Manual) blockKindDisplayDoc "Block Kind Display" :=
+:::::::
+:::proposition "display.proposition"
+Proposition statement.
+:::
+:::::::
+
 set_option verso.blueprint.foldProofBlocks true
 
 #docs (Genre.Manual) foldedProofBlockDoc "Folded Proof Block" :=
@@ -82,6 +89,14 @@ set_option verso.blueprint.foldCodeBlocks false
     hasSubstr out "<div class=\"bp_wrapper bp_kind_proof_wrapper" &&
     !hasSubstr out "<details class=\"bp_wrapper bp_kind_proof_wrapper" &&
     hasSubstr out "Default proof body."
+
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let out ← renderManualDocHtmlString manualImpls blockKindDisplayDoc
+  pure <|
+    hasSubstr out "bp_kind_proposition_wrapper" &&
+    hasSubstr out "Proposition"
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/VersoBlueprintTests/BlueprintGraph/Basics.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraph/Basics.lean
@@ -37,6 +37,7 @@ open Verso.VersoBlueprintTests.BlueprintGraph.Shared
   let status : Data.ProvedStatus :=
     .containsSorry #[{ location := .statement, refs? := some 2 }, { location := .proof, refs? := some 3 }]
   Data.NodeKind.definition.isTheoremLike = false &&
+  Data.NodeKind.proposition.isTheoremLike &&
   Data.NodeKind.theorem.isTheoremLike &&
   status.sorryLocationText = "in statement and proof" &&
   status.statusLabel = "contains sorry" &&

--- a/tests/VersoBlueprintTests/BlueprintInformal/Structure.lean
+++ b/tests/VersoBlueprintTests/BlueprintInformal/Structure.lean
@@ -51,6 +51,22 @@ Second statement.
       | return false
     pure (node.statement.isSome && node.proof.isNone)
 
+#docs (Manual) propositionKindDoc "Proposition Kind" :=
+:::::::
+:::proposition "prop.kind"
+Proposition body.
+:::
+:::::::
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show CoreM Bool from do
+    let state ← currentState
+    let some node := state.data.get? (Name.mkSimple "prop.kind")
+      | return false
+    pure (node.kind == .proposition && node.statement.isSome)
+
 /--
 error: Cannot declare nested definitions
 ---

--- a/tests/VersoBlueprintTests/BlueprintLinkHover.lean
+++ b/tests/VersoBlueprintTests/BlueprintLinkHover.lean
@@ -36,6 +36,12 @@ private def hoverCitePreviewKey : String :=
     (some Informal.Cite.CitePartKind.lemma)
     (some "3")
 
+/-- info: true -/
+#guard_msgs in
+#eval
+  Informal.Cite.CitePartKind.parse? "prop" == some .proposition &&
+  Informal.Cite.CitePartKind.proposition.text == "Proposition"
+
 #docs (Genre.Manual) hoverLinkDoc "Hover Link Doc" :=
 :::::::
 :::lemma_ "lem:hover.link"

--- a/tests/VersoBlueprintTests/BlueprintNumbering.lean
+++ b/tests/VersoBlueprintTests/BlueprintNumbering.lean
@@ -27,10 +27,12 @@ private def emptyState : TraverseState :=
   let localBlock := { base with numberingMode := .local }
   let subBlock := { base with numberingMode := .sub, partPrefix := some "3" }
   let globalBlock := { base with numberingMode := .global, globalCount := some 17 }
+  let propositionBlock := { base with kind := .statement .proposition }
   localBlock.displayNumber emptyState == "4" &&
   subBlock.displayNumber emptyState == "3.4" &&
   globalBlock.displayNumber emptyState == "17" &&
-  subBlock.displayTitle emptyState == "Definition 3.4"
+  subBlock.displayTitle emptyState == "Definition 3.4" &&
+  propositionBlock.displayTitle emptyState == "Proposition 4"
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/VersoBlueprintTests/BlueprintPreviewSchema.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewSchema.lean
@@ -55,7 +55,7 @@ open Informal.PreviewManifest
         entryProps.contains "html" &&
         labelDesc? == some "Canonical target label: informal label, Lean declaration name, or citation label." &&
         proofDepsDesc? == some "Informal nodes used by the proof." &&
-        kindDesc? == some "Kind (definition, lemma, theorem, corollary)." &&
+        kindDesc? == some "Kind (definition, proposition, lemma, theorem, corollary)." &&
         !schemaText.contains "Lean `Name`" &&
         defs.contains "Informal.PreviewManifest.EntryKind" &&
         defs.contains "Informal.Data.NodeKind" &&

--- a/tests/VersoBlueprintTests/BlueprintSummaryStatus.lean
+++ b/tests/VersoBlueprintTests/BlueprintSummaryStatus.lean
@@ -40,18 +40,22 @@ private def mkLiterateCode (definedDefs : Array LiterateDef) (definedTheorems : 
   let proofGap := ProvedStatus.ofRefCounts 0 1
   let bothGap := ProvedStatus.ofRefCounts 1 1
   (!provedStatus.blocksStatementCompletion .definition) &&
+  (!provedStatus.blocksStatementCompletion .proposition) &&
   (!provedStatus.blocksStatementCompletion .lemma) &&
   (!provedStatus.blocksStatementCompletion .theorem) &&
   (!provedStatus.blocksStatementCompletion .corollary) &&
   stmtGap.blocksStatementCompletion .definition &&
+  stmtGap.blocksStatementCompletion .proposition &&
   stmtGap.blocksStatementCompletion .lemma &&
   stmtGap.blocksStatementCompletion .theorem &&
   stmtGap.blocksStatementCompletion .corollary &&
   proofGap.blocksStatementCompletion .definition &&
+  (!proofGap.blocksStatementCompletion .proposition) &&
   (!proofGap.blocksStatementCompletion .lemma) &&
   (!proofGap.blocksStatementCompletion .theorem) &&
   (!proofGap.blocksStatementCompletion .corollary) &&
   bothGap.blocksStatementCompletion .definition &&
+  bothGap.blocksStatementCompletion .proposition &&
   bothGap.blocksStatementCompletion .lemma &&
   bothGap.blocksStatementCompletion .theorem &&
   bothGap.blocksStatementCompletion .corollary &&
@@ -63,6 +67,7 @@ private def mkLiterateCode (definedDefs : Array LiterateDef) (definedTheorems : 
 #eval
   let statuses : Array ProvedStatus := #[.proved, ProvedStatus.ofRefCounts 0 1]
   ProvedStatus.anyBlocksStatementCompletion .definition statuses (fun s => s) &&
+  (!ProvedStatus.anyBlocksStatementCompletion .proposition statuses (fun s => s)) &&
   (!ProvedStatus.anyBlocksStatementCompletion .theorem statuses (fun s => s)) &&
   ProvedStatus.anyBlocksProofCompletion statuses (fun s => s)
 


### PR DESCRIPTION
This PR adds `:::proposition` as a theorem-like Blueprint block kind, including rendering, summary/schema coverage, citation locator support, documentation, and regression tests.

Backport v4.29.0: exempt: new Blueprint block-kind functionality for the default-development line