### PR TITLE
[backport v4.29.0] fix: show proof target titles

### DIFF
--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -620,6 +620,10 @@ block_extension Block.informal (data : BlockData) where
         let informalBlock :=
           renderInformalBlockHtml data {
             numberText := data.displayNumber s
+            captionText? :=
+              match data.kind with
+              | .proof => some (data.displayTitle s)
+              | .statement _ => none
             attrs
             headerExtras := {
               group? := groupEntry.map HeaderExtra.group

--- a/src/VersoBlueprint/Informal/Block/Render.lean
+++ b/src/VersoBlueprint/Informal/Block/Render.lean
@@ -78,7 +78,8 @@ private def blockKindRenderStyle (data : BlockData) : BlockKindRenderStyle :=
         contentCss := "corollary_thmcontent"
       }
 
-private def renderBlockTitleRow (style : BlockKindRenderStyle) (labelText numberText : String) :
+private def renderBlockTitleRow (style : BlockKindRenderStyle)
+    (labelText numberText captionText : String) :
     Verso.Output.Html :=
   open Verso.Output.Html in
   let titleRowClass :=
@@ -90,7 +91,7 @@ private def renderBlockTitleRow (style : BlockKindRenderStyle) (labelText number
   let labelClass := s!"bp_label bp_kind_{style.kindCss}_label {style.labelCss}"
   {{
     <div class={{titleRowClass}}>
-      <span class={{captionClass}} title={{labelText}}> {{.text true style.kindText}} </span>
+      <span class={{captionClass}} title={{labelText}}> {{.text true captionText}} </span>
       {{ if style.showLabel then {{<span class={{labelClass}}> {{.text true numberText}} </span>}} else .empty }}
     </div>
   }}
@@ -311,6 +312,7 @@ HTML IDs, header extras, and the resolved display number.
 -/
 structure InformalBlockRenderContext where
   numberText : String
+  captionText? : Option String := none
   attrs : Array (String × String) := #[]
   headerExtras : HeaderExtras := {}
   folded : Bool := false
@@ -330,7 +332,7 @@ def renderInformalBlockHtml (data : BlockData) (ctx : InformalBlockRenderContext
   let wrapperClass := s!"bp_wrapper bp_kind_{style.kindCss}_wrapper {style.kindCss}_thmwrapper {style.wrapperCss}"
   let headingClass := s!"bp_heading bp_kind_{style.kindCss}_heading {style.headingCss}"
   let contentClass := s!"bp_content bp_kind_{style.kindCss}_content {style.contentCss}"
-  let titleRow := renderBlockTitleRow style labelText ctx.numberText
+  let titleRow := renderBlockTitleRow style labelText ctx.numberText (ctx.captionText?.getD style.kindText)
   let extras : Verso.Output.Html :=
     match data.kind with
     | .proof => .empty

--- a/src/VersoBlueprint/Informal/Block/Store.lean
+++ b/src/VersoBlueprint/Informal/Block/Store.lean
@@ -225,10 +225,33 @@ def blockDisplayTitle (data : BlockData) (numberText : String) : String :=
   | .proof => s!"Proof {numberText}"
   | .statement kind => s!"{kind} {numberText}"
 
+def BlockData.statementKind? (data : BlockData) (st : TraverseState) : Option Data.NodeKind :=
+  match data.kind with
+  | .statement kind => some kind
+  | .proof =>
+      match resolveStoredNodeData? st data.label with
+      | some stored =>
+          match stored.kind with
+          | .statement kind => some kind
+          | .proof => none
+      | none => none
+
+def proofDisplayTitle (statementKind? : Option Data.NodeKind) (numberText : String) : String :=
+  match statementKind? with
+  | some kind => s!"Proof for {kind} {numberText}"
+  | none => s!"Proof {numberText}"
+
+def BlockData.displayProofTitle (data : BlockData)
+    (st : TraverseState) (fallbackPrefix? : Option String := none) : String :=
+  proofDisplayTitle (data.statementKind? st) (data.displayNumber st fallbackPrefix?)
+
 /-- The user-facing title for a block, including kind and resolved number. -/
 def BlockData.displayTitle (data : BlockData)
     (st : TraverseState) (fallbackPrefix? : Option String := none) : String :=
-  blockDisplayTitle data (data.displayNumber st fallbackPrefix?)
+  let numberText := data.displayNumber st fallbackPrefix?
+  match data.kind with
+  | .proof => data.displayProofTitle st fallbackPrefix?
+  | .statement _ => blockDisplayTitle data numberText
 
 /--
 Save one traversed informal block in the semantic node index.

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -716,9 +716,13 @@ private def blockInfo? (state : TraverseState) (label : Name) : Option Informal.
   | some blockData => some (blockData.withResolvedNumbering state)
   | none => none
 
-private def blockTitle (state : TraverseState) (label : Name) (blockData? : Option Informal.BlockData := none) : String :=
+private def blockTitle (state : TraverseState) (label : Name)
+    (facet : PreviewCache.Facet := .statement) (blockData? : Option Informal.BlockData := none) : String :=
   match blockData? <|> blockInfo? state label with
-  | some blockData => blockData.displayTitle state
+  | some blockData =>
+      match facet with
+      | .proof => blockData.displayProofTitle state
+      | .statement => blockData.displayTitle state
   | none => label.toString
 
 private def blockHref (state : TraverseState) (label : Name) : Option String :=
@@ -770,7 +774,7 @@ private def buildTraversalEntries
         label := entry.label
         facet := entry.facet
         kind := blockKind? blockData?
-        title := blockTitle state entry.label blockData?
+        title := blockTitle state entry.label entry.facet blockData?
         href := blockHref state entry.label
         parent := blockData?.bind (·.parent)
         parentTitle := blockParentTitle? state blockData?

--- a/tests/VersoBlueprintTests/BlueprintBlockFolding.lean
+++ b/tests/VersoBlueprintTests/BlueprintBlockFolding.lean
@@ -28,6 +28,17 @@ Default proof body.
 :::
 :::::::
 
+#docs (Genre.Manual) proofTargetTitleDoc "Proof Target Title" :=
+:::::::
+:::lemma_ "display.lemma.proof"
+Lemma statement.
+:::
+
+:::proof "display.lemma.proof"
+Lemma proof body.
+:::
+:::::::
+
 set_option verso.blueprint.foldProofBlocks true
 
 #docs (Genre.Manual) foldedProofBlockDoc "Folded Proof Block" :=
@@ -82,6 +93,14 @@ set_option verso.blueprint.foldCodeBlocks false
     hasSubstr out "<div class=\"bp_wrapper bp_kind_proof_wrapper" &&
     !hasSubstr out "<details class=\"bp_wrapper bp_kind_proof_wrapper" &&
     hasSubstr out "Default proof body."
+
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let out ← renderManualDocHtmlString manualImpls proofTargetTitleDoc
+  pure <|
+    hasSubstr out "Proof for Lemma" &&
+    hasSubstr out "Lemma proof body."
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/VersoBlueprintTests/BlueprintNumbering.lean
+++ b/tests/VersoBlueprintTests/BlueprintNumbering.lean
@@ -135,6 +135,6 @@ private def header (title : String) (number? : Option Numbering) : PartHeader :=
     count := stored.count
   }
   proofRef.displayNumber state == "11" &&
-  proofRef.displayTitle state == "Proof 11"
+  proofRef.displayTitle state == "Proof for Theorem 11"
 
 end Verso.VersoBlueprintTests.BlueprintNumbering


### PR DESCRIPTION
## Summary
Backport #78 to `v4.29.0`.

## Primary Review
- Primary review: #78
- Keep review comments on #78 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.29.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional runtime changes.
- Conflict resolution adapted the block-folding test fixture to the v4.29 line, which does not include the proposition-kind fixture from `v4.30.0`.