### PR TITLE
chore: extract informal block config validation

### DIFF
--- a/src/VersoBlueprint.lean
+++ b/src/VersoBlueprint.lean
@@ -29,6 +29,7 @@ import VersoBlueprint.Commands.Graph
 import VersoBlueprint.Commands.Summary
 import VersoBlueprint.Commands.Bibliography
 import VersoBlueprint.Informal.Block.Assets
+import VersoBlueprint.Informal.Block.Config
 import VersoBlueprint.Informal.Code
 import VersoBlueprint.Informal.RustBlock
 import VersoBlueprint.Informal.Block

--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -18,13 +18,13 @@ import VersoBlueprint.Data
 import VersoBlueprint.Environment
 import VersoBlueprint.Informal.Block.Assets
 import VersoBlueprint.Informal.Block.Common
+import VersoBlueprint.Informal.Block.Config
 import VersoBlueprint.Informal.Block.RelatedPanel
 import VersoBlueprint.Informal.Block.Render
 import VersoBlueprint.Informal.Block.Store
 import VersoBlueprint.Informal.Block.Traversal
 import VersoBlueprint.Informal.CodeSummary
 import VersoBlueprint.Informal.ExternalCode
-import VersoBlueprint.LabelNameParsing
 import VersoBlueprint.PreviewRender
 import VersoBlueprint.Resolve
 import VersoBlueprint.TraversalIndex
@@ -52,69 +52,6 @@ open CodeSummary
 Elaboration, traversal, and rendering are standard, using {ref VersoManual} helpers for custom blocks and inlines.
 
 -/
-
-/-- Configuration for directives / code-blocks. Q: should we allow non-labelled informal objects? -/
-structure Config where
-  label : Data.Label
-  labelSyntax : Syntax := Syntax.missing
-  lean : Option String := none
-  parent : Option Data.Parent := none
-  priority : Option String := none
-  owner : Option Data.AuthorId := none
-  tags : Array String := #[]
-  effort : Option String := none
-  prUrl : Option String := none
-  externalCode : Array Data.ExternalRef := #[]
-  invalidExternalCode : Array String := #[]
---  hide : Bool := false
-
-section
-variable [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m] [MonadFileMap m]
-
-private def normalizePriority? (raw : String) : Option String :=
-  match raw.trimAscii.toString.toLower with
-  | "high" => some "high"
-  | "medium" => some "medium"
-  | "low" => some "low"
-  | _ => none
-
-private def normalizeEffort? (raw : String) : Option String :=
-  match raw.trimAscii.toString.toLower with
-  | "small" | "s" => some "small"
-  | "medium" | "m" => some "medium"
-  | "large" | "l" => some "large"
-  | _ => none
-
-private def normalizeTags (raw : String) : Array String :=
-  raw.splitOn ","
-    |>.toArray
-    |>.map (fun tag => tag.trimAscii.toString.toLower)
-    |>.filter (fun tag => !tag.isEmpty)
-    |>.foldl (init := #[]) fun acc tag => if acc.contains tag then acc else acc.push tag
-
-def Config.parse  : ArgParse m Config :=
-  (fun (labelArg : Verso.ArgParse.WithSyntax String) lean parent priority owner tags effort prUrl =>
-    let (externalCode, invalidExternalCode) := ExternalCode.parseExternalCodeList lean
-    {
-      label := LabelNameParsing.parse labelArg.val
-      labelSyntax := labelArg.syntax
-      lean := lean
-      parent := parent.map LabelNameParsing.parse
-      priority := priority
-      owner := owner.map LabelNameParsing.parse
-      tags := normalizeTags (tags.getD "")
-      effort := effort
-      prUrl := prUrl.map (·.trimAscii.toString)
-      externalCode := externalCode
-      invalidExternalCode := invalidExternalCode
-    }) <$> .positional `label (.withSyntax .string) <*> .named `lean .string true
-        <*> .named `parent .string true <*> .named `priority .string true <*> .named `owner .string true
-        <*> .named `tags .string true <*> .named `effort .string true <*> .named `pr_url .string true
-
-instance : FromArgs Config m where
-  fromArgs := Config.parse
-
-end
 
 /- Informal custom blocks -/
 block_extension Block.informal (data : BlockData) where
@@ -234,92 +171,11 @@ block_extension Block.informal (data : BlockData) where
 private def expanderImpl (kind : Data.NodeKind) (isProof : Bool := false) : DirectiveExpanderOf Config
   | cfg, contents => do
     let blockRef ← getRef
-    let label := cfg.label
-    let envKind : Data.InProgressKind :=
-      if isProof then .proof else .statement kind
-    let resolvedExternalCode ← ExternalCode.resolveExternalCodeList label cfg.labelSyntax kind cfg.externalCode
-    let hasExternalRaw := !resolvedExternalCode.isEmpty
-    if !cfg.invalidExternalCode.isEmpty then
-      logWarningAt cfg.labelSyntax m!"Label {label}: ignoring malformed names in '(lean := ...)' ({String.intercalate ", " cfg.invalidExternalCode.toList})"
-    if isProof && hasExternalRaw then
-      logErrorAt cfg.labelSyntax m!"Label {label} cannot use '(lean := ...)' in a proof block"
-    let priority : Option String ←
-      match cfg.priority with
-      | none => pure none
-      | some raw =>
-        match normalizePriority? raw with
-        | some normalized =>
-          if isProof then
-            logErrorAt cfg.labelSyntax m!"Label {label} cannot use '(priority := ...)' in a proof block"
-            pure none
-          else
-            pure (some normalized)
-        | none =>
-          logErrorAt cfg.labelSyntax m!"Label {label} has invalid '(priority := \"{raw}\")'; expected one of \"high\", \"medium\", \"low\""
-          pure none
-    let owner : Option Data.AuthorId ←
-      match cfg.owner with
-      | none => pure none
-      | some owner =>
-        if isProof then
-          logErrorAt cfg.labelSyntax m!"Label {label} cannot use '(owner := ...)' in a proof block"
-          pure none
-        else if (← Environment.getAuthor? owner).isNone then
-          logErrorAt cfg.labelSyntax m!"Label {label} references unknown owner '{owner}'; declare it first with ':::author'"
-          pure none
-        else
-          pure (some owner)
-    let effort : Option String ←
-      match cfg.effort with
-      | none => pure none
-      | some raw =>
-        match normalizeEffort? raw with
-        | some normalized =>
-          if isProof then
-            logErrorAt cfg.labelSyntax m!"Label {label} cannot use '(effort := ...)' in a proof block"
-            pure none
-          else
-            pure (some normalized)
-        | none =>
-          logErrorAt cfg.labelSyntax m!"Label {label} has invalid '(effort := \"{raw}\")'; expected one of \"small\", \"medium\", \"large\""
-          pure none
-    let tags : Array String :=
-      if isProof && !cfg.tags.isEmpty then
-        #[]
-      else
-        cfg.tags
-    if isProof && !cfg.tags.isEmpty then
-      logErrorAt cfg.labelSyntax m!"Label {label} cannot use '(tags := ...)' in a proof block"
-    let prUrl : Option String :=
-      if isProof then
-        none
-      else
-        match cfg.prUrl with
-        | some url =>
-          let url := url.trimAscii.toString
-          if url.isEmpty then
-            none
-          else if url.startsWith "http://" || url.startsWith "https://" then
-            some url
-          else
-            none
-        | none => none
-    if isProof && cfg.prUrl.isSome then
-      logErrorAt cfg.labelSyntax m!"Label {label} cannot use '(pr_url := ...)' in a proof block"
-    if !isProof then
-      if let some url := cfg.prUrl then
-        let url := url.trimAscii.toString
-        if !url.isEmpty && !(url.startsWith "http://" || url.startsWith "https://") then
-          logErrorAt cfg.labelSyntax m!"Label {label} has invalid '(pr_url := \"{url}\")'; expected an http(s) URL"
-    let hasExternal := hasExternalRaw && !isProof
-    let codeHint : Option Data.CodeRef :=
-      if isProof then
-        none
-      else if hasExternal then
-        some (.external resolvedExternalCode)
-      else
-        none
-    let accepted ← Environment.push label envKind codeHint cfg.parent priority owner tags effort prUrl
+    let resolved ← cfg.resolveForDirective kind isProof
+    let label := resolved.label
+    let accepted ← Environment.push
+      label resolved.envKind resolved.codeHint resolved.parent resolved.priority
+      resolved.owner resolved.tags resolved.effort resolved.prUrl
     let contents ← contents.mapM elabBlock
     if !accepted then
       return ← ``(Block.concat #[$contents,*])
@@ -336,7 +192,7 @@ private def expanderImpl (kind : Data.NodeKind) (isProof : Bool := false) : Dire
           match node? with
             | some node => pure node.kind
             | none =>
-              logErrorAt cfg.labelSyntax m!"Internal error: missing node '{label}' after environment registration"
+              logErrorAt resolved.labelSyntax m!"Internal error: missing node '{label}' after environment registration"
               pure kind
         pure <| .statement nodeKind
     let codeData :=

--- a/src/VersoBlueprint/Informal/Block/Config.lean
+++ b/src/VersoBlueprint/Informal/Block/Config.lean
@@ -1,0 +1,221 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import Lean.Elab.InfoTree.Types
+import VersoManual
+import VersoBlueprint.Data
+import VersoBlueprint.Environment
+import VersoBlueprint.Informal.ExternalCode
+import VersoBlueprint.LabelNameParsing
+
+namespace Informal
+
+open Verso Doc Elab
+open Verso.ArgParse
+open Lean Elab
+
+/-- Raw configuration accepted by informal block directives. -/
+structure Config where
+  label : Data.Label
+  labelSyntax : Syntax := Syntax.missing
+  lean : Option String := none
+  parent : Option Data.Parent := none
+  priority : Option String := none
+  owner : Option Data.AuthorId := none
+  tags : Array String := #[]
+  effort : Option String := none
+  prUrl : Option String := none
+  externalCode : Array Data.ExternalRef := #[]
+  invalidExternalCode : Array String := #[]
+--  hide : Bool := false
+
+private def normalizePriority? (raw : String) : Option String :=
+  match raw.trimAscii.toString.toLower with
+  | "high" => some "high"
+  | "medium" => some "medium"
+  | "low" => some "low"
+  | _ => none
+
+private def normalizeEffort? (raw : String) : Option String :=
+  match raw.trimAscii.toString.toLower with
+  | "small" | "s" => some "small"
+  | "medium" | "m" => some "medium"
+  | "large" | "l" => some "large"
+  | _ => none
+
+private def normalizeTags (raw : String) : Array String :=
+  raw.splitOn ","
+    |>.toArray
+    |>.map (fun tag => tag.trimAscii.toString.toLower)
+    |>.filter (fun tag => !tag.isEmpty)
+    |>.foldl (init := #[]) fun acc tag => if acc.contains tag then acc else acc.push tag
+
+section
+variable [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m] [MonadFileMap m]
+
+def Config.parse : ArgParse m Config :=
+  (fun (labelArg : Verso.ArgParse.WithSyntax String) lean parent priority owner tags effort prUrl =>
+    let (externalCode, invalidExternalCode) := ExternalCode.parseExternalCodeList lean
+    {
+      label := LabelNameParsing.parse labelArg.val
+      labelSyntax := labelArg.syntax
+      lean := lean
+      parent := parent.map LabelNameParsing.parse
+      priority := priority
+      owner := owner.map LabelNameParsing.parse
+      tags := normalizeTags (tags.getD "")
+      effort := effort
+      prUrl := prUrl.map (·.trimAscii.toString)
+      externalCode := externalCode
+      invalidExternalCode := invalidExternalCode
+    }) <$> .positional `label (.withSyntax .string) <*> .named `lean .string true
+        <*> .named `parent .string true <*> .named `priority .string true <*> .named `owner .string true
+        <*> .named `tags .string true <*> .named `effort .string true <*> .named `pr_url .string true
+
+instance : FromArgs Config m where
+  fromArgs := Config.parse
+
+end
+
+/-- Directive configuration after proof-vs-statement validation and name resolution. -/
+structure ResolvedConfig where
+  label : Data.Label
+  labelSyntax : Syntax
+  envKind : Data.InProgressKind
+  codeHint : Option Data.CodeRef := none
+  parent : Option Data.Parent := none
+  priority : Option String := none
+  owner : Option Data.AuthorId := none
+  tags : Array String := #[]
+  effort : Option String := none
+  prUrl : Option String := none
+
+private def resolvePriority? {m}
+    [Monad m] [MonadOptions m] [MonadLog m] [AddMessageContext m] [MonadFileMap m]
+    (cfg : Config) (isProof : Bool) : m (Option String) := do
+  match cfg.priority with
+  | none => pure none
+  | some raw =>
+    match normalizePriority? raw with
+    | some normalized =>
+      if isProof then
+        logErrorAt cfg.labelSyntax m!"Label {cfg.label} cannot use '(priority := ...)' in a proof block"
+        pure none
+      else
+        pure (some normalized)
+    | none =>
+      logErrorAt cfg.labelSyntax m!"Label {cfg.label} has invalid '(priority := \"{raw}\")'; expected one of \"high\", \"medium\", \"low\""
+      pure none
+
+private def resolveOwner? {m}
+    [Monad m] [MonadEnv m] [MonadOptions m] [MonadLog m] [AddMessageContext m]
+    [MonadFileMap m]
+    (cfg : Config) (isProof : Bool) : m (Option Data.AuthorId) := do
+  match cfg.owner with
+  | none => pure none
+  | some owner =>
+    if isProof then
+      logErrorAt cfg.labelSyntax m!"Label {cfg.label} cannot use '(owner := ...)' in a proof block"
+      pure none
+    else if (← Environment.getAuthor? owner).isNone then
+      logErrorAt cfg.labelSyntax m!"Label {cfg.label} references unknown owner '{owner}'; declare it first with ':::author'"
+      pure none
+    else
+      pure (some owner)
+
+private def resolveEffort? {m}
+    [Monad m] [MonadOptions m] [MonadLog m] [AddMessageContext m] [MonadFileMap m]
+    (cfg : Config) (isProof : Bool) : m (Option String) := do
+  match cfg.effort with
+  | none => pure none
+  | some raw =>
+    match normalizeEffort? raw with
+    | some normalized =>
+      if isProof then
+        logErrorAt cfg.labelSyntax m!"Label {cfg.label} cannot use '(effort := ...)' in a proof block"
+        pure none
+      else
+        pure (some normalized)
+    | none =>
+      logErrorAt cfg.labelSyntax m!"Label {cfg.label} has invalid '(effort := \"{raw}\")'; expected one of \"small\", \"medium\", \"large\""
+      pure none
+
+private def resolveTags {m}
+    [Monad m] [MonadOptions m] [MonadLog m] [AddMessageContext m] [MonadFileMap m]
+    (cfg : Config) (isProof : Bool) : m (Array String) := do
+  if isProof && !cfg.tags.isEmpty then
+    logErrorAt cfg.labelSyntax m!"Label {cfg.label} cannot use '(tags := ...)' in a proof block"
+    pure #[]
+  else
+    pure cfg.tags
+
+private def resolvePrUrl? {m}
+    [Monad m] [MonadOptions m] [MonadLog m] [AddMessageContext m] [MonadFileMap m]
+    (cfg : Config) (isProof : Bool) : m (Option String) := do
+  if isProof then
+    if cfg.prUrl.isSome then
+      logErrorAt cfg.labelSyntax m!"Label {cfg.label} cannot use '(pr_url := ...)' in a proof block"
+    pure none
+  else
+    match cfg.prUrl with
+    | some url =>
+      let url := url.trimAscii.toString
+      if url.isEmpty then
+        pure none
+      else if url.startsWith "http://" || url.startsWith "https://" then
+        pure (some url)
+      else
+        logErrorAt cfg.labelSyntax m!"Label {cfg.label} has invalid '(pr_url := \"{url}\")'; expected an http(s) URL"
+        pure none
+    | none => pure none
+
+/--
+Resolve a directive config for environment registration.
+
+This keeps argument normalization and proof-vs-statement validation out of the
+block expander while preserving the existing recovery behavior: invalid
+statement-only metadata logs an error and is omitted from the environment frame.
+-/
+def Config.resolveForDirective {m}
+    [Monad m] [MonadResolveName m] [MonadOptions m] [MonadLiftT CoreM m] [MonadEnv m]
+    [MonadLog m] [AddMessageContext m] [MonadFileMap m] [MonadError m]
+    (cfg : Config) (kind : Data.NodeKind) (isProof : Bool) : m ResolvedConfig := do
+  let envKind : Data.InProgressKind :=
+    if isProof then .proof else .statement kind
+  let resolvedExternalCode ←
+    ExternalCode.resolveExternalCodeList cfg.label cfg.labelSyntax kind cfg.externalCode
+  let hasExternalRaw := !resolvedExternalCode.isEmpty
+  if !cfg.invalidExternalCode.isEmpty then
+    logWarningAt cfg.labelSyntax m!"Label {cfg.label}: ignoring malformed names in '(lean := ...)' ({String.intercalate ", " cfg.invalidExternalCode.toList})"
+  if isProof && hasExternalRaw then
+    logErrorAt cfg.labelSyntax m!"Label {cfg.label} cannot use '(lean := ...)' in a proof block"
+  let priority ← resolvePriority? cfg isProof
+  let owner ← resolveOwner? cfg isProof
+  let effort ← resolveEffort? cfg isProof
+  let tags ← resolveTags cfg isProof
+  let prUrl ← resolvePrUrl? cfg isProof
+  let hasExternal := hasExternalRaw && !isProof
+  let codeHint : Option Data.CodeRef :=
+    if isProof then
+      none
+    else if hasExternal then
+      some (.external resolvedExternalCode)
+    else
+      none
+  pure {
+    label := cfg.label
+    labelSyntax := cfg.labelSyntax
+    envKind
+    codeHint
+    parent := cfg.parent
+    priority
+    owner
+    tags
+    effort
+    prUrl
+  }
+
+end Informal


### PR DESCRIPTION
This PR moves informal block directive argument parsing, metadata normalization, proof-vs-statement validation, owner lookup, PR URL checks, and external-code hint resolution into `Informal.Block.Config`. It keeps `Informal.Block` focused on environment orchestration and block rendering.

Backport v4.29.0: #90