### PR TITLE
feat: split statement and proof uses chips

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ Blueprint can automatically render text such as `Theorem N`.
 Metadata-only dependencies can be written on a block with
 `(uses := "foo, bar")`; inline and metadata-only uses can also carry intent tags
 such as `"regular"`, `"technical"`, or `"auxiliary"`, plus an origin of
-`"manual"` or `"automatic"`.
+`"manual"` or `"automatic"`. Statement and proof directives render separate
+`uses` chips, so proof-only prerequisites can stay attached to the proof header
+without being folded into the statement chip.
 
 Typical directives look like:
 

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -74,6 +74,11 @@ These metadata options are accepted only by dependency-bearing uses: inline
 `uses` roles and block-level `(uses := ...)` entries. `bpref` is link-only and
 does not accept `origin` or `intent`.
 
+Statement and proof directives keep their dependencies separate in the rendered
+headers. A theorem-level `(uses := ...)` or inline `{uses ...}` in the statement
+contributes to the statement `uses` chip, while a proof-level `(uses := ...)` or
+inline proof use contributes to the proof `uses` chip for the same label.
+
 If the payload of `{uses "addition_spec"}[]` or `{bpref "addition_spec"}[]` is
 empty, Blueprint can generate the visible text automatically, for example
 `Theorem N`.

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -81,8 +81,11 @@ These metadata options are accepted only by dependency-bearing uses: inline
 does not accept `origin` or `intent`.
 
 Rendered statement and proof headers include separate `uses` chips that preview
-their own declared dependencies. Non-default dependency metadata such as
-`automatic`, `auxiliary`, and `technical` is shown in those previews.
+their own declared dependencies. Statement-level `(uses := ...)` options and
+inline statement uses stay on the statement chip; proof-level options and inline
+proof uses stay on the proof chip for the same label. Non-default dependency
+metadata such as `automatic`, `auxiliary`, and `technical` is shown in those
+previews.
 
 Proof directives accept the same dependency options, so proof-only
 prerequisites can stay attached to the proof header:
@@ -468,10 +471,11 @@ views.
 Rendered statement headers show related metadata chips in this order: group,
 uses, used by, then Lean status. The statement `uses` chip shows statement-side
 dependencies; proof headers show their own `uses` chip for proof-side
-dependencies. When local or external Lean material is available, the rendered
-page links or previews the associated content. Rows in the uses and used-by
-panels show statement/proof badges plus any non-default dependency origin or
-intent badges.
+dependencies on the same label. This keeps prerequisites for the statement and
+prerequisites used only by the proof visually distinct. When local or external
+Lean material is available, the rendered page links or previews the associated
+content. Rows in the uses and used-by panels show statement/proof badges plus
+any non-default dependency origin or intent badges.
 
 Relation previews show the human title and a right-aligned concrete Blueprint
 label in the preview header; the label links to the target statement. Single

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -459,6 +459,8 @@ views.
 Rendered statement headers show related metadata chips in this order: group,
 uses, used by, then Lean status. When local or external Lean material is
 available, the rendered page links or previews the associated content.
+Rows in the uses and used-by panels show statement/proof badges plus any
+non-default dependency origin or intent badges.
 
 When labeled inline Rust code is attached to a node, the rendered page also
 shows an associated Rust code panel below the statement body.

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -84,6 +84,15 @@ Rendered statement and proof headers include separate `uses` chips that preview
 their own declared dependencies. Non-default dependency metadata such as
 `automatic`, `auxiliary`, and `technical` is shown in those previews.
 
+Proof directives accept the same dependency options, so proof-only
+prerequisites can stay attached to the proof header:
+
+```lean
+:::proof "addition_right_identity" (uses := "induction_setup, zero_simplifier") (uses_intent := "auxiliary")
+Induct on `n`, then discharge the zero case with the simplifier.
+:::
+```
+
 If a role such as `{uses "addition_spec"}[]`, `{bpref "addition_spec"}[]`, or a
 citation has an empty payload, Blueprint can generate the visible text
 automatically, for example `Theorem N`.

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -462,6 +462,11 @@ available, the rendered page links or previews the associated content.
 Rows in the uses and used-by panels show statement/proof badges plus any
 non-default dependency origin or intent badges.
 
+Relation previews show the human title and a right-aligned concrete Blueprint
+label in the preview header; the label links to the target statement. Single
+uses or used-by entries use the same inline preview chrome, with relation
+metadata badges shown in the preview footer.
+
 When labeled inline Rust code is attached to a node, the rendered page also
 shows an associated Rust code panel below the statement body.
 

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -80,9 +80,9 @@ These metadata options are accepted only by dependency-bearing uses: inline
 `uses` roles and block-level `(uses := ...)` entries. `bpref` is link-only and
 does not accept `origin` or `intent`.
 
-Rendered statement headers include a `uses` chip that previews the node's
-declared statement and proof dependencies. Non-default dependency metadata such
-as `automatic`, `auxiliary`, and `technical` is shown in that panel.
+Rendered statement and proof headers include separate `uses` chips that preview
+their own declared dependencies. Non-default dependency metadata such as
+`automatic`, `auxiliary`, and `technical` is shown in those previews.
 
 If a role such as `{uses "addition_spec"}[]`, `{bpref "addition_spec"}[]`, or a
 citation has an empty payload, Blueprint can generate the visible text
@@ -457,10 +457,12 @@ views.
 ### Rendered statement blocks
 
 Rendered statement headers show related metadata chips in this order: group,
-uses, used by, then Lean status. When local or external Lean material is
-available, the rendered page links or previews the associated content.
-Rows in the uses and used-by panels show statement/proof badges plus any
-non-default dependency origin or intent badges.
+uses, used by, then Lean status. The statement `uses` chip shows statement-side
+dependencies; proof headers show their own `uses` chip for proof-side
+dependencies. When local or external Lean material is available, the rendered
+page links or previews the associated content. Rows in the uses and used-by
+panels show statement/proof badges plus any non-default dependency origin or
+intent badges.
 
 Relation previews show the human title and a right-aligned concrete Blueprint
 label in the preview header; the label links to the target statement. Single

--- a/src/VersoBlueprint/Commands/Common.lean
+++ b/src/VersoBlueprint/Commands/Common.lean
@@ -642,6 +642,31 @@ def previewHoverUtilsJs : String := r##"(function () {
     if (bodyNode instanceof Element) bodyNode.innerHTML = "";
   }
 
+  function setPreviewHeaderLink(labelNode, sourceNode) {
+    if (!(labelNode instanceof Element)) return;
+    const label =
+      sourceNode instanceof Element
+        ? (sourceNode.getAttribute("data-bp-preview-header-label") || "").trim()
+        : "";
+    const href =
+      sourceNode instanceof Element
+        ? (sourceNode.getAttribute("data-bp-preview-header-href") || "").trim()
+        : "";
+    if (label.length > 0) {
+      labelNode.textContent = label;
+      if (href.length > 0) {
+        labelNode.setAttribute("href", href);
+      } else {
+        labelNode.removeAttribute("href");
+      }
+      labelNode.hidden = false;
+    } else {
+      labelNode.textContent = "";
+      labelNode.removeAttribute("href");
+      labelNode.hidden = true;
+    }
+  }
+
   function showPanelContent(panel, titleNode, bodyNode, heading, html, behavior, anchor, margin, offset) {
     if (!(panel instanceof Element) || !(titleNode instanceof Element) || !(bodyNode instanceof Element)) {
       return false;
@@ -917,6 +942,7 @@ def previewHoverUtilsJs : String := r##"(function () {
     previewDebug: previewDebug,
     previewDebugLabel: previewDebugLabel,
     hidePanelContent: hidePanelContent,
+    setPreviewHeaderLink: setPreviewHeaderLink,
     showPanelContent: showPanelContent,
     bindTemplatePreview: bindTemplatePreview
   };
@@ -1192,6 +1218,7 @@ def inlineLinkPreviewJs : String := r##"(function () {
       typeof previewUtils.readPanelBehavior !== "function" ||
       typeof previewUtils.showPanelContent !== "function" ||
       typeof previewUtils.hidePanelContent !== "function" ||
+      typeof previewUtils.setPreviewHeaderLink !== "function" ||
       typeof previewUtils.shouldKeepOpen !== "function" ||
       typeof previewUtils.escapeHtml !== "function" ||
       typeof previewUtils.configureCloseButton !== "function" ||
@@ -1272,31 +1299,6 @@ def inlineLinkPreviewJs : String := r##"(function () {
       if (childHideTimer !== null) {
         clearTimeout(childHideTimer);
         childHideTimer = null;
-      }
-    }
-
-    function setPanelHeaderLink(labelNode, trigger) {
-      if (!(labelNode instanceof Element)) return;
-      const label =
-        trigger instanceof Element
-          ? (trigger.getAttribute("data-bp-preview-header-label") || "").trim()
-          : "";
-      const href =
-        trigger instanceof Element
-          ? (trigger.getAttribute("data-bp-preview-header-href") || "").trim()
-          : "";
-      if (label.length > 0) {
-        labelNode.textContent = label;
-        if (href.length > 0) {
-          labelNode.setAttribute("href", href);
-        } else {
-          labelNode.removeAttribute("href");
-        }
-        labelNode.hidden = false;
-      } else {
-        labelNode.textContent = "";
-        labelNode.removeAttribute("href");
-        labelNode.hidden = true;
       }
     }
 
@@ -1470,7 +1472,7 @@ def inlineLinkPreviewJs : String := r##"(function () {
       });
       clearPanelSizeLock();
       previewUtils.hidePanelContent(panel, title, body);
-      setPanelHeaderLink(headerLabel, null);
+      previewUtils.setPreviewHeaderLink(headerLabel, null);
       setPanelFooter(footer, null);
       activeTrigger = null;
       activeHost = null;
@@ -1482,7 +1484,7 @@ def inlineLinkPreviewJs : String := r##"(function () {
       cancelChildHide();
       childShowRequestToken += 1;
       previewUtils.hidePanelContent(childPanel, childTitle, childBody);
-      setPanelHeaderLink(childHeaderLabel, null);
+      previewUtils.setPreviewHeaderLink(childHeaderLabel, null);
       setPanelFooter(childFooter, null);
       childActiveTrigger = null;
       childPreviewKey = "";
@@ -1558,7 +1560,7 @@ def inlineLinkPreviewJs : String := r##"(function () {
       cancelChildHide();
       childPreviewKey = key;
       childActiveTrigger = trigger;
-      setPanelHeaderLink(childHeaderLabel, trigger);
+      previewUtils.setPreviewHeaderLink(childHeaderLabel, trigger);
       setPanelFooter(childFooter, trigger);
       previewUtils.showPanelContent(childPanel, childTitle, childBody, heading, html, childBehavior, trigger, 12, 10);
     }
@@ -1600,7 +1602,7 @@ def inlineLinkPreviewJs : String := r##"(function () {
         activeTrigger = null;
         ignoreNextPanelExit = true;
         title.textContent = heading;
-        setPanelHeaderLink(headerLabel, trigger);
+        previewUtils.setPreviewHeaderLink(headerLabel, trigger);
         setPanelFooter(footer, trigger);
         body.innerHTML = html;
         previewUtils.hydratePreviewSubtree(body);
@@ -1616,7 +1618,7 @@ def inlineLinkPreviewJs : String := r##"(function () {
         hideChildPanel();
         clearPanelSizeLock();
         activeTrigger = trigger;
-        setPanelHeaderLink(headerLabel, trigger);
+        previewUtils.setPreviewHeaderLink(headerLabel, trigger);
         setPanelFooter(footer, trigger);
         previewUtils.showPanelContent(panel, title, body, heading, html, behavior, trigger, 12, 10);
         if (behavior.isDocked && activeHost) {

--- a/src/VersoBlueprint/Commands/Common.lean
+++ b/src/VersoBlueprint/Commands/Common.lean
@@ -979,10 +979,35 @@ def inlinePreviewCss : String := r##"
   background: var(--bp-color-surface-muted);
 }
 
+.bp_inline_preview_panel_heading {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.42rem;
+  min-width: 0;
+}
+
 .bp_inline_preview_panel_title {
   font-size: 0.82rem;
   font-weight: 700;
   color: var(--bp-color-text-strong);
+}
+
+.bp_inline_preview_panel_label {
+  color: var(--bp-color-text-muted);
+  font-family: var(--bp-font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.bp_inline_preview_panel_label[href]:hover {
+  color: var(--bp-color-link);
+  text-decoration: underline;
+}
+
+.bp_inline_preview_panel_label[hidden] {
+  display: none;
 }
 
 .bp_inline_preview_panel_close {
@@ -1137,7 +1162,10 @@ def inlineLinkPreviewJs : String := r##"(function () {
     panel.hidden = true;
     panel.innerHTML =
       '<div class="bp_inline_preview_panel_header">' +
+      '<div class="bp_inline_preview_panel_heading">' +
       '<div class="bp_inline_preview_panel_title"></div>' +
+      '<a class="bp_inline_preview_panel_label" hidden></a>' +
+      "</div>" +
       '<button type="button" class="bp_inline_preview_panel_close" aria-label="Close inline preview">Close</button>' +
       "</div>" +
       '<div class="bp_inline_preview_panel_body"></div>' +
@@ -1183,17 +1211,20 @@ def inlineLinkPreviewJs : String := r##"(function () {
 
     const panel = getPanel("bp-inline-preview-panel", "");
     const title = panel.querySelector(".bp_inline_preview_panel_title");
+    const headerLabel = panel.querySelector(".bp_inline_preview_panel_label");
     const body = panel.querySelector(".bp_inline_preview_panel_body");
     const footer = panel.querySelector(".bp_inline_preview_panel_footer");
     const close = panel.querySelector(".bp_inline_preview_panel_close");
     const childPanel = getPanel("bp-inline-preview-child-panel", "bp_inline_preview_panel_child");
     const childTitle = childPanel.querySelector(".bp_inline_preview_panel_title");
+    const childHeaderLabel = childPanel.querySelector(".bp_inline_preview_panel_label");
     const childBody = childPanel.querySelector(".bp_inline_preview_panel_body");
     const childFooter = childPanel.querySelector(".bp_inline_preview_panel_footer");
     const childClose = childPanel.querySelector(".bp_inline_preview_panel_close");
     if (
-      !(title instanceof Element) || !(body instanceof Element) || !(footer instanceof Element) ||
-      !(close instanceof Element) || !(childTitle instanceof Element) ||
+      !(title instanceof Element) || !(headerLabel instanceof Element) ||
+      !(body instanceof Element) || !(footer instanceof Element) || !(close instanceof Element) ||
+      !(childTitle instanceof Element) || !(childHeaderLabel instanceof Element) ||
       !(childBody instanceof Element) || !(childFooter instanceof Element) ||
       !(childClose instanceof Element)
     ) {
@@ -1241,6 +1272,31 @@ def inlineLinkPreviewJs : String := r##"(function () {
       if (childHideTimer !== null) {
         clearTimeout(childHideTimer);
         childHideTimer = null;
+      }
+    }
+
+    function setPanelHeaderLink(labelNode, trigger) {
+      if (!(labelNode instanceof Element)) return;
+      const label =
+        trigger instanceof Element
+          ? (trigger.getAttribute("data-bp-preview-header-label") || "").trim()
+          : "";
+      const href =
+        trigger instanceof Element
+          ? (trigger.getAttribute("data-bp-preview-header-href") || "").trim()
+          : "";
+      if (label.length > 0) {
+        labelNode.textContent = label;
+        if (href.length > 0) {
+          labelNode.setAttribute("href", href);
+        } else {
+          labelNode.removeAttribute("href");
+        }
+        labelNode.hidden = false;
+      } else {
+        labelNode.textContent = "";
+        labelNode.removeAttribute("href");
+        labelNode.hidden = true;
       }
     }
 
@@ -1414,6 +1470,7 @@ def inlineLinkPreviewJs : String := r##"(function () {
       });
       clearPanelSizeLock();
       previewUtils.hidePanelContent(panel, title, body);
+      setPanelHeaderLink(headerLabel, null);
       setPanelFooter(footer, null);
       activeTrigger = null;
       activeHost = null;
@@ -1425,6 +1482,7 @@ def inlineLinkPreviewJs : String := r##"(function () {
       cancelChildHide();
       childShowRequestToken += 1;
       previewUtils.hidePanelContent(childPanel, childTitle, childBody);
+      setPanelHeaderLink(childHeaderLabel, null);
       setPanelFooter(childFooter, null);
       childActiveTrigger = null;
       childPreviewKey = "";
@@ -1500,6 +1558,7 @@ def inlineLinkPreviewJs : String := r##"(function () {
       cancelChildHide();
       childPreviewKey = key;
       childActiveTrigger = trigger;
+      setPanelHeaderLink(childHeaderLabel, trigger);
       setPanelFooter(childFooter, trigger);
       previewUtils.showPanelContent(childPanel, childTitle, childBody, heading, html, childBehavior, trigger, 12, 10);
     }
@@ -1541,6 +1600,7 @@ def inlineLinkPreviewJs : String := r##"(function () {
         activeTrigger = null;
         ignoreNextPanelExit = true;
         title.textContent = heading;
+        setPanelHeaderLink(headerLabel, trigger);
         setPanelFooter(footer, trigger);
         body.innerHTML = html;
         previewUtils.hydratePreviewSubtree(body);
@@ -1556,6 +1616,7 @@ def inlineLinkPreviewJs : String := r##"(function () {
         hideChildPanel();
         clearPanelSizeLock();
         activeTrigger = trigger;
+        setPanelHeaderLink(headerLabel, trigger);
         setPanelFooter(footer, trigger);
         previewUtils.showPanelContent(panel, title, body, heading, html, behavior, trigger, 12, 10);
         if (behavior.isDocked && activeHost) {

--- a/src/VersoBlueprint/Commands/Common.lean
+++ b/src/VersoBlueprint/Commands/Common.lean
@@ -950,6 +950,10 @@ def inlinePreviewCss : String := r##"
   z-index: 71;
 }
 
+.bp_inline_preview_panel[hidden] {
+  display: none;
+}
+
 .bp_inline_preview_panel[data-bp-preview-placement="anchored"]::before {
   content: "";
   position: absolute;

--- a/src/VersoBlueprint/Commands/Common.lean
+++ b/src/VersoBlueprint/Commands/Common.lean
@@ -1005,7 +1005,7 @@ def inlinePreviewCss : String := r##"
   background: var(--bp-color-surface-muted);
 }
 
-.bp_inline_preview_panel_heading {
+.bp_preview_header_heading {
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;
@@ -1019,7 +1019,7 @@ def inlinePreviewCss : String := r##"
   color: var(--bp-color-text-strong);
 }
 
-.bp_inline_preview_panel_label {
+.bp_preview_header_label {
   color: var(--bp-color-text-muted);
   font-family: var(--bp-font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
   font-size: 0.72rem;
@@ -1027,12 +1027,12 @@ def inlinePreviewCss : String := r##"
   text-decoration: none;
 }
 
-.bp_inline_preview_panel_label[href]:hover {
+.bp_preview_header_label[href]:hover {
   color: var(--bp-color-link);
   text-decoration: underline;
 }
 
-.bp_inline_preview_panel_label[hidden] {
+.bp_preview_header_label[hidden] {
   display: none;
 }
 
@@ -1188,9 +1188,9 @@ def inlineLinkPreviewJs : String := r##"(function () {
     panel.hidden = true;
     panel.innerHTML =
       '<div class="bp_inline_preview_panel_header">' +
-      '<div class="bp_inline_preview_panel_heading">' +
+      '<div class="bp_inline_preview_panel_heading bp_preview_header_heading">' +
       '<div class="bp_inline_preview_panel_title"></div>' +
-      '<a class="bp_inline_preview_panel_label" hidden></a>' +
+      '<a class="bp_inline_preview_panel_label bp_preview_header_label" hidden></a>' +
       "</div>" +
       '<button type="button" class="bp_inline_preview_panel_close" aria-label="Close inline preview">Close</button>' +
       "</div>" +

--- a/src/VersoBlueprint/Commands/Common.lean
+++ b/src/VersoBlueprint/Commands/Common.lean
@@ -929,6 +929,8 @@ def inlinePreviewCss : String := r##"
 
 .bp_inline_preview_panel {
   position: fixed;
+  display: flex;
+  flex-direction: column;
   z-index: 70;
   min-width: 18rem;
   max-width: min(34rem, 86vw);
@@ -992,9 +994,30 @@ def inlinePreviewCss : String := r##"
 
 .bp_inline_preview_panel_body {
   padding: 0.5rem 0.6rem 0.55rem;
+  min-height: 0;
   max-height: min(22rem, 70vh);
   overflow: auto;
   font-size: 0.8rem;
+}
+
+.bp_inline_preview_panel_footer {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  padding: 0.38rem 0.55rem 0.42rem;
+  border-top: 1px solid var(--bp-color-border-soft);
+  background: var(--bp-color-surface-muted);
+  color: var(--bp-color-text-subtle);
+  font-size: 0.72rem;
+}
+
+.bp_inline_preview_panel_footer[hidden] {
+  display: none;
+}
+
+.bp_inline_preview_panel_footer code {
+  font-size: 0.72rem;
 }
 
 .bp_bibliography_hover_entry {
@@ -1113,7 +1136,8 @@ def inlineLinkPreviewJs : String := r##"(function () {
       '<div class="bp_inline_preview_panel_title"></div>' +
       '<button type="button" class="bp_inline_preview_panel_close" aria-label="Close inline preview">Close</button>' +
       "</div>" +
-      '<div class="bp_inline_preview_panel_body"></div>';
+      '<div class="bp_inline_preview_panel_body"></div>' +
+      '<div class="bp_inline_preview_panel_footer" hidden></div>';
     document.body.appendChild(panel);
     return panel;
   }
@@ -1156,14 +1180,18 @@ def inlineLinkPreviewJs : String := r##"(function () {
     const panel = getPanel("bp-inline-preview-panel", "");
     const title = panel.querySelector(".bp_inline_preview_panel_title");
     const body = panel.querySelector(".bp_inline_preview_panel_body");
+    const footer = panel.querySelector(".bp_inline_preview_panel_footer");
     const close = panel.querySelector(".bp_inline_preview_panel_close");
     const childPanel = getPanel("bp-inline-preview-child-panel", "bp_inline_preview_panel_child");
     const childTitle = childPanel.querySelector(".bp_inline_preview_panel_title");
     const childBody = childPanel.querySelector(".bp_inline_preview_panel_body");
+    const childFooter = childPanel.querySelector(".bp_inline_preview_panel_footer");
     const childClose = childPanel.querySelector(".bp_inline_preview_panel_close");
     if (
-      !(title instanceof Element) || !(body instanceof Element) || !(close instanceof Element) ||
-      !(childTitle instanceof Element) || !(childBody instanceof Element) || !(childClose instanceof Element)
+      !(title instanceof Element) || !(body instanceof Element) || !(footer instanceof Element) ||
+      !(close instanceof Element) || !(childTitle instanceof Element) ||
+      !(childBody instanceof Element) || !(childFooter instanceof Element) ||
+      !(childClose instanceof Element)
     ) {
       return;
     }
@@ -1209,6 +1237,23 @@ def inlineLinkPreviewJs : String := r##"(function () {
       if (childHideTimer !== null) {
         clearTimeout(childHideTimer);
         childHideTimer = null;
+      }
+    }
+
+    function setPanelFooter(footerNode, trigger) {
+      if (!(footerNode instanceof Element)) return;
+      const footerHtml =
+        trigger instanceof Element
+          ? (trigger.getAttribute("data-bp-preview-footer-html") || "").trim()
+          : "";
+      if (footerHtml.length > 0) {
+        footerNode.innerHTML = footerHtml;
+        footerNode.hidden = false;
+        previewUtils.hydratePreviewSubtree(footerNode);
+        previewUtils.renderMath(footerNode);
+      } else {
+        footerNode.innerHTML = "";
+        footerNode.hidden = true;
       }
     }
 
@@ -1365,6 +1410,7 @@ def inlineLinkPreviewJs : String := r##"(function () {
       });
       clearPanelSizeLock();
       previewUtils.hidePanelContent(panel, title, body);
+      setPanelFooter(footer, null);
       activeTrigger = null;
       activeHost = null;
       activePreviewKey = "";
@@ -1375,6 +1421,7 @@ def inlineLinkPreviewJs : String := r##"(function () {
       cancelChildHide();
       childShowRequestToken += 1;
       previewUtils.hidePanelContent(childPanel, childTitle, childBody);
+      setPanelFooter(childFooter, null);
       childActiveTrigger = null;
       childPreviewKey = "";
     }
@@ -1449,6 +1496,7 @@ def inlineLinkPreviewJs : String := r##"(function () {
       cancelChildHide();
       childPreviewKey = key;
       childActiveTrigger = trigger;
+      setPanelFooter(childFooter, trigger);
       previewUtils.showPanelContent(childPanel, childTitle, childBody, heading, html, childBehavior, trigger, 12, 10);
     }
 
@@ -1489,6 +1537,7 @@ def inlineLinkPreviewJs : String := r##"(function () {
         activeTrigger = null;
         ignoreNextPanelExit = true;
         title.textContent = heading;
+        setPanelFooter(footer, trigger);
         body.innerHTML = html;
         previewUtils.hydratePreviewSubtree(body);
         previewUtils.renderMath(body);
@@ -1503,6 +1552,7 @@ def inlineLinkPreviewJs : String := r##"(function () {
         hideChildPanel();
         clearPanelSizeLock();
         activeTrigger = trigger;
+        setPanelFooter(footer, trigger);
         previewUtils.showPanelContent(panel, title, body, heading, html, behavior, trigger, 12, 10);
         if (behavior.isDocked && activeHost) {
           positionDockedPanel(activeHost);

--- a/src/VersoBlueprint/Commands/Common.lean
+++ b/src/VersoBlueprint/Commands/Common.lean
@@ -948,6 +948,42 @@ def previewHoverUtilsJs : String := r##"(function () {
   };
 })();"##
 
+def previewHeaderCss : String := r##"
+.bp_preview_header_heading {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.42rem;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.bp_preview_header_heading > *:first-child {
+  min-width: 0;
+}
+
+.bp_preview_header_label {
+  margin-left: auto;
+  max-width: 100%;
+  color: var(--bp-color-text-muted);
+  font-family: var(--bp-font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  font-size: 0.72rem;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+  text-align: right;
+  text-decoration: none;
+}
+
+.bp_preview_header_label[href]:hover {
+  color: var(--bp-color-link);
+  text-decoration: underline;
+}
+
+.bp_preview_header_label[hidden] {
+  display: none;
+}
+"##
+
 def inlinePreviewCss : String := r##"
 .bp_inline_preview_ref {
   cursor: help;
@@ -1005,35 +1041,10 @@ def inlinePreviewCss : String := r##"
   background: var(--bp-color-surface-muted);
 }
 
-.bp_preview_header_heading {
-  display: flex;
-  align-items: baseline;
-  flex-wrap: wrap;
-  gap: 0.42rem;
-  min-width: 0;
-}
-
 .bp_inline_preview_panel_title {
   font-size: 0.82rem;
   font-weight: 700;
   color: var(--bp-color-text-strong);
-}
-
-.bp_preview_header_label {
-  color: var(--bp-color-text-muted);
-  font-family: var(--bp-font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
-  font-size: 0.72rem;
-  font-weight: 600;
-  text-decoration: none;
-}
-
-.bp_preview_header_label[href]:hover {
-  color: var(--bp-color-link);
-  text-decoration: underline;
-}
-
-.bp_preview_header_label[hidden] {
-  display: none;
 }
 
 .bp_inline_preview_panel_close {
@@ -1749,10 +1760,10 @@ def withPreviewPanelCssAssets (extras : List String := []) : List String :=
   withBlueprintCssAssets ([previewPanelCss] ++ extras)
 
 def withInlinePreviewCssAssets (extras : List String := []) : List String :=
-  withBlueprintCssAssets (extras ++ [inlinePreviewCss])
+  withBlueprintCssAssets (extras ++ [previewHeaderCss, inlinePreviewCss])
 
 def withPreviewPanelInlinePreviewCssAssets (extras : List String := []) : List String :=
-  withPreviewPanelCssAssets (extras ++ [inlinePreviewCss])
+  withPreviewPanelCssAssets (extras ++ [previewHeaderCss, inlinePreviewCss])
 
 def previewRuntimeJsAssets : List String :=
   [previewHoverUtilsJs]

--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -139,6 +139,19 @@ block_extension Block.informal (data : BlockData) where
           match data.kind with
           | .proof => data.foldProofBlock
           | .statement _ => false
+        let headerExtras : HeaderExtras :=
+          match data.kind with
+          | .proof =>
+            {
+              uses? := some <| HeaderExtra.uses usesEntry
+            }
+          | .statement _ =>
+            {
+              group? := groupEntry.map HeaderExtra.group
+              uses? := some <| HeaderExtra.uses usesEntry
+              usedBy? := some <| HeaderExtra.usedBy usedByEntry
+              code? := some <| HeaderExtra.code codeEntry
+            }
         let informalBlock :=
           renderInformalBlockHtml data {
             numberText := data.displayNumber s
@@ -147,12 +160,7 @@ block_extension Block.informal (data : BlockData) where
               | .proof => some (data.displayTitle s)
               | .statement _ => none
             attrs
-            headerExtras := {
-              group? := groupEntry.map HeaderExtra.group
-              uses? := some <| HeaderExtra.uses usesEntry
-              usedBy? := some <| HeaderExtra.usedBy usedByEntry
-              code? := some <| HeaderExtra.code codeEntry
-            }
+            headerExtras
             folded := foldInformalBlock
           } content
         return .seq #[informalBlock, externalPanel]

--- a/src/VersoBlueprint/Informal/Block/Assets.lean
+++ b/src/VersoBlueprint/Informal/Block/Assets.lean
@@ -133,6 +133,10 @@ span[class$="_thmlabel"]::after {
   justify-content: flex-start;
 }
 
+.bp_extras_with_uses:not(.bp_extras_with_group):not(.bp_extras_with_used_by):not(.bp_extras_with_code) .bp_extra_slot_uses {
+  justify-content: flex-end;
+}
+
 .bp_extra_slot_used_by {
   grid-area: used;
   justify-content: flex-start;

--- a/src/VersoBlueprint/Informal/Block/Assets.lean
+++ b/src/VersoBlueprint/Informal/Block/Assets.lean
@@ -826,11 +826,36 @@ span[class$="_thmlabel"]::after {
   color: var(--bp-color-text-faint);
 }
 
+.bp_relation_preview_heading {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.42rem;
+  min-width: 0;
+}
+
 .bp_relation_preview_title {
   margin-top: 0.16rem;
   font-size: 0.8rem;
   font-weight: 700;
   color: var(--bp-color-text-strong);
+}
+
+.bp_relation_preview_header_label {
+  color: var(--bp-color-text-muted);
+  font-family: var(--bp-font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.bp_relation_preview_header_label[href]:hover {
+  color: var(--bp-color-link);
+  text-decoration: underline;
+}
+
+.bp_relation_preview_header_label[hidden] {
+  display: none;
 }
 
 .bp_relation_preview_body {
@@ -1607,8 +1632,9 @@ def relationPanelJs : String := r##"(function () {
     const wrap = panel.closest(".bp_relation_wrap");
     const chip = wrap instanceof Element ? wrap.querySelector(".bp_relation_chip") : null;
     const title = panel.querySelector(".bp_relation_preview_title");
+    const headerLabel = panel.querySelector(".bp_relation_preview_header_label");
     const body = panel.querySelector(".bp_relation_preview_body");
-    if (!(title instanceof Element) || !(body instanceof Element)) return;
+    if (!(title instanceof Element) || !(headerLabel instanceof Element) || !(body instanceof Element)) return;
 
     const defaultTitle = (title.textContent || "").trim() || "Relation preview";
     const items = Array.from(panel.querySelectorAll(".bp_relation_item[data-bp-relation-preview-id]"));
@@ -1643,6 +1669,9 @@ def relationPanelJs : String := r##"(function () {
         }
       });
       title.textContent = itemTitle;
+      if (previewUtils && typeof previewUtils.setPreviewHeaderLink === "function") {
+        previewUtils.setPreviewHeaderLink(headerLabel, item);
+      }
       body.innerHTML = "";
     }
 

--- a/src/VersoBlueprint/Informal/Block/Assets.lean
+++ b/src/VersoBlueprint/Informal/Block/Assets.lean
@@ -36,6 +36,10 @@ def css : String := r##"
   gap: 0.35rem;
 }
 
+.bp_kind_proof_heading {
+  align-items: baseline;
+}
+
 .bp_heading_title_row_statement {
   display: inline-grid;
   grid-template-columns: 11ch 3ch;

--- a/src/VersoBlueprint/Informal/Block/Assets.lean
+++ b/src/VersoBlueprint/Informal/Block/Assets.lean
@@ -83,8 +83,11 @@ span[class$="_thmlabel"]::after {
 }
 
 .bp_extras_with_uses:not(.bp_extras_with_group):not(.bp_extras_with_used_by):not(.bp_extras_with_code) {
-  grid-template-columns: minmax(4.2rem, max-content);
-  grid-template-areas: "uses";
+  grid-template-columns:
+    minmax(4.2rem, max-content)
+    minmax(7.2rem, max-content)
+    minmax(3.35rem, max-content);
+  grid-template-areas: "uses . .";
 }
 
 .bp_extras_with_group {
@@ -135,10 +138,6 @@ span[class$="_thmlabel"]::after {
 .bp_extra_slot_uses {
   grid-area: uses;
   justify-content: flex-start;
-}
-
-.bp_extras_with_uses:not(.bp_extras_with_group):not(.bp_extras_with_used_by):not(.bp_extras_with_code) .bp_extra_slot_uses {
-  justify-content: flex-end;
 }
 
 .bp_extra_slot_used_by {

--- a/src/VersoBlueprint/Informal/Block/Assets.lean
+++ b/src/VersoBlueprint/Informal/Block/Assets.lean
@@ -16,6 +16,11 @@ def css : String := r##"
   margin: 0.85rem 0;
 }
 
+/* Leave scroll room for relation panels opened near the end of a page. */
+.content-wrapper > section:has(.bp_relation_panel) {
+  padding-bottom: min(18rem, 42vh);
+}
+
 .bp_heading {
   display: flex;
   align-items: center;
@@ -728,17 +733,75 @@ span[class$="_thmlabel"]::after {
 }
 
 .bp_relation_axis_badge {
+  --bp-relation-badge-bg: var(--bp-color-surface);
+  --bp-relation-badge-border: var(--bp-color-border);
+  --bp-relation-badge-text: var(--bp-color-text-muted);
+  --bp-relation-badge-prefix: var(--bp-color-text-faint);
   display: inline-flex;
   align-items: center;
-  border: 1px solid var(--bp-color-border);
+  border: 1px solid var(--bp-relation-badge-border);
   border-radius: var(--bp-radius-pill);
-  background: var(--bp-color-surface);
-  color: var(--bp-color-text-muted);
+  background: var(--bp-relation-badge-bg);
+  color: var(--bp-relation-badge-text);
   font-size: 0.66rem;
   font-weight: 700;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-  padding: 0.08rem 0.34rem;
+  letter-spacing: 0;
+  line-height: 1.2;
+  text-transform: none;
+  padding: 0.1rem 0.36rem;
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.35);
+}
+
+.bp_relation_badge_axis {
+  font-weight: 700;
+}
+
+.bp_relation_badge_statement {
+  --bp-relation-badge-bg: rgba(37, 99, 235, 0.1);
+  --bp-relation-badge-border: rgba(37, 99, 235, 0.28);
+  --bp-relation-badge-text: #1d4ed8;
+}
+
+.bp_relation_badge_proof {
+  --bp-relation-badge-bg: rgba(5, 150, 105, 0.12);
+  --bp-relation-badge-border: rgba(5, 150, 105, 0.28);
+  --bp-relation-badge-text: #047857;
+}
+
+.bp_relation_badge_origin::before,
+.bp_relation_badge_intent::before {
+  color: var(--bp-relation-badge-prefix);
+  font-weight: 600;
+  margin-right: 0.22rem;
+}
+
+.bp_relation_badge_origin::before {
+  content: "origin";
+}
+
+.bp_relation_badge_intent::before {
+  content: "intent";
+}
+
+.bp_relation_badge_origin_automatic {
+  --bp-relation-badge-bg: rgba(124, 58, 237, 0.1);
+  --bp-relation-badge-border: rgba(124, 58, 237, 0.26);
+  --bp-relation-badge-text: #6d28d9;
+  --bp-relation-badge-prefix: #7c3aed;
+}
+
+.bp_relation_badge_intent_auxiliary {
+  --bp-relation-badge-bg: rgba(245, 158, 11, 0.14);
+  --bp-relation-badge-border: rgba(245, 158, 11, 0.32);
+  --bp-relation-badge-text: #92400e;
+  --bp-relation-badge-prefix: #b45309;
+}
+
+.bp_relation_badge_intent_technical {
+  --bp-relation-badge-bg: rgba(79, 70, 229, 0.1);
+  --bp-relation-badge-border: rgba(79, 70, 229, 0.26);
+  --bp-relation-badge-text: #4338ca;
+  --bp-relation-badge-prefix: #4f46e5;
 }
 
 .bp_relation_preview_surface {

--- a/src/VersoBlueprint/Informal/Block/Assets.lean
+++ b/src/VersoBlueprint/Informal/Block/Assets.lean
@@ -78,6 +78,11 @@ span[class$="_thmlabel"]::after {
   grid-template-areas: "uses used code";
 }
 
+.bp_extras_with_uses:not(.bp_extras_with_group):not(.bp_extras_with_used_by):not(.bp_extras_with_code) {
+  grid-template-columns: minmax(4.2rem, max-content);
+  grid-template-areas: "uses";
+}
+
 .bp_extras_with_group {
   grid-template-columns: minmax(5rem, max-content) minmax(7.2rem, max-content) max-content;
   grid-template-areas: "group used code";

--- a/src/VersoBlueprint/Informal/Block/Assets.lean
+++ b/src/VersoBlueprint/Informal/Block/Assets.lean
@@ -68,30 +68,42 @@ span[class$="_thmlabel"]::after {
 }
 
 .bp_extras {
+  --bp-extra-group-col: minmax(5rem, max-content);
+  --bp-extra-uses-col: minmax(4.2rem, max-content);
+  --bp-extra-used-by-col: minmax(7.2rem, max-content);
+  --bp-extra-code-col: max-content;
+  --bp-extra-code-placeholder-col: minmax(3.35rem, max-content);
   display: inline-grid;
   align-items: baseline;
   justify-content: end;
   column-gap: 0.55rem;
-  grid-template-columns: minmax(7.2rem, max-content) max-content;
+  grid-template-columns: var(--bp-extra-used-by-col) var(--bp-extra-code-col);
   grid-template-areas: "used code";
   margin-left: auto;
 }
 
 .bp_extras_with_uses {
-  grid-template-columns: minmax(4.2rem, max-content) minmax(7.2rem, max-content) max-content;
+  grid-template-columns:
+    var(--bp-extra-uses-col)
+    var(--bp-extra-used-by-col)
+    var(--bp-extra-code-col);
   grid-template-areas: "uses used code";
 }
 
 .bp_extras_with_uses:not(.bp_extras_with_group):not(.bp_extras_with_used_by):not(.bp_extras_with_code) {
+  /* Keep proof-only uses aligned with the statement uses column. */
   grid-template-columns:
-    minmax(4.2rem, max-content)
-    minmax(7.2rem, max-content)
-    minmax(3.35rem, max-content);
+    var(--bp-extra-uses-col)
+    var(--bp-extra-used-by-col)
+    var(--bp-extra-code-placeholder-col);
   grid-template-areas: "uses . .";
 }
 
 .bp_extras_with_group {
-  grid-template-columns: minmax(5rem, max-content) minmax(7.2rem, max-content) max-content;
+  grid-template-columns:
+    var(--bp-extra-group-col)
+    var(--bp-extra-used-by-col)
+    var(--bp-extra-code-col);
   grid-template-areas: "group used code";
 }
 
@@ -111,10 +123,10 @@ span[class$="_thmlabel"]::after {
 
 .bp_extras_with_group.bp_extras_with_uses {
   grid-template-columns:
-    minmax(5rem, max-content)
-    minmax(4.2rem, max-content)
-    minmax(7.2rem, max-content)
-    max-content;
+    var(--bp-extra-group-col)
+    var(--bp-extra-uses-col)
+    var(--bp-extra-used-by-col)
+    var(--bp-extra-code-col);
   grid-template-areas: "group uses used code";
 }
 

--- a/src/VersoBlueprint/Informal/Block/Assets.lean
+++ b/src/VersoBlueprint/Informal/Block/Assets.lean
@@ -826,36 +826,11 @@ span[class$="_thmlabel"]::after {
   color: var(--bp-color-text-faint);
 }
 
-.bp_relation_preview_heading {
-  display: flex;
-  align-items: baseline;
-  flex-wrap: wrap;
-  gap: 0.42rem;
-  min-width: 0;
-}
-
 .bp_relation_preview_title {
   margin-top: 0.16rem;
   font-size: 0.8rem;
   font-weight: 700;
   color: var(--bp-color-text-strong);
-}
-
-.bp_relation_preview_header_label {
-  color: var(--bp-color-text-muted);
-  font-family: var(--bp-font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
-  font-size: 0.72rem;
-  font-weight: 600;
-  text-decoration: none;
-}
-
-.bp_relation_preview_header_label[href]:hover {
-  color: var(--bp-color-link);
-  text-decoration: underline;
-}
-
-.bp_relation_preview_header_label[hidden] {
-  display: none;
 }
 
 .bp_relation_preview_body {

--- a/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
+++ b/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
@@ -99,6 +99,16 @@ structure PanelConfig where
 def usedByChipText (count : Nat) : String :=
   s!"used by {count}"
 
+/-- Human-facing statement/proof wording for forward dependency previews. -/
+private structure UsesScopeText where
+  lowercase : String
+  titlecase : String
+
+private def usesScopeText (data : BlockData) : UsesScopeText :=
+  match data.kind with
+  | .proof => { lowercase := "proof", titlecase := "Proof" }
+  | .statement _ => { lowercase := "statement", titlecase := "Statement" }
+
 /-- Standard reverse-dependency panel presentation. -/
 def usedByPanelConfig (targetLabel? : Option Data.Label := none) : PanelConfig := {
   chipText := usedByChipText
@@ -117,43 +127,23 @@ def usedByPanelConfig (targetLabel? : Option Data.Label := none) : PanelConfig :
 }
 
 /-- Standard forward-dependency panel presentation for statement and proof uses. -/
-def usesPanelConfig (sourceLabel : Data.Label) (isProof : Bool) : PanelConfig := {
+def usesPanelConfig (sourceLabel : Data.Label) (scope : UsesScopeText) : PanelConfig := {
   chipText := fun n => s!"uses {n}"
   chipTitle := fun n =>
     if n == 0 then
-      if isProof then
-        "No declared proof dependencies"
-      else
-        "No declared statement dependencies"
-    else if isProof then
-      s!"Proof dependencies used by {sourceLabel}"
+      s!"No declared {scope.lowercase} dependencies"
     else
-      s!"Statement dependencies used by {sourceLabel}"
+      s!"{scope.titlecase} dependencies used by {sourceLabel}"
   singleTitle := fun entry =>
-    if isProof then
-      s!"Proof dependency: {entry.previewTitle}"
-    else
-      s!"Statement dependency: {entry.previewTitle}"
+    s!"{scope.titlecase} dependency: {entry.previewTitle}"
   panelTitle := fun n =>
-    if isProof then
-      s!"Proof uses {n}"
-    else
-      s!"Statement uses {n}"
+    s!"{scope.titlecase} uses {n}"
   panelMeta :=
-    if isProof then
-      "Proof dependency previews"
-    else
-      "Statement dependency previews"
+    s!"{scope.titlecase} dependency previews"
   previewDefaultTitle :=
-    if isProof then
-      "Proof dependency preview"
-    else
-      "Statement dependency preview"
+    s!"{scope.titlecase} dependency preview"
   previewEmptyText :=
-    if isProof then
-      "Proof dependency preview content is loaded from the Blueprint HTML cache."
-    else
-      "Statement dependency preview content is loaded from the Blueprint HTML cache."
+    s!"{scope.titlecase} dependency preview content is loaded from the Blueprint HTML cache."
   chipClass := "bp_relation_chip bp_uses_chip"
   emptyChipClass := "bp_relation_chip bp_relation_chip_empty bp_uses_chip"
 }
@@ -574,10 +564,7 @@ def renderUsesExtra {m}
     (data : BlockData) :
     Verso.Doc.Html.HtmlT Verso.Genre.Manual m Output.Html := do
   let entries := collectUsesEntries ctx data
-  let isProof :=
-    match data.kind with
-    | .proof => true
-    | .statement _ => false
+  let scope := usesScopeText data
   let panelEntries ← entries.mapM fun entry => do
     let badgesHtml := {{
       {{renderUseAxisBadges entry}}
@@ -592,7 +579,7 @@ def renderUsesExtra {m}
       mkLabelEntry ctx entry.label
         (usesPreviewId data.label entry.label)
         (badgesHtml := badgesHtml)
-  pure <| renderPanel (usesPanelConfig data.label isProof) panelEntries
+  pure <| renderPanel (usesPanelConfig data.label scope) panelEntries
 
 /-- Render the group-membership header extra, if the block belongs to a group. -/
 def renderGroupExtra {m}

--- a/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
+++ b/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
@@ -420,10 +420,14 @@ def renderPanel (cfg : PanelConfig) (entries : Array PanelEntry) : Output.Html :
           </a>}}
       else
         renderChip cfg.chipClass (cfg.singleTitle entry) 1
+    let previewFooterHtml? :=
+      let html := entry.metaHtml.asString
+      if html.isEmpty then none else some html
     Informal.HoverRender.inlinePreviewNode
       chipNode entry.previewId entry.previewTitle
       (previewLookupKey? := some entry.previewKey)
       (previewFallbackLabel? := entry.previewFallbackLabel?)
+      (previewFooterHtml? := previewFooterHtml?)
   let selectedEntry? := selectedPanelEntry? cfg entries
   let renderRow (entry : PanelEntry) : Output.Html :=
     let itemClass :=

--- a/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
+++ b/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
@@ -304,16 +304,40 @@ private def groupPreviewId (targetLabel sourceLabel : Data.Label) : String :=
 private def previewLookupKey (source : BlockData) : String :=
   PreviewCache.key source.label (PreviewCache.Facet.ofInProgressKind source.kind)
 
-private def renderAxisBadges (inStatement inProof : Bool) : Output.Html :=
+/-- Render a relation-row badge with both legacy and semantic styling classes. -/
+private def relationBadge (className title text : String) : Output.Html :=
   open Verso.Output.Html in
+  {{<span class={{className}} title={{title}}>{{.text true text}}</span>}}
+
+private def useOriginBadgeClass : Data.UseOrigin → String
+  | .manual =>
+    "bp_relation_axis_badge bp_relation_badge_origin bp_uses_origin_badge bp_relation_badge_origin_manual"
+  | .automatic =>
+    "bp_relation_axis_badge bp_relation_badge_origin bp_uses_origin_badge bp_relation_badge_origin_automatic"
+
+private def useIntentBadgeClass : Data.UseIntent → String
+  | .regular =>
+    "bp_relation_axis_badge bp_relation_badge_intent bp_uses_intent_badge bp_relation_badge_intent_regular"
+  | .auxiliary =>
+    "bp_relation_axis_badge bp_relation_badge_intent bp_uses_intent_badge bp_relation_badge_intent_auxiliary"
+  | .technical =>
+    "bp_relation_axis_badge bp_relation_badge_intent bp_uses_intent_badge bp_relation_badge_intent_technical"
+
+private def renderAxisBadges (inStatement inProof : Bool) : Output.Html :=
   let statementBadge : Array Output.Html :=
     if inStatement then
-      #[{{<span class="bp_relation_axis_badge">"statement"</span>}}]
+      #[relationBadge
+          "bp_relation_axis_badge bp_relation_badge_axis bp_relation_badge_statement"
+          "Declared in the statement"
+          "statement"]
     else
       #[]
   let proofBadge : Array Output.Html :=
     if inProof then
-      #[{{<span class="bp_relation_axis_badge">"proof"</span>}}]
+      #[relationBadge
+          "bp_relation_axis_badge bp_relation_badge_axis bp_relation_badge_proof"
+          "Declared in the proof"
+          "proof"]
     else
       #[]
   .seq (statementBadge ++ proofBadge)
@@ -326,13 +350,14 @@ private def renderUseAxisBadges (entry : UsesEntry) : Output.Html :=
 
 private def renderUseMetadataBadges
     (origins : Array Data.UseOrigin) (intents : Array Data.UseIntent) : Output.Html :=
-  open Verso.Output.Html in
   let originBadges :=
     origins.filter (· != .manual) |>.map fun origin =>
-      {{<span class="bp_relation_axis_badge bp_uses_origin_badge">{{.text true (toString origin)}}</span>}}
+      let text := toString origin
+      relationBadge (useOriginBadgeClass origin) s!"Origin: {text}" text
   let intentBadges :=
     intents.filter (· != .regular) |>.map fun intent =>
-      {{<span class="bp_relation_axis_badge bp_uses_intent_badge">{{.text true (toString intent)}}</span>}}
+      let text := toString intent
+      relationBadge (useIntentBadgeClass intent) s!"Intent: {text}" text
   .seq (originBadges ++ intentBadges)
 
 private def mkBlockEntry {m}

--- a/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
+++ b/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
@@ -104,10 +104,11 @@ private structure UsesScopeText where
   lowercase : String
   titlecase : String
 
-private def usesScopeText (data : BlockData) : UsesScopeText :=
-  match data.kind with
-  | .proof => { lowercase := "proof", titlecase := "Proof" }
-  | .statement _ => { lowercase := "statement", titlecase := "Statement" }
+private def usesScopeText (isProof : Bool) : UsesScopeText :=
+  if isProof then
+    { lowercase := "proof", titlecase := "Proof" }
+  else
+    { lowercase := "statement", titlecase := "Statement" }
 
 /-- Standard reverse-dependency panel presentation. -/
 def usedByPanelConfig (targetLabel? : Option Data.Label := none) : PanelConfig := {
@@ -127,7 +128,9 @@ def usedByPanelConfig (targetLabel? : Option Data.Label := none) : PanelConfig :
 }
 
 /-- Standard forward-dependency panel presentation for statement and proof uses. -/
-def usesPanelConfig (sourceLabel : Data.Label) (scope : UsesScopeText) : PanelConfig := {
+def usesPanelConfig (sourceLabel : Data.Label) (isProof : Bool) : PanelConfig :=
+  let scope := usesScopeText isProof
+  {
   chipText := fun n => s!"uses {n}"
   chipTitle := fun n =>
     if n == 0 then
@@ -564,7 +567,10 @@ def renderUsesExtra {m}
     (data : BlockData) :
     Verso.Doc.Html.HtmlT Verso.Genre.Manual m Output.Html := do
   let entries := collectUsesEntries ctx data
-  let scope := usesScopeText data
+  let isProof :=
+    match data.kind with
+    | .proof => true
+    | .statement _ => false
   let panelEntries ← entries.mapM fun entry => do
     let badgesHtml := {{
       {{renderUseAxisBadges entry}}
@@ -579,7 +585,7 @@ def renderUsesExtra {m}
       mkLabelEntry ctx entry.label
         (usesPreviewId data.label entry.label)
         (badgesHtml := badgesHtml)
-  pure <| renderPanel (usesPanelConfig data.label scope) panelEntries
+  pure <| renderPanel (usesPanelConfig data.label isProof) panelEntries
 
 /-- Render the group-membership header extra, if the block belongs to a group. -/
 def renderGroupExtra {m}

--- a/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
+++ b/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
@@ -66,8 +66,9 @@ structure PanelEntry where
   previewId : String
   previewKey : String
   previewTitle : String
+  label : Data.Label
   href : Option String := none
-  metaHtml : Output.Html := .empty
+  badgesHtml : Output.Html := .empty
   previewFallbackLabel? : Option String := none
   active : Bool := false
 
@@ -363,7 +364,7 @@ private def mkBlockEntry {m}
     [Monad m]
     (ctx : Context)
     (source : BlockData) (previewId : String)
-    (metaHtml : Output.Html := .empty) :
+    (badgesHtml : Output.Html := .empty) :
     Verso.Doc.Html.HtmlT Verso.Genre.Manual m PanelEntry := do
   let previewTitle := blockSummaryTitle ctx source
   let href := Informal.TraversalIndex.Nodes.href? ctx.state source.label
@@ -371,8 +372,9 @@ private def mkBlockEntry {m}
     previewId
     previewKey := previewLookupKey source
     previewTitle
+    label := source.label
     href
-    metaHtml
+    badgesHtml
     previewFallbackLabel? := some s!"{source.label}"
   }
 
@@ -380,15 +382,16 @@ private def mkLabelEntry {m}
     [Monad m]
     (ctx : Context)
     (label : Data.Label) (previewId : String)
-    (metaHtml : Output.Html := .empty) :
+    (badgesHtml : Output.Html := .empty) :
     Verso.Doc.Html.HtmlT Verso.Genre.Manual m PanelEntry := do
   let previewTitle := s!"{label}"
   pure {
     previewId
     previewKey := PreviewCache.key label .statement
     previewTitle
+    label
     href := Informal.TraversalIndex.Nodes.href? ctx.state label
-    metaHtml
+    badgesHtml
     previewFallbackLabel? := some s!"{label}"
   }
 
@@ -421,12 +424,14 @@ def renderPanel (cfg : PanelConfig) (entries : Array PanelEntry) : Output.Html :
       else
         renderChip cfg.chipClass (cfg.singleTitle entry) 1
     let previewFooterHtml? :=
-      let html := entry.metaHtml.asString
+      let html := entry.badgesHtml.asString
       if html.isEmpty then none else some html
     Informal.HoverRender.inlinePreviewNode
       chipNode entry.previewId entry.previewTitle
       (previewLookupKey? := some entry.previewKey)
       (previewFallbackLabel? := entry.previewFallbackLabel?)
+      (previewHeaderLabel? := some s!"{entry.label}")
+      (previewHeaderHref? := entry.href)
       (previewFooterHtml? := previewFooterHtml?)
   let selectedEntry? := selectedPanelEntry? cfg entries
   let renderRow (entry : PanelEntry) : Output.Html :=
@@ -443,7 +448,8 @@ def renderPanel (cfg : PanelConfig) (entries : Array PanelEntry) : Output.Html :
       let titleNode := {{<span class="bp_relation_target_title">{{.text true entry.previewTitle}}</span>}}
       let metaNode := {{
         <span class="bp_relation_target_meta">
-          {{entry.metaHtml}}
+          <code>s!"{entry.label}"</code>
+          {{entry.badgesHtml}}
         </span>
       }}
       if let some href := entry.href then
@@ -517,8 +523,7 @@ def renderUsedByExtra {m}
     let panelEntries ← entries.mapM fun entry =>
       mkBlockEntry ctx entry.source
         (usedByPreviewId data.label entry.source.label)
-        (metaHtml := {{
-          <code>s!"{entry.source.label}"</code>
+        (badgesHtml := {{
           {{renderUsedByAxisBadges entry}}
           {{renderUseMetadataBadges entry.origins entry.intents}}
         }})
@@ -535,8 +540,7 @@ def renderUsesExtra {m}
   | .statement _ =>
     let entries := collectUsesEntries ctx data
     let panelEntries ← entries.mapM fun entry => do
-      let metaHtml := {{
-        <code>s!"{entry.label}"</code>
+      let badgesHtml := {{
         {{renderUseAxisBadges entry}}
         {{renderUseMetadataBadges entry.origins entry.intents}}
       }}
@@ -544,11 +548,11 @@ def renderUsesExtra {m}
       | some target =>
         mkBlockEntry ctx target
           (usesPreviewId data.label entry.label)
-          (metaHtml := metaHtml)
+          (badgesHtml := badgesHtml)
       | none =>
         mkLabelEntry ctx entry.label
           (usesPreviewId data.label entry.label)
-          (metaHtml := metaHtml)
+          (badgesHtml := badgesHtml)
     pure <| renderPanel usesPanelConfig panelEntries
 
 /-- Render the group-membership header extra, if the block belongs to a group. -/
@@ -567,7 +571,6 @@ def renderGroupExtra {m}
     let panelEntries ← siblings.mapM fun source =>
       mkBlockEntry ctx source
         (groupPreviewId data.label source.label)
-        (metaHtml := {{<code>s!"{source.label}"</code>}})
     let cfg := groupPanelConfig group.label group.title group.declared
     pure <| some (renderPanel cfg panelEntries)
 

--- a/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
+++ b/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
@@ -461,11 +461,10 @@ def renderPanel (cfg : PanelConfig) (entries : Array PanelEntry) : Output.Html :
         ("class", itemClass),
         ("data-bp-relation-preview-id", entry.previewId),
         ("data-bp-relation-preview-key", entry.previewKey),
-        ("data-bp-relation-preview-title", entry.previewTitle),
-        ("data-bp-preview-header-label", s!"{entry.label}")
+        ("data-bp-relation-preview-title", entry.previewTitle)
       ]
-      if let some href := entry.href then
-        attrs := attrs.push ("data-bp-preview-header-href", href)
+      for attr in Informal.HoverRender.previewHeaderLinkAttrs (some s!"{entry.label}") entry.href do
+        attrs := attrs.push attr
       pure attrs
     .tag "li" attrs rowNode
   let previewTitle :=
@@ -488,9 +487,9 @@ def renderPanel (cfg : PanelConfig) (entries : Array PanelEntry) : Output.Html :
           <div class="bp_relation_preview_surface">
             <div class="bp_relation_preview_header">
               <div class="bp_relation_preview_label">"Preview"</div>
-              <div class="bp_relation_preview_heading">
+              <div class="bp_relation_preview_heading bp_preview_header_heading">
                 <div class="bp_relation_preview_title">{{.text true previewTitle}}</div>
-                <a class="bp_relation_preview_header_label" hidden></a>
+                <a class="bp_relation_preview_header_label bp_preview_header_label" hidden></a>
               </div>
             </div>
             <div class="bp_relation_preview_body">

--- a/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
+++ b/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
@@ -183,6 +183,8 @@ private structure UsedByEntry where
   source : BlockData
   inStatement : Bool := false
   inProof : Bool := false
+  origins : Array Data.UseOrigin := #[]
+  intents : Array Data.UseIntent := #[]
 
 private structure UsesEntry where
   label : Data.Label
@@ -196,21 +198,44 @@ private def sortUsedByEntries (entries : Array UsedByEntry) : Array UsedByEntry 
   entries.qsort fun a b =>
     BlockData.traversalOrderLess a.source b.source
 
+private def pushUnique [DecidableEq α] (values : Array α) (value : α) : Array α :=
+  if values.contains value then values else values.push value
+
+private def mergeUsedByEntry (existing : UsedByEntry) (useRef : Data.UseRef) (isProof : Bool) :
+    UsedByEntry :=
+  {
+    existing with
+      inStatement := existing.inStatement || !isProof
+      inProof := existing.inProof || isProof
+      origins := pushUnique existing.origins useRef.origin
+      intents := pushUnique existing.intents useRef.intent
+  }
+
+private def addUsedByEntry
+    (acc : Array UsedByEntry) (source : BlockData) (useRef : Data.UseRef) (isProof : Bool)
+    (target : Data.Label) : Array UsedByEntry :=
+  if useRef.label != target then
+    acc
+  else if acc.any (·.source.label == source.label) then
+    acc.map fun entry =>
+      if entry.source.label == source.label then
+        mergeUsedByEntry entry useRef isProof
+      else
+        entry
+  else
+    acc.push <| mergeUsedByEntry { source } useRef isProof
+
 private def collectUsedByEntries
     (ctx : Context) (target : Data.Label) : Array UsedByEntry :=
   sortUsedByEntries <| ctx.storedBlocks.foldl (init := #[]) fun acc source =>
     if source.label == target then
       acc
     else
-      let inStatement := source.statementDeps.contains target
-      let inProof := source.proofDeps.contains target
-      if !inStatement && !inProof then
-        acc
-      else
-        acc.push { source, inStatement, inProof }
-
-private def pushUnique [DecidableEq α] (values : Array α) (value : α) : Array α :=
-  if values.contains value then values else values.push value
+      let acc :=
+        source.statementUses.foldl (init := acc) fun acc useRef =>
+          addUsedByEntry acc source useRef false target
+      source.proofUses.foldl (init := acc) fun acc useRef =>
+        addUsedByEntry acc source useRef true target
 
 private def mergeUsesEntry (existing : UsesEntry) (useRef : Data.UseRef) (isProof : Bool) :
     UsesEntry :=
@@ -299,13 +324,14 @@ private def renderUsedByAxisBadges (entry : UsedByEntry) : Output.Html :=
 private def renderUseAxisBadges (entry : UsesEntry) : Output.Html :=
   renderAxisBadges entry.inStatement entry.inProof
 
-private def renderUseMetadataBadges (entry : UsesEntry) : Output.Html :=
+private def renderUseMetadataBadges
+    (origins : Array Data.UseOrigin) (intents : Array Data.UseIntent) : Output.Html :=
   open Verso.Output.Html in
   let originBadges :=
-    entry.origins.filter (· != .manual) |>.map fun origin =>
+    origins.filter (· != .manual) |>.map fun origin =>
       {{<span class="bp_relation_axis_badge bp_uses_origin_badge">{{.text true (toString origin)}}</span>}}
   let intentBadges :=
-    entry.intents.filter (· != .regular) |>.map fun intent =>
+    intents.filter (· != .regular) |>.map fun intent =>
       {{<span class="bp_relation_axis_badge bp_uses_intent_badge">{{.text true (toString intent)}}</span>}}
   .seq (originBadges ++ intentBadges)
 
@@ -466,6 +492,7 @@ def renderUsedByExtra {m}
         (metaHtml := {{
           <code>s!"{entry.source.label}"</code>
           {{renderUsedByAxisBadges entry}}
+          {{renderUseMetadataBadges entry.origins entry.intents}}
         }})
     pure <| renderPanel (usedByPanelConfig (some data.label)) panelEntries
 
@@ -483,7 +510,7 @@ def renderUsesExtra {m}
       let metaHtml := {{
         <code>s!"{entry.label}"</code>
         {{renderUseAxisBadges entry}}
-        {{renderUseMetadataBadges entry}}
+        {{renderUseMetadataBadges entry.origins entry.intents}}
       }}
       match entry.target? with
       | some target =>

--- a/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
+++ b/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
@@ -116,15 +116,44 @@ def usedByPanelConfig (targetLabel? : Option Data.Label := none) : PanelConfig :
   previewEmptyText := "Reverse dependency preview content is loaded from the Blueprint HTML cache."
 }
 
-/-- Standard forward-dependency panel presentation. -/
-def usesPanelConfig : PanelConfig := {
+/-- Standard forward-dependency panel presentation for statement and proof uses. -/
+def usesPanelConfig (sourceLabel : Data.Label) (isProof : Bool) : PanelConfig := {
   chipText := fun n => s!"uses {n}"
-  chipTitle := fun _ => "Statement and proof dependencies"
-  singleTitle := fun _ => "Statement and proof dependencies"
-  panelTitle := fun n => s!"Uses {n}"
-  panelMeta := "Dependency previews"
-  previewDefaultTitle := "Dependency preview"
-  previewEmptyText := "Dependency preview content is loaded from the Blueprint HTML cache."
+  chipTitle := fun n =>
+    if n == 0 then
+      if isProof then
+        "No declared proof dependencies"
+      else
+        "No declared statement dependencies"
+    else if isProof then
+      s!"Proof dependencies used by {sourceLabel}"
+    else
+      s!"Statement dependencies used by {sourceLabel}"
+  singleTitle := fun entry =>
+    if isProof then
+      s!"Proof dependency: {entry.previewTitle}"
+    else
+      s!"Statement dependency: {entry.previewTitle}"
+  panelTitle := fun n =>
+    if isProof then
+      s!"Proof uses {n}"
+    else
+      s!"Statement uses {n}"
+  panelMeta :=
+    if isProof then
+      "Proof dependency previews"
+    else
+      "Statement dependency previews"
+  previewDefaultTitle :=
+    if isProof then
+      "Proof dependency preview"
+    else
+      "Statement dependency preview"
+  previewEmptyText :=
+    if isProof then
+      "Proof dependency preview content is loaded from the Blueprint HTML cache."
+    else
+      "Statement dependency preview content is loaded from the Blueprint HTML cache."
   chipClass := "bp_relation_chip bp_uses_chip"
   emptyChipClass := "bp_relation_chip bp_relation_chip_empty bp_uses_chip"
 }
@@ -272,11 +301,14 @@ private def usesEntryLess (a b : UsesEntry) : Bool :=
 private def collectUsesEntries
     (ctx : Context) (data : BlockData) : Array UsesEntry :=
   let source := (storedBlockByLabel? ctx data.label).getD data
-  let entries :=
-    source.statementUses.foldl (init := #[]) fun acc useRef =>
-      addUsesEntry ctx acc useRef false
-  source.proofUses.foldl (init := entries) fun acc useRef =>
-    addUsesEntry ctx acc useRef true
+  let isProof :=
+    match data.kind with
+    | .proof => true
+    | .statement _ => false
+  let sourceUses :=
+    if isProof then source.proofUses else source.statementUses
+  sourceUses.foldl (init := #[]) (fun acc useRef =>
+    addUsesEntry ctx acc useRef isProof)
   |>.qsort usesEntryLess
 
 private def collectGroupEntries
@@ -535,31 +567,32 @@ def renderUsedByExtra {m}
         }})
     pure <| renderPanel (usedByPanelConfig (some data.label)) panelEntries
 
-/-- Render the forward-dependency header extra for a statement block. -/
+/-- Render the forward-dependency header extra for a statement or proof block. -/
 def renderUsesExtra {m}
     [Monad m]
     (ctx : Context)
     (data : BlockData) :
     Verso.Doc.Html.HtmlT Verso.Genre.Manual m Output.Html := do
-  match data.kind with
-  | .proof => pure .empty
-  | .statement _ =>
-    let entries := collectUsesEntries ctx data
-    let panelEntries ← entries.mapM fun entry => do
-      let badgesHtml := {{
-        {{renderUseAxisBadges entry}}
-        {{renderUseMetadataBadges entry.origins entry.intents}}
-      }}
-      match entry.target? with
-      | some target =>
-        mkBlockEntry ctx target
-          (usesPreviewId data.label entry.label)
-          (badgesHtml := badgesHtml)
-      | none =>
-        mkLabelEntry ctx entry.label
-          (usesPreviewId data.label entry.label)
-          (badgesHtml := badgesHtml)
-    pure <| renderPanel usesPanelConfig panelEntries
+  let entries := collectUsesEntries ctx data
+  let isProof :=
+    match data.kind with
+    | .proof => true
+    | .statement _ => false
+  let panelEntries ← entries.mapM fun entry => do
+    let badgesHtml := {{
+      {{renderUseAxisBadges entry}}
+      {{renderUseMetadataBadges entry.origins entry.intents}}
+    }}
+    match entry.target? with
+    | some target =>
+      mkBlockEntry ctx target
+        (usesPreviewId data.label entry.label)
+        (badgesHtml := badgesHtml)
+    | none =>
+      mkLabelEntry ctx entry.label
+        (usesPreviewId data.label entry.label)
+        (badgesHtml := badgesHtml)
+  pure <| renderPanel (usesPanelConfig data.label isProof) panelEntries
 
 /-- Render the group-membership header extra, if the block belongs to a group. -/
 def renderGroupExtra {m}

--- a/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
+++ b/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
@@ -126,7 +126,6 @@ def usesPanelConfig : PanelConfig := {
   previewEmptyText := "Dependency preview content is loaded from the Blueprint HTML cache."
   chipClass := "bp_relation_chip bp_uses_chip"
   emptyChipClass := "bp_relation_chip bp_relation_chip_empty bp_uses_chip"
-  singleMode := .panel
 }
 
 private def groupChipClass (declared : Bool) : String :=

--- a/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
+++ b/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
@@ -456,14 +456,18 @@ def renderPanel (cfg : PanelConfig) (entries : Array PanelEntry) : Output.Html :
         {{<a class="bp_relation_target" href={{href}}>{{titleNode}}{{metaNode}}</a>}}
       else
         {{<span class="bp_relation_target">{{titleNode}}{{metaNode}}</span>}}
-    {{
-      <li class={{itemClass}}
-          "data-bp-relation-preview-id"={{entry.previewId}}
-          "data-bp-relation-preview-key"={{entry.previewKey}}
-          "data-bp-relation-preview-title"={{entry.previewTitle}}>
-        {{rowNode}}
-      </li>
-    }}
+    let attrs := Id.run do
+      let mut attrs := #[
+        ("class", itemClass),
+        ("data-bp-relation-preview-id", entry.previewId),
+        ("data-bp-relation-preview-key", entry.previewKey),
+        ("data-bp-relation-preview-title", entry.previewTitle),
+        ("data-bp-preview-header-label", s!"{entry.label}")
+      ]
+      if let some href := entry.href then
+        attrs := attrs.push ("data-bp-preview-header-href", href)
+      pure attrs
+    .tag "li" attrs rowNode
   let previewTitle :=
     match selectedEntry? with
     | some entry => entry.previewTitle
@@ -484,7 +488,10 @@ def renderPanel (cfg : PanelConfig) (entries : Array PanelEntry) : Output.Html :
           <div class="bp_relation_preview_surface">
             <div class="bp_relation_preview_header">
               <div class="bp_relation_preview_label">"Preview"</div>
-              <div class="bp_relation_preview_title">{{.text true previewTitle}}</div>
+              <div class="bp_relation_preview_heading">
+                <div class="bp_relation_preview_title">{{.text true previewTitle}}</div>
+                <a class="bp_relation_preview_header_label" hidden></a>
+              </div>
             </div>
             <div class="bp_relation_preview_body">
               {{previewBody}}

--- a/src/VersoBlueprint/Informal/Block/Render.lean
+++ b/src/VersoBlueprint/Informal/Block/Render.lean
@@ -213,6 +213,10 @@ private def HeaderExtras.wrapperClass (extras : HeaderExtras) : String :=
       classes := classes.push "bp_extras_with_group"
     if extras.uses?.isSome then
       classes := classes.push "bp_extras_with_uses"
+    if extras.usedBy?.isSome then
+      classes := classes.push "bp_extras_with_used_by"
+    if extras.code?.isSome then
+      classes := classes.push "bp_extras_with_code"
     if !extras.custom.isEmpty then
       classes := classes.push "bp_extras_with_custom"
     return classes
@@ -227,7 +231,7 @@ private def renderHeaderExtraSlot (extra : HeaderExtra) : Verso.Output.Html :=
       s!"{extra.kind.slotClass} {extra.wrapperClass}"
   {{<span class={{slotClass}}>{{extra.html}}</span>}}
 
-def renderStatementHeaderExtras (extras : HeaderExtras) : Verso.Output.Html :=
+def renderHeaderExtras (extras : HeaderExtras) : Verso.Output.Html :=
   open Verso.Output.Html in
   let renderable := extras.renderable
   if renderable.isEmpty then
@@ -367,7 +371,7 @@ def renderInformalBlockShell (shell : InformalBlockShell)
   let headingClass := s!"bp_heading bp_kind_{style.kindCss}_heading {style.headingCss}"
   let contentClass := s!"bp_content bp_kind_{style.kindCss}_content {style.contentCss}"
   let titleRow := renderShellTitleRow shell
-  let extras := renderStatementHeaderExtras shell.headerExtras
+  let extras := renderHeaderExtras shell.headerExtras
   if shell.folded then
     {{
       <details class={{wrapperClass}} title={{shell.labelText}} {{shell.attrs}}>
@@ -403,10 +407,6 @@ def renderInformalBlockHtml (data : BlockData) (ctx : InformalBlockRenderContext
   open Verso.Output.Html in
   let style := blockKindRenderStyle data
   let labelText := s!"{data.label}"
-  let headerExtras :=
-    match data.kind with
-    | .proof => {}
-    | .statement _ => ctx.headerExtras
   let metadataPanel : Verso.Output.Html :=
     match data.kind with
     | .proof => .empty
@@ -419,7 +419,7 @@ def renderInformalBlockHtml (data : BlockData) (ctx : InformalBlockRenderContext
       captionText := ctx.captionText?.getD style.kindText
       attrs := ctx.attrs
       titleRowAttrs? := ctx.titleRowAttrs?
-      headerExtras
+      headerExtras := ctx.headerExtras
       metadataPanel
       folded := ctx.folded
     }

--- a/src/VersoBlueprint/Lib/HoverRender.lean
+++ b/src/VersoBlueprint/Lib/HoverRender.lean
@@ -208,8 +208,9 @@ All attributes needed to bind one inline preview trigger to its runtime panel.
 
 `triggerId` is the page-local UI id used for hover state. `lookupKey?` is the
 shared preview-data key used to load the preview body; the two are often but
-not always the same value. `footerHtml?` carries optional, already-rendered
-metadata for the inline preview chrome below the preview body.
+not always the same value. `headerLabel?` and `headerHref?` carry an optional
+label link for the preview header. `footerHtml?` carries optional,
+already-rendered metadata for the inline preview chrome below the preview body.
 -/
 structure InlinePreviewTarget where
   triggerId : String
@@ -217,6 +218,8 @@ structure InlinePreviewTarget where
   lookupKey? : Option String := none
   fallbackLabel? : Option String := none
   fallbackDetail? : Option String := none
+  headerLabel? : Option String := none
+  headerHref? : Option String := none
   footerHtml? : Option String := none
 
 /-- Build a target whose trigger id and manifest lookup key are the same. -/
@@ -224,6 +227,8 @@ def InlinePreviewTarget.manifestBacked
     (lookupKey title : String)
     (fallbackLabel? : Option String := none)
     (fallbackDetail? : Option String := none)
+    (headerLabel? : Option String := none)
+    (headerHref? : Option String := none)
     (footerHtml? : Option String := none) : InlinePreviewTarget :=
   {
     triggerId := lookupKey
@@ -231,6 +236,8 @@ def InlinePreviewTarget.manifestBacked
     lookupKey? := some lookupKey
     fallbackLabel?
     fallbackDetail?
+    headerLabel?
+    headerHref?
     footerHtml?
   }
 
@@ -239,6 +246,8 @@ def InlinePreviewTarget.withLookupKey
     (triggerId title lookupKey : String)
     (fallbackLabel? : Option String := none)
     (fallbackDetail? : Option String := none)
+    (headerLabel? : Option String := none)
+    (headerHref? : Option String := none)
     (footerHtml? : Option String := none) : InlinePreviewTarget :=
   {
     triggerId
@@ -246,6 +255,8 @@ def InlinePreviewTarget.withLookupKey
     lookupKey? := some lookupKey
     fallbackLabel?
     fallbackDetail?
+    headerLabel?
+    headerHref?
     footerHtml?
   }
 
@@ -254,6 +265,8 @@ private def inlinePreviewRefAttrs
     (previewLookupKey? : Option String := none)
     (previewFallbackLabel? : Option String := none)
     (previewFallbackDetail? : Option String := none)
+    (previewHeaderLabel? : Option String := none)
+    (previewHeaderHref? : Option String := none)
     (previewFooterHtml? : Option String := none) :
     Array (String × String) := Id.run do
   let mut attrs := #[
@@ -267,6 +280,10 @@ private def inlinePreviewRefAttrs
     attrs := attrs.push ("data-bp-preview-fallback-label", label)
   if let some detail := previewFallbackDetail? then
     attrs := attrs.push ("data-bp-preview-fallback-detail", detail)
+  if let some label := previewHeaderLabel? then
+    attrs := attrs.push ("data-bp-preview-header-label", label)
+  if let some href := previewHeaderHref? then
+    attrs := attrs.push ("data-bp-preview-header-href", href)
   if let some footerHtml := previewFooterHtml? then
     attrs := attrs.push ("data-bp-preview-footer-html", footerHtml)
   pure attrs
@@ -277,11 +294,13 @@ def inlinePreviewRef
     (previewLookupKey? : Option String := none)
     (previewFallbackLabel? : Option String := none)
     (previewFallbackDetail? : Option String := none)
+    (previewHeaderLabel? : Option String := none)
+    (previewHeaderHref? : Option String := none)
     (previewFooterHtml? : Option String := none) :
     Verso.Output.Html :=
   .tag "span"
     (inlinePreviewRefAttrs previewId previewTitle previewLookupKey? previewFallbackLabel?
-      previewFallbackDetail? previewFooterHtml?)
+      previewFallbackDetail? previewHeaderLabel? previewHeaderHref? previewFooterHtml?)
     node
 
 /--
@@ -296,14 +315,17 @@ def inlinePreviewNode (node : Verso.Output.Html)
     (previewLookupKey? : Option String := none)
     (previewFallbackLabel? : Option String := none)
     (previewFallbackDetail? : Option String := none)
+    (previewHeaderLabel? : Option String := none)
+    (previewHeaderHref? : Option String := none)
     (previewFooterHtml? : Option String := none) : Verso.Output.Html :=
   inlinePreviewRef node previewId previewTitle previewLookupKey? previewFallbackLabel?
-    previewFallbackDetail? previewFooterHtml?
+    previewFallbackDetail? previewHeaderLabel? previewHeaderHref? previewFooterHtml?
 
 /-- Render one inline preview trigger from a bundled preview target. -/
 def inlinePreviewTargetNode
     (node : Verso.Output.Html) (target : InlinePreviewTarget) : Verso.Output.Html :=
   inlinePreviewNode node target.triggerId target.title target.lookupKey?
-    target.fallbackLabel? target.fallbackDetail? target.footerHtml?
+    target.fallbackLabel? target.fallbackDetail? target.headerLabel? target.headerHref?
+    target.footerHtml?
 
 end Informal.HoverRender

--- a/src/VersoBlueprint/Lib/HoverRender.lean
+++ b/src/VersoBlueprint/Lib/HoverRender.lean
@@ -208,7 +208,8 @@ All attributes needed to bind one inline preview trigger to its runtime panel.
 
 `triggerId` is the page-local UI id used for hover state. `lookupKey?` is the
 shared preview-data key used to load the preview body; the two are often but
-not always the same value.
+not always the same value. `footerHtml?` carries optional, already-rendered
+metadata for the inline preview chrome below the preview body.
 -/
 structure InlinePreviewTarget where
   triggerId : String
@@ -216,38 +217,44 @@ structure InlinePreviewTarget where
   lookupKey? : Option String := none
   fallbackLabel? : Option String := none
   fallbackDetail? : Option String := none
+  footerHtml? : Option String := none
 
 /-- Build a target whose trigger id and manifest lookup key are the same. -/
 def InlinePreviewTarget.manifestBacked
     (lookupKey title : String)
     (fallbackLabel? : Option String := none)
-    (fallbackDetail? : Option String := none) : InlinePreviewTarget :=
+    (fallbackDetail? : Option String := none)
+    (footerHtml? : Option String := none) : InlinePreviewTarget :=
   {
     triggerId := lookupKey
     title
     lookupKey? := some lookupKey
     fallbackLabel?
     fallbackDetail?
+    footerHtml?
   }
 
 /-- Build a target with a distinct trigger id and manifest lookup key. -/
 def InlinePreviewTarget.withLookupKey
     (triggerId title lookupKey : String)
     (fallbackLabel? : Option String := none)
-    (fallbackDetail? : Option String := none) : InlinePreviewTarget :=
+    (fallbackDetail? : Option String := none)
+    (footerHtml? : Option String := none) : InlinePreviewTarget :=
   {
     triggerId
     title
     lookupKey? := some lookupKey
     fallbackLabel?
     fallbackDetail?
+    footerHtml?
   }
 
 private def inlinePreviewRefAttrs
     (previewId previewTitle : String)
     (previewLookupKey? : Option String := none)
     (previewFallbackLabel? : Option String := none)
-    (previewFallbackDetail? : Option String := none) :
+    (previewFallbackDetail? : Option String := none)
+    (previewFooterHtml? : Option String := none) :
     Array (String × String) := Id.run do
   let mut attrs := #[
     ("class", "bp_inline_preview_ref"),
@@ -260,6 +267,8 @@ private def inlinePreviewRefAttrs
     attrs := attrs.push ("data-bp-preview-fallback-label", label)
   if let some detail := previewFallbackDetail? then
     attrs := attrs.push ("data-bp-preview-fallback-detail", detail)
+  if let some footerHtml := previewFooterHtml? then
+    attrs := attrs.push ("data-bp-preview-footer-html", footerHtml)
   pure attrs
 
 def inlinePreviewRef
@@ -267,10 +276,12 @@ def inlinePreviewRef
     (previewId previewTitle : String)
     (previewLookupKey? : Option String := none)
     (previewFallbackLabel? : Option String := none)
-    (previewFallbackDetail? : Option String := none) :
+    (previewFallbackDetail? : Option String := none)
+    (previewFooterHtml? : Option String := none) :
     Verso.Output.Html :=
   .tag "span"
-    (inlinePreviewRefAttrs previewId previewTitle previewLookupKey? previewFallbackLabel? previewFallbackDetail?)
+    (inlinePreviewRefAttrs previewId previewTitle previewLookupKey? previewFallbackLabel?
+      previewFallbackDetail? previewFooterHtml?)
     node
 
 /--
@@ -284,13 +295,15 @@ def inlinePreviewNode (node : Verso.Output.Html)
     (previewId previewTitle : String)
     (previewLookupKey? : Option String := none)
     (previewFallbackLabel? : Option String := none)
-    (previewFallbackDetail? : Option String := none) : Verso.Output.Html :=
-  inlinePreviewRef node previewId previewTitle previewLookupKey? previewFallbackLabel? previewFallbackDetail?
+    (previewFallbackDetail? : Option String := none)
+    (previewFooterHtml? : Option String := none) : Verso.Output.Html :=
+  inlinePreviewRef node previewId previewTitle previewLookupKey? previewFallbackLabel?
+    previewFallbackDetail? previewFooterHtml?
 
 /-- Render one inline preview trigger from a bundled preview target. -/
 def inlinePreviewTargetNode
     (node : Verso.Output.Html) (target : InlinePreviewTarget) : Verso.Output.Html :=
   inlinePreviewNode node target.triggerId target.title target.lookupKey?
-    target.fallbackLabel? target.fallbackDetail?
+    target.fallbackLabel? target.fallbackDetail? target.footerHtml?
 
 end Informal.HoverRender

--- a/src/VersoBlueprint/Lib/HoverRender.lean
+++ b/src/VersoBlueprint/Lib/HoverRender.lean
@@ -222,6 +222,18 @@ structure InlinePreviewTarget where
   headerHref? : Option String := none
   footerHtml? : Option String := none
 
+/-- Attributes consumed by the shared preview-header label-link renderer. -/
+def previewHeaderLinkAttrs
+    (headerLabel? : Option String := none)
+    (headerHref? : Option String := none) :
+    Array (String × String) := Id.run do
+  let mut attrs := #[]
+  if let some label := headerLabel? then
+    attrs := attrs.push ("data-bp-preview-header-label", label)
+  if let some href := headerHref? then
+    attrs := attrs.push ("data-bp-preview-header-href", href)
+  pure attrs
+
 /-- Build a target whose trigger id and manifest lookup key are the same. -/
 def InlinePreviewTarget.manifestBacked
     (lookupKey title : String)
@@ -280,10 +292,8 @@ private def inlinePreviewRefAttrs
     attrs := attrs.push ("data-bp-preview-fallback-label", label)
   if let some detail := previewFallbackDetail? then
     attrs := attrs.push ("data-bp-preview-fallback-detail", detail)
-  if let some label := previewHeaderLabel? then
-    attrs := attrs.push ("data-bp-preview-header-label", label)
-  if let some href := previewHeaderHref? then
-    attrs := attrs.push ("data-bp-preview-header-href", href)
+  for attr in previewHeaderLinkAttrs previewHeaderLabel? previewHeaderHref? do
+    attrs := attrs.push attr
   if let some footerHtml := previewFooterHtml? then
     attrs := attrs.push ("data-bp-preview-footer-html", footerHtml)
   pure attrs

--- a/src/VersoBlueprint/PreviewManifest/BlockRender.lean
+++ b/src/VersoBlueprint/PreviewManifest/BlockRender.lean
@@ -169,7 +169,7 @@ private def renderUsesExtra?
       renderRelatedPanel
         cfg
         .uses
-        Informal.RelatedPanel.usesPanelConfig
+        (Informal.RelatedPanel.usesPanelConfig entry.label (entry.facet == .proof))
         entry.uses
         entry
         Name.anonymous
@@ -254,11 +254,7 @@ def renderWithRenderedContent
             | .proof => some entry.title
             | .statement _ => some title.caption
           titleRowAttrs? := cfg.titleRowAttrs? entry
-          headerExtras :=
-            match blockData.kind with
-            | .proof => {}
-            | .statement _ =>
-              renderHeaderExtras cfg.relationPanels entry blockData
+          headerExtras := renderHeaderExtras cfg.relationPanels entry blockData
         }
         #[content.body]
     let codePanel :=

--- a/src/VersoBlueprint/PreviewManifest/RelatedPanel.lean
+++ b/src/VersoBlueprint/PreviewManifest/RelatedPanel.lean
@@ -25,10 +25,8 @@ def RelatedEntry.displayTitle (entry : RelatedEntry) : String :=
 def RelationAxis.badgeHtml (axis : RelationAxis) : Html :=
   {{<span class="bp_relation_axis_badge">{{Html.ofString axis.display}}</span>}}
 
-def RelatedEntry.metaHtml (entry : RelatedEntry) : Html :=
-  .seq <| #[
-    {{<code>{{Html.ofString entry.displayLabel}}</code>}}
-  ] ++ entry.axes.map RelationAxis.badgeHtml
+def RelatedEntry.badgesHtml (entry : RelatedEntry) : Html :=
+  .seq <| entry.axes.map RelationAxis.badgeHtml
 
 def RelatedEntry.panelEntry
     (entry : RelatedEntry)
@@ -38,8 +36,9 @@ def RelatedEntry.panelEntry
     previewId := Informal.HoverRender.previewId idPrefix entry.displayLabel
     previewKey := entry.previewKey
     previewTitle := entry.displayTitle
+    label := entry.label
     href := entry.href
-    metaHtml := entry.metaHtml
+    badgesHtml := entry.badgesHtml
     previewFallbackLabel? := some entry.displayLabel
     active := entry.label == currentLabel
   }

--- a/tests/VersoBlueprintTests/BlueprintHeaderExtras.lean
+++ b/tests/VersoBlueprintTests/BlueprintHeaderExtras.lean
@@ -17,7 +17,7 @@ private def textHtml (text : String) : Output.Html :=
   .text true text
 
 private def renderedHeaderExtras : String :=
-  (renderStatementHeaderExtras {
+  (renderHeaderExtras {
     group? := some <| HeaderExtra.group (textHtml "group")
     uses? := some <| HeaderExtra.uses (textHtml "uses")
     code? := some <| HeaderExtra.code (textHtml "code")

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
@@ -104,15 +104,18 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
     let (out, st) ← renderManualDocHtmlStringAndState manualImpls usesPreviewDoc
     let relationJs? := findExtraJsContaining? st "function bindRelationPanel(panel)"
     pure (
-      hasSubstr out "uses 3" &&
+      hasSubstr out "uses 2" &&
+      hasSubstr out "uses 1" &&
       hasSubstr out "class=\"bp_extra_slot bp_extra_slot_uses\"" &&
       hasSubstr out "class=\"bp_relation_chip bp_uses_chip\"" &&
       hasSubstr out "class=\"bp_relation_panel\"" &&
-      hasSubstr out "Uses 3" &&
-      hasSubstr out "Dependency previews" &&
+      hasSubstr out "Statement uses 2" &&
+      hasSubstr out "Statement dependency previews" &&
+      hasSubstr out "Proof dependency:" &&
       !hasSubstr out "Hover a dependency to preview it." &&
       hasSubstr out "class=\"bp_relation_preview_header_label bp_preview_header_label\"" &&
       hasSubstr out "data-bp-relation-preview-id=\"bp-uses-" &&
+      hasSubstr out "data-bp-preview-id=\"bp-uses-" &&
       hasSubstr out "data-bp-preview-header-label=" &&
       hasSubstr out "data-bp-preview-header-href=" &&
       hasSubstr out "def:uses.hidden" &&

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
@@ -38,6 +38,14 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
       hasSubstr out ">automatic</span>" &&
       hasSubstr out ">technical</span>" &&
       hasSubstr out ">auxiliary</span>" &&
+      hasSubstr out "bp_relation_badge_statement" &&
+      hasSubstr out "bp_relation_badge_proof" &&
+      hasSubstr out "bp_relation_badge_origin_automatic" &&
+      hasSubstr out "bp_relation_badge_intent_technical" &&
+      hasSubstr out "bp_relation_badge_intent_auxiliary" &&
+      hasExtraCss st ".content-wrapper > section:has(.bp_relation_panel)" &&
+      hasExtraCss st ".bp_relation_badge_origin::before" &&
+      hasExtraCss st ".bp_relation_badge_intent_technical" &&
       appearsBefore out "class=\"bp_extra_slot bp_extra_slot_uses\"" "class=\"bp_extra_slot bp_extra_slot_used_by\"" &&
       appearsBefore out "class=\"bp_extra_slot bp_extra_slot_used_by\"" "class=\"bp_extra_slot bp_extra_slot_code\"" &&
       match relationJs? with
@@ -102,6 +110,11 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
       hasSubstr out ">automatic</span>" &&
       hasSubstr out ">technical</span>" &&
       hasSubstr out ">auxiliary</span>" &&
+      hasSubstr out "bp_relation_badge_statement" &&
+      hasSubstr out "bp_relation_badge_proof" &&
+      hasSubstr out "bp_relation_badge_origin_automatic" &&
+      hasSubstr out "bp_relation_badge_intent_technical" &&
+      hasSubstr out "bp_relation_badge_intent_auxiliary" &&
       appearsBefore out "class=\"bp_extra_slot bp_extra_slot_uses\"" "class=\"bp_extra_slot bp_extra_slot_used_by\"" &&
       appearsBefore out "class=\"bp_extra_slot bp_extra_slot_used_by\"" "class=\"bp_extra_slot bp_extra_slot_code\"" &&
       match relationJs? with

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
@@ -83,7 +83,9 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
       hasSubstr out "class=\"bp_relation_chip bp_relation_chip_empty\"" &&
       hasSubstr out "class=\"bp_inline_preview_ref\"" &&
       !hasSubstr out "class=\"bp_inline_preview_tpl\" data-bp-preview-id=\"bp-used-by-" &&
+      !hasSubstr out "data-bp-relation-preview-id=\"bp-uses-" &&
       hasSubstr out "data-bp-preview-id=\"bp-used-by-" &&
+      hasSubstr out "data-bp-preview-id=\"bp-uses-" &&
       hasSubstr out "data-bp-preview-key="
     )
 

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
@@ -35,6 +35,9 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
       hasSubstr out "data-bp-relation-preview-key" &&
       hasSubstr out ">statement</span>" &&
       hasSubstr out ">proof</span>" &&
+      hasSubstr out ">automatic</span>" &&
+      hasSubstr out ">technical</span>" &&
+      hasSubstr out ">auxiliary</span>" &&
       appearsBefore out "class=\"bp_extra_slot bp_extra_slot_uses\"" "class=\"bp_extra_slot bp_extra_slot_used_by\"" &&
       appearsBefore out "class=\"bp_extra_slot bp_extra_slot_used_by\"" "class=\"bp_extra_slot bp_extra_slot_code\"" &&
       match relationJs? with

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
@@ -86,6 +86,7 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
       !hasSubstr out "data-bp-relation-preview-id=\"bp-uses-" &&
       hasSubstr out "data-bp-preview-id=\"bp-used-by-" &&
       hasSubstr out "data-bp-preview-id=\"bp-uses-" &&
+      hasSubstr out "data-bp-preview-footer-html=" &&
       hasSubstr out "data-bp-preview-key="
     )
 

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
@@ -31,7 +31,7 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
       hasSubstr out "Reverse dependency previews" &&
       !hasSubstr out "Hover a use site to preview it." &&
       !hasSubstr out "class=\"bp_relation_preview_empty\"" &&
-      hasSubstr out "class=\"bp_relation_preview_header_label\"" &&
+      hasSubstr out "class=\"bp_relation_preview_header_label bp_preview_header_label\"" &&
       hasSubstr out "data-bp-relation-preview-id" &&
       hasSubstr out "data-bp-relation-preview-key" &&
       hasSubstr out "data-bp-preview-header-label=" &&
@@ -47,7 +47,7 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
       hasSubstr out "bp_relation_badge_intent_technical" &&
       hasSubstr out "bp_relation_badge_intent_auxiliary" &&
       hasExtraCss st ".content-wrapper > section:has(.bp_relation_panel)" &&
-      hasExtraCss st ".bp_relation_preview_header_label" &&
+      hasExtraCss st ".bp_preview_header_label" &&
       hasExtraCss st ".bp_relation_badge_origin::before" &&
       hasExtraCss st ".bp_relation_badge_intent_technical" &&
       appearsBefore out "class=\"bp_extra_slot bp_extra_slot_uses\"" "class=\"bp_extra_slot bp_extra_slot_used_by\"" &&
@@ -111,7 +111,7 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
       hasSubstr out "Uses 3" &&
       hasSubstr out "Dependency previews" &&
       !hasSubstr out "Hover a dependency to preview it." &&
-      hasSubstr out "class=\"bp_relation_preview_header_label\"" &&
+      hasSubstr out "class=\"bp_relation_preview_header_label bp_preview_header_label\"" &&
       hasSubstr out "data-bp-relation-preview-id=\"bp-uses-" &&
       hasSubstr out "data-bp-preview-header-label=" &&
       hasSubstr out "data-bp-preview-header-href=" &&

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
@@ -105,22 +105,22 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
     let relationJs? := findExtraJsContaining? st "function bindRelationPanel(panel)"
     pure (
       hasSubstr out "uses 2" &&
-      hasSubstr out "uses 1" &&
       hasSubstr out "class=\"bp_extra_slot bp_extra_slot_uses\"" &&
       hasSubstr out "class=\"bp_relation_chip bp_uses_chip\"" &&
       hasSubstr out "class=\"bp_relation_panel\"" &&
       hasSubstr out "Statement uses 2" &&
       hasSubstr out "Statement dependency previews" &&
-      hasSubstr out "Proof dependency:" &&
+      hasSubstr out "Proof uses 2" &&
+      hasSubstr out "Proof dependency previews" &&
       !hasSubstr out "Hover a dependency to preview it." &&
       hasSubstr out "class=\"bp_relation_preview_header_label bp_preview_header_label\"" &&
       hasSubstr out "data-bp-relation-preview-id=\"bp-uses-" &&
-      hasSubstr out "data-bp-preview-id=\"bp-uses-" &&
       hasSubstr out "data-bp-preview-header-label=" &&
       hasSubstr out "data-bp-preview-header-href=" &&
       hasSubstr out "def:uses.hidden" &&
       hasSubstr out "def:uses.inline" &&
       hasSubstr out "def:uses.proof" &&
+      hasSubstr out "def:uses.proof.extra" &&
       hasSubstr out ">statement</span>" &&
       hasSubstr out ">proof</span>" &&
       hasSubstr out ">automatic</span>" &&

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
@@ -31,8 +31,11 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
       hasSubstr out "Reverse dependency previews" &&
       !hasSubstr out "Hover a use site to preview it." &&
       !hasSubstr out "class=\"bp_relation_preview_empty\"" &&
+      hasSubstr out "class=\"bp_relation_preview_header_label\"" &&
       hasSubstr out "data-bp-relation-preview-id" &&
       hasSubstr out "data-bp-relation-preview-key" &&
+      hasSubstr out "data-bp-preview-header-label=" &&
+      hasSubstr out "data-bp-preview-header-href=" &&
       hasSubstr out ">statement</span>" &&
       hasSubstr out ">proof</span>" &&
       hasSubstr out ">automatic</span>" &&
@@ -44,6 +47,7 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
       hasSubstr out "bp_relation_badge_intent_technical" &&
       hasSubstr out "bp_relation_badge_intent_auxiliary" &&
       hasExtraCss st ".content-wrapper > section:has(.bp_relation_panel)" &&
+      hasExtraCss st ".bp_relation_preview_header_label" &&
       hasExtraCss st ".bp_relation_badge_origin::before" &&
       hasExtraCss st ".bp_relation_badge_intent_technical" &&
       appearsBefore out "class=\"bp_extra_slot bp_extra_slot_uses\"" "class=\"bp_extra_slot bp_extra_slot_used_by\"" &&
@@ -58,6 +62,7 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
         hasSubstr relationJs "const initialItem = items.find(function (item) {" &&
         hasSubstr relationJs "item.classList.contains(\"bp_relation_item_active\")" &&
         hasSubstr relationJs "function loadActivePreview()" &&
+        hasSubstr relationJs "previewUtils.setPreviewHeaderLink(headerLabel, item)" &&
         hasSubstr relationJs "selectItem(initialItem)" &&
         !hasSubstr relationJs "activate(initialItem, { openWrap: false })" &&
         hasSubstr relationJs "item.addEventListener(\"mouseenter\"" &&
@@ -106,7 +111,10 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
       hasSubstr out "Uses 3" &&
       hasSubstr out "Dependency previews" &&
       !hasSubstr out "Hover a dependency to preview it." &&
+      hasSubstr out "class=\"bp_relation_preview_header_label\"" &&
       hasSubstr out "data-bp-relation-preview-id=\"bp-uses-" &&
+      hasSubstr out "data-bp-preview-header-label=" &&
+      hasSubstr out "data-bp-preview-header-href=" &&
       hasSubstr out "def:uses.hidden" &&
       hasSubstr out "def:uses.inline" &&
       hasSubstr out "def:uses.proof" &&
@@ -126,6 +134,7 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
       | some relationJs =>
         hasSubstr relationJs "function bindRelationPanel(panel)" &&
         hasSubstr relationJs "previewUtils.loadBlueprintHtmlCacheEntry(previewKey)" &&
+        hasSubstr relationJs "previewUtils.setPreviewHeaderLink(headerLabel, item)" &&
         hasSubstr relationJs "selectItem(initialItem)"
       | none => false
     )

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
@@ -86,6 +86,8 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
       !hasSubstr out "data-bp-relation-preview-id=\"bp-uses-" &&
       hasSubstr out "data-bp-preview-id=\"bp-used-by-" &&
       hasSubstr out "data-bp-preview-id=\"bp-uses-" &&
+      hasSubstr out "data-bp-preview-header-label=" &&
+      hasSubstr out "data-bp-preview-header-href=" &&
       hasSubstr out "data-bp-preview-footer-html=" &&
       hasSubstr out "data-bp-preview-key="
     )

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/Shared.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/Shared.lean
@@ -72,11 +72,15 @@ Inline dependency target.
 Proof dependency target.
 :::
 
+:::definition "def:uses.proof.extra"
+Proof metadata-only dependency target.
+:::
+
 :::theorem "thm:uses.panel" (uses := "def:uses.hidden") (uses_origin := "automatic") (uses_intent := "technical")
 Statement depends on {uses "def:uses.inline" (intent := "auxiliary")}[].
 :::
 
-:::proof "thm:uses.panel"
+:::proof "thm:uses.panel" (uses := "def:uses.proof.extra")
 Proof depends on {uses "def:uses.proof"}[].
 :::
 :::::::

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/Shared.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/Shared.lean
@@ -46,7 +46,7 @@ def usedByPreviewTarget : Nat := 0
 ```
 
 :::lemma_ "lem:used.statement"
-Statement depends on {uses "def:used.target"}[].
+Statement depends on {uses "def:used.target" (origin := "automatic") (intent := "technical")}[].
 :::
 
 :::theorem "thm:used.proof"
@@ -54,7 +54,7 @@ Separate theorem with a proof-only dependency.
 :::
 
 :::proof "thm:used.proof"
-Proof depends on {uses "def:used.target"}[].
+Proof depends on {uses "def:used.target" (intent := "auxiliary")}[].
 :::
 :::::::
 

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/Summary.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/Summary.lean
@@ -30,6 +30,7 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
       hasSubstr out "data-bp-preview-placement=\"anchored\"" &&
       hasSubstr out "bp_summary_preview_wrap_active" &&
       hasSubstr out "data-bp-preview-key=\"«def:preview.base»--statement\"" &&
+      hasExtraCss st ".bp_inline_preview_panel[hidden]" &&
       hasExtraCss st ".bp_inline_preview_panel_footer" &&
       !hasSubstr out "data-bp-tex-prelude=\"" &&
       !hasSubstr out "bp_preview_tex_prelude" &&

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/Summary.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/Summary.lean
@@ -31,7 +31,7 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
       hasSubstr out "bp_summary_preview_wrap_active" &&
       hasSubstr out "data-bp-preview-key=\"«def:preview.base»--statement\"" &&
       hasExtraCss st ".bp_inline_preview_panel[hidden]" &&
-      hasExtraCss st ".bp_inline_preview_panel_label" &&
+      hasExtraCss st ".bp_preview_header_label" &&
       hasExtraCss st ".bp_inline_preview_panel_footer" &&
       !hasSubstr out "data-bp-tex-prelude=\"" &&
       !hasSubstr out "bp_preview_tex_prelude" &&

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/Summary.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/Summary.lean
@@ -30,6 +30,7 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
       hasSubstr out "data-bp-preview-placement=\"anchored\"" &&
       hasSubstr out "bp_summary_preview_wrap_active" &&
       hasSubstr out "data-bp-preview-key=\"«def:preview.base»--statement\"" &&
+      hasExtraCss st ".bp_inline_preview_panel_footer" &&
       !hasSubstr out "data-bp-tex-prelude=\"" &&
       !hasSubstr out "bp_preview_tex_prelude" &&
       !hasSubstr out "verso-tex-prelude" &&
@@ -56,6 +57,8 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
         hasSubstr inlineJs "bp-inline-preview-child-panel" &&
         hasSubstr inlineJs "function cancelChildHide()" &&
         hasSubstr inlineJs "function showChildFromTrigger(trigger)" &&
+        hasSubstr inlineJs "function setPanelFooter(footerNode, trigger)" &&
+        hasSubstr inlineJs "data-bp-preview-footer-html" &&
         hasSubstr inlineJs "triggerInsidePanel = panel.contains(trigger) || childPanel.contains(trigger)" &&
         hasSubstr inlineJs "behavior: makeBehavior(\"hover\", \"anchored\")" &&
         !hasSubstr inlineJs ".replaceAll(\"&\", \"&amp;\")" &&

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/Summary.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/Summary.lean
@@ -55,12 +55,13 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
         hasSubstr previewUtilsJs "Blueprint HTML cache contains duplicate key " &&
         hasSubstr previewUtilsJs "function hydratePreviewSubtree(root)" &&
         hasSubstr previewUtilsJs "escapeHtml: escapeHtml" &&
+        hasSubstr previewUtilsJs "function setPreviewHeaderLink(labelNode, sourceNode)" &&
+        hasSubstr previewUtilsJs "data-bp-preview-header-label" &&
         hasSubstr previewUtilsJs "window.setTimeout(function () {" &&
         hasSubstr inlineJs "bp-inline-preview-child-panel" &&
         hasSubstr inlineJs "function cancelChildHide()" &&
         hasSubstr inlineJs "function showChildFromTrigger(trigger)" &&
-        hasSubstr inlineJs "function setPanelHeaderLink(labelNode, trigger)" &&
-        hasSubstr inlineJs "data-bp-preview-header-label" &&
+        hasSubstr inlineJs "previewUtils.setPreviewHeaderLink(headerLabel, trigger)" &&
         hasSubstr inlineJs "function setPanelFooter(footerNode, trigger)" &&
         hasSubstr inlineJs "data-bp-preview-footer-html" &&
         hasSubstr inlineJs "triggerInsidePanel = panel.contains(trigger) || childPanel.contains(trigger)" &&

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/Summary.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/Summary.lean
@@ -31,6 +31,7 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
       hasSubstr out "bp_summary_preview_wrap_active" &&
       hasSubstr out "data-bp-preview-key=\"«def:preview.base»--statement\"" &&
       hasExtraCss st ".bp_inline_preview_panel[hidden]" &&
+      hasExtraCss st ".bp_inline_preview_panel_label" &&
       hasExtraCss st ".bp_inline_preview_panel_footer" &&
       !hasSubstr out "data-bp-tex-prelude=\"" &&
       !hasSubstr out "bp_preview_tex_prelude" &&
@@ -58,6 +59,8 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
         hasSubstr inlineJs "bp-inline-preview-child-panel" &&
         hasSubstr inlineJs "function cancelChildHide()" &&
         hasSubstr inlineJs "function showChildFromTrigger(trigger)" &&
+        hasSubstr inlineJs "function setPanelHeaderLink(labelNode, trigger)" &&
+        hasSubstr inlineJs "data-bp-preview-header-label" &&
         hasSubstr inlineJs "function setPanelFooter(footerNode, trigger)" &&
         hasSubstr inlineJs "data-bp-preview-footer-html" &&
         hasSubstr inlineJs "triggerInsidePanel = panel.contains(trigger) || childPanel.contains(trigger)" &&

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -438,6 +438,11 @@ class TestPreviewRuntimeRegressions:
         )
         expect(wrap.locator(".bp_relation_item.bp_relation_item_active")).to_have_count(1)
 
+        header_label = wrap.locator(".bp_relation_preview_header_label")
+        expect(header_label).to_be_visible()
+        expect(header_label).to_contain_text("used_statement")
+        expect(header_label).to_have_attribute("href", re.compile(r"#--informal-preview-used_statement"))
+
         body = wrap.locator(".bp_relation_preview_body")
         page.wait_for_function(
             "(el) => !!el && el.innerHTML.includes('<p')",

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -447,31 +447,30 @@ class TestPreviewRuntimeRegressions:
 
         assert_no_runtime_errors(errors)
 
-    def test_uses_panel_loads_manifest_backed_preview(self, server: str, page: Page):
+    def test_uses_single_dependency_loads_manifest_backed_inline_preview(
+        self, server: str, page: Page
+    ):
         errors = record_runtime_errors(page)
         page.goto(f"{server}/Preview-Relationships/")
+        page.locator("body[data-bp-inline-preview-bound='1']").wait_for()
 
         slot = page.locator('.bp_wrapper[title="used_statement"] .bp_extra_slot_uses').first
-        wrap = slot.locator(".bp_relation_wrap").first
-        expect(wrap).to_have_count(1)
+        trigger = slot.locator(".bp_inline_preview_ref").first
+        expect(trigger).to_have_count(1)
+        expect(slot.locator(".bp_relation_wrap")).to_have_count(0)
+        expect(slot.locator(".bp_relation_panel")).to_have_count(0)
         assert "bp_relation_preview_fallback_tpl" not in page.content()
 
-        chip = wrap.locator(".bp_relation_chip").first
+        chip = trigger.locator(".bp_relation_chip").first
         expect(chip).to_have_text("uses 1")
-        chip.hover()
+        expect(trigger).to_have_attribute("data-bp-preview-id", re.compile(r"^bp-uses-"))
+        expect(trigger).to_have_attribute("data-bp-preview-key", re.compile(r"used_target"))
+        trigger.hover()
 
-        panel = wrap.locator(".bp_relation_panel").first
+        panel = page.locator("#bp-inline-preview-panel")
         expect(panel).to_be_visible()
-        expect(panel.locator(".bp_relation_panel_title")).to_have_text("Uses 1")
-        expect(panel.locator(".bp_relation_panel_meta")).to_have_text("Dependency previews")
-        expect(panel.locator(".bp_relation_item")).to_have_count(1)
-        expect(panel.locator(".bp_relation_target_meta")).to_contain_text("used_target")
-        expect(panel.locator(".bp_relation_target_meta")).to_contain_text("statement")
-        expect(panel.locator(".bp_relation_item")).to_have_attribute(
-            "data-bp-relation-preview-id", re.compile(r"^bp-uses-")
-        )
 
-        body = panel.locator(".bp_relation_preview_body")
+        body = panel.locator(".bp_inline_preview_panel_body")
         page.wait_for_function(
             "(el) => !!el && el.innerHTML.includes('<p')",
             arg=body.element_handle(),

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -477,6 +477,11 @@ class TestPreviewRuntimeRegressions:
         )
         expect(body).to_contain_text("Target statement with associated Lean code.")
 
+        footer = panel.locator(".bp_inline_preview_panel_footer")
+        expect(footer).to_be_visible()
+        expect(footer).to_contain_text("used_target")
+        expect(footer).to_contain_text("statement")
+
         assert_no_runtime_errors(errors)
 
     def test_bibliography_hover_does_not_throw_and_opens_panel(self, server: str, page: Page):

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -583,6 +583,11 @@ class TestPreviewRuntimeRegressions:
 
         chip = wrap.locator("button.bp_relation_chip").first
         expect(chip).to_have_text("uses 2")
+        slot_box = slot.bounding_box()
+        chip_box = chip.bounding_box()
+        assert slot_box is not None
+        assert chip_box is not None
+        assert abs((slot_box["x"] + slot_box["width"]) - (chip_box["x"] + chip_box["width"])) < 1
         chip.hover()
 
         expect(wrap.locator(".bp_relation_panel .bp_relation_panel_title")).to_have_text(

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -162,7 +162,10 @@ class TestPreviewRuntimeRegressions:
         page.route("**/-verso-data/blueprint-html-cache.json", count_cache_fetch)
         page.goto(f"{server}/Preview-Relationships/")
         page.locator("body[data-bp-inline-preview-bound='1']").wait_for()
-        page.locator('.bp_wrapper[title="used_target"] .bp_relation_wrap').first.wait_for()
+        used_by_wrap = page.locator(
+            '.bp_wrapper[title="used_target"] .bp_extra_slot_used_by .bp_relation_wrap'
+        ).first
+        used_by_wrap.wait_for()
         page.wait_for_timeout(250)
 
         status = page.evaluate(
@@ -174,7 +177,7 @@ class TestPreviewRuntimeRegressions:
         assert attempts["count"] == 0
         assert status["state"] == "idle"
 
-        page.locator('.bp_wrapper[title="used_target"] .bp_relation_chip').first.hover()
+        used_by_wrap.locator(".bp_relation_chip").first.hover()
         page.wait_for_function(
             """() => {
                 const utils = window.bpPreviewUtils;

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -507,6 +507,58 @@ class TestPreviewRuntimeRegressions:
 
         assert_no_runtime_errors(errors)
 
+    def test_proof_uses_single_dependency_loads_from_proof_header(
+        self, server: str, page: Page
+    ):
+        errors = record_runtime_errors(page)
+        page.goto(f"{server}/Preview-Relationships/")
+        page.locator("body[data-bp-inline-preview-bound='1']").wait_for()
+
+        statement = page.locator(
+            '.bp_wrapper.bp_kind_theorem_wrapper[title="used_proof"]'
+        ).first
+        statement_uses = statement.locator(".bp_extra_slot_uses .bp_relation_chip").first
+        expect(statement_uses).to_have_text("uses 0")
+
+        proof = page.locator('.bp_wrapper.bp_kind_proof_wrapper[title="used_proof"]').first
+        slot = proof.locator(".bp_extra_slot_uses").first
+        trigger = slot.locator(".bp_inline_preview_ref").first
+        expect(trigger).to_have_count(1)
+        expect(proof.locator(".bp_extra_slot_used_by")).to_have_count(0)
+        expect(proof.locator(".bp_extra_slot_code")).to_have_count(0)
+        expect(slot.locator(".bp_relation_wrap")).to_have_count(0)
+        expect(slot.locator(".bp_relation_panel")).to_have_count(0)
+
+        chip = trigger.locator(".bp_relation_chip").first
+        expect(chip).to_have_text("uses 1")
+        expect(trigger).to_have_attribute("data-bp-preview-id", re.compile(r"^bp-uses-"))
+        expect(trigger).to_have_attribute("data-bp-preview-key", re.compile(r"used_target"))
+        trigger.hover()
+
+        panel = page.locator("#bp-inline-preview-panel")
+        expect(panel).to_be_visible()
+
+        body = panel.locator(".bp_inline_preview_panel_body")
+        page.wait_for_function(
+            "(el) => !!el && el.innerHTML.includes('<p')",
+            arg=body.element_handle(),
+        )
+        expect(body).to_contain_text("Target statement with associated Lean code.")
+
+        header_label = panel.locator(".bp_inline_preview_panel_label")
+        expect(header_label).to_be_visible()
+        expect(header_label).to_contain_text("used_target")
+        expect(header_label).to_have_attribute("href", re.compile(r"#--informal-preview-used_target"))
+
+        footer = panel.locator(".bp_inline_preview_panel_footer")
+        expect(footer).to_be_visible()
+        expect(footer).to_contain_text("proof")
+
+        page.mouse.move(0, 0)
+        expect(panel).to_be_hidden(timeout=1000)
+
+        assert_no_runtime_errors(errors)
+
     def test_bibliography_hover_does_not_throw_and_opens_panel(self, server: str, page: Page):
         errors = record_runtime_errors(page)
         page.goto(f"{server}/Inline-Hover-Previews/")

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -482,6 +482,9 @@ class TestPreviewRuntimeRegressions:
         expect(footer).to_contain_text("used_target")
         expect(footer).to_contain_text("statement")
 
+        page.mouse.move(0, 0)
+        expect(panel).to_be_hidden(timeout=1000)
+
         assert_no_runtime_errors(errors)
 
     def test_bibliography_hover_does_not_throw_and_opens_panel(self, server: str, page: Page):

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -569,9 +569,8 @@ class TestPreviewRuntimeRegressions:
         statement = page.locator(
             '.bp_wrapper.bp_kind_theorem_wrapper[title="used_proof_panel"]'
         ).first
-        expect(statement.locator(".bp_extra_slot_uses .bp_relation_chip").first).to_have_text(
-            "uses 0"
-        )
+        statement_uses_chip = statement.locator(".bp_extra_slot_uses .bp_relation_chip").first
+        expect(statement_uses_chip).to_have_text("uses 0")
 
         proof = page.locator(
             '.bp_wrapper.bp_kind_proof_wrapper[title="used_proof_panel"]'
@@ -583,13 +582,13 @@ class TestPreviewRuntimeRegressions:
 
         chip = wrap.locator("button.bp_relation_chip").first
         expect(chip).to_have_text("uses 2")
+        statement_uses_box = statement_uses_chip.bounding_box()
         caption_box = proof.locator(".bp_caption").first.bounding_box()
-        slot_box = slot.bounding_box()
         chip_box = chip.bounding_box()
+        assert statement_uses_box is not None
         assert caption_box is not None
-        assert slot_box is not None
         assert chip_box is not None
-        assert abs((slot_box["x"] + slot_box["width"]) - (chip_box["x"] + chip_box["width"])) < 1
+        assert abs(statement_uses_box["x"] - chip_box["x"]) < 1
         assert abs((caption_box["y"] + caption_box["height"]) - (chip_box["y"] + chip_box["height"])) < 1
         chip.hover()
 

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -559,6 +559,63 @@ class TestPreviewRuntimeRegressions:
 
         assert_no_runtime_errors(errors)
 
+    def test_proof_uses_multiple_dependencies_loads_panel_previews(
+        self, server: str, page: Page
+    ):
+        errors = record_runtime_errors(page)
+        page.goto(f"{server}/Preview-Relationships/")
+        page.locator("body[data-bp-inline-preview-bound='1']").wait_for()
+
+        statement = page.locator(
+            '.bp_wrapper.bp_kind_theorem_wrapper[title="used_proof_panel"]'
+        ).first
+        expect(statement.locator(".bp_extra_slot_uses .bp_relation_chip").first).to_have_text(
+            "uses 0"
+        )
+
+        proof = page.locator(
+            '.bp_wrapper.bp_kind_proof_wrapper[title="used_proof_panel"]'
+        ).first
+        slot = proof.locator(".bp_extra_slot_uses").first
+        wrap = slot.locator(".bp_relation_wrap").first
+        expect(wrap).to_have_count(1)
+        expect(slot.locator(".bp_inline_preview_ref")).to_have_count(0)
+
+        chip = wrap.locator("button.bp_relation_chip").first
+        expect(chip).to_have_text("uses 2")
+        chip.hover()
+
+        expect(wrap.locator(".bp_relation_panel .bp_relation_panel_title")).to_have_text(
+            "Proof uses 2"
+        )
+        expect(wrap.locator(".bp_relation_panel .bp_relation_panel_meta")).to_have_text(
+            "Proof dependency previews"
+        )
+        expect(wrap.locator(".bp_relation_badge_proof").first).to_be_visible()
+
+        header_label = wrap.locator(".bp_relation_preview_header_label")
+        expect(header_label).to_be_visible()
+        expect(header_label).to_contain_text("used_target")
+        expect(header_label).to_have_attribute("href", re.compile(r"#--informal-preview-used_target"))
+
+        body = wrap.locator(".bp_relation_preview_body")
+        page.wait_for_function(
+            "(el) => !!el && el.textContent.includes('Target statement with associated Lean code.')",
+            arg=body.element_handle(),
+        )
+
+        second_item = wrap.locator(".bp_relation_item").nth(1)
+        second_item.hover()
+        expect(second_item).to_have_class(re.compile(r"bp_relation_item_active"))
+        expect(header_label).to_contain_text("used_aux_target")
+        expect(header_label).to_have_attribute("href", re.compile(r"#--informal-preview-used_aux_target"))
+        page.wait_for_function(
+            "(el) => !!el && el.textContent.includes('Auxiliary target statement for multi-use proof previews.')",
+            arg=body.element_handle(),
+        )
+
+        assert_no_runtime_errors(errors)
+
     def test_bibliography_hover_does_not_throw_and_opens_panel(self, server: str, page: Page):
         errors = record_runtime_errors(page)
         page.goto(f"{server}/Inline-Hover-Previews/")

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -477,9 +477,13 @@ class TestPreviewRuntimeRegressions:
         )
         expect(body).to_contain_text("Target statement with associated Lean code.")
 
+        header_label = panel.locator(".bp_inline_preview_panel_label")
+        expect(header_label).to_be_visible()
+        expect(header_label).to_contain_text("used_target")
+        expect(header_label).to_have_attribute("href", re.compile(r"#--informal-preview-used_target"))
+
         footer = panel.locator(".bp_inline_preview_panel_footer")
         expect(footer).to_be_visible()
-        expect(footer).to_contain_text("used_target")
         expect(footer).to_contain_text("statement")
 
         page.mouse.move(0, 0)

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -2,9 +2,15 @@ import json
 import re
 import urllib.request
 
-from playwright.sync_api import expect, Page
+from playwright.sync_api import expect, Locator, Page
 
 from support import assert_no_runtime_errors, record_runtime_errors
+
+
+def require_box(locator: Locator):
+    box = locator.bounding_box()
+    assert box is not None
+    return box
 
 
 class TestPreviewRuntimeRegressions:
@@ -582,12 +588,9 @@ class TestPreviewRuntimeRegressions:
 
         chip = wrap.locator("button.bp_relation_chip").first
         expect(chip).to_have_text("uses 2")
-        statement_uses_box = statement_uses_chip.bounding_box()
-        caption_box = proof.locator(".bp_caption").first.bounding_box()
-        chip_box = chip.bounding_box()
-        assert statement_uses_box is not None
-        assert caption_box is not None
-        assert chip_box is not None
+        statement_uses_box = require_box(statement_uses_chip)
+        caption_box = require_box(proof.locator(".bp_caption").first)
+        chip_box = require_box(chip)
         assert abs(statement_uses_box["x"] - chip_box["x"]) < 1
         assert abs((caption_box["y"] + caption_box["height"]) - (chip_box["y"] + chip_box["height"])) < 1
         chip.hover()
@@ -620,6 +623,52 @@ class TestPreviewRuntimeRegressions:
             "(el) => !!el && el.textContent.includes('Auxiliary target statement for multi-use proof previews.')",
             arg=body.element_handle(),
         )
+
+        assert_no_runtime_errors(errors)
+
+    def test_grouped_statement_and_proof_uses_columns_align(
+        self, server: str, page: Page
+    ):
+        errors = record_runtime_errors(page)
+        page.goto(f"{server}/Preview-Relationships/")
+        page.locator("body[data-bp-inline-preview-bound='1']").wait_for()
+
+        statement = page.locator(
+            '.bp_wrapper.bp_kind_theorem_wrapper[title="used_grouped_proof_panel"]'
+        ).first
+        expect(statement.locator(".bp_extra_slot_group .bp_relation_chip").first).to_have_text(
+            "group"
+        )
+        statement_uses_chip = statement.locator(".bp_extra_slot_uses .bp_relation_chip").first
+        expect(statement_uses_chip).to_have_text("uses 0")
+        expect(statement.locator(".bp_extra_slot_used_by .bp_relation_chip").first).to_have_text(
+            "used by 1"
+        )
+        expect(statement.locator(".bp_extra_slot_code .bp_code_link")).to_have_count(1)
+
+        proof = page.locator(
+            '.bp_wrapper.bp_kind_proof_wrapper[title="used_grouped_proof_panel"]'
+        ).first
+        expect(proof.locator(".bp_extra_slot_group")).to_have_count(0)
+        expect(proof.locator(".bp_extra_slot_used_by")).to_have_count(0)
+        expect(proof.locator(".bp_extra_slot_code")).to_have_count(0)
+
+        chip = proof.locator(".bp_extra_slot_uses .bp_relation_chip").first
+        expect(chip).to_have_text("uses 2")
+
+        group_box = require_box(statement.locator(".bp_extra_slot_group").first)
+        statement_uses_box = require_box(statement_uses_chip)
+        used_by_box = require_box(statement.locator(".bp_extra_slot_used_by").first)
+        code_box = require_box(statement.locator(".bp_extra_slot_code").first)
+        proof_caption_box = require_box(proof.locator(".bp_caption").first)
+        proof_uses_box = require_box(chip)
+
+        assert group_box["x"] < statement_uses_box["x"] < used_by_box["x"] < code_box["x"]
+        assert abs(statement_uses_box["x"] - proof_uses_box["x"]) < 1
+        assert abs(
+            (proof_caption_box["y"] + proof_caption_box["height"])
+            - (proof_uses_box["y"] + proof_uses_box["height"])
+        ) < 1
 
         assert_no_runtime_errors(errors)
 

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -450,6 +450,17 @@ class TestPreviewRuntimeRegressions:
         )
         expect(body).to_contain_text("Statement depends on")
 
+        second_item = wrap.locator(".bp_relation_item").nth(1)
+        second_item.hover()
+        expect(second_item).to_have_class(re.compile(r"bp_relation_item_active"))
+        expect(header_label).to_contain_text("used_proof")
+        expect(header_label).to_have_attribute("href", re.compile(r"#--informal-preview-used_proof"))
+        page.wait_for_function(
+            "(el) => !!el && el.textContent.includes('Statement facet marker for preview relationships.')",
+            arg=body.element_handle(),
+        )
+        expect(body).to_contain_text("Statement facet marker for preview relationships.")
+
         assert_no_runtime_errors(errors)
 
     def test_uses_single_dependency_loads_manifest_backed_inline_preview(

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -583,11 +583,14 @@ class TestPreviewRuntimeRegressions:
 
         chip = wrap.locator("button.bp_relation_chip").first
         expect(chip).to_have_text("uses 2")
+        caption_box = proof.locator(".bp_caption").first.bounding_box()
         slot_box = slot.bounding_box()
         chip_box = chip.bounding_box()
+        assert caption_box is not None
         assert slot_box is not None
         assert chip_box is not None
         assert abs((slot_box["x"] + slot_box["width"]) - (chip_box["x"] + chip_box["width"])) < 1
+        assert abs((caption_box["y"] + caption_box["height"]) - (chip_box["y"] + chip_box["height"])) < 1
         chip.hover()
 
         expect(wrap.locator(".bp_relation_panel .bp_relation_panel_title")).to_have_text(

--- a/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/PreviewRelationships.lean
+++ b/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/PreviewRelationships.lean
@@ -16,6 +16,10 @@ Target statement with associated Lean code.
 Auxiliary target statement for multi-use proof previews.
 :::
 
+:::group "preview_relation_group"
+Preview relation group.
+:::
+
 :::lemma_ "used_statement"
 Statement depends on {uses "used_target"}[].
 :::
@@ -34,6 +38,18 @@ Statement facet for a proof with multiple dependencies.
 
 :::proof "used_proof_panel" (uses := "used_target")
 Proof panel marker for preview relationships, also depending on {uses "used_aux_target"}[].
+:::
+
+:::theorem "used_grouped_proof_panel" (parent := "preview_relation_group") (lean := "Nat.add")
+Grouped statement facet with group, used-by, and Lean metadata.
+:::
+
+:::proof "used_grouped_proof_panel" (uses := "used_target")
+Grouped proof panel marker for preview relationships, also depending on {uses "used_aux_target"}[].
+:::
+
+:::lemma_ "used_grouped_consumer" (parent := "preview_relation_group") (uses := "used_grouped_proof_panel")
+Consumer statement that makes the grouped statement used-by and group chips non-empty.
 :::
 
 :::theorem "preview_facets"

--- a/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/PreviewRelationships.lean
+++ b/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/PreviewRelationships.lean
@@ -12,6 +12,10 @@ open Informal
 Target statement with associated Lean code.
 :::
 
+:::definition "used_aux_target"
+Auxiliary target statement for multi-use proof previews.
+:::
+
 :::lemma_ "used_statement"
 Statement depends on {uses "used_target"}[].
 :::
@@ -22,6 +26,14 @@ Statement facet marker for preview relationships.
 
 :::proof "used_proof"
 Proof facet marker for preview relationships, depending on {uses "used_target"}[].
+:::
+
+:::theorem "used_proof_panel"
+Statement facet for a proof with multiple dependencies.
+:::
+
+:::proof "used_proof_panel" (uses := "used_target")
+Proof panel marker for preview relationships, also depending on {uses "used_aux_target"}[].
 :::
 
 :::theorem "preview_facets"


### PR DESCRIPTION
This PR improves uses relation handling and rendering by keeping dependency intent metadata visible, keeping single-entry relationships lightweight, and separating statement-side and proof-side uses into their own header chips.

- Thread structured use metadata through forward and reverse dependency aggregation.
- Render statement/proof, origin, and intent badges in uses and used-by previews, including inline-preview footers and linked preview headers.
- Split statement and proof uses rendering so statement headers show statement dependencies and proof headers show proof dependencies.
- Pin Verso to a v4.30-compatible backport of leanprover/verso#854 to avoid the CI olean-size issue.
- Document the statement/proof uses split and cover it in preview wiring and browser tests.

Backport v4.29.0: #100
