### PR TITLE
[backport v4.29.0] fix: deduplicate external declaration hovers

### DIFF
--- a/scripts/lean-low-priority
+++ b/scripts/lean-low-priority
@@ -9,8 +9,22 @@ fi
 
 niceness="${BP_LEAN_NICENESS:-10}"
 
-if command -v nice >/dev/null 2>&1; then
-  exec nice -n "$niceness" "$@"
+# Heavy reference projects can exceed hosted-runner resources at Lake's default
+# parallelism. Keep the throttle specific to the GitHub reference workflow so
+# ordinary local builds and user-invoked wrapper calls retain Lake's defaults.
+if [[ "${GITHUB_WORKFLOW:-}" == "Reference Blueprints" && "$1" == "lake" ]]; then
+  lake_threads="${BP_LAKE_THREADS:-2}"
+  if [[ -n "$lake_threads" ]]; then
+    command_args=("lake" "-Kthreads=$lake_threads" "${@:2}")
+  else
+    command_args=("$@")
+  fi
 else
-  exec "$@"
+  command_args=("$@")
+fi
+
+if command -v nice >/dev/null 2>&1; then
+  exec nice -n "$niceness" "${command_args[@]}"
+else
+  exec "${command_args[@]}"
 fi

--- a/scripts/lean-low-priority
+++ b/scripts/lean-low-priority
@@ -13,11 +13,20 @@ niceness="${BP_LEAN_NICENESS:-10}"
 # parallelism. Keep the throttle specific to the GitHub reference workflow so
 # ordinary local builds and user-invoked wrapper calls retain Lake's defaults.
 if [[ "${GITHUB_WORKFLOW:-}" == "Reference Blueprints" && "$1" == "lake" ]]; then
-  lake_threads="${BP_LAKE_THREADS:-2}"
+  lake_threads="${BP_LAKE_THREADS:-1}"
+  lean_threads="${BP_LEAN_THREADS:-$lake_threads}"
+  command_args=("lake")
   if [[ -n "$lake_threads" ]]; then
-    command_args=("lake" "-Kthreads=$lake_threads" "${@:2}")
+    command_args+=("-Kthreads=$lake_threads")
+  fi
+  if [[ "${2:-}" == "env" && "${3:-}" == "lean" ]]; then
+    command_args+=("env" "lean")
+    if [[ -n "$lean_threads" ]]; then
+      command_args+=("-Dweak.threads=$lean_threads")
+    fi
+    command_args+=("${@:4}")
   else
-    command_args=("$@")
+    command_args+=("${@:2}")
   fi
 else
   command_args=("$@")

--- a/src/VersoBlueprint/Data.lean
+++ b/src/VersoBlueprint/Data.lean
@@ -248,7 +248,7 @@ instance [Quote ε] [Quote α] : Quote (Except ε α) where
     | .ok value => Syntax.mkApp (mkCIdent ``Except.ok) #[quote value]
     | .error error => Syntax.mkApp (mkCIdent ``Except.error) #[quote error]
 
-abbrev ExternalDeclRender := Except Informal.ExternalDeclRenderError String
+abbrev ExternalDeclRender := Except Informal.ExternalDeclRenderError Informal.ExternalDeclRenderedHtml
 
 /--
 Reference to an external declaration mentioned by a blueprint node.

--- a/src/VersoBlueprint/ExternalDeclRender.lean
+++ b/src/VersoBlueprint/ExternalDeclRender.lean
@@ -49,10 +49,11 @@ deriving Repr, Inhabited, Lean.ToJson, Lean.FromJson, Lean.Quote
 /--
 Rendered external declaration HTML in both forms needed by Blueprint.
 
-`html` is the compact page form: it uses Blueprint-local hover ids and carries
-hover bodies separately in `hoverPayloads`, allowing the final page renderer to
-deduplicate repeated declaration hovers. `selfContainedHtml` is the standalone
-form used by preview and manifest paths that are rendered without page state.
+`html` is a compact template: it uses Blueprint-local hover ids, carries hover
+bodies separately in `hoverPayloads`, and contains a tiny marker where the
+standalone hover body should be reinserted. The final page renderer rewrites the
+local ids into Verso page hover ids and removes the markers; preview and
+manifest paths inline the payloads at the markers to recover standalone HTML.
 
 The local ids in `html` are not stable semantic ids. They are only positions in
 the isolated highlighted-code hover table produced while rendering this snippet.
@@ -61,12 +62,27 @@ The page renderer must therefore translate them before emitting normal
 -/
 structure ExternalDeclRenderedHtml where
   html : String
-  selfContainedHtml : String
   hoverPayloads : Array ExternalDeclHoverPayload
 deriving Repr, Inhabited, Lean.ToJson, Lean.FromJson, Lean.Quote
 
+def externalDeclHoverLocalAttrName : String := "data-bp-external-hover-local"
+
+def externalDeclHoverInlineMarkerAttrName : String := "data-bp-external-hover-inline-local"
+
+def externalDeclHoverLocalAttr (localId : Nat) : String :=
+  s!"{externalDeclHoverLocalAttrName}=\"{localId}\""
+
+def externalDeclHoverInlineMarker (localId : Nat) : String :=
+  s!"<span {externalDeclHoverInlineMarkerAttrName}=\"{localId}\"></span>"
+
 def ExternalDeclRenderedHtml.selfContained (rendered : ExternalDeclRenderedHtml) : String :=
-  rendered.selfContainedHtml
+  rendered.hoverPayloads.foldl
+    (init := rendered.html)
+    (fun html payload =>
+      html
+        |>.replace (externalDeclHoverLocalAttr payload.localId) ""
+        |>.replace (externalDeclHoverInlineMarker payload.localId)
+          s!"<span class=\"hover-info\">{payload.html}</span>")
 
 abbrev ExternalDeclRenderResult := Except ExternalDeclRenderError ExternalDeclRenderedHtml
 
@@ -88,30 +104,30 @@ private def runHighlightedHtml
   set hoverState
   pure html
 
-private def inlineVersoHoverAttrs
+private def templateVersoHoverAttrs
     (html : ExternalDeclHtml) (hoverDedup : Verso.Code.Hover.Dedup ExternalDeclHtml) :
     ExternalDeclHtml :=
   Id.run <|
     html.visitM (tag := fun name attrs contents => do
-      let mut inlineHover? : Option ExternalDeclHtml := none
+      let mut marker? : Option Nat := none
       let mut attrs' : Array (String × String) := #[]
-      for (attr, value) in attrs do
-        if attr == "data-verso-hover" then
-          inlineHover? := value.toNat? >>= hoverDedup.get?
-        else
-          attrs' := attrs'.push (attr, value)
+      for attr in attrs do
+        match attr with
+        | ("data-verso-hover", value) =>
+            match value.toNat? with
+            | some localId =>
+                if (hoverDedup.get? localId).isSome then
+                  marker? := some localId
+                  attrs' := attrs'.push (externalDeclHoverLocalAttrName, value)
+                else
+                  attrs' := attrs'.push attr
+            | none => attrs' := attrs'.push attr
+        | attr => attrs' := attrs'.push attr
       let contents :=
-        match inlineHover? with
-        | some hoverHtml => contents ++ .tag "span" #[("class", "hover-info")] hoverHtml
+        match marker? with
+        | some localId =>
+            contents ++ .tag "span" #[(externalDeclHoverInlineMarkerAttrName, toString localId)] .empty
         | none => contents
-      pure <| some <| .tag name attrs' contents)
-
-private def localizeVersoHoverAttrs (html : ExternalDeclHtml) : ExternalDeclHtml :=
-  Id.run <|
-    html.visitM (tag := fun name attrs contents => do
-      let attrs' := attrs.map fun
-        | ("data-verso-hover", value) => ("data-bp-external-hover-local", value)
-        | attr => attr
       pure <| some <| .tag name attrs' contents)
 
 private def hoverPayloads
@@ -123,10 +139,12 @@ private def hoverPayloads
 /--
 Run isolated highlighted-code rendering and preserve both useful outcomes.
 
-The compact result is what normal pages should use: hover references are kept as
-local ids so repeated payloads can be registered once in the page hover table.
-The self-contained result is intentionally still available for snippet previews,
-where there is no surrounding page table to consult.
+The compact template is what normal pages should use: hover references are kept
+as local ids so repeated payloads can be registered once in the page hover
+table. The same template also reconstructs self-contained snippets for previews,
+where there is no surrounding page table to consult. Keeping one template avoids
+holding both full HTML forms for every external declaration while a large
+blueprint page is generated.
 
 We do not assign final Verso hover ids here because there is no final page
 `Html.State` yet. Assigning stable ids would require a separate Blueprint hover
@@ -137,8 +155,7 @@ private def renderWithHoverPayloads
     (html : ExternalDeclHighlightRender ExternalDeclHtml) : ExternalDeclRenderedHtml :=
   let (html, hoverState) := html.run {}
   {
-    html := (localizeVersoHoverAttrs html).asString
-    selfContainedHtml := (inlineVersoHoverAttrs html hoverState.dedup).asString
+    html := (templateVersoHoverAttrs html hoverState.dedup).asString
     hoverPayloads := hoverPayloads hoverState.dedup
   }
 

--- a/src/VersoBlueprint/ExternalDeclRender.lean
+++ b/src/VersoBlueprint/ExternalDeclRender.lean
@@ -29,65 +29,143 @@ instance : Lean.Quote ExternalDeclRenderError where
     | .exception decl message =>
         Lean.Syntax.mkApp (Lean.mkCIdent ``ExternalDeclRenderError.exception) #[Lean.quote decl, Lean.quote message]
 
-abbrev ExternalDeclRenderResult := Except ExternalDeclRenderError ExternalDeclHtml
-
 def ExternalDeclRenderError.message : ExternalDeclRenderError → String
   | .moduleUnavailable decl => s!"module unavailable for {decl}"
   | .exception decl message => s!"{decl}: {message}"
 
-private def runHighlightedHtml
-    (html : Verso.Code.HighlightHtmlM Verso.Genre.Manual ExternalDeclHtml) : ExternalDeclHtml :=
-  let ctx : Verso.Code.HighlightHtmlM.Context Verso.Genre.Manual := {
-    linkTargets := {}
-    traverseContext := { logError := fun _ => pure () }
-    definitionIds := {}
-    options := {}
-  }
-  let (html, hoverState) := ((html.run ctx).run {})
-  inlineVersoHoverAttrs html hoverState.dedup
-where
-  /-
-  Direct external declaration rendering is isolated from the page-level Verso hover table,
-  so deduplicated hover ids would otherwise point at unrelated page content. Inline the
-  resolved hover payloads locally to keep the rendered snippet self-contained.
-  -/
-  inlineVersoHoverAttrs
-      (html : ExternalDeclHtml) (hoverDedup : Verso.Code.Hover.Dedup ExternalDeclHtml) :
-      ExternalDeclHtml :=
-    Id.run <|
-      html.visitM (tag := fun name attrs contents => do
-        let mut inlineHover? : Option ExternalDeclHtml := none
-        let mut attrs' : Array (String × String) := #[]
-        for (attr, value) in attrs do
-          if attr == "data-verso-hover" then
-            inlineHover? := value.toNat? >>= hoverDedup.get?
-          else
-            attrs' := attrs'.push (attr, value)
-        let contents :=
-          match inlineHover? with
-          | some hoverHtml => contents ++ .tag "span" #[("class", "hover-info")] hoverHtml
-          | none => contents
-        pure <| some <| .tag name attrs' contents)
+/--
+One hover payload captured while rendering an external declaration snippet.
 
-private def highlightedToHtml (h : SubVerso.Highlighting.Highlighted) : ExternalDeclHtml :=
+External declarations are rendered before the final page `Html.State` exists, so
+their highlighted-code hovers cannot be inserted into Verso's page hover table
+immediately. Each payload records the snippet-local id plus the hover body that
+the page renderer can later deduplicate against all other page hovers.
+-/
+structure ExternalDeclHoverPayload where
+  localId : Nat
+  html : String
+deriving Repr, Inhabited, Lean.ToJson, Lean.FromJson, Lean.Quote
+
+/--
+Rendered external declaration HTML in both forms needed by Blueprint.
+
+`html` is the compact page form: it uses Blueprint-local hover ids and carries
+hover bodies separately in `hoverPayloads`, allowing the final page renderer to
+deduplicate repeated declaration hovers. `selfContainedHtml` is the standalone
+form used by preview and manifest paths that are rendered without page state.
+
+The local ids in `html` are not stable semantic ids. They are only positions in
+the isolated highlighted-code hover table produced while rendering this snippet.
+The page renderer must therefore translate them before emitting normal
+`data-verso-hover` attributes.
+-/
+structure ExternalDeclRenderedHtml where
+  html : String
+  selfContainedHtml : String
+  hoverPayloads : Array ExternalDeclHoverPayload
+deriving Repr, Inhabited, Lean.ToJson, Lean.FromJson, Lean.Quote
+
+def ExternalDeclRenderedHtml.selfContained (rendered : ExternalDeclRenderedHtml) : String :=
+  rendered.selfContainedHtml
+
+abbrev ExternalDeclRenderResult := Except ExternalDeclRenderError ExternalDeclRenderedHtml
+
+private abbrev ExternalDeclHighlightRender :=
+  StateT (Verso.Code.Hover.State ExternalDeclHtml) Id
+
+private def highlightedHtmlContext : Verso.Code.HighlightHtmlM.Context Verso.Genre.Manual := {
+  linkTargets := {}
+  traverseContext := { logError := fun _ => pure () }
+  definitionIds := {}
+  options := {}
+}
+
+private def runHighlightedHtml
+    (html : Verso.Code.HighlightHtmlM Verso.Genre.Manual ExternalDeclHtml) :
+    ExternalDeclHighlightRender ExternalDeclHtml := do
+  let hoverState ← get
+  let (html, hoverState) := ((html.run highlightedHtmlContext).run hoverState)
+  set hoverState
+  pure html
+
+private def inlineVersoHoverAttrs
+    (html : ExternalDeclHtml) (hoverDedup : Verso.Code.Hover.Dedup ExternalDeclHtml) :
+    ExternalDeclHtml :=
+  Id.run <|
+    html.visitM (tag := fun name attrs contents => do
+      let mut inlineHover? : Option ExternalDeclHtml := none
+      let mut attrs' : Array (String × String) := #[]
+      for (attr, value) in attrs do
+        if attr == "data-verso-hover" then
+          inlineHover? := value.toNat? >>= hoverDedup.get?
+        else
+          attrs' := attrs'.push (attr, value)
+      let contents :=
+        match inlineHover? with
+        | some hoverHtml => contents ++ .tag "span" #[("class", "hover-info")] hoverHtml
+        | none => contents
+      pure <| some <| .tag name attrs' contents)
+
+private def localizeVersoHoverAttrs (html : ExternalDeclHtml) : ExternalDeclHtml :=
+  Id.run <|
+    html.visitM (tag := fun name attrs contents => do
+      let attrs' := attrs.map fun
+        | ("data-verso-hover", value) => ("data-bp-external-hover-local", value)
+        | attr => attr
+      pure <| some <| .tag name attrs' contents)
+
+private def hoverPayloads
+    (hoverDedup : Verso.Code.Hover.Dedup ExternalDeclHtml) : Array ExternalDeclHoverPayload :=
+  hoverDedup.contentId.fold (init := #[]) (fun out localId html =>
+    out.push { localId, html := html.asString })
+  |>.qsort (fun a b => a.localId < b.localId)
+
+/--
+Run isolated highlighted-code rendering and preserve both useful outcomes.
+
+The compact result is what normal pages should use: hover references are kept as
+local ids so repeated payloads can be registered once in the page hover table.
+The self-contained result is intentionally still available for snippet previews,
+where there is no surrounding page table to consult.
+
+We do not assign final Verso hover ids here because there is no final page
+`Html.State` yet. Assigning stable ids would require a separate Blueprint hover
+lookup scheme for every highlighted token payload, duplicating Verso's page
+dedup table instead of using it.
+-/
+private def renderWithHoverPayloads
+    (html : ExternalDeclHighlightRender ExternalDeclHtml) : ExternalDeclRenderedHtml :=
+  let (html, hoverState) := html.run {}
+  {
+    html := (localizeVersoHoverAttrs html).asString
+    selfContainedHtml := (inlineVersoHoverAttrs html hoverState.dedup).asString
+    hoverPayloads := hoverPayloads hoverState.dedup
+  }
+
+private def highlightedToHtml (h : SubVerso.Highlighting.Highlighted) :
+    ExternalDeclHighlightRender ExternalDeclHtml :=
   runHighlightedHtml (h.toHtml (g := Verso.Genre.Manual))
 
 private def renderExternalDeclSignatureVariant
-    (keywordText : String) (signature : SubVerso.Highlighting.Highlighted) : ExternalDeclHtml :=
-  open Verso.Output.Html in
-  {{
+    (keywordText : String) (signature : SubVerso.Highlighting.Highlighted) :
+    ExternalDeclHighlightRender ExternalDeclHtml :=
+  open Verso.Output.Html in do
+  let signatureHtml ← highlightedToHtml signature
+  pure {{
     <pre class="bp_external_decl_signature signature hl lean block">
-      <span class="keyword token">{{.text true keywordText}}</span> " " {{highlightedToHtml signature}}
+      <span class="keyword token">{{.text true keywordText}}</span> " " {{signatureHtml}}
     </pre>
   }}
 
 private def signatureToHtml (keywordText : String) (sig : Verso.Genre.Manual.Signature) :
-    ExternalDeclHtml :=
-  open Verso.Output.Html in
-  {{
+    ExternalDeclHighlightRender ExternalDeclHtml :=
+  open Verso.Output.Html in do
+  let wide ← renderExternalDeclSignatureVariant keywordText sig.wide
+  let narrow ← renderExternalDeclSignatureVariant keywordText sig.narrow
+  pure {{
     <div class="bp_external_decl_signature_wrap">
-      <div class="wide-only">{{renderExternalDeclSignatureVariant keywordText sig.wide}}</div>
-      <div class="narrow-only">{{renderExternalDeclSignatureVariant keywordText sig.narrow}}</div>
+      <div class="wide-only">{{wide}}</div>
+      <div class="narrow-only">{{narrow}}</div>
     </div>
   }}
 
@@ -230,18 +308,19 @@ private def visibilityHtml (v : Verso.Genre.Manual.Block.Docstring.Visibility) :
   | .protected => .empty
 
 private def renderDocNameCtor (docName : Verso.Genre.Manual.Block.Docstring.DocName) :
-    ExternalDeclHtml :=
-  open Verso.Output.Html in
-  {{
+    ExternalDeclHighlightRender ExternalDeclHtml :=
+  open Verso.Output.Html in do
+  let signatureHtml ← highlightedToHtml docName.signature
+  pure {{
     <div class="constructor">
-      <pre class="name-and-type hl lean">{{highlightedToHtml docName.signature}}</pre>
+      <pre class="name-and-type hl lean">{{signatureHtml}}</pre>
       {{docsHtml docName.docstring?}}
     </div>
   }}
 
 private def renderFieldSignature (field : Verso.Genre.Manual.Block.Docstring.FieldInfo) :
-    ExternalDeclHtml :=
-  open Verso.Output.Html in
+    ExternalDeclHighlightRender ExternalDeclHtml :=
+  open Verso.Output.Html in do
   let inheritedInfo : ExternalDeclHtml :=
     if field.fieldFrom.isEmpty then
       .empty
@@ -255,10 +334,12 @@ private def renderFieldSignature (field : Verso.Genre.Manual.Block.Docstring.Fie
           <ol>{{inheritedRows}}</ol>
         </div>
       }}
-  {{
+  let fieldNameHtml ← highlightedToHtml field.fieldName
+  let fieldTypeHtml ← highlightedToHtml field.type
+  pure {{
     <section class="subdocs">
       <pre class="name-and-type hl lean">
-        {{visibilityHtml field.visibility}}{{highlightedToHtml field.fieldName}} " : " {{highlightedToHtml field.type}}
+        {{visibilityHtml field.visibility}}{{fieldNameHtml}} " : " {{fieldTypeHtml}}
       </pre>
       {{inheritedInfo}}
       {{docsHtml field.docString?}}
@@ -267,15 +348,15 @@ private def renderFieldSignature (field : Verso.Genre.Manual.Block.Docstring.Fie
 
 private def renderParentsSection
     (parents : Array Verso.Genre.Manual.Block.Docstring.ParentInfo) :
-    Option ExternalDeclHtml :=
-  open Verso.Output.Html in
+    ExternalDeclHighlightRender (Option ExternalDeclHtml) :=
+  open Verso.Output.Html in do
   if parents.isEmpty then
-    none
+    pure none
   else
-    let rows :=
-      parents.map fun parent =>
-        {{<li><code class="hl lean inline">{{highlightedToHtml parent.parent}}</code></li>}}
-    some {{
+    let rows ← parents.mapM fun parent => do
+      let parentHtml ← highlightedToHtml parent.parent
+      pure {{<li><code class="hl lean inline">{{parentHtml}}</code></li>}}
+    pure <| some {{
       <h1>"Extends"</h1>
       <ul class="extends">{{rows}}</ul>
     }}
@@ -325,54 +406,60 @@ private def renderDeclHtmlDocstringFromInfoE
   let signature ← Verso.Genre.Manual.Signature.forName decl
   let docs? ← liftM <| findDocString? env decl
 
-  let ctorSection? : Option ExternalDeclHtml :=
-    match declType with
-    | .structure isClass ctor? _ _ _ _ =>
-      ctor?.bind fun ctor =>
-        let title := if isClass then "Instance Constructor" else "Constructor"
-        renderTitledSection? title #[renderDocNameCtor ctor]
-    | _ => none
+  let rendered := renderWithHoverPayloads <| do
+    let ctorSection? : Option ExternalDeclHtml ←
+      match declType with
+      | .structure isClass ctor? _ _ _ _ =>
+        match ctor? with
+        | some ctor =>
+          let title := if isClass then "Instance Constructor" else "Constructor"
+          let ctorHtml ← renderDocNameCtor ctor
+          pure <| renderTitledSection? title #[ctorHtml]
+        | none => pure none
+      | _ => pure none
 
-  let methodsOrFieldsSection? : Option ExternalDeclHtml :=
-    match declType with
-    | .structure isClass _ _ fieldInfo _ _ =>
-      let rows := fieldInfo.filter (fun f => f.subobject?.isNone) |>.map renderFieldSignature
-      renderTitledSection? (if isClass then "Methods" else "Fields") rows
-    | _ => none
+    let methodsOrFieldsSection? : Option ExternalDeclHtml ←
+      match declType with
+      | .structure isClass _ _ fieldInfo _ _ =>
+        let rows ← fieldInfo.filter (fun f => f.subobject?.isNone) |>.mapM renderFieldSignature
+        pure <| renderTitledSection? (if isClass then "Methods" else "Fields") rows
+      | _ => pure none
 
-  let parentsSection? : Option ExternalDeclHtml :=
-    match declType with
-    | .structure _ _ _ _ parents _ => renderParentsSection parents
-    | _ => none
+    let parentsSection? : Option ExternalDeclHtml ←
+      match declType with
+      | .structure _ _ _ _ parents _ => renderParentsSection parents
+      | _ => pure none
 
-  let inductiveCtorsSection? : Option ExternalDeclHtml :=
-    match declType with
-    | .inductive ctors _ _ =>
-      renderTitledSection? "Constructors" (ctors.map renderDocNameCtor)
-    | _ => none
+    let inductiveCtorsSection? : Option ExternalDeclHtml ←
+      match declType with
+      | .inductive ctors _ _ =>
+        let rows ← ctors.mapM renderDocNameCtor
+        pure <| renderTitledSection? "Constructors" rows
+      | _ => pure none
 
-  let mut sections : Array ExternalDeclHtml := #[]
-  if let some s := ctorSection? then
-    sections := sections.push s
-  if let some s := parentsSection? then
-    sections := sections.push s
-  if let some s := methodsOrFieldsSection? then
-    sections := sections.push s
-  if let some s := inductiveCtorsSection? then
-    sections := sections.push s
+    let mut sections : Array ExternalDeclHtml := #[]
+    if let some s := ctorSection? then
+      sections := sections.push s
+    if let some s := parentsSection? then
+      sections := sections.push s
+    if let some s := methodsOrFieldsSection? then
+      sections := sections.push s
+    if let some s := inductiveCtorsSection? then
+      sections := sections.push s
 
-  let presentation := externalDeclPresentation declType cinfo
-  let signatureHtml := signatureToHtml presentation.keywordText signature
-  let headerMeta := safetyHeaderMeta cinfo ++ renderExternalDeclHeaderMeta declType
+    let presentation := externalDeclPresentation declType cinfo
+    let signatureHtml ← signatureToHtml presentation.keywordText signature
+    let headerMeta := safetyHeaderMeta cinfo ++ renderExternalDeclHeaderMeta declType
 
-  let body : ExternalDeclHtml :=
-    if sections.isEmpty then
-      plainDocstringHtml docs?
-    else
-      {{ {{plainDocstringHtml docs?}} {{sections}} }}
-  pure <| .ok <| renderExternalDeclWrapper
-    decl presentation.kindClass presentation.kindMarker signatureHtml body
-    (headerBadge? := headerBadge?) (headerMeta := headerMeta) (headerSource? := headerSource?)
+    let body : ExternalDeclHtml :=
+      if sections.isEmpty then
+        plainDocstringHtml docs?
+      else
+        {{ {{plainDocstringHtml docs?}} {{sections}} }}
+    pure <| renderExternalDeclWrapper
+      decl presentation.kindClass presentation.kindMarker signatureHtml body
+      (headerBadge? := headerBadge?) (headerMeta := headerMeta) (headerSource? := headerSource?)
+  pure <| .ok rendered
 
 /--
 Render one declaration directly from known declaration facts.
@@ -394,7 +481,7 @@ Core external-rendering dataflow should use typed HTML payloads.
 -/
 def renderDeclHtmlStringDirectFromInfoE
     (decl : Name) (cinfo : ConstantInfo) : MetaM (Except ExternalDeclRenderError String) := do
-  return (← renderDeclHtmlDirectFromInfoE decl cinfo).map (·.asString)
+  return (← renderDeclHtmlDirectFromInfoE decl cinfo).map (·.selfContained)
 
 /-- Render one declaration directly from the in-memory `Environment` (no database, no source parsing). -/
 def renderDeclHtmlNodeDirect? (decl : Name) : MetaM (Option ExternalDeclHtml) := do
@@ -404,7 +491,7 @@ def renderDeclHtmlNodeDirect? (decl : Name) : MetaM (Option ExternalDeclHtml) :=
     let some cinfo := env.find? decl
       | return none
     match ← renderDeclHtmlDirectFromInfoE decl cinfo with
-    | .ok html => return some html
+    | .ok html => return some (.text false html.selfContained)
     | .error err =>
       logError m!"External declaration rendering failed for {decl}: {err.message}"
       return none

--- a/src/VersoBlueprint/ExternalRefSnapshot.lean
+++ b/src/VersoBlueprint/ExternalRefSnapshot.lean
@@ -296,7 +296,7 @@ def externalRefSnapshot (opts : Lean.Options) (workspaceRoot : System.FilePath)
         (headerSource? := headerSource?)).run'
     let render : Data.ExternalDeclRender :=
       match renderResult with
-      | .ok html => .ok html.asString
+      | .ok html => .ok html
       | .error err => .error err
     pure {
       ref with

--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -113,14 +113,14 @@ block_extension Block.informal (data : BlockData) where
           match data.kind with
           | .statement _ => some <| CodeSummary.renderParts data cdata getDeclHref
           | .proof => none
-        let externalParts? : Option ExternalCode.RenderParts :=
+        let externalParts? : Option ExternalCode.RenderParts ←
           match data.kind, codeSource with
           | .statement _, some (.external decls) =>
             if decls.isEmpty then
-              none
+              pure none
             else
               let panelHeader := codePanelHeader data (data.displayNumber s)
-              some <| ExternalCode.renderParts
+              some <$> ExternalCode.renderPartsWithPageHovers
                 panelHeader
                 panelSummary.summaryTitle
                 panelSummary.indicator
@@ -128,7 +128,7 @@ block_extension Block.informal (data : BlockData) where
                 getDeclHref
                 getDeclAnchorAttrs
                 (folded := data.foldCodeBlock)
-          | _, _ => none
+          | _, _ => pure none
         let externalPanel := (externalParts?.map (·.externalCodePanel)).getD .empty
         let content := (← blocks.mapM goB)
         let codeEntry := (headingParts?.map (·.codeEntry)).getD .empty

--- a/src/VersoBlueprint/Informal/ExternalCode.lean
+++ b/src/VersoBlueprint/Informal/ExternalCode.lean
@@ -270,12 +270,54 @@ private def externalDeclRendered (item : LinkedExternalDecl) : Output.Html :=
   match item.decl.render with
   | .ok renderedHtml =>
     {{
-      <div class="bp_external_decl_rendered">{{.text false renderedHtml}}</div>
+      <div class="bp_external_decl_rendered">{{.text false renderedHtml.selfContained}}</div>
     }}
   | .error err =>
     {{
       <pre class="bp_external_decl_stmt bp_external_decl_render_error">{{.text true s!"Render failed: {err.message}"}}</pre>
     }}
+
+private def registerPageHoverPayload [Monad m]
+    (payload : ExternalDeclHoverPayload) :
+    Verso.Doc.Html.HtmlT Verso.Genre.Manual m Nat :=
+  modifyGet fun st =>
+    let (id, dedup) := st.dedup.insert (.text false payload.html)
+    (id, { st with dedup })
+
+/--
+Convert compact external declaration HTML into normal page HTML.
+
+Each snippet-local hover payload is inserted into the real Verso page hover
+table. Identical payloads therefore share a page hover id, while preview-only
+HTML can still remain self-contained through `externalDeclRendered`.
+
+The string replacement is deliberately only an id-scope translation:
+`data-bp-external-hover-local` means "this id is valid only for the external
+declaration snapshot", and `data-verso-hover` means "this id is valid in the
+current page's Verso hover table". The payload body is registered through
+Verso's normal dedup table before the page id is emitted.
+-/
+private def renderedHtmlWithPageHovers [Monad m]
+    (renderedHtml : ExternalDeclRenderedHtml) :
+    Verso.Doc.Html.HtmlT Verso.Genre.Manual m String := do
+  let replacements ← renderedHtml.hoverPayloads.mapM fun payload => do
+    let pageId ← registerPageHoverPayload payload
+    pure (s!"data-bp-external-hover-local=\"{payload.localId}\"", s!"data-verso-hover=\"{pageId}\"")
+  return replacements.foldl
+    (fun html replacement => html.replace replacement.1 replacement.2)
+    renderedHtml.html
+
+private def externalDeclRenderedWithPageHovers [Monad m]
+    (item : LinkedExternalDecl) :
+    Verso.Doc.Html.HtmlT Verso.Genre.Manual m Output.Html := do
+  match item.decl.render with
+  | .ok renderedHtml =>
+    let renderedHtml ← renderedHtmlWithPageHovers renderedHtml
+    pure <| .tag "div" #[("class", "bp_external_decl_rendered")] (.text false renderedHtml)
+  | .error err =>
+    pure <| .tag "pre"
+      #[("class", "bp_external_decl_stmt bp_external_decl_render_error")]
+      (.text true s!"Render failed: {err.message}")
 
 private def missingExternalDeclBody : Output.Html :=
   open Verso.Output.Html in
@@ -285,27 +327,31 @@ private def missingExternalDeclBody : Output.Html :=
     </pre>
   }}
 
-private def externalDeclRowData (item : LinkedExternalDecl) : ExternalDeclRowData :=
+private def externalDeclRowDataWith [Monad m]
+    (renderBody : LinkedExternalDecl → m Output.Html)
+    (item : LinkedExternalDecl) : m ExternalDeclRowData := do
   let statusTxt := externalDeclPanelStatusText item
   if !item.decl.present then
-    {
+    pure {
       liAttrs := #[("class", "bp_external_decl_item")] ++ item.anchorAttrs
       head := externalDeclHead item statusTxt
       body := missingExternalDeclBody
     }
-  else if (externalRenderFailure? item.decl).isSome then
-    {
-      liAttrs := #[("class", "bp_external_decl_item")] ++ item.anchorAttrs
-      head := externalDeclHead item statusTxt
-      body := externalDeclRendered item
-      footer := externalDeclRenderedMeta item statusTxt
-    }
   else
-    {
-      liAttrs := #[("class", "bp_external_decl_item bp_external_decl_item_rendered")] ++ item.anchorAttrs
-      body := externalDeclRendered item
-      footer := externalDeclRenderedMeta item statusTxt (includeStatus := false)
-    }
+    let body ← renderBody item
+    if (externalRenderFailure? item.decl).isSome then
+      pure {
+        liAttrs := #[("class", "bp_external_decl_item")] ++ item.anchorAttrs
+        head := externalDeclHead item statusTxt
+        body
+        footer := externalDeclRenderedMeta item statusTxt
+      }
+    else
+      pure {
+        liAttrs := #[("class", "bp_external_decl_item bp_external_decl_item_rendered")] ++ item.anchorAttrs
+        body
+        footer := externalDeclRenderedMeta item statusTxt (includeStatus := false)
+      }
 
 private def renderExternalDeclRow (row : ExternalDeclRowData) : Output.Html :=
   open Verso.Output.Html in
@@ -318,6 +364,28 @@ private def renderExternalDeclRow (row : ExternalDeclRowData) : Output.Html :=
   }}
 
 /--
+Render external declaration rows while leaving the declaration body strategy
+abstract.
+
+Preview and manifest rendering pass the self-contained body renderer. Normal
+page rendering passes the page-hover body renderer, but both paths share the row
+status, anchors, and footer layout.
+-/
+private def renderExternalDeclRowsWith [Monad m]
+    (renderBody : LinkedExternalDecl → m Output.Html)
+    (linkedDecls : Array LinkedExternalDecl) : m (Array Output.Html) :=
+  linkedDecls.mapM fun item => do
+    let rowData ← externalDeclRowDataWith renderBody item
+    pure <| renderExternalDeclRow rowData
+
+private def renderExternalDeclRows (linkedDecls : Array LinkedExternalDecl) : Array Output.Html :=
+  Id.run <| renderExternalDeclRowsWith (fun item => pure <| externalDeclRendered item) linkedDecls
+
+private def renderExternalDeclList (rows : Array Output.Html) : Output.Html :=
+  open Verso.Output.Html in
+  {{<ul class="bp_code_hover_list bp_external_decl_list">{{.seq rows}}</ul>}}
+
+/--
 Rendered fragments produced by `ExternalCode.renderParts` for external panel content.
 -/
 structure RenderParts where
@@ -326,45 +394,64 @@ structure RenderParts where
 /--
 Render the canonical hover-preview body for external Lean code references.
 
-This is shared by the external code panel and the manifest-backed code-preview
-path used by explicit Lean-code links.
+This path deliberately uses self-contained declaration snippets because preview
+payloads may be consumed outside the page that originally generated them.
 -/
 def renderPreviewHtml
     (externalDecls : Array Data.ExternalRef)
     (getDeclHref : Name → Option String := fun _ => none) : Output.Html :=
-  open Verso.Output.Html in
   if externalDecls.isEmpty then
     .empty
   else
     let linkedDecls := externalDecls.map (linkedExternalDecl getDeclHref (fun _ => #[]))
-    {{
-      <ul class="bp_code_hover_list bp_external_decl_list">
-        {{.seq <| linkedDecls.map (renderExternalDeclRow ∘ externalDeclRowData)}}
-      </ul>
-    }}
+    renderExternalDeclList <| renderExternalDeclRows linkedDecls
 
 /--
 Render external-code UI fragments for an informal block.
 
-This function only renders optional external code panel body for `(lean := ...)` references.
+This self-contained variant is kept for callers that do not have access to the
+page `Html.State`, such as preview and manifest generation. Page rendering
+should use `renderPartsWithPageHovers` so repeated hover payloads deduplicate.
 -/
 def renderParts (panelHeader : CodePanelHeader)
     (summaryTitle : String) (indicator : Output.Html)
     (externalDecls : Array Data.ExternalRef) (getDeclHref : Name → Option String)
     (getDeclAnchorAttrs : Data.ExternalRef → Array (String × String) := fun _ => #[])
     (folded : Bool := false) : RenderParts :=
-  open Verso.Output.Html in
   if externalDecls.isEmpty then
     {}
   else
     let linkedDecls := externalDecls.map (linkedExternalDecl getDeclHref getDeclAnchorAttrs)
     let externalCodePanel : Output.Html :=
       mkCodePanel panelHeader summaryTitle indicator
-        {{<ul class="bp_code_hover_list bp_external_decl_list">
-            {{.seq <| linkedDecls.map (renderExternalDeclRow ∘ externalDeclRowData)}}
-          </ul>}}
+        (renderExternalDeclList <| renderExternalDeclRows linkedDecls)
         (folded := folded)
     { externalCodePanel }
+
+/--
+Render external-code UI fragments into a real page `Html.State`.
+
+This is the normal page-rendering path for `(lean := ...)` references. It
+remaps declaration-local highlighted-code hover ids into Verso's page hover
+table, so repeated external declaration docstrings are emitted once per page
+instead of once per occurrence.
+-/
+def renderPartsWithPageHovers [Monad m] (panelHeader : CodePanelHeader)
+    (summaryTitle : String) (indicator : Output.Html)
+    (externalDecls : Array Data.ExternalRef) (getDeclHref : Name → Option String)
+    (getDeclAnchorAttrs : Data.ExternalRef → Array (String × String) := fun _ => #[])
+    (folded : Bool := false) :
+    Verso.Doc.Html.HtmlT Verso.Genre.Manual m RenderParts := do
+  if externalDecls.isEmpty then
+    pure {}
+  else
+    let linkedDecls := externalDecls.map (linkedExternalDecl getDeclHref getDeclAnchorAttrs)
+    let rows ← renderExternalDeclRowsWith externalDeclRenderedWithPageHovers linkedDecls
+    let externalCodePanel : Output.Html :=
+      mkCodePanel panelHeader summaryTitle indicator
+        (renderExternalDeclList rows)
+        (folded := folded)
+    pure { externalCodePanel }
 
 end ExternalCode
 end Informal

--- a/src/VersoBlueprint/Informal/ExternalCode.lean
+++ b/src/VersoBlueprint/Informal/ExternalCode.lean
@@ -300,12 +300,12 @@ Verso's normal dedup table before the page id is emitted.
 private def renderedHtmlWithPageHovers [Monad m]
     (renderedHtml : ExternalDeclRenderedHtml) :
     Verso.Doc.Html.HtmlT Verso.Genre.Manual m String := do
-  let replacements ← renderedHtml.hoverPayloads.mapM fun payload => do
+  let mut html := renderedHtml.html
+  for payload in renderedHtml.hoverPayloads do
     let pageId ← registerPageHoverPayload payload
-    pure (s!"data-bp-external-hover-local=\"{payload.localId}\"", s!"data-verso-hover=\"{pageId}\"")
-  return replacements.foldl
-    (fun html replacement => html.replace replacement.1 replacement.2)
-    renderedHtml.html
+    html := html.replace (externalDeclHoverLocalAttr payload.localId) s!"data-verso-hover=\"{pageId}\""
+    html := html.replace (externalDeclHoverInlineMarker payload.localId) ""
+  return html
 
 private def externalDeclRenderedWithPageHovers [Monad m]
     (item : LinkedExternalDecl) :

--- a/tests/VersoBlueprintTests/ExternalDeclRender.lean
+++ b/tests/VersoBlueprintTests/ExternalDeclRender.lean
@@ -182,9 +182,11 @@ private def htmlTestContext :
         rendered.hoverPayloads.size > 0 &&
         rendered.hoverPayloads.any (fun payload => payload.html.contains "class=\"docstring\"") &&
         rendered.html.contains "data-bp-external-hover-local=\"" &&
+        rendered.html.contains "data-bp-external-hover-inline-local=\"" &&
         !rendered.html.contains "class=\"hover-info\"" &&
         rendered.selfContained.contains "class=\"hover-info\"" &&
-        !rendered.selfContained.contains "data-bp-external-hover-local="
+        !rendered.selfContained.contains "data-bp-external-hover-local=" &&
+        !rendered.selfContained.contains "data-bp-external-hover-inline-local="
     | .error _ => pure false
 
 /-- info: true -/
@@ -217,9 +219,11 @@ private def htmlTestContext :
       hoverState.dedup.contentId.size == payloadCount &&
       pageHtml.contains "data-verso-hover=\"" &&
       !pageHtml.contains "data-bp-external-hover-local=\"" &&
+      !pageHtml.contains "data-bp-external-hover-inline-local=\"" &&
       !pageHtml.contains "class=\"hover-info\"" &&
       previewHtml.contains "class=\"hover-info\"" &&
-      !previewHtml.contains "data-bp-external-hover-local=\""
+      !previewHtml.contains "data-bp-external-hover-local=\"" &&
+      !previewHtml.contains "data-bp-external-hover-inline-local=\""
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/VersoBlueprintTests/ExternalDeclRender.lean
+++ b/tests/VersoBlueprintTests/ExternalDeclRender.lean
@@ -5,6 +5,7 @@ Author: Emilio J. Gallego Arias
 -/
 
 import VersoBlueprint.ExternalRefSnapshot
+import VersoBlueprint.Informal.ExternalCode
 
 namespace Verso.VersoBlueprintTests.ExternalDeclRender
 
@@ -154,6 +155,71 @@ theorem sameModuleRenderPackageExists (x y : Nat) (hxy : x <= y) :
         samePackage?.isSome &&
         samePackageExists?.isSome &&
         missing?.isNone)
+
+private def htmlTestContext :
+    Verso.Doc.Html.HtmlT.Context Verso.Genre.Manual Id := {
+  options := {
+    headerLevel := 1
+    logError := fun _ => pure ()
+  }
+  traverseContext := { logError := fun _ => pure () }
+  traverseState := Verso.Genre.Manual.TraverseState.initialize {}
+  definitionIds := {}
+  linkTargets := {}
+  codeOptions := {}
+}
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Lean.CoreM Bool from do
+    let env ← getEnv
+    let some cinfo := env.find? `Nat.add
+      | return false
+    match ← (Informal.renderDeclHtmlDirectFromInfoE `Nat.add cinfo).run' with
+    | .ok rendered =>
+      pure <|
+        rendered.hoverPayloads.size > 0 &&
+        rendered.hoverPayloads.any (fun payload => payload.html.contains "class=\"docstring\"") &&
+        rendered.html.contains "data-bp-external-hover-local=\"" &&
+        !rendered.html.contains "class=\"hover-info\"" &&
+        rendered.selfContained.contains "class=\"hover-info\"" &&
+        !rendered.selfContained.contains "data-bp-external-hover-local="
+    | .error _ => pure false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Lean.CoreM Bool from do
+    let opts ← Lean.getOptions
+    let ref ← Informal.externalRefSnapshotAtCurrentDir opts (Informal.Data.ExternalRef.ofName `Nat.add)
+    let some payloadCount :=
+      (match ref.render with
+      | .ok rendered =>
+        if rendered.hoverPayloads.any (fun payload => payload.html.contains "class=\"docstring\"") then
+          some rendered.hoverPayloads.size
+        else
+          none
+      | .error _ => none)
+      | return false
+    let previewHtml := Informal.ExternalCode.renderPreviewHtml #[ref, ref] |>.asString
+    let renderPage :=
+      Informal.ExternalCode.renderPartsWithPageHovers
+        { caption := "Code for theorem", number? := some "1" }
+        "Lean declarations"
+        .empty
+        #[ref, ref]
+        (fun _ => none)
+    let (parts, hoverState) := (renderPage htmlTestContext).run {}
+    let pageHtml := parts.externalCodePanel.asString
+    pure <|
+      payloadCount > 0 &&
+      hoverState.dedup.contentId.size == payloadCount &&
+      pageHtml.contains "data-verso-hover=\"" &&
+      !pageHtml.contains "data-bp-external-hover-local=\"" &&
+      !pageHtml.contains "class=\"hover-info\"" &&
+      previewHtml.contains "class=\"hover-info\"" &&
+      !previewHtml.contains "data-bp-external-hover-local=\""
 
 /-- info: true -/
 #guard_msgs in


### PR DESCRIPTION
## Summary
Backport #26 to `v4.29.0`.

## Primary Review
- Primary review: #26
- Keep review comments on #26 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.29.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- The patch IDs match the default-development source commits.