### PR TITLE
fix: use section-local blueprint numbering

### DIFF
--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -640,6 +640,8 @@ that elaborates the Blueprint chapter or document:
 
 ```lean
 set_option verso.blueprint.numbering global
+set_option verso.blueprint.subNumberingPrefix full
+set_option verso.blueprint.subNumberingCounter prefix
 set_option verso.blueprint.foldProofBlocks true
 set_option verso.blueprint.foldCodeBlocks false
 ```
@@ -648,9 +650,25 @@ Current options:
 
 - `verso.blueprint.numbering`
   - default: `sub`
-  - `sub`: chapter-prefixed numbering such as `Theorem 5.5`
+  - `sub`: prefixed numbering such as `Theorem 1.3.2`; the prefix and counter
+    are controlled by the sub-numbering options below
   - `global`: document-order numbering such as `Theorem 27`
   - `local`: legacy local numbering without a chapter prefix
+- `verso.blueprint.subNumberingPrefix`
+  - default: `full`
+  - `full`: use the full numbered section path, such as `1.3`
+  - `first`: use only the first numbered ancestor, such as `1`
+- `verso.blueprint.subNumberingCounter`
+  - default: `prefix`
+  - `prefix`: reset the block counter for each rendered prefix, such as
+    `Theorem 1.3.2`
+  - `document`: use the document-order block count after the prefix, such as
+    `Theorem 1.93`
+
+Set `verso.blueprint.subNumberingPrefix first` together with
+`verso.blueprint.subNumberingCounter document` to recover chapter-only
+prefixes with document-order block counts.
+
 - `verso.blueprint.foldProofs`
   - default: `true`
   - folds proof bodies in rendered Lean code panels after `by`

--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -516,31 +516,6 @@ private def registerExternalDeclAnchors
   for decl in decls do
     registerExternalDeclAnchor label decl
 
-private def storeTraversedBlockData
-    {m}
-    [Monad m]
-    [MonadReaderOf TraverseContext m]
-    [MonadStateOf TraverseState m]
-    [MonadLiftT IO m]
-    (id : Verso.Multi.InternalId)
-    (blockData : BlockData) :
-    m Unit := do
-  let label := blockData.label
-  let storedBlockData := blockData.toStoredData
-  match Informal.TraversalIndex.Nodes.storedData? (← get) label with
-  | some existing =>
-    let mergedData := mergeStoredBlockData existing storedBlockData
-    modify λ s => Informal.TraversalIndex.Nodes.saveData s label (toJson mergedData)
-  | none =>
-    let path := (← read).path
-    let _ ← Verso.Genre.Manual.externalTag id path s!"--informal-{label}"
-    modify fun s =>
-      let (globalCount, s) := reserveGlobalBlockNumber s
-      let blockData := { storedBlockData with globalCount := storedBlockData.globalCount <|> some globalCount }
-      s
-        |> (fun s => Informal.TraversalIndex.Nodes.saveId s label id)
-        |> (fun s => Informal.TraversalIndex.Nodes.saveData s label (toJson blockData))
-
 /- Informal custom blocks -/
 block_extension Block.informal (data : BlockData) where
   -- for TOC
@@ -553,13 +528,12 @@ block_extension Block.informal (data : BlockData) where
       logError s!"Malformed data ({err}): {data}"
       pure none
     | .ok blockData =>
-      let partPrefix := numberedPartPrefix? (← read)
-      let blockData := { blockData with partPrefix := blockData.partPrefix <|> partPrefix }
+      let blockData := blockData.withTraversalNumberingContext (← read)
       let externalDecls := externalDeclsOfBlock blockData
       registerBlockPreviewData id blockData _contents
       registerExternalCodePreviews id externalDecls
       registerExternalDeclAnchors blockData.label externalDecls
-      storeTraversedBlockData id blockData
+      saveTraversedBlockData id blockData
       return none
   toTeX := none
   extraCss := Informal.Block.Assets.blockCssAssets
@@ -575,7 +549,7 @@ block_extension Block.informal (data : BlockData) where
       | .ok data =>
         let s ← HtmlT.state
         let ctxt ← HtmlT.context
-        let data := data.withResolvedNumbering s (numberedPartPrefix? ctxt)
+        let data := data.withResolvedNumberingInContext s ctxt
         let relatedPanelContext := mkRelatedPanelContext s
         let attrs := s.htmlId id
         let codeHref : Option String :=
@@ -785,6 +759,8 @@ private def expanderImpl (kind : Data.NodeKind) (isProof : Bool := false) : Dire
       parent := node?.bind (·.parent)
       count
       numberingMode := numberingMode opts
+      subNumberingPrefix := subNumberingPrefix opts
+      subNumberingCounter := subNumberingCounter opts
       statementDeps
       proofDeps
       owner

--- a/src/VersoBlueprint/Informal/Block/Model.lean
+++ b/src/VersoBlueprint/Informal/Block/Model.lean
@@ -11,10 +11,23 @@ namespace Informal
 
 open Lean
 
+/-- Which broad numbering scheme should informal blocks use? -/
 inductive NumberingMode where
   | sub
   | global
   | local
+deriving Repr, Inhabited, BEq, FromJson, ToJson, Quote
+
+/-- Which numbered ancestors should appear before the local sub-number? -/
+inductive SubNumberingPrefix where
+  | full
+  | first
+deriving Repr, Inhabited, BEq, FromJson, ToJson, Quote
+
+/-- Which counter should be appended after the rendered sub-numbering prefix? -/
+inductive SubNumberingCounter where
+  | prefix
+  | document
 deriving Repr, Inhabited, BEq, FromJson, ToJson, Quote
 
 def NumberingMode.parse? (raw : String) : Option NumberingMode :=
@@ -24,15 +37,47 @@ def NumberingMode.parse? (raw : String) : Option NumberingMode :=
   | "local" => some .local
   | _ => none
 
+def SubNumberingPrefix.parse? (raw : String) : Option SubNumberingPrefix :=
+  match raw.trimAscii.toString.toLower with
+  | "full" | "path" | "section" | "sections" => some .full
+  | "first" | "top" | "chapter" => some .first
+  | _ => none
+
+def SubNumberingCounter.parse? (raw : String) : Option SubNumberingCounter :=
+  match raw.trimAscii.toString.toLower with
+  | "prefix" | "section" | "sections" | "local" => some .prefix
+  | "document" | "global" => some .document
+  | _ => none
+
 register_option verso.blueprint.numbering : String := {
   defValue := "sub"
-  descr := "Numbering mode for blueprint informal blocks: `sub` (default; prefix with numbered part path), `global`, or `local`"
+  descr := "Numbering mode for blueprint informal blocks: `sub` (default; prefix according to sub-numbering options), `global`, or `local`"
+}
+
+register_option verso.blueprint.subNumberingPrefix : String := {
+  defValue := "full"
+  descr := "Prefix used by `verso.blueprint.numbering = sub`: `full` (default; full numbered part path) or `first` (first numbered ancestor)"
+}
+
+register_option verso.blueprint.subNumberingCounter : String := {
+  defValue := "prefix"
+  descr := "Counter used by `verso.blueprint.numbering = sub`: `prefix` (default; reset for each rendered prefix) or `document` (document-order count)"
 }
 
 def numberingMode (opts : Lean.Options) : NumberingMode :=
   match NumberingMode.parse? (verso.blueprint.numbering.get opts) with
   | some mode => mode
   | none => .sub
+
+def subNumberingPrefix (opts : Lean.Options) : SubNumberingPrefix :=
+  match SubNumberingPrefix.parse? (verso.blueprint.subNumberingPrefix.get opts) with
+  | some mode => mode
+  | none => .full
+
+def subNumberingCounter (opts : Lean.Options) : SubNumberingCounter :=
+  match SubNumberingCounter.parse? (verso.blueprint.subNumberingCounter.get opts) with
+  | some mode => mode
+  | none => .prefix
 
 structure CodeDeclData where
   name : Name
@@ -111,8 +156,12 @@ structure BlockData where
   parent : Option Data.Parent := none
   count : Nat
   numberingMode : NumberingMode := .sub
+  /-- Prefix policy for `numberingMode = .sub`. -/
+  subNumberingPrefix : SubNumberingPrefix := .full
+  /-- Counter policy for `numberingMode = .sub`. -/
+  subNumberingCounter : SubNumberingCounter := .prefix
   /--
-  Top-level rendered part prefix assigned during traversal (for example `3` or `A`).
+  Rendered part prefix assigned during traversal (for example `3`, `A`, or `1.3`).
 
   This is stored as `String` rather than `Manual.Numbering` because it is a
   render-facing cache: the upstream part numbering may be numeric or alphabetic,
@@ -149,6 +198,10 @@ structure StoredBlockData where
   parent : Option Data.Parent := none
   count : Nat
   numberingMode : NumberingMode := .sub
+  /-- Prefix policy for `numberingMode = .sub`. -/
+  subNumberingPrefix : SubNumberingPrefix := .full
+  /-- Counter policy for `numberingMode = .sub`. -/
+  subNumberingCounter : SubNumberingCounter := .prefix
   partPrefix : Option String := none
   globalCount : Option Nat := none
   statementDeps : Array Data.Label := #[]
@@ -169,6 +222,8 @@ def BlockData.toStoredData (data : BlockData) : StoredBlockData := {
   parent := data.parent
   count := data.count
   numberingMode := data.numberingMode
+  subNumberingPrefix := data.subNumberingPrefix
+  subNumberingCounter := data.subNumberingCounter
   partPrefix := data.partPrefix
   globalCount := data.globalCount
   statementDeps := data.statementDeps
@@ -191,6 +246,8 @@ def StoredBlockData.toBlockData (data : StoredBlockData)
   parent := data.parent
   count := data.count
   numberingMode := data.numberingMode
+  subNumberingPrefix := data.subNumberingPrefix
+  subNumberingCounter := data.subNumberingCounter
   partPrefix := data.partPrefix
   globalCount := data.globalCount
   statementDeps := data.statementDeps

--- a/src/VersoBlueprint/Informal/Block/Store.lean
+++ b/src/VersoBlueprint/Informal/Block/Store.lean
@@ -13,27 +13,110 @@ open Lean
 open Verso
 open Verso.Genre Manual
 
+/-- Traversal-state key for the next document-order informal block number. -/
 def numberingCounterState : Name := Lean.Name.mkSimple "Informal.Block.numberingCounter"
 
+/-- Traversal-state key for the next informal block number under each rendered prefix. -/
+def prefixNumberingCounterState : Name :=
+  Lean.Name.mkSimple "Informal.Block.prefixNumberingCounter"
+
+/-- The next document-order informal block number, defaulting to `1`. -/
 def nextGlobalBlockNumber (st : TraverseState) : Nat :=
   match st.get? numberingCounterState with
   | some (.ok (n : Nat)) => n
   | _ => 1
 
+/-- Reserve one document-order informal block number and advance the global counter. -/
 def reserveGlobalBlockNumber (st : TraverseState) : Nat × TraverseState :=
   let next := nextGlobalBlockNumber st
   (next, st.set numberingCounterState (next + 1))
 
-/-- The first numbered part above the current block, used for chapter-style sub-numbering. -/
-def numberedPartPrefix? (ctxt : TraverseContext) : Option String := Id.run do
-  for header in ctxt.headers[1:] do
-    if let some n := header.metadata.bind (·.assignedNumber) then
-      return some (toString n)
+/-- Prefix-local counters, stored as a small association list in traversal state. -/
+private def prefixBlockCounters (st : TraverseState) : Array (String × Nat) :=
+  match st.get? prefixNumberingCounterState with
+  | some (.ok (counters : Array (String × Nat))) => counters
+  | _ => #[]
+
+private def nextPrefixBlockNumber (counters : Array (String × Nat)) (partPrefix : String) : Nat :=
+  (counters.findSome? fun (candidate, next) =>
+    if candidate == partPrefix then some next else none).getD 1
+
+private def setPrefixBlockCounter
+    (counters : Array (String × Nat)) (partPrefix : String) (next : Nat) :
+    Array (String × Nat) :=
+  let counters := counters.filter fun (candidate, _) => candidate != partPrefix
+  counters.push (partPrefix, next)
+
+/-- Reserve one informal block number under `partPrefix`. -/
+def reservePrefixBlockNumber (st : TraverseState) (partPrefix : String) : Nat × TraverseState :=
+  let counters := prefixBlockCounters st
+  let next := nextPrefixBlockNumber counters partPrefix
+  (next, st.set prefixNumberingCounterState (setPrefixBlockCounter counters partPrefix (next + 1)))
+
+private def numberingPartString : Numbering → String
+  | .nat n => toString n
+  | .letter a => toString a
+
+/-- First numbered ancestor above the block, for chapter-style prefixes. -/
+private def firstNumberedPartPrefix? (ctxt : TraverseContext) : Option String := Id.run do
+  for num? in ctxt.sectionNumber[1:] do
+    if let some num := num? then
+      return some (numberingPartString num)
   none
 
+/-- Full numbered ancestor path above the block, for section-local prefixes. -/
+private def fullNumberedPartPrefix? (ctxt : TraverseContext) : Option String := Id.run do
+  let mut nums : Array String := #[]
+  for num? in ctxt.sectionNumber[1:] do
+    if let some num := num? then
+      nums := nums.push (numberingPartString num)
+  if nums.isEmpty then none else some (String.intercalate "." nums.toList)
+
+/-- The rendered section prefix above the current block, according to the sub-numbering policy. -/
+def numberedPartPrefix? (mode : SubNumberingPrefix) (ctxt : TraverseContext) : Option String :=
+  match mode with
+  | .full => fullNumberedPartPrefix? ctxt
+  | .first => firstNumberedPartPrefix? ctxt
+
+/--
+Resolve the appended number for a sub-numbered block.
+
+Only `SubNumberingCounter.prefix` reserves a new prefix-local number. In
+document-order mode, the block keeps the elaboration-time `count`.
+-/
+def reserveSubBlockNumber (st : TraverseState) (data : StoredBlockData) : Nat × TraverseState :=
+  match data.subNumberingCounter, data.partPrefix with
+  | .prefix, some partPrefix => reservePrefixBlockNumber st partPrefix
+  | _, _ => (data.count, st)
+
+/-- Attach the current traversal prefix to a block before it is stored. -/
+def BlockData.withTraversalNumberingContext (data : BlockData) (ctxt : TraverseContext) :
+    BlockData :=
+  { data with partPrefix := data.partPrefix <|> numberedPartPrefix? data.subNumberingPrefix ctxt }
+
+/--
+Reserve the traversal numbers for a newly seen block.
+
+Every stored block gets a document-order `globalCount`. Sub-numbered blocks may
+also replace `count` with a prefix-local count, depending on their policy.
+-/
+private def StoredBlockData.withReservedNumbering
+    (data : StoredBlockData) (st : TraverseState) : StoredBlockData × TraverseState :=
+  let (globalCount, st) :=
+    match data.globalCount with
+    | some globalCount => (globalCount, st)
+    | none => reserveGlobalBlockNumber st
+  let (count, st) :=
+    match data.numberingMode with
+    | .sub => reserveSubBlockNumber st data
+    | _ => (data.count, st)
+  ({ data with count, globalCount := some globalCount }, st)
+
+/-- Look up the stored semantic payload for an informal block label. -/
 def resolveStoredNodeData? (st : TraverseState) (label : Data.Label) : Option StoredBlockData :=
   Informal.TraversalIndex.Nodes.storedData? st label
 
+/-- Look up stored informal block data in render-facing `BlockData` form. -/
 def resolveStoredBlockData? (st : TraverseState) (label : Data.Label) : Option BlockData :=
   (resolveStoredNodeData? st label).map (·.toBlockData)
 
@@ -45,6 +128,13 @@ private def mergeStringArrays (xs ys : Array String) : Array String :=
   ys.foldl (init := xs) fun acc value =>
     if acc.contains value then acc else acc.push value
 
+/--
+Merge two stored entries for the same label.
+
+Numbering stays with the first stored entry, while semantic metadata is filled
+in from later entries. If either entry is a statement, the merged node is a
+statement so summaries do not treat it as proof-only.
+-/
 def mergeStoredBlockData (existing incoming : StoredBlockData) : StoredBlockData :=
   let kind :=
     match existing.kind, incoming.kind with
@@ -68,6 +158,7 @@ def mergeStoredBlockData (existing incoming : StoredBlockData) : StoredBlockData
       prUrl := existing.prUrl <|> incoming.prUrl
   }
 
+/-- Sort stored blocks by traversal order, using the label as a stable tiebreaker. -/
 private def sortStoredBlocks (entries : Array BlockData) : Array BlockData :=
   entries.qsort fun a b =>
     let aNum := a.globalCount.getD a.count
@@ -75,6 +166,7 @@ private def sortStoredBlocks (entries : Array BlockData) : Array BlockData :=
     aNum < bNum ||
       (aNum == bNum && a.label.toString < b.label.toString)
 
+/-- Collect every informal block stored in the traversal index, in traversal order. -/
 def collectStoredBlocks (state : TraverseState) : Array BlockData :=
   match Informal.TraversalIndex.Nodes.domain? state with
   | none => #[]
@@ -84,18 +176,38 @@ def collectStoredBlocks (state : TraverseState) : Array BlockData :=
       | some block => acc.push block.toBlockData
       | none => acc
 
+/-- Overlay stored numbering onto render-time block data. -/
+private def BlockData.withStoredNumbering
+    (data : BlockData) (stored : StoredBlockData) (fallbackPrefix? : Option String := none) :
+    BlockData :=
+  { data with
+      count := stored.count
+      numberingMode := stored.numberingMode
+      subNumberingPrefix := stored.subNumberingPrefix
+      subNumberingCounter := stored.subNumberingCounter
+      partPrefix := data.partPrefix <|> stored.partPrefix <|> fallbackPrefix?
+      globalCount := data.globalCount <|> stored.globalCount
+  }
+
+/-- Resolve stored numbering for a block, with an optional caller-provided prefix fallback. -/
 def BlockData.withResolvedNumbering
     (data : BlockData) (st : TraverseState) (fallbackPrefix? : Option String := none) : BlockData :=
   match resolveStoredNodeData? st data.label with
   | some stored =>
-    { data with
-        numberingMode := stored.numberingMode
-        partPrefix := data.partPrefix <|> stored.partPrefix <|> fallbackPrefix?
-        globalCount := data.globalCount <|> stored.globalCount
-    }
+    data.withStoredNumbering stored fallbackPrefix?
   | none =>
     { data with partPrefix := data.partPrefix <|> fallbackPrefix? }
 
+/-- Resolve stored numbering for a block, computing the fallback prefix from traversal context. -/
+def BlockData.withResolvedNumberingInContext
+    (data : BlockData) (st : TraverseState) (ctxt : TraverseContext) : BlockData :=
+  match resolveStoredNodeData? st data.label with
+  | some stored =>
+    data.withStoredNumbering stored (numberedPartPrefix? stored.subNumberingPrefix ctxt)
+  | none =>
+    data.withTraversalNumberingContext ctxt
+
+/-- The user-facing number for a block, after applying stored numbering metadata. -/
 def BlockData.displayNumber (data : BlockData)
     (st : TraverseState) (fallbackPrefix? : Option String := none) : String :=
   let data := data.withResolvedNumbering st fallbackPrefix?
@@ -107,13 +219,45 @@ def BlockData.displayNumber (data : BlockData)
       | some numPrefix => s!"{numPrefix}.{data.count}"
       | none => s!"{data.count}"
 
+/-- Add the block kind to a rendered number, for example `Definition 1.3.2`. -/
 def blockDisplayTitle (data : BlockData) (numberText : String) : String :=
   match data.kind with
   | .proof => s!"Proof {numberText}"
   | .statement kind => s!"{kind} {numberText}"
 
+/-- The user-facing title for a block, including kind and resolved number. -/
 def BlockData.displayTitle (data : BlockData)
     (st : TraverseState) (fallbackPrefix? : Option String := none) : String :=
   blockDisplayTitle data (data.displayNumber st fallbackPrefix?)
+
+/--
+Save one traversed informal block in the semantic node index.
+
+New labels get ids, external tags, and reserved numbering. Repeated labels merge
+their metadata without consuming another number.
+-/
+def saveTraversedBlockData
+    {m}
+    [Monad m]
+    [MonadReaderOf TraverseContext m]
+    [MonadStateOf TraverseState m]
+    [MonadLiftT IO m]
+    (id : Verso.Multi.InternalId)
+    (blockData : BlockData) :
+    m Unit := do
+  let label := blockData.label
+  let storedBlockData := blockData.toStoredData
+  match Informal.TraversalIndex.Nodes.storedData? (← get) label with
+  | some existing =>
+    let mergedData := mergeStoredBlockData existing storedBlockData
+    modify λ s => Informal.TraversalIndex.Nodes.saveData s label (toJson mergedData)
+  | none =>
+    let path := (← read).path
+    let _ ← Verso.Genre.Manual.externalTag id path s!"--informal-{label}"
+    modify fun st =>
+      let (storedBlockData, st) := storedBlockData.withReservedNumbering st
+      st
+        |> (fun st => Informal.TraversalIndex.Nodes.saveId st label id)
+        |> (fun st => Informal.TraversalIndex.Nodes.saveData st label (toJson storedBlockData))
 
 end Informal

--- a/src/VersoBlueprint/Informal/Code.lean
+++ b/src/VersoBlueprint/Informal/Code.lean
@@ -85,7 +85,7 @@ block_extension Block.informalCode (data : InlineCodeData) where
       let panelHeader :=
         match Informal.TraversalIndex.Nodes.data? s label with
         | some b =>
-          let b := b.withResolvedNumbering s (numberedPartPrefix? ctxt)
+          let b := b.withResolvedNumberingInContext s ctxt
           codePanelHeader b (b.displayNumber s)
         | none => fallbackCodePanelHeader
       let getDeclHref (decl : Name) : Option String :=

--- a/src/VersoBlueprint/Informal/RustBlock.lean
+++ b/src/VersoBlueprint/Informal/RustBlock.lean
@@ -50,7 +50,7 @@ block_extension Block.informalRustCode (data : Informal.Rust.InlineCodeData) whe
       let panelHeader :=
         match Informal.TraversalIndex.Nodes.data? s cdata.label with
         | some b =>
-          let b := b.withResolvedNumbering s (numberedPartPrefix? ctxt)
+          let b := b.withResolvedNumberingInContext s ctxt
           Informal.Rust.codePanelHeader b (b.displayNumber s)
         | none => Informal.Rust.fallbackCodePanelHeader
       pure <| Informal.Rust.renderRawCodePanel panelHeader s!"Rust code for {cdata.label}" cdata.raw

--- a/tests/VersoBlueprintTests/BlueprintNumbering.lean
+++ b/tests/VersoBlueprintTests/BlueprintNumbering.lean
@@ -5,6 +5,7 @@ Author: Emilio J. Gallego Arias
 -/
 
 import VersoBlueprint
+import VersoBlueprint.Informal.Block.Store
 import VersoManual
 
 namespace Verso.VersoBlueprintTests.BlueprintNumbering
@@ -15,6 +16,12 @@ open Verso.Genre Manual
 
 private def emptyState : TraverseState :=
   TraverseState.initialize default
+
+private def header (title : String) (number? : Option Numbering) : PartHeader := {
+  titleString := title
+  metadata := number?.map fun number => { ({} : PartMetadata) with assignedNumber := some number }
+  properties := {}
+}
 
 /-- info: true -/
 #guard_msgs in
@@ -31,6 +38,80 @@ private def emptyState : TraverseState :=
   subBlock.displayNumber emptyState == "3.4" &&
   globalBlock.displayNumber emptyState == "17" &&
   subBlock.displayTitle emptyState == "Definition 3.4"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  let base : BlockData := {
+    kind := .statement .theorem
+    label := `bp.numbering.sectionSub
+    count := 2
+  }
+  let subBlock := { base with numberingMode := .sub, partPrefix := some "1.3" }
+  subBlock.displayNumber emptyState == "1.3.2" &&
+  subBlock.displayTitle emptyState == "Theorem 1.3.2"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  let context : TraverseContext := {
+    path := #[]
+    headers := #[
+      header "Root" none,
+      header "Chapter" (some (.nat 1)),
+      header "Section" (some (.nat 3)),
+      header "Appendix" (some (.letter 'A'))
+    ]
+    blockContext := #[]
+    draft := false
+    logError := fun _ => pure ()
+  }
+  numberedPartPrefix? .full context == some "1.3.A" &&
+  numberedPartPrefix? .first context == some "1"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  let stored : BlockData := {
+    kind := .statement .lemma
+    label := `bp.numbering.storedSub
+    count := 9
+    numberingMode := .sub
+    partPrefix := some "1.3"
+  }
+  let state :=
+    Informal.TraversalIndex.Nodes.saveData
+      (TraverseState.initialize default)
+      stored.label
+      (toJson stored.toStoredData)
+  let renderData := { stored with count := 120 }
+  renderData.displayNumber state == "1.3.9" &&
+  renderData.displayTitle state == "Lemma 1.3.9"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  let (first, state) := reservePrefixBlockNumber emptyState "1.3"
+  let (second, state) := reservePrefixBlockNumber state "1.3"
+  let (other, _) := reservePrefixBlockNumber state "1.4"
+  first == 1 &&
+  second == 2 &&
+  other == 1
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  let data : StoredBlockData := {
+    kind := .statement .theorem
+    label := `bp.numbering.documentCounter
+    count := 42
+    numberingMode := .sub
+    subNumberingCounter := .document
+    partPrefix := some "1"
+  }
+  let (count, state) := reserveSubBlockNumber emptyState data
+  count == 42 &&
+  (reservePrefixBlockNumber state "1").fst == 1
 
 /-- info: true -/
 #guard_msgs in


### PR DESCRIPTION
This PR makes sub-numbered Blueprint blocks use configurable section-prefix and counter policies, so nested sections can render labels such as 1.3.2 while projects can still opt back into chapter-only prefixes or document-order counts.

- derive sub-numbering prefixes from either the full numbered section path or the first numbered ancestor
- support prefix-local and document-order counters for sub-numbered blocks
- delegate traversal numbering resolution and semantic node storage to `Informal.Block.Store`
- store resolved numbering policy and counts during traversal so block headers and cross-references agree
- document the new sub-numbering options and cover them with regression tests

Backport v4.29.0: #80