### PR TITLE
[backport v4.29.0] fix: reconcile reference blueprint toolchains

### DIFF
--- a/scripts/blueprint_harness_branches.py
+++ b/scripts/blueprint_harness_branches.py
@@ -13,7 +13,10 @@ ROOT_WORKTREE_NAME = "root"
 CHECKOUT_ROLE_DEFAULT_DEV = "default_dev"
 CHECKOUT_ROLE_BACKPORT = "backport"
 CHECKOUT_ROLE_CHOICES = (CHECKOUT_ROLE_DEFAULT_DEV, CHECKOUT_ROLE_BACKPORT)
-NUMERIC_LEAN_RELEASE_PATTERN = re.compile(r"^v?\d+\.\d+\.\d+(?:[-.A-Za-z0-9]+)?$")
+NUMERIC_LEAN_RELEASE_PATTERN = re.compile(r"^v?\d+\.\d+\.\d+$")
+LEAN_RELEASE_CANDIDATE_PATTERN = re.compile(
+    r"^v?(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?-rc(?P<rc>\d+)$"
+)
 
 
 @dataclass(frozen=True)
@@ -24,22 +27,95 @@ class BranchPolicy:
     source_path: Path
 
 
-def normalize_lean_release_ref(raw_ref: str) -> str:
+def clean_lean_ref(raw_ref: str) -> str:
     ref = raw_ref.strip()
     if ref.startswith(LEAN_TOOLCHAIN_PREFIX):
         ref = ref[len(LEAN_TOOLCHAIN_PREFIX) :]
     if not ref or any(char.isspace() for char in ref) or any(char in ref for char in {'"', "\n", "\r"}):
         raise SystemExit("[blueprint-harness] expected a Lean release ref without whitespace, quotes, or newlines")
+    return ref
+
+
+def normalize_release_candidate_name(raw_ref: str) -> str:
+    ref = clean_lean_ref(raw_ref)
+    match = LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(ref)
+    if match is None:
+        raise SystemExit("[blueprint-harness] expected an official Lean release candidate name like `4.30-rc2`")
+
+    major = match.group("major")
+    minor = match.group("minor")
+    patch = match.group("patch")
+    rc = match.group("rc")
+    if patch is None or patch == "0":
+        return f"{major}.{minor}-rc{rc}"
+    return f"{major}.{minor}.{patch}-rc{rc}"
+
+
+def release_candidate_name_or_none(raw_ref: str) -> str | None:
+    ref = clean_lean_ref(raw_ref)
+    if LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(ref) is None:
+        return None
+    return normalize_release_candidate_name(ref)
+
+
+def release_candidate_ref(raw_ref: str) -> str:
+    name = normalize_release_candidate_name(raw_ref)
+    match = LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(name)
+    if match is None:
+        raise AssertionError(f"normalized release candidate did not parse: {name}")
+
+    patch = match.group("patch") or "0"
+    return f"v{match.group('major')}.{match.group('minor')}.{patch}-rc{match.group('rc')}"
+
+
+def normalize_lean_release_ref(raw_ref: str) -> str:
+    ref = clean_lean_ref(raw_ref)
+    if LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(ref) is not None:
+        return release_candidate_ref(ref)
     if NUMERIC_LEAN_RELEASE_PATTERN.fullmatch(ref) is not None and not ref.startswith("v"):
         ref = f"v{ref}"
     return ref
+
+
+def release_branch_from_lean_ref(raw_ref: str) -> str:
+    ref = normalize_lean_release_ref(raw_ref)
+    match = LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(ref)
+    if match is not None:
+        patch = match.group("patch") or "0"
+        return f"v{match.group('major')}.{match.group('minor')}.{patch}"
+    return ref
+
+
+def lean_release_order_key(raw_ref: str) -> tuple[int, int, int, int] | None:
+    ref = normalize_lean_release_ref(raw_ref)
+    if NUMERIC_LEAN_RELEASE_PATTERN.fullmatch(ref) is not None:
+        version = ref[1:] if ref.startswith("v") else ref
+        major, minor, patch = (int(part) for part in version.split("."))
+        return major, minor, patch, 1_000_000
+
+    match = LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(ref)
+    if match is None:
+        return None
+
+    patch = int(match.group("patch") or "0")
+    return int(match.group("major")), int(match.group("minor")), patch, int(match.group("rc"))
+
+
+def lean_toolchain_spec(lean_ref: str) -> str:
+    return f"{LEAN_TOOLCHAIN_PREFIX}{lean_ref}"
+
+
+def rewrite_lean_toolchain(path: Path, lean_ref: str) -> None:
+    existing = path.read_text(encoding="utf-8")
+    suffix = "\n" if existing.endswith("\n") else ""
+    path.write_text(f"{lean_toolchain_spec(lean_ref)}{suffix}", encoding="utf-8")
 
 
 def active_release_branch(repo_root: Path) -> str:
     toolchain_path = repo_root / "lean-toolchain"
     if not toolchain_path.exists():
         raise SystemExit(f"[blueprint-harness] missing lean toolchain file: {toolchain_path}")
-    return normalize_lean_release_ref(toolchain_path.read_text(encoding="utf-8"))
+    return release_branch_from_lean_ref(toolchain_path.read_text(encoding="utf-8"))
 
 
 def branch_policy_path(checkout_root: Path) -> Path:
@@ -81,8 +157,8 @@ def load_branch_policy(checkout_root: Path) -> BranchPolicy:
 
     return BranchPolicy(
         version=raw_version,
-        default_dev_branch=normalize_lean_release_ref(raw_default),
-        required_backport_branches=tuple(normalize_lean_release_ref(item) for item in raw_backports),
+        default_dev_branch=release_branch_from_lean_ref(raw_default),
+        required_backport_branches=tuple(release_branch_from_lean_ref(item) for item in raw_backports),
         source_path=path,
     )
 

--- a/scripts/blueprint_harness_project_commands.py
+++ b/scripts/blueprint_harness_project_commands.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import contextmanager
+import os
+from pathlib import Path
+import re
+import subprocess
+
+from scripts.blueprint_harness_utils import lean_low_priority_command, rebuild_embedded_asset_owners, run
+
+
+OFFICIAL_BLUEPRINT_REPOSITORY = "leanprover/verso-blueprint"
+OFFICIAL_BLUEPRINT_REQUIRE = (
+    f'require VersoBlueprint from git "https://github.com/{OFFICIAL_BLUEPRINT_REPOSITORY}"@"v4.30.0"'
+)
+OFFICIAL_BLUEPRINT_URL_PATTERNS = (
+    rf"https://github\.com/{OFFICIAL_BLUEPRINT_REPOSITORY}(?:\.git)?",
+    rf"git@github\.com:{OFFICIAL_BLUEPRINT_REPOSITORY}\.git",
+    rf"ssh://git@github\.com/{OFFICIAL_BLUEPRINT_REPOSITORY}\.git",
+)
+OFFICIAL_BLUEPRINT_SOURCE_DESCRIPTION = f"`{OFFICIAL_BLUEPRINT_REPOSITORY}`"
+OFFICIAL_BLUEPRINT_REQUIRE_PATTERN = re.compile(
+    r'^(?P<indent>\s*)require\s+VersoBlueprint\s+from\s+git\s+"(?P<url>[^"]+)"(?:\s*@\s*"(?P<ref>[^"]+)")?\s*$',
+    re.MULTILINE,
+)
+
+
+def _require_official_blueprint_git_dependency(project_dir: Path, *, action: str) -> tuple[Path, str, re.Match[str]]:
+    lakefile = project_dir / "lakefile.lean"
+    if not lakefile.exists():
+        raise SystemExit(f"[blueprint-harness] missing lakefile for cloned project: {lakefile}")
+
+    text = lakefile.read_text(encoding="utf-8")
+    match = next(
+        (
+            candidate
+            for candidate in OFFICIAL_BLUEPRINT_REQUIRE_PATTERN.finditer(text)
+            if any(re.fullmatch(pattern, candidate.group("url")) for pattern in OFFICIAL_BLUEPRINT_URL_PATTERNS)
+        ),
+        None,
+    )
+    if match is None:
+        raise SystemExit(
+            "[blueprint-harness] expected the cloned project to declare `VersoBlueprint` in "
+            "`lakefile.lean` from an approved `VersoBlueprint` Git source "
+            f"({OFFICIAL_BLUEPRINT_SOURCE_DESCRIPTION}); cannot {action}."
+        )
+    return lakefile, text, match
+
+
+def rewrite_local_blueprint_dependency(project_dir: Path, package_root: Path) -> Path:
+    lakefile, text, match = _require_official_blueprint_git_dependency(
+        project_dir,
+        action="inject the local path override automatically",
+    )
+    relative_path = os.path.relpath(package_root, start=project_dir)
+    replacement = f'{match.group("indent")}require VersoBlueprint from "{relative_path}"'
+    rewritten = text[: match.start()] + replacement + text[match.end() :]
+    lakefile.write_text(rewritten, encoding="utf-8")
+    return lakefile
+
+
+def rewrite_pinned_blueprint_dependency(project_dir: Path, ref: str) -> tuple[Path, str | None]:
+    if not ref or any(char in ref for char in ('"', "\n", "\r")):
+        raise SystemExit("[blueprint-harness] expected a non-empty `VersoBlueprint` ref without quotes or newlines")
+
+    lakefile, text, match = _require_official_blueprint_git_dependency(
+        project_dir,
+        action="rewrite the pinned `VersoBlueprint` ref automatically",
+    )
+    replacement = f'{match.group("indent")}require VersoBlueprint from git "{match.group("url")}"@"{ref}"'
+    rewritten = text[: match.start()] + replacement + text[match.end() :]
+    lakefile.write_text(rewritten, encoding="utf-8")
+    return lakefile, match.group("ref")
+
+
+def git_tracks_file(project_dir: Path, relative_path: str) -> bool:
+    return (
+        subprocess.run(
+            ["git", "ls-files", "--error-unmatch", relative_path],
+            cwd=project_dir,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def tracked_project_manifest_path(project_dir: Path) -> Path | None:
+    manifest = project_dir / "lake-manifest.json"
+    if not manifest.exists():
+        return None
+    if not git_tracks_file(project_dir, manifest.name):
+        return None
+    return manifest
+
+
+def discard_untracked_project_manifest(project_dir: Path) -> None:
+    manifest = project_dir / "lake-manifest.json"
+    if manifest.exists() and tracked_project_manifest_path(project_dir) is None:
+        manifest.unlink()
+
+
+def snapshot_tracked_project_manifest(project_dir: Path) -> tuple[Path, str] | None:
+    manifest = tracked_project_manifest_path(project_dir)
+    if manifest is None:
+        return None
+    return manifest, manifest.read_text(encoding="utf-8")
+
+
+def restore_tracked_project_manifest(snapshot: tuple[Path, str] | None) -> None:
+    if snapshot is None:
+        return
+    manifest, original_text = snapshot
+    manifest.write_text(original_text, encoding="utf-8")
+
+
+def project_lake_update_command(package_root: Path, project_dir: Path) -> list[str]:
+    manifest = tracked_project_manifest_path(project_dir)
+    if manifest is not None:
+        print(
+            "[blueprint-harness] committed lake-manifest.json detected; "
+            "running full `lake update` from committed pins"
+        )
+        return lean_low_priority_command(package_root, "lake", "update")
+
+    print(
+        "[blueprint-harness] no committed lake-manifest.json detected; "
+        "falling back to full `lake update`"
+    )
+    return lean_low_priority_command(package_root, "lake", "update")
+
+
+def run_project_lake_update(package_root: Path, project_dir: Path) -> list[str]:
+    command = project_lake_update_command(package_root, project_dir)
+    run(command, cwd=project_dir)
+    return command
+
+
+def maybe_rewrite_in_repo_blueprint_dependency(project_dir: Path, package_root: Path) -> tuple[Path | None, str | None]:
+    lakefile = project_dir / "lakefile.lean"
+    if not lakefile.exists():
+        return None, None
+
+    text = lakefile.read_text(encoding="utf-8")
+    if 'require VersoBlueprint from "' in text:
+        return None, None
+    if "require VersoBlueprint from git" not in text:
+        return None, None
+
+    rewrite_local_blueprint_dependency(project_dir, package_root)
+    return lakefile, text
+
+
+@contextmanager
+def maybe_in_repo_blueprint_dependency_override(
+    project_dir: Path,
+    package_root: Path,
+    *,
+    log: bool = False,
+):
+    rewritten_lakefile, original_lakefile_text = maybe_rewrite_in_repo_blueprint_dependency(project_dir, package_root)
+    if rewritten_lakefile is not None and log:
+        print(f"[blueprint-harness] local package override: rewrote {rewritten_lakefile}")
+    try:
+        yield rewritten_lakefile
+    finally:
+        if rewritten_lakefile is not None and original_lakefile_text is not None:
+            rewritten_lakefile.write_text(original_lakefile_text, encoding="utf-8")
+
+
+@contextmanager
+def local_blueprint_dependency_override(
+    package_root: Path,
+    project_dir: Path,
+    *,
+    restore_lakefile: bool,
+    log: bool = False,
+):
+    lakefile = project_dir / "lakefile.lean"
+    original_text = lakefile.read_text(encoding="utf-8") if restore_lakefile else None
+    rewritten_lakefile = rewrite_local_blueprint_dependency(project_dir, package_root)
+    if log:
+        print(f"[blueprint-harness] local package override: rewrote {rewritten_lakefile}")
+    try:
+        yield rewritten_lakefile
+    finally:
+        if original_text is not None:
+            lakefile.write_text(original_text, encoding="utf-8")
+
+
+def rebuild_and_log_embedded_asset_owners(package_root: Path) -> list[str]:
+    rebuilt = rebuild_embedded_asset_owners(package_root)
+    for target in rebuilt:
+        print(f"[blueprint-harness] rebuilt embedded-asset owner target: {target}")
+    return rebuilt
+
+
+def run_project_update_build_generate(
+    package_root: Path,
+    project_dir: Path,
+    *,
+    update_project: Callable[[], object],
+    build_command: tuple[str, ...] | None,
+    generate_command: tuple[str, ...],
+    format_command: Callable[[tuple[str, ...]], list[str]],
+    skip_build: bool,
+) -> None:
+    update_project()
+    if not skip_build and build_command is not None:
+        run(
+            lean_low_priority_command(package_root, *format_command(build_command)),
+            cwd=project_dir,
+        )
+    run(
+        lean_low_priority_command(package_root, *format_command(generate_command)),
+        cwd=project_dir,
+    )

--- a/scripts/blueprint_harness_project_commands.py
+++ b/scripts/blueprint_harness_project_commands.py
@@ -12,7 +12,7 @@ from scripts.blueprint_harness_utils import lean_low_priority_command, rebuild_e
 
 OFFICIAL_BLUEPRINT_REPOSITORY = "leanprover/verso-blueprint"
 OFFICIAL_BLUEPRINT_REQUIRE = (
-    f'require VersoBlueprint from git "https://github.com/{OFFICIAL_BLUEPRINT_REPOSITORY}"@"v4.30.0"'
+    f'require VersoBlueprint from git "https://github.com/{OFFICIAL_BLUEPRINT_REPOSITORY}"@"v4.29.0"'
 )
 OFFICIAL_BLUEPRINT_URL_PATTERNS = (
     rf"https://github\.com/{OFFICIAL_BLUEPRINT_REPOSITORY}(?:\.git)?",
@@ -122,9 +122,9 @@ def project_lake_update_command(package_root: Path, project_dir: Path) -> list[s
     if manifest is not None:
         print(
             "[blueprint-harness] committed lake-manifest.json detected; "
-            "running full `lake update` from committed pins"
+            "updating `VersoBlueprint` only to keep existing release-line pins"
         )
-        return lean_low_priority_command(package_root, "lake", "update")
+        return lean_low_priority_command(package_root, "lake", "update", "VersoBlueprint")
 
     print(
         "[blueprint-harness] no committed lake-manifest.json detected; "

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -1,27 +1,35 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import os
 import re
 import shutil
 import subprocess
 from pathlib import Path
 import tomllib
 
+from scripts.blueprint_harness_branches import (
+    lean_release_order_key,
+    lean_toolchain_spec,
+    normalize_lean_release_ref,
+    release_branch_from_lean_ref,
+    rewrite_lean_toolchain,
+)
 from scripts.blueprint_harness_projects import HarnessProject
-from scripts.blueprint_harness_utils import lean_low_priority_command, rebuild_embedded_asset_owners, run
+from scripts.blueprint_harness_project_commands import (
+    discard_untracked_project_manifest,
+    local_blueprint_dependency_override,
+    maybe_in_repo_blueprint_dependency_override,
+    project_lake_update_command,
+    rebuild_and_log_embedded_asset_owners,
+    restore_tracked_project_manifest,
+    rewrite_pinned_blueprint_dependency,
+    run_project_update_build_generate,
+    snapshot_tracked_project_manifest,
+    tracked_project_manifest_path,
+)
+from scripts.blueprint_harness_utils import lean_low_priority_command, run
 
 
-OFFICIAL_BLUEPRINT_REPOSITORY = "leanprover/verso-blueprint"
-OFFICIAL_BLUEPRINT_REQUIRE = (
-    f'require VersoBlueprint from git "https://github.com/{OFFICIAL_BLUEPRINT_REPOSITORY}"@"v4.29.0"'
-)
-OFFICIAL_BLUEPRINT_URL_PATTERNS = (
-    rf"https://github\.com/{OFFICIAL_BLUEPRINT_REPOSITORY}(?:\.git)?",
-    rf"git@github\.com:{OFFICIAL_BLUEPRINT_REPOSITORY}\.git",
-    rf"ssh://git@github\.com/{OFFICIAL_BLUEPRINT_REPOSITORY}\.git",
-)
-OFFICIAL_BLUEPRINT_SOURCE_DESCRIPTION = f"`{OFFICIAL_BLUEPRINT_REPOSITORY}`"
 COMMIT_HASH_PATTERN = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
 GITHUB_SUBMODULE_URL_REWRITE_ARGS = (
     "-c",
@@ -30,10 +38,6 @@ GITHUB_SUBMODULE_URL_REWRITE_ARGS = (
     "url.https://github.com/.insteadOf=ssh://git@github.com/",
 )
 REFERENCE_HARNESS_CONFIG = "verso-harness.toml"
-OFFICIAL_BLUEPRINT_REQUIRE_PATTERN = re.compile(
-    r'^(?P<indent>\s*)require\s+VersoBlueprint\s+from\s+git\s+"(?P<url>[^"]+)"(?:\s*@\s*"(?P<ref>[^"]+)")?\s*$',
-    re.MULTILINE,
-)
 
 
 @dataclass(frozen=True)
@@ -46,6 +50,32 @@ class ReferenceProjectBumpResult:
     committed: bool
     pushed: bool
     output_dir: Path | None
+
+
+@dataclass(frozen=True)
+class ReferenceToolchainCandidate:
+    path: Path
+    lean_ref: str
+    release_branch: str
+    order_key: tuple[int, int, int, int]
+
+
+@dataclass(frozen=True)
+class ReferenceToolchainReconciliationResult:
+    selected_ref: str | None
+    release_branch: str | None
+    changed_paths: tuple[Path, ...]
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.changed_paths)
+
+
+@dataclass(frozen=True)
+class ReferenceLakeUpdateResult:
+    command: list[str]
+    reconciliation: ReferenceToolchainReconciliationResult
+
 
 def output_dir_for(project: HarnessProject, output_root: Path) -> Path:
     return output_root / project.project_id
@@ -67,8 +97,82 @@ def reference_edit_checkout_dir(layout, project: HarnessProject) -> Path:
     return layout.reference_project_edit_root / project.project_id
 
 
-def use_shared_reference_checkout() -> bool:
-    return os.getenv("BP_REFERENCE_CHECKOUT_MODE") == "shared"
+def lake_packages_dir(project_dir: Path) -> Path:
+    return project_dir / ".lake" / "packages"
+
+
+def read_reference_toolchain_candidate(path: Path) -> ReferenceToolchainCandidate | None:
+    if not path.exists():
+        return None
+    try:
+        lean_ref = normalize_lean_release_ref(path.read_text(encoding="utf-8"))
+    except SystemExit:
+        return None
+
+    order_key = lean_release_order_key(lean_ref)
+    if order_key is None:
+        return None
+    return ReferenceToolchainCandidate(
+        path=path,
+        lean_ref=lean_ref,
+        release_branch=release_branch_from_lean_ref(lean_ref),
+        order_key=order_key,
+    )
+
+
+def reference_dependency_toolchain_paths(project_dir: Path) -> list[Path]:
+    packages = lake_packages_dir(project_dir)
+    if not packages.exists():
+        return []
+    return sorted(path / "lean-toolchain" for path in packages.iterdir() if (path / "lean-toolchain").exists())
+
+
+def reconcile_reference_toolchains(package_root: Path, project_dir: Path) -> ReferenceToolchainReconciliationResult:
+    package_candidate = read_reference_toolchain_candidate(package_root / "lean-toolchain")
+    project_candidate = read_reference_toolchain_candidate(project_dir / "lean-toolchain")
+    if package_candidate is None or project_candidate is None:
+        return ReferenceToolchainReconciliationResult(
+            selected_ref=None,
+            release_branch=None,
+            changed_paths=(),
+        )
+    if package_candidate.release_branch != project_candidate.release_branch:
+        return ReferenceToolchainReconciliationResult(
+            selected_ref=None,
+            release_branch=None,
+            changed_paths=(),
+        )
+
+    common_branch = package_candidate.release_branch
+    candidates = [package_candidate, project_candidate]
+    for path in reference_dependency_toolchain_paths(project_dir):
+        candidate = read_reference_toolchain_candidate(path)
+        if candidate is not None and candidate.release_branch == common_branch:
+            candidates.append(candidate)
+
+    selected = max(candidates, key=lambda candidate: candidate.order_key)
+    package_toolchain_path = package_candidate.path.resolve()
+    changed_paths: list[Path] = []
+    for candidate in candidates:
+        # The package checkout is the source for the run; reconcile only the
+        # disposable reference checkout files.
+        if candidate.path.resolve() == package_toolchain_path:
+            continue
+        if candidate.lean_ref == selected.lean_ref:
+            continue
+        rewrite_lean_toolchain(candidate.path, selected.lean_ref)
+        changed_paths.append(candidate.path)
+
+    if changed_paths:
+        print(
+            "[blueprint-harness] reconciled reference Lean toolchain to "
+            f"{lean_toolchain_spec(selected.lean_ref)} for {len(changed_paths)} file(s) sharing {common_branch}"
+        )
+    return ReferenceToolchainReconciliationResult(
+        selected_ref=selected.lean_ref,
+        release_branch=common_branch,
+        changed_paths=tuple(changed_paths),
+    )
 
 
 def short_git_ref(ref: str) -> str:
@@ -299,128 +403,24 @@ def prepare_reference_edit_checkout(
     return edit_dir, target_branch, target_base_ref
 
 
-def _require_official_blueprint_git_dependency(project_dir: Path, *, action: str) -> tuple[Path, str, re.Match[str]]:
-    lakefile = project_dir / "lakefile.lean"
-    if not lakefile.exists():
-        raise SystemExit(f"[blueprint-harness] missing lakefile for cloned project: {lakefile}")
-
-    text = lakefile.read_text(encoding="utf-8")
-    match = next(
-        (
-            candidate
-            for candidate in OFFICIAL_BLUEPRINT_REQUIRE_PATTERN.finditer(text)
-            if any(re.fullmatch(pattern, candidate.group("url")) for pattern in OFFICIAL_BLUEPRINT_URL_PATTERNS)
-        ),
-        None,
-    )
-    if match is None:
-        raise SystemExit(
-            "[blueprint-harness] expected the cloned project to declare `VersoBlueprint` in "
-            "`lakefile.lean` from an approved `VersoBlueprint` Git source "
-            f"({OFFICIAL_BLUEPRINT_SOURCE_DESCRIPTION}); cannot {action}."
+def run_reference_lake_update(
+    package_root: Path,
+    project_dir: Path,
+    *,
+    reconcile_toolchains: bool = True,
+) -> ReferenceLakeUpdateResult:
+    reconciliation = (
+        reconcile_reference_toolchains(package_root, project_dir)
+        if reconcile_toolchains
+        else ReferenceToolchainReconciliationResult(
+            selected_ref=None,
+            release_branch=None,
+            changed_paths=(),
         )
-    return lakefile, text, match
-
-
-def rewrite_local_blueprint_dependency(project_dir: Path, package_root: Path) -> Path:
-    lakefile, text, match = _require_official_blueprint_git_dependency(
-        project_dir,
-        action="inject the local path override automatically",
     )
-    relative_path = os.path.relpath(package_root, start=project_dir)
-    replacement = f'{match.group("indent")}require VersoBlueprint from "{relative_path}"'
-    rewritten = text[: match.start()] + replacement + text[match.end() :]
-    lakefile.write_text(rewritten, encoding="utf-8")
-    return lakefile
-
-
-def rewrite_pinned_blueprint_dependency(project_dir: Path, ref: str) -> tuple[Path, str | None]:
-    if not ref or any(char in ref for char in ('"', "\n", "\r")):
-        raise SystemExit("[blueprint-harness] expected a non-empty `VersoBlueprint` ref without quotes or newlines")
-
-    lakefile, text, match = _require_official_blueprint_git_dependency(
-        project_dir,
-        action="rewrite the pinned `VersoBlueprint` ref automatically",
-    )
-    replacement = (
-        f'{match.group("indent")}require VersoBlueprint from git "{match.group("url")}"@"{ref}"'
-    )
-    rewritten = text[: match.start()] + replacement + text[match.end() :]
-    lakefile.write_text(rewritten, encoding="utf-8")
-    return lakefile, match.group("ref")
-
-
-def git_tracks_file(project_dir: Path, relative_path: str) -> bool:
-    return (
-        subprocess.run(
-            ["git", "ls-files", "--error-unmatch", relative_path],
-            cwd=project_dir,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=False,
-        ).returncode
-        == 0
-    )
-
-
-def tracked_project_manifest_path(project_dir: Path) -> Path | None:
-    manifest = project_dir / "lake-manifest.json"
-    if not manifest.exists():
-        return None
-    if not git_tracks_file(project_dir, manifest.name):
-        return None
-    return manifest
-
-
-def discard_untracked_project_manifest(project_dir: Path) -> None:
-    manifest = project_dir / "lake-manifest.json"
-    if manifest.exists() and tracked_project_manifest_path(project_dir) is None:
-        manifest.unlink()
-
-
-def snapshot_tracked_project_manifest(project_dir: Path) -> tuple[Path, str] | None:
-    manifest = tracked_project_manifest_path(project_dir)
-    if manifest is None:
-        return None
-    return manifest, manifest.read_text(encoding="utf-8")
-
-
-def restore_tracked_project_manifest(snapshot: tuple[Path, str] | None) -> None:
-    if snapshot is None:
-        return
-    manifest, original_text = snapshot
-    manifest.write_text(original_text, encoding="utf-8")
-
-
-def reference_update_command(package_root: Path, project_dir: Path) -> list[str]:
-    manifest = tracked_project_manifest_path(project_dir)
-    if manifest is not None:
-        print(
-            "[blueprint-harness] committed lake-manifest.json detected; "
-            "updating `VersoBlueprint` only to keep `verso` pinned"
-        )
-        return lean_low_priority_command(package_root, "lake", "update", "VersoBlueprint")
-
-    print(
-        "[blueprint-harness] no committed lake-manifest.json detected; "
-        "falling back to full `lake update`"
-    )
-    return lean_low_priority_command(package_root, "lake", "update")
-
-
-def maybe_rewrite_in_repo_blueprint_dependency(project_dir: Path, package_root: Path) -> tuple[Path | None, str | None]:
-    lakefile = project_dir / "lakefile.lean"
-    if not lakefile.exists():
-        return None, None
-
-    text = lakefile.read_text(encoding="utf-8")
-    if 'require VersoBlueprint from "' in text:
-        return None, None
-    if "require VersoBlueprint from git" not in text:
-        return None, None
-
-    rewrite_local_blueprint_dependency(project_dir, package_root)
-    return lakefile, text
+    command = project_lake_update_command(package_root, project_dir)
+    run(command, cwd=project_dir)
+    return ReferenceLakeUpdateResult(command=command, reconciliation=reconciliation)
 
 
 def project_checkout_pathspec(checkout_root: Path, project_dir: Path) -> str:
@@ -510,7 +510,7 @@ def bump_reference_project(
 
     project_dir = edit_dir / project.project_root
     _lakefile, previous_ref = rewrite_pinned_blueprint_dependency(project_dir, ref)
-    run(reference_update_command(layout.package_root, project_dir), cwd=project_dir)
+    run_reference_lake_update(layout.package_root, project_dir)
 
     generated_output: Path | None = None
     command_output_root = output_root or (layout.artifact_root / "reference-blueprints-edit")
@@ -583,15 +583,10 @@ def sync_reference_cache_checkout(layout, project: HarnessProject, *, warm_build
     project_dir = cache_dir / project.project_root
     discard_untracked_project_manifest(project_dir)
     bootstrap_reference_checkout(project_dir=project_dir)
-    cache_lakefile = project_dir / "lakefile.lean"
-    original_text = cache_lakefile.read_text(encoding="utf-8")
-    rewrite_local_blueprint_dependency(project_dir, layout.repo_root)
-    try:
-        run(reference_update_command(layout.package_root, project_dir), cwd=project_dir)
+    with local_blueprint_dependency_override(layout.package_root, project_dir, restore_lakefile=True):
+        run_reference_lake_update(layout.package_root, project_dir)
         if warm_build and project.build_command is not None:
             run(lean_low_priority_command(layout.package_root, *project.build_command), cwd=project_dir)
-    finally:
-        cache_lakefile.write_text(original_text, encoding="utf-8")
     return cache_dir
 
 
@@ -624,103 +619,65 @@ def generate_in_repo_command_project(layout, output_root: Path, project: Harness
 
     output_dir = output_dir_for(project, output_root)
     output_dir.mkdir(parents=True, exist_ok=True)
-    rebuilt = rebuild_embedded_asset_owners(layout.package_root)
-    for target in rebuilt:
-        print(f"[blueprint-harness] rebuilt embedded-asset owner target: {target}")
+    rebuild_and_log_embedded_asset_owners(layout.package_root)
     discard_untracked_project_manifest(project_dir)
     original_manifest = snapshot_tracked_project_manifest(project_dir)
-    rewritten_lakefile, original_lakefile_text = maybe_rewrite_in_repo_blueprint_dependency(project_dir, layout.package_root)
-    if rewritten_lakefile is not None:
-        print(f"[blueprint-harness] local package override: rewrote {rewritten_lakefile}")
     try:
-        run(reference_update_command(layout.package_root, project_dir), cwd=project_dir)
-        if not skip_build and project.build_command is not None:
-            run(
-                lean_low_priority_command(
-                    layout.package_root,
-                    *format_external_command(
-                        project.build_command,
-                        project=project,
-                        package_root=layout.package_root,
-                        checkout_root=project_dir,
-                        project_dir=project_dir,
-                        output_dir=output_dir,
-                    ),
-                ),
-                cwd=project_dir,
-            )
-        run(
-            lean_low_priority_command(
+        with maybe_in_repo_blueprint_dependency_override(project_dir, layout.package_root, log=True):
+            run_project_update_build_generate(
                 layout.package_root,
-                *format_external_command(
-                    project.generate_command or (),
+                project_dir,
+                update_project=lambda: run_reference_lake_update(
+                    layout.package_root,
+                    project_dir,
+                    reconcile_toolchains=False,
+                ),
+                build_command=project.build_command,
+                generate_command=project.generate_command or (),
+                format_command=lambda command: format_external_command(
+                    command,
                     project=project,
                     package_root=layout.package_root,
                     checkout_root=project_dir,
                     project_dir=project_dir,
                     output_dir=output_dir,
                 ),
-            ),
-            cwd=project_dir,
-        )
+                skip_build=skip_build,
+            )
     finally:
         restore_tracked_project_manifest(original_manifest)
-        if rewritten_lakefile is not None and original_lakefile_text is not None:
-            rewritten_lakefile.write_text(original_lakefile_text, encoding="utf-8")
 
 
 def generate_git_project(layout, output_root: Path, project: HarnessProject, *, skip_build: bool) -> None:
-    # Shared cache warm builds run against `layout.repo_root` so linked worktree
-    # validations must skip them here and build only after rewriting the local
-    # checkout dependency to `layout.package_root`.
-    cache_warm_build = (not skip_build) and use_shared_reference_checkout()
-    rebuilt = rebuild_embedded_asset_owners(layout.package_root)
-    for target in rebuilt:
-        print(f"[blueprint-harness] rebuilt embedded-asset owner target: {target}")
-    cache_dir = sync_reference_cache_checkout(layout, project, warm_build=cache_warm_build)
-    checkout_root = cache_dir if use_shared_reference_checkout() else sync_reference_local_checkout(layout, project, cache_dir)
+    rebuild_and_log_embedded_asset_owners(layout.package_root)
+    cache_dir = sync_reference_cache_checkout(layout, project, warm_build=False)
+    checkout_root = sync_reference_local_checkout(layout, project, cache_dir)
     project_dir = checkout_root / project.project_root
     discard_untracked_project_manifest(project_dir)
     output_dir = output_dir_for(project, output_root)
     output_dir.mkdir(parents=True, exist_ok=True)
-    original_text = (project_dir / "lakefile.lean").read_text(encoding="utf-8") if use_shared_reference_checkout() else None
-    try:
-        bootstrap_reference_checkout(project_dir=project_dir)
-        rewritten_lakefile = rewrite_local_blueprint_dependency(project_dir, layout.package_root)
-        print(f"[blueprint-harness] local package override: rewrote {rewritten_lakefile}")
-        run(reference_update_command(layout.package_root, project_dir), cwd=project_dir)
-        if not skip_build and project.build_command is not None:
-            run(
-                lean_low_priority_command(
-                    layout.package_root,
-                    *format_external_command(
-                        project.build_command,
-                        project=project,
-                        package_root=layout.package_root,
-                        checkout_root=checkout_root,
-                        project_dir=project_dir,
-                        output_dir=output_dir,
-                    ),
-                ),
-                cwd=project_dir,
-            )
-        run(
-            lean_low_priority_command(
+    bootstrap_reference_checkout(project_dir=project_dir)
+    with local_blueprint_dependency_override(layout.package_root, project_dir, restore_lakefile=False, log=True):
+        run_project_update_build_generate(
+            layout.package_root,
+            project_dir,
+            update_project=lambda: run_reference_lake_update(
                 layout.package_root,
-                *format_external_command(
-                    project.generate_command or (),
-                    project=project,
-                    package_root=layout.package_root,
-                    checkout_root=checkout_root,
-                    project_dir=project_dir,
-                    output_dir=output_dir,
-                ),
+                project_dir,
+                reconcile_toolchains=True,
             ),
-            cwd=project_dir,
+            build_command=project.build_command,
+            generate_command=project.generate_command or (),
+            format_command=lambda command: format_external_command(
+                command,
+                project=project,
+                package_root=layout.package_root,
+                checkout_root=checkout_root,
+                project_dir=project_dir,
+                output_dir=output_dir,
+            ),
+            skip_build=skip_build,
         )
-    finally:
-        if original_text is not None:
-            (project_dir / "lakefile.lean").write_text(original_text, encoding="utf-8")
 
 
 def sync_reference_blueprints(layout, projects: list[HarnessProject], *, warm_build: bool, prepare_local_checkout: bool) -> None:

--- a/scripts/blueprint_harness_toolchains.py
+++ b/scripts/blueprint_harness_toolchains.py
@@ -6,11 +6,12 @@ import subprocess
 from pathlib import Path
 
 from scripts.blueprint_harness_branches import (
-    LEAN_TOOLCHAIN_PREFIX,
+    lean_toolchain_spec,
     normalize_lean_release_ref,
+    rewrite_lean_toolchain,
 )
-from scripts.blueprint_harness_references import (
-    maybe_rewrite_in_repo_blueprint_dependency,
+from scripts.blueprint_harness_project_commands import (
+    maybe_in_repo_blueprint_dependency_override,
     rewrite_pinned_blueprint_dependency,
 )
 from scripts.blueprint_harness_utils import lean_low_priority_command, run
@@ -36,22 +37,12 @@ class ToolchainBumpResult:
     verso_tag_oid: str
 
 
-def lean_toolchain_spec(lean_ref: str) -> str:
-    return f"{LEAN_TOOLCHAIN_PREFIX}{lean_ref}"
-
-
 def managed_toolchain_project_dirs(package_root: Path) -> tuple[Path, ...]:
     return (
         package_root,
         package_root / "project_template",
         package_root / "tests" / "test_blueprints" / "preview_runtime_showcase",
     )
-
-
-def rewrite_lean_toolchain(path: Path, lean_ref: str) -> None:
-    existing = path.read_text(encoding="utf-8")
-    suffix = "\n" if existing.endswith("\n") else ""
-    path.write_text(f"{lean_toolchain_spec(lean_ref)}{suffix}", encoding="utf-8")
 
 
 def _require_official_verso_git_dependency(project_dir: Path, *, action: str) -> tuple[Path, str, re.Match[str]]:
@@ -110,12 +101,8 @@ def resolve_remote_verso_tag_oid(package_root: Path, ref: str) -> str | None:
 
 
 def refresh_managed_manifest(package_root: Path, project_dir: Path) -> None:
-    rewritten_lakefile, original_lakefile_text = maybe_rewrite_in_repo_blueprint_dependency(project_dir, package_root)
-    try:
+    with maybe_in_repo_blueprint_dependency_override(project_dir, package_root):
         run(lean_low_priority_command(package_root, "lake", "update"), cwd=project_dir)
-    finally:
-        if rewritten_lakefile is not None and original_lakefile_text is not None:
-            rewritten_lakefile.write_text(original_lakefile_text, encoding="utf-8")
 
 
 def validate_bumped_toolchain(package_root: Path) -> None:

--- a/scripts/blueprint_harness_toolchains.py
+++ b/scripts/blueprint_harness_toolchains.py
@@ -23,6 +23,10 @@ OFFICIAL_VERSO_URL_PATTERNS = (
     r"git@github\.com:leanprover/verso\.git",
     r"ssh://git@github\.com/leanprover/verso\.git",
 )
+TEMPORARY_VERSO_FIX_URL_PATTERNS = (
+    r"https://github\.com/ejgallego/verso(?:\.git)?",
+)
+MANAGED_VERSO_URL_PATTERNS = OFFICIAL_VERSO_URL_PATTERNS + TEMPORARY_VERSO_FIX_URL_PATTERNS
 VERSO_REQUIRE_PATTERN = re.compile(
     r'^(?P<indent>\s*)require\s+verso\s+from\s+git\s+"(?P<url>[^"]+)"(?:\s*@\s*"(?P<ref>[^"]+)")?\s*$',
     re.MULTILINE,
@@ -45,7 +49,11 @@ def managed_toolchain_project_dirs(package_root: Path) -> tuple[Path, ...]:
     )
 
 
-def _require_official_verso_git_dependency(project_dir: Path, *, action: str) -> tuple[Path, str, re.Match[str]]:
+def _matches_any(patterns: tuple[str, ...], value: str) -> bool:
+    return any(re.fullmatch(pattern, value) for pattern in patterns)
+
+
+def _require_managed_verso_git_dependency(project_dir: Path, *, action: str) -> tuple[Path, str, re.Match[str]]:
     lakefile = project_dir / "lakefile.lean"
     if not lakefile.exists():
         raise SystemExit(f"[blueprint-harness] missing lakefile: {lakefile}")
@@ -55,14 +63,14 @@ def _require_official_verso_git_dependency(project_dir: Path, *, action: str) ->
         (
             candidate
             for candidate in VERSO_REQUIRE_PATTERN.finditer(text)
-            if any(re.fullmatch(pattern, candidate.group("url")) for pattern in OFFICIAL_VERSO_URL_PATTERNS)
+            if _matches_any(MANAGED_VERSO_URL_PATTERNS, candidate.group("url"))
         ),
         None,
     )
     if match is None:
         raise SystemExit(
             "[blueprint-harness] expected the managed project to declare `verso` in `lakefile.lean` "
-            "from the official `leanprover/verso` Git source; cannot "
+            "from the official `leanprover/verso` Git source or a recognized temporary fix fork; cannot "
             f"{action}."
         )
     return lakefile, text, match
@@ -72,11 +80,13 @@ def rewrite_pinned_verso_dependency(project_dir: Path, ref: str) -> tuple[Path, 
     if not ref or any(char.isspace() for char in ref) or any(char in ref for char in {'"', "\n", "\r"}):
         raise SystemExit("[blueprint-harness] expected a non-empty `verso` ref without whitespace, quotes, or newlines")
 
-    lakefile, text, match = _require_official_verso_git_dependency(
+    lakefile, text, match = _require_managed_verso_git_dependency(
         project_dir,
         action="rewrite the pinned `verso` ref automatically",
     )
-    replacement = f'{match.group("indent")}require verso from git "{match.group("url")}"@"{ref}"'
+    url = match.group("url")
+    replacement_url = url if _matches_any(OFFICIAL_VERSO_URL_PATTERNS, url) else VERSO_REPOSITORY_URL
+    replacement = f'{match.group("indent")}require verso from git "{replacement_url}"@"{ref}"'
     rewritten = text[: match.start()] + replacement + text[match.end() :]
     lakefile.write_text(rewritten, encoding="utf-8")
     return lakefile, match.group("ref")

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -28,9 +28,9 @@ from scripts.blueprint_harness_projects import (
     resolve_projects_for_release,
     resolve_release_target,
 )
+from scripts.blueprint_harness_project_commands import OFFICIAL_BLUEPRINT_URL_PATTERNS
 from scripts.blueprint_harness_references import (
     bump_reference_project,
-    OFFICIAL_BLUEPRINT_URL_PATTERNS,
     clone_git_project,
     generate_in_repo_command_project,
     generate_git_project,

--- a/scripts/blueprint_test_blueprints.py
+++ b/scripts/blueprint_test_blueprints.py
@@ -9,10 +9,12 @@ import shutil
 import subprocess
 
 from scripts.blueprint_harness_paths import detect_harness_layout
-from scripts.blueprint_harness_references import (
-    maybe_rewrite_in_repo_blueprint_dependency,
-    reference_update_command,
+from scripts.blueprint_harness_project_commands import (
+    maybe_in_repo_blueprint_dependency_override,
+    rebuild_and_log_embedded_asset_owners,
     restore_tracked_project_manifest,
+    run_project_lake_update,
+    run_project_update_build_generate,
     snapshot_tracked_project_manifest,
 )
 from scripts.blueprint_harness_utils import (
@@ -20,7 +22,6 @@ from scripts.blueprint_harness_utils import (
     format_command,
     lean_low_priority_command,
     print_failure_summary,
-    rebuild_embedded_asset_owners,
     run,
     run_capturing_failure,
 )
@@ -598,44 +599,27 @@ def generate_standalone_test_blueprint(package_root: Path, fixture: StandaloneTe
     if not project_dir.exists():
         raise SystemExit(f"[blueprint-test-blueprints] missing project root for `{fixture.slug}`: {project_dir}")
     output_dir.mkdir(parents=True, exist_ok=True)
-    rebuilt = rebuild_embedded_asset_owners(package_root)
-    for target in rebuilt:
-        print(f"[blueprint-harness] rebuilt embedded-asset owner target: {target}")
+    rebuild_and_log_embedded_asset_owners(package_root)
     original_manifest = snapshot_tracked_project_manifest(project_dir)
-    rewritten_lakefile, original_lakefile_text = maybe_rewrite_in_repo_blueprint_dependency(project_dir, package_root)
     try:
-        run(reference_update_command(package_root, project_dir), cwd=project_dir)
-        if fixture.build_command is not None:
-            run(
-                lean_low_priority_command(
-                    package_root,
-                    *format_project_command(
-                        fixture.build_command,
-                        package_root=package_root,
-                        project_dir=project_dir,
-                        output_dir=output_dir,
-                        slug=fixture.slug,
-                    ),
-                ),
-                cwd=project_dir,
-            )
-        run(
-            lean_low_priority_command(
+        with maybe_in_repo_blueprint_dependency_override(project_dir, package_root):
+            run_project_update_build_generate(
                 package_root,
-                *format_project_command(
-                    fixture.generate_command,
+                project_dir,
+                update_project=lambda: run_project_lake_update(package_root, project_dir),
+                build_command=fixture.build_command,
+                generate_command=fixture.generate_command,
+                format_command=lambda command: format_project_command(
+                    command,
                     package_root=package_root,
                     project_dir=project_dir,
                     output_dir=output_dir,
                     slug=fixture.slug,
                 ),
-            ),
-            cwd=project_dir,
-        )
+                skip_build=False,
+            )
     finally:
         restore_tracked_project_manifest(original_manifest)
-        if rewritten_lakefile is not None and original_lakefile_text is not None:
-            rewritten_lakefile.write_text(original_lakefile_text, encoding="utf-8")
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scripts/check_project_template_fresh_repo.py
+++ b/scripts/check_project_template_fresh_repo.py
@@ -14,7 +14,7 @@ TEMPLATE_ROOT = PACKAGE_ROOT / "project_template"
 if str(PACKAGE_ROOT) not in sys.path:
     sys.path.insert(0, str(PACKAGE_ROOT))
 
-from scripts.blueprint_harness_references import rewrite_local_blueprint_dependency
+from scripts.blueprint_harness_project_commands import rewrite_local_blueprint_dependency
 
 
 def run(command: list[str], *, cwd: Path) -> None:

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -80,7 +80,7 @@
           "ref": "3aa1a4d2f2952d5c2d7fa1e68ae9a57284149184"
         }
       ],
-      "build_command": ["lake", "build", "SpherePackingBlueprint"],
+      "build_command": ["lake", "build", "+SpherePackingBlueprint.Contents"],
       "generate_command": ["lake", "env", "lean", "--run", "SpherePackingBlueprintMain.lean", "--output", "{output_dir}"],
       "site_subdir": "html-multi"
     },

--- a/tests/harness/test_blueprint_harness_branches.py
+++ b/tests/harness/test_blueprint_harness_branches.py
@@ -24,6 +24,48 @@ class BlueprintHarnessBranchPolicyTests(unittest.TestCase):
             self.assertEqual(policy.required_backport_branches, ())
             self.assertEqual(policy.source_path, root / "branch-policy.json")
 
+    def test_release_candidate_names_normalize_to_tags_and_branch_ids(self) -> None:
+        self.assertEqual(branches_mod.normalize_release_candidate_name("4.30-rc2"), "4.30-rc2")
+        self.assertEqual(branches_mod.normalize_release_candidate_name("v4.30.0-rc2"), "4.30-rc2")
+        self.assertEqual(branches_mod.release_candidate_name_or_none("v4.30.0-rc2"), "4.30-rc2")
+        self.assertIsNone(branches_mod.release_candidate_name_or_none("v4.30.0"))
+        self.assertEqual(branches_mod.release_candidate_ref("4.30-rc2"), "v4.30.0-rc2")
+        self.assertEqual(branches_mod.normalize_lean_release_ref("4.30-rc2"), "v4.30.0-rc2")
+        self.assertEqual(branches_mod.release_branch_from_lean_ref("leanprover/lean4:v4.30.0-rc2"), "v4.30.0")
+
+    def test_lean_release_order_key_orders_release_candidates_before_final_release(self) -> None:
+        self.assertLess(
+            branches_mod.lean_release_order_key("v4.30.0-rc1"),
+            branches_mod.lean_release_order_key("v4.30.0-rc2"),
+        )
+        self.assertLess(
+            branches_mod.lean_release_order_key("v4.30.0-rc2"),
+            branches_mod.lean_release_order_key("v4.30.0"),
+        )
+        self.assertEqual(branches_mod.lean_release_order_key("v4.30-rc2"), branches_mod.lean_release_order_key("v4.30.0-rc2"))
+        self.assertIsNone(branches_mod.lean_release_order_key("nightly-testing"))
+
+    def test_rewrite_lean_toolchain_preserves_existing_final_newline_style(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with_newline = root / "with-newline" / "lean-toolchain"
+            without_newline = root / "without-newline" / "lean-toolchain"
+            self.write(with_newline, "leanprover/lean4:v4.29.0\n")
+            self.write(without_newline, "leanprover/lean4:v4.29.0")
+
+            branches_mod.rewrite_lean_toolchain(with_newline, "v4.30.0")
+            branches_mod.rewrite_lean_toolchain(without_newline, "v4.30.0")
+
+            self.assertEqual(with_newline.read_text(encoding="utf-8"), "leanprover/lean4:v4.30.0\n")
+            self.assertEqual(without_newline.read_text(encoding="utf-8"), "leanprover/lean4:v4.30.0")
+
+    def test_active_release_branch_uses_release_id_for_release_candidate_toolchain(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write(root / "lean-toolchain", "leanprover/lean4:v4.30.0-rc2\n")
+
+            self.assertEqual(branches_mod.active_release_branch(root), "v4.30.0")
+
     def test_load_branch_policy_reads_required_backport_branches(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/harness/test_blueprint_harness_project_commands.py
+++ b/tests/harness/test_blueprint_harness_project_commands.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+from scripts.blueprint_harness_project_commands import (
+    OFFICIAL_BLUEPRINT_REQUIRE,
+    discard_untracked_project_manifest,
+    project_lake_update_command,
+    rewrite_local_blueprint_dependency,
+    rewrite_pinned_blueprint_dependency,
+    run_project_update_build_generate,
+    tracked_project_manifest_path,
+)
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+
+
+class BlueprintHarnessProjectCommandTests(unittest.TestCase):
+    def init_git_repo(self, root: Path) -> None:
+        subprocess.run(["git", "init"], cwd=root, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    def test_rewrite_local_blueprint_dependency_replaces_official_git_require(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            lakefile = project_dir / "lakefile.lean"
+            lakefile.write_text(
+                "\n".join(
+                    [
+                        "import Lake",
+                        "open Lake DSL",
+                        OFFICIAL_BLUEPRINT_REQUIRE,
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = rewrite_local_blueprint_dependency(project_dir, PACKAGE_ROOT)
+
+            self.assertEqual(result, lakefile)
+            text = lakefile.read_text(encoding="utf-8")
+            self.assertNotIn(OFFICIAL_BLUEPRINT_REQUIRE, text)
+            self.assertIn('require VersoBlueprint from "', text)
+
+    def test_rewrite_local_blueprint_dependency_accepts_official_repo_with_non_main_ref(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            lakefile = project_dir / "lakefile.lean"
+            lakefile.write_text(
+                'require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint.git"@"v1.2.3"\n',
+                encoding="utf-8",
+            )
+
+            rewrite_local_blueprint_dependency(project_dir, PACKAGE_ROOT)
+
+            text = lakefile.read_text(encoding="utf-8")
+            self.assertIn('require VersoBlueprint from "', text)
+            self.assertNotIn('from git "https://github.com/leanprover/verso-blueprint.git"', text)
+
+    def test_rewrite_local_blueprint_dependency_rejects_unofficial_source(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            lakefile = project_dir / "lakefile.lean"
+            lakefile.write_text(
+                'require VersoBlueprint from git "https://github.com/example/verso-blueprint.git"@"v1.2.3"\n',
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(SystemExit, "approved `VersoBlueprint` Git source"):
+                rewrite_local_blueprint_dependency(project_dir, PACKAGE_ROOT)
+
+    def test_rewrite_local_blueprint_dependency_rejects_unexpected_require_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            lakefile = project_dir / "lakefile.lean"
+            lakefile.write_text(
+                'require VersoBlueprint from git "https://github.com/example/fork"@"main"\n',
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(SystemExit, "approved `VersoBlueprint` Git source"):
+                rewrite_local_blueprint_dependency(project_dir, PACKAGE_ROOT)
+
+    def test_rewrite_pinned_blueprint_dependency_updates_ref_and_preserves_repo_url(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            lakefile = project_dir / "lakefile.lean"
+            lakefile.write_text(
+                'require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint.git"@"old-ref"\n',
+                encoding="utf-8",
+            )
+
+            result_path, previous_ref = rewrite_pinned_blueprint_dependency(project_dir, "v1.2.3")
+
+            self.assertEqual(result_path, lakefile)
+            self.assertEqual(previous_ref, "old-ref")
+            self.assertEqual(
+                lakefile.read_text(encoding="utf-8").strip(),
+                'require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint.git"@"v1.2.3"',
+            )
+
+    def test_tracked_project_manifest_path_accepts_git_tracked_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            self.init_git_repo(project_dir)
+            manifest = project_dir / "lake-manifest.json"
+            manifest.write_text("{}\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "add", "lake-manifest.json"],
+                cwd=project_dir,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
+            self.assertEqual(tracked_project_manifest_path(project_dir), manifest)
+
+    def test_tracked_project_manifest_path_ignores_untracked_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            self.init_git_repo(project_dir)
+            manifest = project_dir / "lake-manifest.json"
+            manifest.write_text("{}\n", encoding="utf-8")
+
+            self.assertIsNone(tracked_project_manifest_path(project_dir))
+
+    def test_discard_untracked_project_manifest_removes_generated_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            self.init_git_repo(project_dir)
+            manifest = project_dir / "lake-manifest.json"
+            manifest.write_text("{}\n", encoding="utf-8")
+
+            discard_untracked_project_manifest(project_dir)
+
+            self.assertFalse(manifest.exists())
+
+    def test_discard_untracked_project_manifest_preserves_tracked_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            self.init_git_repo(project_dir)
+            manifest = project_dir / "lake-manifest.json"
+            manifest.write_text("{}\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "add", "lake-manifest.json"],
+                cwd=project_dir,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
+            discard_untracked_project_manifest(project_dir)
+
+            self.assertTrue(manifest.exists())
+
+    def test_project_lake_update_command_uses_full_update_when_manifest_is_committed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            self.init_git_repo(project_dir)
+            manifest = project_dir / "lake-manifest.json"
+            manifest.write_text("{}\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "add", "lake-manifest.json"],
+                cwd=project_dir,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
+            command = project_lake_update_command(PACKAGE_ROOT, project_dir)
+
+            self.assertEqual(command[-2:], ["lake", "update"])
+
+    def test_project_lake_update_command_falls_back_to_full_update_without_tracked_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            self.init_git_repo(project_dir)
+
+            command = project_lake_update_command(PACKAGE_ROOT, project_dir)
+
+            self.assertEqual(command[-2:], ["lake", "update"])
+
+    def test_run_project_update_build_generate_updates_builds_then_generates(self) -> None:
+        import scripts.blueprint_harness_project_commands as commands_mod
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_root = root / "pkg"
+            project_dir = root / "project"
+            package_root.mkdir()
+            project_dir.mkdir()
+            original_run = commands_mod.run
+            commands: list[list[str]] = []
+            try:
+                commands_mod.run = lambda command, *, cwd: commands.append(command)
+
+                run_project_update_build_generate(
+                    package_root,
+                    project_dir,
+                    update_project=lambda: commands.append(["lake", "update"]),
+                    build_command=("lake", "build"),
+                    generate_command=("lake", "exe", "blueprint-gen"),
+                    format_command=lambda command: [*command, "--formatted"],
+                    skip_build=False,
+                )
+            finally:
+                commands_mod.run = original_run
+
+        self.assertEqual(
+            commands,
+            [
+                ["lake", "update"],
+                [str(package_root / "scripts" / "lean-low-priority"), "lake", "build", "--formatted"],
+                [str(package_root / "scripts" / "lean-low-priority"), "lake", "exe", "blueprint-gen", "--formatted"],
+            ],
+        )
+
+    def test_run_project_update_build_generate_can_skip_build(self) -> None:
+        import scripts.blueprint_harness_project_commands as commands_mod
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_root = root / "pkg"
+            project_dir = root / "project"
+            package_root.mkdir()
+            project_dir.mkdir()
+            original_run = commands_mod.run
+            commands: list[list[str]] = []
+            try:
+                commands_mod.run = lambda command, *, cwd: commands.append(command)
+
+                run_project_update_build_generate(
+                    package_root,
+                    project_dir,
+                    update_project=lambda: commands.append(["lake", "update"]),
+                    build_command=("lake", "build"),
+                    generate_command=("lake", "exe", "blueprint-gen"),
+                    format_command=list,
+                    skip_build=True,
+                )
+            finally:
+                commands_mod.run = original_run
+
+        self.assertEqual(
+            commands,
+            [
+                ["lake", "update"],
+                [str(package_root / "scripts" / "lean-low-priority"), "lake", "exe", "blueprint-gen"],
+            ],
+        )

--- a/tests/harness/test_blueprint_harness_project_commands.py
+++ b/tests/harness/test_blueprint_harness_project_commands.py
@@ -157,7 +157,7 @@ class BlueprintHarnessProjectCommandTests(unittest.TestCase):
 
             self.assertTrue(manifest.exists())
 
-    def test_project_lake_update_command_uses_full_update_when_manifest_is_committed(self) -> None:
+    def test_project_lake_update_command_updates_blueprint_only_when_manifest_is_committed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             project_dir = Path(tmp)
             self.init_git_repo(project_dir)
@@ -173,7 +173,7 @@ class BlueprintHarnessProjectCommandTests(unittest.TestCase):
 
             command = project_lake_update_command(PACKAGE_ROOT, project_dir)
 
-            self.assertEqual(command[-2:], ["lake", "update"])
+            self.assertEqual(command[-3:], ["lake", "update", "VersoBlueprint"])
 
     def test_project_lake_update_command_falls_back_to_full_update_without_tracked_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 import subprocess
 import tempfile
@@ -21,24 +20,22 @@ from scripts.blueprint_harness_projects import (
     resolve_release_target,
 )
 from scripts.emit_reference_deploy_matrix import deploy_matrix_from_release_catalogs
-from scripts.blueprint_harness_references import (
+from scripts.blueprint_harness_project_commands import (
     OFFICIAL_BLUEPRINT_REQUIRE,
+    tracked_project_manifest_path,
+)
+from scripts.blueprint_harness_references import (
     bootstrap_reference_checkout,
     bump_reference_project,
     clone_git_project,
     default_reference_bump_branch,
-    discard_untracked_project_manifest,
     default_reference_edit_base,
     generate_git_project,
-    reference_update_command,
     reference_submodule_update_command,
+    reconcile_reference_toolchains,
     require_reference_harness_layout,
-    rewrite_local_blueprint_dependency,
-    rewrite_pinned_blueprint_dependency,
     seed_reference_edit_checkout_lake,
-    tracked_project_manifest_path,
     update_git_checkout,
-    use_shared_reference_checkout,
 )
 
 
@@ -499,172 +496,144 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "duplicate project id"):
                 load_projects_manifest(manifest)
 
-    def test_rewrite_local_blueprint_dependency_replaces_official_git_require(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            project_dir = Path(tmp)
-            lakefile = project_dir / "lakefile.lean"
-            lakefile.write_text(
-                "\n".join(
-                    [
-                        "import Lake",
-                        "open Lake DSL",
-                        OFFICIAL_BLUEPRINT_REQUIRE,
-                        "",
-                    ]
-                ),
-                encoding="utf-8",
-            )
-
-            result = rewrite_local_blueprint_dependency(project_dir, PACKAGE_ROOT)
-
-            self.assertEqual(result, lakefile)
-            text = lakefile.read_text(encoding="utf-8")
-            self.assertNotIn(OFFICIAL_BLUEPRINT_REQUIRE, text)
-            self.assertIn('require VersoBlueprint from "', text)
-
-    def test_rewrite_local_blueprint_dependency_accepts_official_repo_with_non_main_ref(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            project_dir = Path(tmp)
-            lakefile = project_dir / "lakefile.lean"
-            lakefile.write_text(
-                'require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint.git"@"v1.2.3"\n',
-                encoding="utf-8",
-            )
-
-            rewrite_local_blueprint_dependency(project_dir, PACKAGE_ROOT)
-
-            text = lakefile.read_text(encoding="utf-8")
-            self.assertIn('require VersoBlueprint from "', text)
-            self.assertNotIn('from git "https://github.com/leanprover/verso-blueprint.git"', text)
-
-    def test_rewrite_local_blueprint_dependency_rejects_unofficial_source(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            project_dir = Path(tmp)
-            lakefile = project_dir / "lakefile.lean"
-            lakefile.write_text(
-                'require VersoBlueprint from git "https://github.com/example/verso-blueprint.git"@"v1.2.3"\n',
-                encoding="utf-8",
-            )
-
-            with self.assertRaisesRegex(SystemExit, "approved `VersoBlueprint` Git source"):
-                rewrite_local_blueprint_dependency(project_dir, PACKAGE_ROOT)
-
-    def test_rewrite_local_blueprint_dependency_rejects_unexpected_require_shape(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            project_dir = Path(tmp)
-            lakefile = project_dir / "lakefile.lean"
-            lakefile.write_text(
-                'require VersoBlueprint from git "https://github.com/example/fork"@"main"\n',
-                encoding="utf-8",
-            )
-
-            with self.assertRaisesRegex(SystemExit, "approved `VersoBlueprint` Git source"):
-                rewrite_local_blueprint_dependency(project_dir, PACKAGE_ROOT)
-
-    def test_rewrite_pinned_blueprint_dependency_updates_ref_and_preserves_repo_url(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            project_dir = Path(tmp)
-            lakefile = project_dir / "lakefile.lean"
-            lakefile.write_text(
-                'require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint.git"@"old-ref"\n',
-                encoding="utf-8",
-            )
-
-            result_path, previous_ref = rewrite_pinned_blueprint_dependency(project_dir, "v1.2.3")
-
-            self.assertEqual(result_path, lakefile)
-            self.assertEqual(previous_ref, "old-ref")
-            self.assertEqual(
-                lakefile.read_text(encoding="utf-8").strip(),
-                'require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint.git"@"v1.2.3"',
-            )
-
     def test_default_reference_bump_branch_shortens_commit_hash(self) -> None:
         self.assertEqual(
             default_reference_bump_branch("9b50e39c17434ee1a574fd27ed97006adfdc5dc1"),
             "chore/bump-verso-blueprint-9b50e39c1743",
         )
 
-    def test_tracked_project_manifest_path_accepts_git_tracked_manifest(self) -> None:
+    def test_reconcile_reference_toolchains_promotes_same_release_branch_to_newest_ref(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            project_dir = Path(tmp)
-            self.init_git_repo(project_dir)
-            manifest = project_dir / "lake-manifest.json"
-            manifest.write_text("{}\n", encoding="utf-8")
-            subprocess.run(
-                ["git", "add", "lake-manifest.json"],
-                cwd=project_dir,
-                check=True,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+            root = Path(tmp)
+            package_root = root / "pkg"
+            project_dir = root / "external"
+            mathlib_dir = project_dir / ".lake" / "packages" / "mathlib"
+            other_dir = project_dir / ".lake" / "packages" / "other"
+            package_root.mkdir()
+            mathlib_dir.mkdir(parents=True)
+            other_dir.mkdir(parents=True)
+            (package_root / "lean-toolchain").write_text("leanprover/lean4:v4.30.0\n", encoding="utf-8")
+            (project_dir / "lean-toolchain").write_text("leanprover/lean4:4.30-rc1\n", encoding="utf-8")
+            (mathlib_dir / "lean-toolchain").write_text("leanprover/lean4:v4.30.0-rc2", encoding="utf-8")
+            (other_dir / "lean-toolchain").write_text("leanprover/lean4:v4.29.0\n", encoding="utf-8")
+
+            result = reconcile_reference_toolchains(package_root, project_dir)
+
+            self.assertTrue(result.changed)
+            self.assertEqual(result.selected_ref, "v4.30.0")
+            self.assertEqual(result.release_branch, "v4.30.0")
+            self.assertEqual(
+                set(result.changed_paths),
+                {
+                    project_dir / "lean-toolchain",
+                    mathlib_dir / "lean-toolchain",
+                },
+            )
+            self.assertEqual(
+                (project_dir / "lean-toolchain").read_text(encoding="utf-8"),
+                "leanprover/lean4:v4.30.0\n",
+            )
+            self.assertEqual(
+                (mathlib_dir / "lean-toolchain").read_text(encoding="utf-8"),
+                "leanprover/lean4:v4.30.0",
+            )
+            self.assertEqual(
+                (other_dir / "lean-toolchain").read_text(encoding="utf-8"),
+                "leanprover/lean4:v4.29.0\n",
             )
 
-            self.assertEqual(tracked_project_manifest_path(project_dir), manifest)
-
-    def test_tracked_project_manifest_path_ignores_untracked_manifest(self) -> None:
+    def test_reconcile_reference_toolchains_leaves_different_release_branches_alone(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            project_dir = Path(tmp)
-            self.init_git_repo(project_dir)
-            manifest = project_dir / "lake-manifest.json"
-            manifest.write_text("{}\n", encoding="utf-8")
+            root = Path(tmp)
+            package_root = root / "pkg"
+            project_dir = root / "external"
+            mathlib_dir = project_dir / ".lake" / "packages" / "mathlib"
+            package_root.mkdir()
+            mathlib_dir.mkdir(parents=True)
+            (package_root / "lean-toolchain").write_text("leanprover/lean4:v4.30.0\n", encoding="utf-8")
+            (project_dir / "lean-toolchain").write_text("leanprover/lean4:v4.29.0\n", encoding="utf-8")
+            (mathlib_dir / "lean-toolchain").write_text("leanprover/lean4:v4.29.0\n", encoding="utf-8")
 
-            self.assertIsNone(tracked_project_manifest_path(project_dir))
+            result = reconcile_reference_toolchains(package_root, project_dir)
 
-    def test_discard_untracked_project_manifest_removes_generated_file(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            project_dir = Path(tmp)
-            self.init_git_repo(project_dir)
-            manifest = project_dir / "lake-manifest.json"
-            manifest.write_text("{}\n", encoding="utf-8")
-
-            discard_untracked_project_manifest(project_dir)
-
-            self.assertFalse(manifest.exists())
-
-    def test_discard_untracked_project_manifest_preserves_tracked_file(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            project_dir = Path(tmp)
-            self.init_git_repo(project_dir)
-            manifest = project_dir / "lake-manifest.json"
-            manifest.write_text("{}\n", encoding="utf-8")
-            subprocess.run(
-                ["git", "add", "lake-manifest.json"],
-                cwd=project_dir,
-                check=True,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+            self.assertFalse(result.changed)
+            self.assertIsNone(result.selected_ref)
+            self.assertIsNone(result.release_branch)
+            self.assertEqual(result.changed_paths, ())
+            self.assertEqual(
+                (project_dir / "lean-toolchain").read_text(encoding="utf-8"),
+                "leanprover/lean4:v4.29.0\n",
+            )
+            self.assertEqual(
+                (mathlib_dir / "lean-toolchain").read_text(encoding="utf-8"),
+                "leanprover/lean4:v4.29.0\n",
             )
 
-            discard_untracked_project_manifest(project_dir)
+    def test_reference_cache_checkout_uses_current_package_root_override(self) -> None:
+        import scripts.blueprint_harness_project_commands as commands_mod
+        import scripts.blueprint_harness_references as refs_mod
 
-            self.assertTrue(manifest.exists())
-
-    def test_reference_update_command_targets_blueprint_when_manifest_is_committed(self) -> None:
+        project = HarnessProject(
+            project_id="external-blueprint",
+            source_kind="git_checkout",
+            project_root="nested/blueprint",
+            build_target=None,
+            generator=None,
+            repository="https://github.com/example/external-blueprint.git",
+            ref="main",
+            build_command=("lake", "build"),
+            generate_command=("lake", "exe", "blueprint-gen"),
+            site_subdir="html-multi",
+            panel_regression_script=None,
+            browser_tests_path=None,
+            description=None,
+        )
         with tempfile.TemporaryDirectory() as tmp:
-            project_dir = Path(tmp)
-            self.init_git_repo(project_dir)
-            manifest = project_dir / "lake-manifest.json"
-            manifest.write_text("{}\n", encoding="utf-8")
-            subprocess.run(
-                ["git", "add", "lake-manifest.json"],
-                cwd=project_dir,
-                check=True,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+            root = Path(tmp)
+            cache_dir = root / "cache" / project.project_id
+            project_dir = cache_dir / "nested" / "blueprint"
+            project_dir.mkdir(parents=True)
+            (cache_dir / ".git").mkdir()
+            lakefile = project_dir / "lakefile.lean"
+            lakefile.write_text(OFFICIAL_BLUEPRINT_REQUIRE + "\n", encoding="utf-8")
+            layout = SimpleNamespace(
+                package_root=root / "worktree",
+                repo_root=root / "root",
+                reference_project_cache_root=root / "cache",
             )
+            layout.package_root.mkdir()
+            layout.repo_root.mkdir()
 
-            command = reference_update_command(PACKAGE_ROOT, project_dir)
+            originals = {
+                "command_rewrite_local_blueprint_dependency": commands_mod.rewrite_local_blueprint_dependency,
+                "update_git_checkout": refs_mod.update_git_checkout,
+                "bootstrap_reference_checkout": refs_mod.bootstrap_reference_checkout,
+                "project_lake_update_command": refs_mod.project_lake_update_command,
+                "run": refs_mod.run,
+            }
+            seen: dict[str, object] = {}
+            try:
+                refs_mod.update_git_checkout = lambda _project, _cache_dir: None
+                refs_mod.bootstrap_reference_checkout = lambda *, project_dir: None
 
-            self.assertEqual(command[-3:], ["lake", "update", "VersoBlueprint"])
+                def fake_rewrite(_project_dir, package_root):
+                    seen["package_root"] = package_root
+                    return lakefile
 
-    def test_reference_update_command_falls_back_to_full_update_without_tracked_manifest(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            project_dir = Path(tmp)
-            self.init_git_repo(project_dir)
+                commands_mod.rewrite_local_blueprint_dependency = fake_rewrite
+                refs_mod.project_lake_update_command = lambda _package_root, _project_dir: ["lake", "update"]
+                refs_mod.run = lambda _command, *, cwd: None
 
-            command = reference_update_command(PACKAGE_ROOT, project_dir)
+                refs_mod.sync_reference_cache_checkout(layout, project, warm_build=False)
+            finally:
+                for name, value in originals.items():
+                    if name == "command_rewrite_local_blueprint_dependency":
+                        commands_mod.rewrite_local_blueprint_dependency = value
+                    else:
+                        setattr(refs_mod, name, value)
 
-            self.assertEqual(command[-2:], ["lake", "update"])
+            self.assertEqual(seen["package_root"], layout.package_root)
+            self.assertEqual(lakefile.read_text(encoding="utf-8"), OFFICIAL_BLUEPRINT_REQUIRE + "\n")
 
     def test_child_manifests_inherit_verso_and_subverso_from_root_without_mathlib(self) -> None:
         root_manifest_path = PACKAGE_ROOT / "lake-manifest.json"
@@ -854,20 +823,8 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             ).stdout.strip()
             self.assertEqual(status, "")
 
-    def test_use_shared_reference_checkout_env_switch(self) -> None:
-        old = os.environ.get("BP_REFERENCE_CHECKOUT_MODE")
-        try:
-            os.environ.pop("BP_REFERENCE_CHECKOUT_MODE", None)
-            self.assertFalse(use_shared_reference_checkout())
-            os.environ["BP_REFERENCE_CHECKOUT_MODE"] = "shared"
-            self.assertTrue(use_shared_reference_checkout())
-        finally:
-            if old is None:
-                os.environ.pop("BP_REFERENCE_CHECKOUT_MODE", None)
-            else:
-                os.environ["BP_REFERENCE_CHECKOUT_MODE"] = old
-
-    def test_generate_git_project_skips_cache_warm_build_for_local_checkout_mode(self) -> None:
+    def test_generate_git_project_uses_local_checkout_without_cache_warm_build(self) -> None:
+        import scripts.blueprint_harness_project_commands as commands_mod
         import scripts.blueprint_harness_references as refs_mod
 
         project = HarnessProject(
@@ -917,27 +874,34 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             layout.repo_root.mkdir()
 
             originals = {
+                "command_rewrite_local_blueprint_dependency": commands_mod.rewrite_local_blueprint_dependency,
+                "command_run": commands_mod.run,
                 "sync_reference_cache_checkout": refs_mod.sync_reference_cache_checkout,
                 "sync_reference_local_checkout": refs_mod.sync_reference_local_checkout,
-                "rewrite_local_blueprint_dependency": refs_mod.rewrite_local_blueprint_dependency,
-                "reference_update_command": refs_mod.reference_update_command,
+                "project_lake_update_command": refs_mod.project_lake_update_command,
                 "run": refs_mod.run,
-                "use_shared_reference_checkout": refs_mod.use_shared_reference_checkout,
             }
             commands: list[list[str]] = []
             warm_build_values: list[bool] = []
             try:
                 refs_mod.sync_reference_cache_checkout = lambda _layout, _project, *, warm_build: warm_build_values.append(warm_build) or cache_dir
                 refs_mod.sync_reference_local_checkout = lambda _layout, _project, _cache_dir: local_dir
-                refs_mod.rewrite_local_blueprint_dependency = lambda _project_dir, _package_root: local_dir / "lakefile.lean"
-                refs_mod.reference_update_command = lambda _package_root, _project_dir: ["lake", "update", "VersoBlueprint"]
+                commands_mod.rewrite_local_blueprint_dependency = (
+                    lambda _project_dir, _package_root: local_dir / "lakefile.lean"
+                )
+                refs_mod.project_lake_update_command = lambda _package_root, _project_dir: ["lake", "update", "VersoBlueprint"]
                 refs_mod.run = lambda command, *, cwd: commands.append(command)
-                refs_mod.use_shared_reference_checkout = lambda: False
+                commands_mod.run = lambda command, *, cwd: commands.append(command)
 
                 generate_git_project(layout, output_root, project, skip_build=False)
             finally:
                 for name, value in originals.items():
-                    setattr(refs_mod, name, value)
+                    if name == "command_rewrite_local_blueprint_dependency":
+                        commands_mod.rewrite_local_blueprint_dependency = value
+                    elif name == "command_run":
+                        commands_mod.run = value
+                    else:
+                        setattr(refs_mod, name, value)
 
         self.assertEqual(warm_build_values, [False])
         self.assertEqual(commands[0], reference_submodule_update_command())
@@ -1016,7 +980,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             "prepare_reference_edit_checkout": refs_mod.prepare_reference_edit_checkout,
             "git_checkout_is_clean": refs_mod.git_checkout_is_clean,
             "rewrite_pinned_blueprint_dependency": refs_mod.rewrite_pinned_blueprint_dependency,
-            "reference_update_command": refs_mod.reference_update_command,
+            "project_lake_update_command": refs_mod.project_lake_update_command,
             "run": refs_mod.run,
             "git_has_tracked_changes": refs_mod.git_has_tracked_changes,
             "commit_project_tracked_changes": refs_mod.commit_project_tracked_changes,
@@ -1035,7 +999,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 edit_dir / "lakefile.lean",
                 "old-ref",
             )
-            refs_mod.reference_update_command = lambda _package_root, _project_dir: ["lake", "update", "VersoBlueprint"]
+            refs_mod.project_lake_update_command = lambda _package_root, _project_dir: ["lake", "update", "VersoBlueprint"]
             refs_mod.run = lambda command, *, cwd: commands.append(command)
             refs_mod.git_has_tracked_changes = lambda _checkout_root, _pathspec: True
 
@@ -1105,7 +1069,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 "prepare_reference_edit_checkout": refs_mod.prepare_reference_edit_checkout,
                 "git_checkout_is_clean": refs_mod.git_checkout_is_clean,
                 "rewrite_pinned_blueprint_dependency": refs_mod.rewrite_pinned_blueprint_dependency,
-                "reference_update_command": refs_mod.reference_update_command,
+                "project_lake_update_command": refs_mod.project_lake_update_command,
                 "run": refs_mod.run,
                 "git_has_tracked_changes": refs_mod.git_has_tracked_changes,
             }
@@ -1121,7 +1085,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                     edit_dir / "lakefile.lean",
                     "old-ref",
                 )
-                refs_mod.reference_update_command = lambda _package_root, _project_dir: ["lake", "update", "VersoBlueprint"]
+                refs_mod.project_lake_update_command = lambda _package_root, _project_dir: ["lake", "update", "VersoBlueprint"]
                 refs_mod.run = lambda command, *, cwd: commands.append(command)
                 refs_mod.git_has_tracked_changes = lambda _checkout_root, _pathspec: False
 

--- a/tests/harness/test_blueprint_harness_toolchains.py
+++ b/tests/harness/test_blueprint_harness_toolchains.py
@@ -43,6 +43,34 @@ class BlueprintHarnessToolchainTests(unittest.TestCase):
             self.assertEqual(previous_ref, "main")
             self.assertIn('require verso from git "https://github.com/leanprover/verso"@"v4.29.0"', lakefile.read_text(encoding="utf-8"))
 
+    def test_rewrite_pinned_verso_dependency_canonicalizes_temporary_fix_fork(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            lakefile = project_dir / "lakefile.lean"
+            lakefile.write_text(
+                '\n'.join(
+                    [
+                        "import Lake",
+                        "open Lake DSL",
+                        (
+                            'require verso from git "https://github.com/ejgallego/verso"'
+                            '@"a61eb8993e8d1a617a60c502020f95f3525e6c9d"'
+                        ),
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result, previous_ref = toolchains_mod.rewrite_pinned_verso_dependency(project_dir, "v4.30.0")
+
+            self.assertEqual(result, lakefile)
+            self.assertEqual(previous_ref, "a61eb8993e8d1a617a60c502020f95f3525e6c9d")
+            self.assertIn(
+                'require verso from git "https://github.com/leanprover/verso"@"v4.30.0"',
+                lakefile.read_text(encoding="utf-8"),
+            )
+
     def test_bump_toolchain_checkout_updates_managed_files_and_preserves_inherited_dependencies(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             package_root = Path(tmp)

--- a/tests/harness/test_blueprint_harness_toolchains.py
+++ b/tests/harness/test_blueprint_harness_toolchains.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 
 from scripts.blueprint_harness_branches import active_release_branch
-from scripts.blueprint_harness_references import OFFICIAL_BLUEPRINT_REQUIRE_PATTERN
+from scripts.blueprint_harness_project_commands import OFFICIAL_BLUEPRINT_REQUIRE_PATTERN
 import scripts.blueprint_harness_toolchains as toolchains_mod
 
 


### PR DESCRIPTION
## Summary
Backport #98 to `v4.29.0`.

## Primary Review
- Primary review: #98
- Keep review comments on #98 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.29.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x` where the default-development commit applies directly.

## Backport Delta
- Preserve v4.29's committed-manifest behavior by updating only `VersoBlueprint`, so older reference dependency pins are not refreshed during validation.
- Set the shared helper's default `VersoBlueprint` require string to `v4.29.0` for this release line.
- Backport the temporary Verso fix-fork recognition in the toolchain helper, but leave v4.29's `verso` dependency pinned to `v4.29.0`; no v4.29-compatible commit for leanprover/verso#854 is currently advertised.
- Build the sphere-packing reference contents target before running its generator to avoid extra aggregate-library CI work on the heavy v4.29 catalog.