### PR TITLE
fix: prune warmed reference package copies

### DIFF
--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -117,6 +117,17 @@ def store_lake_packages_in_dependency_cache(layout, project: HarnessProject, pro
     return destination_packages
 
 
+def discard_lake_packages(project_dir: Path) -> Path | None:
+    packages = lake_packages_dir(project_dir)
+    if not packages.exists() and not packages.is_symlink():
+        return None
+    if packages.is_symlink() or packages.is_file():
+        packages.unlink()
+    else:
+        shutil.rmtree(packages)
+    return packages
+
+
 def short_git_ref(ref: str) -> str:
     return ref[:12] if COMMIT_HASH_PATTERN.fullmatch(ref) is not None else ref
 
@@ -666,7 +677,11 @@ def sync_reference_cache_checkout(layout, project: HarnessProject, *, warm_build
         run(reference_update_command(layout.package_root, project_dir), cwd=project_dir)
         if warm_build and project.build_command is not None:
             run(lean_low_priority_command(layout.package_root, *project.build_command), cwd=project_dir)
-        store_lake_packages_in_dependency_cache(layout, project, project_dir)
+        if store_lake_packages_in_dependency_cache(layout, project, project_dir) is not None:
+            # The dependency cache is now the source of truth. Drop the warmed
+            # cache checkout copy so large external projects do not keep two
+            # Mathlib package trees before the local checkout is prepared.
+            discard_lake_packages(project_dir)
     finally:
         cache_lakefile.write_text(original_text, encoding="utf-8")
     return cache_dir

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -265,6 +265,22 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             ],
         )
 
+    def test_discard_lake_packages_prunes_warmed_checkout_copy(self) -> None:
+        import scripts.blueprint_harness_references as refs_mod
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            project_dir = root / "checkout"
+            packages = project_dir / ".lake" / "packages"
+            mathlib_artifact = packages / "mathlib" / ".lake" / "build" / "Mathlib.olean"
+            mathlib_artifact.parent.mkdir(parents=True)
+            mathlib_artifact.write_text("warm", encoding="utf-8")
+
+            pruned = refs_mod.discard_lake_packages(project_dir)
+
+        self.assertEqual(pruned, packages)
+        self.assertFalse(packages.exists())
+
     def test_reference_pages_workflow_stages_every_manifest_project(self) -> None:
         catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
         release = resolve_release_target(catalog, "v4.29.0", PACKAGE_ROOT)


### PR DESCRIPTION
This PR trims duplicate warmed external reference package copies after the dedicated dependency cache has been refreshed.

- Remove the cache checkout's .lake/packages tree after storing it in the dependency cache.
- Reduce CI disk pressure for large reference projects before preparing the per-worktree checkout.

Backport v4.29.0: exempt: does not have the v4.30 dedicated reference dependency-cache layout