### PR TITLE
fix: validate public PR titles

### DIFF
--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -59,6 +59,13 @@ from scripts.blueprint_harness_worktrees import (
 )
 
 PUBLIC_REPOSITORY = "leanprover/verso-blueprint"
+PUBLIC_PR_TITLE_TYPES = ("feat", "fix", "doc", "style", "refactor", "test", "chore", "perf")
+PUBLIC_PR_TITLE_RE = re.compile(
+    r"^(" + "|".join(re.escape(title_type) for title_type in PUBLIC_PR_TITLE_TYPES) + r"): \S.*$"
+)
+PUBLIC_PR_SCOPED_TITLE_RE = re.compile(
+    r"^(" + "|".join(re.escape(title_type) for title_type in PUBLIC_PR_TITLE_TYPES) + r")\([^)]*\):"
+)
 
 
 @dataclass(frozen=True)
@@ -162,6 +169,25 @@ def current_commit_subject(repo_root: Path) -> str:
     if not subject:
         raise SystemExit("[blueprint-harness] unable to derive a PR title from the current commit subject")
     return subject
+
+
+def validate_public_pr_title(title: str) -> str:
+    normalized = title.strip()
+    if normalized != title or not normalized:
+        raise SystemExit("[blueprint-harness] public PR title must not be empty or padded with whitespace")
+    if PUBLIC_PR_SCOPED_TITLE_RE.match(normalized):
+        raise SystemExit(
+            "[blueprint-harness] invalid public PR title: follow Lean upstream style "
+            "`<type>: <subject>` without type scopes such as `feat(entry): ...`; "
+            "put the affected area in the subject instead."
+        )
+    if not PUBLIC_PR_TITLE_RE.match(normalized):
+        allowed = ", ".join(PUBLIC_PR_TITLE_TYPES)
+        raise SystemExit(
+            "[blueprint-harness] invalid public PR title: expected Lean upstream style "
+            f"`<type>: <subject>` with one of: {allowed}."
+        )
+    return normalized
 
 
 def source_commit_series(repo_root: Path, source_branch: str) -> list[str]:
@@ -858,7 +884,7 @@ def command_prepare_pr(args: argparse.Namespace) -> int:
     if not source_branch:
         raise SystemExit("[blueprint-harness] unable to determine a source branch; pass `--source-branch` explicitly")
 
-    title = args.title or current_commit_subject(layout.package_root)
+    title = validate_public_pr_title(args.title or current_commit_subject(layout.package_root))
     print_public_pr_message_scaffold(
         default_dev=policy.default_dev_branch,
         source_branch=source_branch,
@@ -878,7 +904,7 @@ def command_prepare_backport_pr(args: argparse.Namespace) -> int:
     if not source_branch:
         raise SystemExit("[blueprint-harness] unable to determine a source branch; pass `--source-branch` explicitly")
 
-    main_title = args.main_title or current_commit_subject(layout.package_root)
+    main_title = validate_public_pr_title(args.main_title or current_commit_subject(layout.package_root))
     source_commits = source_commit_series(layout.package_root, source_branch)
     default_dev = default_dev_branch(layout.package_root)
 

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -577,6 +577,47 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertNotIn("Worktree:", output)
         self.assertNotIn("Write scope:", output)
 
+    def test_public_pr_title_validation_rejects_scopes(self) -> None:
+        self.assertEqual(
+            harness_mod.validate_public_pr_title("feat: support Blueprint preview nodes in slides"),
+            "feat: support Blueprint preview nodes in slides",
+        )
+        with self.assertRaisesRegex(SystemExit, "without type scopes"):
+            harness_mod.validate_public_pr_title("feat(slides): render Blueprint preview nodes")
+        with self.assertRaisesRegex(SystemExit, "expected Lean upstream style"):
+            harness_mod.validate_public_pr_title("update slides")
+
+    def test_prepare_pr_rejects_scoped_current_commit_subject(self) -> None:
+        args = argparse.Namespace(
+            title=None,
+            summary=None,
+            change=None,
+            source_branch=None,
+            exempt=None,
+        )
+        layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
+        originals = {
+            "detect_harness_layout": harness_mod.detect_harness_layout,
+            "load_branch_policy": harness_mod.load_branch_policy,
+            "require_checkout_role": harness_mod.require_checkout_role,
+            "current_branch_name": harness_mod.current_branch_name,
+            "current_commit_subject": harness_mod.current_commit_subject,
+        }
+        try:
+            harness_mod.detect_harness_layout = lambda _start=None: layout
+            harness_mod.load_branch_policy = lambda _checkout_root: SimpleNamespace(
+                default_dev_branch="v4.30.0",
+                required_backport_branches=("v4.29.0",),
+            )
+            harness_mod.require_checkout_role = lambda *_args, **_kwargs: None
+            harness_mod.current_branch_name = lambda _checkout_root: "feat/slides"
+            harness_mod.current_commit_subject = lambda _checkout_root: "feat(slides): render Blueprint preview nodes"
+            with self.assertRaisesRegex(SystemExit, "without type scopes"):
+                harness_mod.command_prepare_pr(args)
+        finally:
+            for name, value in originals.items():
+                setattr(harness_mod, name, value)
+
     def test_prepare_pr_allows_squash_when_all_backports_are_exempt(self) -> None:
         out = io.StringIO()
         with redirect_stdout(out):
@@ -649,6 +690,37 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertIn("## PR Body", output)
         self.assertIn("Primary review: #11", output)
         self.assertIn("Keep review comments on #11 unless this backport diverges materially.", output)
+
+    def test_prepare_backport_pr_rejects_scoped_main_title(self) -> None:
+        args = argparse.Namespace(
+            release="v4.28.0",
+            all_required=False,
+            main_pr=11,
+            main_title="fix(harness): require public PR titles",
+            source_branch="fix/public-pr-title",
+        )
+        layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
+        originals = {
+            "detect_harness_layout": harness_mod.detect_harness_layout,
+            "load_branch_policy": harness_mod.load_branch_policy,
+            "default_dev_branch": harness_mod.default_dev_branch,
+            "require_checkout_role": harness_mod.require_checkout_role,
+            "source_commit_series": harness_mod.source_commit_series,
+        }
+        try:
+            harness_mod.detect_harness_layout = lambda _start=None: layout
+            harness_mod.load_branch_policy = lambda _checkout_root: SimpleNamespace(
+                default_dev_branch="v4.30.0",
+                required_backport_branches=("v4.28.0",),
+            )
+            harness_mod.default_dev_branch = lambda _checkout_root: "v4.30.0"
+            harness_mod.require_checkout_role = lambda *_args, **_kwargs: None
+            harness_mod.source_commit_series = lambda _repo_root, _source_branch: ["abc123"]
+            with self.assertRaisesRegex(SystemExit, "without type scopes"):
+                harness_mod.command_prepare_backport_pr(args)
+        finally:
+            for name, value in originals.items():
+                setattr(harness_mod, name, value)
 
     def test_prepare_backport_pr_all_required_prints_multiple_scaffolds(self) -> None:
         args = argparse.Namespace(


### PR DESCRIPTION
This PR makes the PR harness reject scoped or malformed public PR titles before generating default-development or backport PR metadata, matching the repository title convention.

Backport v4.29.0: #88