### PR TITLE
refactor: centralize informal external declaration links

### DIFF
--- a/src/VersoBlueprint/Commands/Summary.lean
+++ b/src/VersoBlueprint/Commands/Summary.lean
@@ -1707,9 +1707,7 @@ private def summaryBlockToHtml : BlockToHtml Manual (ReaderT AllRemotes (ReaderT
     let ctx : SummaryHtmlContext := {
       entryHref? := fun label => Informal.TraversalIndex.Nodes.href? s label
       declHref? := fun label decl =>
-        match Resolve.resolveRenderedExternalDeclHref? s label decl with
-        | Option.some href => Option.some href
-        | Option.none => Resolve.resolveInlineLeanDeclHref? s decl
+        Resolve.resolveInformalDeclHref? s label decl
       previewLookupKey? := fun label => previewLookupKeys.get? label
     }
     let previewUi := Informal.HoverRender.summaryPreviewUi

--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -101,22 +101,9 @@ block_extension Block.informal (data : BlockData) where
           | .statement _ => data.codeData
         let codeSource := BlockCodeData.ofHintAndInline codeHint? codeData?
         let getDeclHref (decl : Name) : Option String :=
-          match Resolve.resolveRenderedExternalDeclHref? s data.label decl with
-          | some href => some href
-          | none => Resolve.resolveInlineLeanDeclHref? s decl
+          Resolve.resolveInformalDeclHref? s data.label decl
         let getDeclAnchorAttrs (decl : Data.ExternalRef) : Array (String × String) :=
-          let attrsFor (declName : Name) : Array (String × String) :=
-            let key := Resolve.externalRenderedDeclTargetKey data.label declName
-            match Informal.TraversalIndex.ExternalDeclAnchors.object? s key with
-            | none => #[]
-            | some obj =>
-              match obj.ids.toArray[0]? with
-              | some targetId => s.htmlId targetId
-              | none => #[]
-          -- Targets are keyed by canonical declaration name; fallback to the written name keeps
-          -- links stable if older cached objects were keyed before canonicalization.
-          let canonicalAttrs := attrsFor decl.canonical
-          if canonicalAttrs.isEmpty then attrsFor decl.written else canonicalAttrs
+          Informal.TraversalIndex.ExternalDeclAnchors.refHtmlIdAttrs s data.label decl
         let cdata := {
           codeHref
           source := codeSource

--- a/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
+++ b/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
@@ -12,6 +12,15 @@ import VersoBlueprint.Lib.HoverRender
 import VersoBlueprint.PreviewCache
 import VersoBlueprint.TraversalIndex
 
+/-!
+Rendering for the small relationship panels attached to informal blocks.
+
+These panels answer two local navigation questions: which blocks use this one,
+and which sibling/group entries belong with it. The data comes from traversal
+stores; this module keeps the HTML presentation separate from the main block
+renderer.
+-/
+
 namespace Informal
 namespace RelatedPanel
 
@@ -76,10 +85,7 @@ private structure UsedByEntry where
 
 private def sortUsedByEntries (entries : Array UsedByEntry) : Array UsedByEntry :=
   entries.qsort fun a b =>
-    let aNum := a.source.globalCount.getD a.source.count
-    let bNum := b.source.globalCount.getD b.source.count
-    aNum < bNum ||
-      (aNum == bNum && a.source.label.toString < b.source.label.toString)
+    BlockData.traversalOrderLess a.source b.source
 
 private def collectUsedByEntries
     (ctx : Context) (target : Data.Label) : Array UsedByEntry :=

--- a/src/VersoBlueprint/Informal/Block/Store.lean
+++ b/src/VersoBlueprint/Informal/Block/Store.lean
@@ -7,6 +7,15 @@ Author: Emilio J. Gallego Arias
 import VersoBlueprint.Informal.Block.Model
 import VersoBlueprint.TraversalIndex
 
+/-!
+Traversal-time storage and numbering logic for informal blocks.
+
+The renderer receives local block data from the directive syntax, but final HTML
+needs document-order numbers, optional section prefixes, and metadata gathered
+from all occurrences of a label. This module owns that stored view and exposes
+small helpers for rendering code to ask for display numbers and titles.
+-/
+
 namespace Informal
 
 open Lean
@@ -158,13 +167,22 @@ def mergeStoredBlockData (existing incoming : StoredBlockData) : StoredBlockData
       prUrl := existing.prUrl <|> incoming.prUrl
   }
 
+/--
+Stable document-order comparison for informal blocks.
+
+`globalCount` is the traversal-order number assigned while walking the document.
+Older or partially populated stored data may not have it, so the local block
+counter remains the fallback. Labels break ties deterministically.
+-/
+def BlockData.traversalOrderLess (a b : BlockData) : Bool :=
+  let aNum := a.globalCount.getD a.count
+  let bNum := b.globalCount.getD b.count
+  aNum < bNum ||
+    (aNum == bNum && a.label.toString < b.label.toString)
+
 /-- Sort stored blocks by traversal order, using the label as a stable tiebreaker. -/
 private def sortStoredBlocks (entries : Array BlockData) : Array BlockData :=
-  entries.qsort fun a b =>
-    let aNum := a.globalCount.getD a.count
-    let bNum := b.globalCount.getD b.count
-    aNum < bNum ||
-      (aNum == bNum && a.label.toString < b.label.toString)
+  entries.qsort BlockData.traversalOrderLess
 
 /-- Collect every informal block stored in the traversal index, in traversal order. -/
 def collectStoredBlocks (state : TraverseState) : Array BlockData :=

--- a/src/VersoBlueprint/Informal/ExternalCode.lean
+++ b/src/VersoBlueprint/Informal/ExternalCode.lean
@@ -12,6 +12,15 @@ import VersoBlueprint.Informal.Block.Common
 import VersoBlueprint.Informal.LeanCodeLink
 import VersoBlueprint.LeanNameParsing
 
+/-!
+Parsing and rendering support for external Lean declarations attached to an
+informal block.
+
+Directive authors write names with `(lean := "...")`. This module turns those
+names into stable external references during elaboration, then renders the
+shared external-code panel and hover-preview rows during HTML generation.
+-/
+
 namespace Informal
 
 /--
@@ -124,6 +133,33 @@ private structure LinkedExternalDecl where
   decl : Data.ExternalRef
   href : Option String := none
   anchorAttrs : Array (String × String) := #[]
+
+/--
+Resolve the row link for an external reference.
+
+For present declarations we prefer the canonical Lean name, but fall back to the
+written name so older data and unresolved names still produce the best available
+link. Missing declarations only have the written name to try.
+-/
+private def externalRefHref?
+    (getDeclHref : Name → Option String) (decl : Data.ExternalRef) : Option String :=
+  if decl.present then
+    match getDeclHref decl.canonical with
+    | some href => some href
+    | none => getDeclHref decl.written
+  else
+    getDeclHref decl.written
+
+/-- Build the small render model used by both preview and panel rows. -/
+private def linkedExternalDecl
+    (getDeclHref : Name → Option String)
+    (getDeclAnchorAttrs : Data.ExternalRef → Array (String × String))
+    (decl : Data.ExternalRef) : LinkedExternalDecl :=
+  {
+    decl
+    href := externalRefHref? getDeclHref decl
+    anchorAttrs := getDeclAnchorAttrs decl
+  }
 
 private def externalDeclSorryLocation (decl : LinkedExternalDecl) : String :=
   if decl.decl.present then
@@ -300,15 +336,7 @@ def renderPreviewHtml
   if externalDecls.isEmpty then
     .empty
   else
-    let linkedDecls := externalDecls.map fun decl =>
-      let href :=
-        if decl.present then
-          match getDeclHref decl.canonical with
-          | some href => some href
-          | none => getDeclHref decl.written
-        else
-          getDeclHref decl.written
-      { decl, href }
+    let linkedDecls := externalDecls.map (linkedExternalDecl getDeclHref (fun _ => #[]))
     {{
       <ul class="bp_code_hover_list bp_external_decl_list">
         {{.seq <| linkedDecls.map (renderExternalDeclRow ∘ externalDeclRowData)}}
@@ -329,15 +357,7 @@ def renderParts (panelHeader : CodePanelHeader)
   if externalDecls.isEmpty then
     {}
   else
-    let linkedDecls := externalDecls.map fun decl =>
-      let href :=
-        if decl.present then
-          match getDeclHref decl.canonical with
-          | some href => some href
-          | none => getDeclHref decl.written
-        else
-          getDeclHref decl.written
-      { decl, href, anchorAttrs := getDeclAnchorAttrs decl }
+    let linkedDecls := externalDecls.map (linkedExternalDecl getDeclHref getDeclAnchorAttrs)
     let externalCodePanel : Output.Html :=
       mkCodePanel panelHeader summaryTitle indicator
         {{<ul class="bp_code_hover_list bp_external_decl_list">

--- a/src/VersoBlueprint/Resolve.lean
+++ b/src/VersoBlueprint/Resolve.lean
@@ -7,6 +7,15 @@ Author: Emilio J. Gallego Arias
 import Lean
 import VersoManual
 
+/-!
+Shared link-resolution policies for Blueprint renderers.
+
+Most callers should not need to know which Verso traversal domain stores a
+target. This module gives them small, named policies instead: resolve a plain
+domain object, resolve an inline Lean declaration, or resolve the best link for
+an informal block's Lean declaration.
+-/
+
 namespace Informal.Resolve
 
 open Lean
@@ -84,5 +93,19 @@ def resolveInlineLeanDeclHref? (s : Verso.Genre.Manual.TraverseState) (decl : Na
 def resolveRenderedExternalDeclHref? (s : Verso.Genre.Manual.TraverseState)
     (label decl : Name) : Option String :=
   resolveDomainHref? s externalRenderedDeclDomainName (externalRenderedDeclTargetKey label decl)
+
+/--
+Resolve a Lean declaration link as seen from one informal block.
+
+If the block rendered the declaration in its external-code panel, prefer that
+row: it lands the reader on the concrete code that the block is discussing.
+If no row was registered, fall back to the ordinary inline-Lean declaration
+anchor shared by the rest of the document.
+-/
+def resolveInformalDeclHref? (s : Verso.Genre.Manual.TraverseState)
+    (label decl : Name) : Option String :=
+  match resolveRenderedExternalDeclHref? s label decl with
+  | some href => some href
+  | none => resolveInlineLeanDeclHref? s decl
 
 end Informal.Resolve

--- a/src/VersoBlueprint/TraversalIndex.lean
+++ b/src/VersoBlueprint/TraversalIndex.lean
@@ -12,6 +12,15 @@ import VersoBlueprint.Informal.LeanDeclPreviewKey
 import VersoBlueprint.PreviewCache
 import VersoBlueprint.Resolve
 
+/-!
+Typed accessors for Blueprint's traversal-time stores.
+
+Verso traversal domains are flexible, but raw domain names and JSON payloads are
+easy to misuse. This module is the small typed facade used by renderers and
+traversal hooks. Each namespace names one store and exposes only the operations
+callers should need.
+-/
+
 namespace Informal.TraversalIndex
 
 open Lean
@@ -233,6 +242,30 @@ def object? (state : TraverseState) (targetKey : String) : Option Verso.Multi.Ob
 
 def href? (state : TraverseState) (label decl : Name) : Option String :=
   Resolve.resolveRenderedExternalDeclHref? state label decl
+
+/-- HTML `id` attributes for a registered rendered external-declaration row. -/
+def htmlIdAttrs (state : TraverseState) (label decl : Name) : Array (String × String) :=
+  match object? state (key label decl) with
+  | none => #[]
+  | some obj =>
+    match obj.ids.toArray[0]? with
+    | some targetId => state.htmlId targetId
+    | none => #[]
+
+/--
+HTML `id` attributes for an external reference row.
+
+Rendered external-declaration rows are keyed by canonical declaration names.
+The written-name fallback keeps links stable for older traversal objects that
+were stored before canonicalization became the convention.
+-/
+def refHtmlIdAttrs (state : TraverseState) (label : Name)
+    (decl : Informal.Data.ExternalRef) : Array (String × String) :=
+  let canonicalAttrs := htmlIdAttrs state label decl.canonical
+  if canonicalAttrs.isEmpty then
+    htmlIdAttrs state label decl.written
+  else
+    canonicalAttrs
 
 def saveId
     (state : TraverseState) (targetKey : String) (id : Verso.Multi.InternalId) : TraverseState :=


### PR DESCRIPTION
This PR centralizes the shared informal external-declaration link fallback and anchor lookup so block rendering, summary rendering, and external-code panels use one policy.

Backport v4.29.0: #93