### PR TITLE
[backport v4.29.0] chore: share harness helper logic

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -94,6 +94,9 @@ script map, not a second command reference.
   Local test-blueprint fixture catalog, generation, and validation CLI.
 - `blueprint_harness_cli.py`
   Shared argparse helper functions used by the harness CLIs.
+- `blueprint_harness_manifest.py`
+  Shared JSON manifest loading, path resolution, and field validators used by
+  the harness catalog loaders.
 - `blueprint_harness_projects.py`
   Project-manifest loader and schema checks for
   [`tests/harness/projects.json`](../tests/harness/projects.json).

--- a/scripts/blueprint_harness_manifest.py
+++ b/scripts/blueprint_harness_manifest.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json_object(path: Path, *, context: str | None = None) -> dict[str, Any]:
+    label = context or str(path)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as err:
+        raise ValueError(f"{label}: invalid JSON: {err.msg}") from err
+    if not isinstance(data, dict):
+        raise ValueError(f"{label}: expected JSON object")
+    return data
+
+
+def resolve_manifest_path(path_text: str | None, default_path: Path) -> Path:
+    if path_text is None:
+        return default_path
+
+    path = Path(path_text)
+    if path.is_absolute():
+        return path.resolve()
+    return (Path.cwd() / path).resolve()
+
+
+def require_string(data: dict[str, Any], key: str, *, context: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{context}: expected non-empty string field `{key}`")
+    return value
+
+
+def optional_string(data: dict[str, Any], key: str, *, context: str) -> str | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{context}: expected non-empty string field `{key}`")
+    return value
+
+
+def optional_bool(data: dict[str, Any], key: str, *, default: bool, context: str) -> bool:
+    value = data.get(key, default)
+    if not isinstance(value, bool):
+        raise ValueError(f"{context}: expected boolean field `{key}`")
+    return value
+
+
+def string_list(
+    data: dict[str, Any],
+    key: str,
+    *,
+    context: str,
+    required: bool,
+    non_empty: bool,
+    unique: bool = False,
+) -> tuple[str, ...] | None:
+    value = data.get(key)
+    if value is None and not required:
+        return None
+
+    expected = "non-empty string list" if non_empty else "string list"
+    if (
+        not isinstance(value, list)
+        or (non_empty and not value)
+        or not all(isinstance(item, str) and item for item in value)
+    ):
+        raise ValueError(f"{context}: expected {expected} field `{key}`")
+
+    items = tuple(value)
+    if unique and len(set(items)) != len(items):
+        raise ValueError(f"{context}: duplicate values in `{key}`")
+    return items
+
+
+def require_string_list(
+    data: dict[str, Any],
+    key: str,
+    *,
+    context: str,
+    non_empty: bool = True,
+    unique: bool = False,
+) -> tuple[str, ...]:
+    items = string_list(data, key, context=context, required=True, non_empty=non_empty, unique=unique)
+    if items is None:
+        raise AssertionError("required string list parser returned None")
+    return items
+
+
+def optional_string_list(
+    data: dict[str, Any],
+    key: str,
+    *,
+    context: str,
+    non_empty: bool = False,
+    unique: bool = False,
+) -> tuple[str, ...] | None:
+    return string_list(data, key, context=context, required=False, non_empty=non_empty, unique=unique)
+
+
+def optional_command(data: dict[str, Any], key: str, *, context: str) -> tuple[str, ...] | None:
+    return optional_string_list(data, key, context=context, non_empty=True)

--- a/scripts/blueprint_harness_project_commands.py
+++ b/scripts/blueprint_harness_project_commands.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from contextlib import contextmanager
 import os
 from pathlib import Path
@@ -196,6 +196,11 @@ def rebuild_and_log_embedded_asset_owners(package_root: Path) -> list[str]:
     for target in rebuilt:
         print(f"[blueprint-harness] rebuilt embedded-asset owner target: {target}")
     return rebuilt
+
+
+def format_project_command(command: tuple[str, ...], placeholders: Mapping[str, object]) -> list[str]:
+    values = {key: str(value) for key, value in placeholders.items()}
+    return [part.format(**values) for part in command]
 
 
 def run_project_update_build_generate(

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -5,6 +5,14 @@ import json
 from pathlib import Path
 
 from scripts.blueprint_harness_branches import active_release_branch, normalize_lean_release_ref
+from scripts.blueprint_harness_manifest import (
+    load_json_object,
+    optional_bool as _optional_bool,
+    optional_command as _optional_command,
+    optional_string as _optional_string,
+    require_string as _require_string,
+    resolve_manifest_path as resolve_manifest_file_path,
+)
 
 
 IN_REPO_PROJECT_SOURCE_KIND = "in_repo_project"
@@ -93,45 +101,7 @@ def default_project_manifest(package_root: Path) -> Path:
 
 
 def resolve_manifest_path(path_text: str | None, package_root: Path) -> Path:
-    if path_text is None:
-        return default_project_manifest(package_root)
-
-    path = Path(path_text)
-    if path.is_absolute():
-        return path.resolve()
-    return (Path.cwd() / path).resolve()
-
-
-def _require_string(data: dict, key: str, *, context: str) -> str:
-    value = data.get(key)
-    if not isinstance(value, str) or not value:
-        raise ValueError(f"{context}: expected non-empty string field `{key}`")
-    return value
-
-
-def _optional_string(data: dict, key: str) -> str | None:
-    value = data.get(key)
-    if value is None:
-        return None
-    if not isinstance(value, str) or not value:
-        raise ValueError(f"expected non-empty string field `{key}`")
-    return value
-
-
-def _optional_command(data: dict, key: str, *, context: str) -> tuple[str, ...] | None:
-    value = data.get(key)
-    if value is None:
-        return None
-    if not isinstance(value, list) or not value or not all(isinstance(item, str) and item for item in value):
-        raise ValueError(f"{context}: expected non-empty string list field `{key}`")
-    return tuple(value)
-
-
-def _optional_bool(data: dict, key: str, *, default: bool, context: str) -> bool:
-    value = data.get(key, default)
-    if not isinstance(value, bool):
-        raise ValueError(f"{context}: expected boolean field `{key}`")
-    return value
+    return resolve_manifest_file_path(path_text, default_project_manifest(package_root))
 
 
 def _load_release_targets(raw: dict, manifest_path: Path | str) -> tuple[HarnessReleaseTarget, ...]:
@@ -212,7 +182,7 @@ def _load_project_targets(
         if release in seen_releases:
             raise ValueError(f"{target_context}: duplicate release target `{release}`")
         seen_releases.add(release)
-        ref = _optional_string(raw_target, "ref")
+        ref = _optional_string(raw_target, "ref", context=target_context)
         if source_kind == GIT_CHECKOUT_SOURCE_KIND and ref is None:
             raise ValueError(f"{target_context}: git checkout targets must declare `ref`")
         if source_kind == IN_REPO_PROJECT_SOURCE_KIND and ref is not None:
@@ -253,22 +223,22 @@ def load_project_catalog_data(raw: dict, manifest_path: Path | str) -> HarnessPr
         if not isinstance(source, dict):
             raise ValueError(f"{context}: missing object field `source`")
         source_kind = _require_string(source, "kind", context=context)
-        project_root = _optional_string(source, "project_root") or "."
+        project_root = _optional_string(source, "project_root", context=context) or "."
 
-        build_target = _optional_string(entry, "build_target")
-        generator = _optional_string(entry, "generator")
-        repository = _optional_string(source, "repository")
-        ref = _optional_string(source, "ref")
+        build_target = _optional_string(entry, "build_target", context=context)
+        generator = _optional_string(entry, "generator", context=context)
+        repository = _optional_string(source, "repository", context=context)
+        ref = _optional_string(source, "ref", context=context)
         build_command = _optional_command(entry, "build_command", context=context)
         generate_command = _optional_command(entry, "generate_command", context=context)
 
         validation = entry.get("validation") or {}
         if not isinstance(validation, dict):
             raise ValueError(f"{context}: expected object field `validation`")
-        panel_regression_script = _optional_string(validation, "panel_regression_script")
-        browser_tests_path = _optional_string(validation, "browser_tests_path")
-        description = _optional_string(entry, "description")
-        site_subdir = _optional_string(entry, "site_subdir") or "html-multi"
+        panel_regression_script = _optional_string(validation, "panel_regression_script", context=context)
+        browser_tests_path = _optional_string(validation, "browser_tests_path", context=context)
+        description = _optional_string(entry, "description", context=context)
+        site_subdir = _optional_string(entry, "site_subdir", context=context) or "html-multi"
         targets = _load_project_targets(entry, context=context, release_ids=release_ids, source_kind=source_kind)
 
         if source_kind == IN_REPO_PROJECT_SOURCE_KIND:
@@ -372,7 +342,7 @@ def load_project_catalog_data(raw: dict, manifest_path: Path | str) -> HarnessPr
 
 
 def load_project_catalog(manifest_path: Path) -> HarnessProjectCatalog:
-    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    raw = load_json_object(manifest_path)
     return load_project_catalog_data(raw, manifest_path)
 
 

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -17,6 +17,7 @@ from scripts.blueprint_harness_branches import (
 from scripts.blueprint_harness_projects import HarnessProject
 from scripts.blueprint_harness_project_commands import (
     discard_untracked_project_manifest,
+    format_project_command,
     local_blueprint_dependency_override,
     maybe_in_repo_blueprint_dependency_override,
     project_lake_update_command,
@@ -186,25 +187,22 @@ def default_reference_bump_branch(ref: str) -> str:
     return f"chore/bump-verso-blueprint-{slug}"
 
 
-def format_external_command(
-    command: tuple[str, ...],
-    *,
+def reference_command_placeholders(
     project: HarnessProject,
+    *,
     package_root: Path,
     checkout_root: Path,
     project_dir: Path,
     output_dir: Path,
-) -> list[str]:
-    site_dir = site_dir_for(project, output_dir.parent)
-    placeholders = {
-        "checkout_root": str(checkout_root),
-        "package_root": str(package_root),
-        "project_dir": str(project_dir),
-        "output_dir": str(output_dir),
+) -> dict[str, object]:
+    return {
+        "checkout_root": checkout_root,
+        "package_root": package_root,
+        "project_dir": project_dir,
+        "output_dir": output_dir,
         "project_id": project.project_id,
-        "site_dir": str(site_dir),
+        "site_dir": site_dir_for(project, output_dir.parent),
     }
-    return [part.format(**placeholders) for part in command]
 
 
 def reference_submodule_update_command() -> list[str]:
@@ -519,13 +517,15 @@ def bump_reference_project(
         run(
             lean_low_priority_command(
                 layout.package_root,
-                *format_external_command(
+                *format_project_command(
                     project.build_command,
-                    project=project,
-                    package_root=layout.package_root,
-                    checkout_root=edit_dir,
-                    project_dir=project_dir,
-                    output_dir=output_dir_for(project, command_output_root),
+                    reference_command_placeholders(
+                        project,
+                        package_root=layout.package_root,
+                        checkout_root=edit_dir,
+                        project_dir=project_dir,
+                        output_dir=output_dir_for(project, command_output_root),
+                    ),
                 ),
             ),
             cwd=project_dir,
@@ -537,13 +537,15 @@ def bump_reference_project(
         run(
             lean_low_priority_command(
                 layout.package_root,
-                *format_external_command(
+                *format_project_command(
                     project.generate_command or (),
-                    project=project,
-                    package_root=layout.package_root,
-                    checkout_root=edit_dir,
-                    project_dir=project_dir,
-                    output_dir=generated_output,
+                    reference_command_placeholders(
+                        project,
+                        package_root=layout.package_root,
+                        checkout_root=edit_dir,
+                        project_dir=project_dir,
+                        output_dir=generated_output,
+                    ),
                 ),
             ),
             cwd=project_dir,
@@ -634,13 +636,15 @@ def generate_in_repo_command_project(layout, output_root: Path, project: Harness
                 ),
                 build_command=project.build_command,
                 generate_command=project.generate_command or (),
-                format_command=lambda command: format_external_command(
+                format_command=lambda command: format_project_command(
                     command,
-                    project=project,
-                    package_root=layout.package_root,
-                    checkout_root=project_dir,
-                    project_dir=project_dir,
-                    output_dir=output_dir,
+                    reference_command_placeholders(
+                        project,
+                        package_root=layout.package_root,
+                        checkout_root=project_dir,
+                        project_dir=project_dir,
+                        output_dir=output_dir,
+                    ),
                 ),
                 skip_build=skip_build,
             )
@@ -668,13 +672,15 @@ def generate_git_project(layout, output_root: Path, project: HarnessProject, *, 
             ),
             build_command=project.build_command,
             generate_command=project.generate_command or (),
-            format_command=lambda command: format_external_command(
+            format_command=lambda command: format_project_command(
                 command,
-                project=project,
-                package_root=layout.package_root,
-                checkout_root=checkout_root,
-                project_dir=project_dir,
-                output_dir=output_dir,
+                reference_command_placeholders(
+                    project,
+                    package_root=layout.package_root,
+                    checkout_root=checkout_root,
+                    project_dir=project_dir,
+                    output_dir=output_dir,
+                ),
             ),
             skip_build=skip_build,
         )

--- a/scripts/blueprint_test_blueprints.py
+++ b/scripts/blueprint_test_blueprints.py
@@ -8,8 +8,18 @@ import re
 import shutil
 import subprocess
 
+from scripts.blueprint_harness_manifest import (
+    load_json_object,
+    optional_command as _optional_command,
+    optional_string as _optional_string,
+    optional_string_list as _optional_string_list,
+    require_string as _require_string,
+    require_string_list as _require_string_list,
+    resolve_manifest_path,
+)
 from scripts.blueprint_harness_paths import detect_harness_layout
 from scripts.blueprint_harness_project_commands import (
+    format_project_command,
     maybe_in_repo_blueprint_dependency_override,
     rebuild_and_log_embedded_asset_owners,
     restore_tracked_project_manifest,
@@ -66,57 +76,11 @@ def default_test_blueprint_manifest(package_root: Path) -> Path:
 
 
 def resolve_test_blueprint_manifest(path_text: str | None, package_root: Path) -> Path:
-    if path_text is None:
-        return default_test_blueprint_manifest(package_root)
-    path = Path(path_text)
-    if path.is_absolute():
-        return path.resolve()
-    return (Path.cwd() / path).resolve()
-
-
-def _require_string(data: dict, key: str, *, context: str) -> str:
-    value = data.get(key)
-    if not isinstance(value, str) or not value:
-        raise ValueError(f"{context}: expected non-empty string field `{key}`")
-    return value
-
-
-def _optional_string(data: dict, key: str, *, context: str) -> str | None:
-    value = data.get(key)
-    if value is None:
-        return None
-    if not isinstance(value, str) or not value:
-        raise ValueError(f"{context}: expected non-empty string field `{key}`")
-    return value
-
-
-def _optional_command(data: dict, key: str, *, context: str) -> tuple[str, ...] | None:
-    value = data.get(key)
-    if value is None:
-        return None
-    if not isinstance(value, list) or not value or not all(isinstance(item, str) and item for item in value):
-        raise ValueError(f"{context}: expected non-empty string list field `{key}`")
-    return tuple(value)
-
-
-def _required_string_list(data: dict, key: str, *, context: str) -> tuple[str, ...]:
-    value = data.get(key)
-    if not isinstance(value, list) or not value or not all(isinstance(item, str) and item for item in value):
-        raise ValueError(f"{context}: expected non-empty string list field `{key}`")
-    if len(set(value)) != len(value):
-        raise ValueError(f"{context}: duplicate values in `{key}`")
-    return tuple(value)
+    return resolve_manifest_path(path_text, default_test_blueprint_manifest(package_root))
 
 
 def _optional_tags(data: dict, key: str, *, context: str) -> tuple[str, ...]:
-    value = data.get(key)
-    if value is None:
-        return ()
-    if not isinstance(value, list) or not all(isinstance(item, str) and item for item in value):
-        raise ValueError(f"{context}: expected string list field `{key}`")
-    tags = tuple(value)
-    if len(set(tags)) != len(tags):
-        raise ValueError(f"{context}: duplicate values in `{key}`")
+    tags = _optional_string_list(data, key, context=context, unique=True) or ()
     invalid = [tag for tag in tags if not TAG_PATTERN.fullmatch(tag)]
     if invalid:
         raise ValueError(f"{context}: invalid tag values in `{key}`: {', '.join(invalid)}")
@@ -124,11 +88,11 @@ def _optional_tags(data: dict, key: str, *, context: str) -> tuple[str, ...]:
 
 
 def load_test_blueprint_catalog(manifest_path: Path) -> tuple[tuple[str, ...], list[StandaloneTestBlueprint]]:
-    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    raw = load_json_object(manifest_path)
     if raw.get("version") != 1:
         raise ValueError(f"{manifest_path}: unsupported manifest version {raw.get('version')!r}")
 
-    categories = _required_string_list(raw, "categories", context=str(manifest_path))
+    categories = _require_string_list(raw, "categories", context=str(manifest_path), unique=True)
 
     entries = raw.get("fixtures")
     if not isinstance(entries, list):
@@ -584,16 +548,6 @@ def find_test_blueprint(fixtures: list[StandaloneTestBlueprint], slug: str) -> S
     raise SystemExit(f"[blueprint-test-blueprints] unknown fixture `{slug}`; known fixtures: {known}")
 
 
-def format_project_command(command: tuple[str, ...], *, package_root: Path, project_dir: Path, output_dir: Path, slug: str) -> list[str]:
-    placeholders = {
-        "package_root": str(package_root),
-        "project_dir": str(project_dir),
-        "output_dir": str(output_dir),
-        "slug": slug,
-    }
-    return [part.format(**placeholders) for part in command]
-
-
 def generate_standalone_test_blueprint(package_root: Path, fixture: StandaloneTestBlueprint, output_dir: Path) -> None:
     project_dir = package_root / fixture.project_root
     if not project_dir.exists():
@@ -611,10 +565,12 @@ def generate_standalone_test_blueprint(package_root: Path, fixture: StandaloneTe
                 generate_command=fixture.generate_command,
                 format_command=lambda command: format_project_command(
                     command,
-                    package_root=package_root,
-                    project_dir=project_dir,
-                    output_dir=output_dir,
-                    slug=fixture.slug,
+                    {
+                        "package_root": package_root,
+                        "project_dir": project_dir,
+                        "output_dir": output_dir,
+                        "slug": fixture.slug,
+                    },
                 ),
                 skip_build=False,
             )

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import argparse
-from contextlib import redirect_stderr, redirect_stdout
+from collections.abc import Iterator
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
 import io
 from pathlib import Path
 from types import SimpleNamespace
@@ -20,6 +21,18 @@ from scripts.blueprint_harness_projects import (
     IN_REPO_PROJECT_SOURCE_KIND,
 )
 from scripts.blueprint_harness_worktrees import GitWorktree
+
+
+@contextmanager
+def patched_attrs(target: object, **replacements: object) -> Iterator[None]:
+    originals = {name: getattr(target, name) for name in replacements}
+    try:
+        for name, value in replacements.items():
+            setattr(target, name, value)
+        yield
+    finally:
+        for name, value in originals.items():
+            setattr(target, name, value)
 
 
 class BlueprintHarnessCliTests(unittest.TestCase):
@@ -265,109 +278,75 @@ class BlueprintHarnessCliTests(unittest.TestCase):
 
     def test_create_worktree_uses_preferred_main_ref_by_default(self) -> None:
         layout = SimpleNamespace(repo_root=Path("/tmp/repo"))
-        originals = {
-            "preferred_main_ref": harness_mod.preferred_main_ref,
-            "active_release_branch": harness_mod.active_release_branch,
-        }
-        try:
-            harness_mod.preferred_main_ref = lambda _repo_root: "origin/v4.29.0"
-            harness_mod.active_release_branch = lambda _repo_root: "v4.29.0"
+        with patched_attrs(
+            harness_mod,
+            preferred_main_ref=lambda _repo_root: "origin/v4.29.0",
+            active_release_branch=lambda _repo_root: "v4.29.0",
+        ):
             self.assertEqual(harness_mod.resolve_create_worktree_base(layout, None), "origin/v4.29.0")
-        finally:
-            for name, value in originals.items():
-                setattr(harness_mod, name, value)
 
     def test_create_worktree_rejects_unsynced_local_main_base(self) -> None:
         layout = SimpleNamespace(repo_root=Path("/tmp/repo"))
-        originals = {
-            "preferred_main_ref": harness_mod.preferred_main_ref,
-            "main_sync_status": harness_mod.main_sync_status,
-            "active_release_branch": harness_mod.active_release_branch,
-        }
-        try:
-            harness_mod.preferred_main_ref = lambda _repo_root: "origin/v4.29.0"
-            harness_mod.active_release_branch = lambda _repo_root: "v4.29.0"
-            harness_mod.main_sync_status = lambda _repo_root: harness_mod.RefSyncStatus(
+        with patched_attrs(
+            harness_mod,
+            preferred_main_ref=lambda _repo_root: "origin/v4.29.0",
+            active_release_branch=lambda _repo_root: "v4.29.0",
+            main_sync_status=lambda _repo_root: harness_mod.RefSyncStatus(
                 local_ref="v4.29.0",
                 upstream_ref="origin/v4.29.0",
                 local_oid="abc",
                 upstream_oid="def",
                 relationship="diverged",
-            )
+            ),
+        ):
             with self.assertRaisesRegex(SystemExit, "refusing to use local `v4.29.0` as the worktree base"):
                 harness_mod.resolve_create_worktree_base(layout, "v4.29.0")
-        finally:
-            for name, value in originals.items():
-                setattr(harness_mod, name, value)
 
     def test_main_status_require_sync_returns_nonzero_when_unsynced(self) -> None:
         args = argparse.Namespace(require_sync=True)
         layout = SimpleNamespace(repo_root=Path("/tmp/repo"), package_root=Path("/tmp/worktree"))
-        originals = {
-            "detect_harness_layout": harness_mod.detect_harness_layout,
-            "main_sync_status": harness_mod.main_sync_status,
-            "current_branch_name": harness_mod.current_branch_name,
-            "active_release_branch": harness_mod.active_release_branch,
-            "branch_policy_path": harness_mod.branch_policy_path,
-            "default_dev_branch": harness_mod.default_dev_branch,
-            "checkout_branch_role": harness_mod.checkout_branch_role,
-            "checkout_is_backport_only": harness_mod.checkout_is_backport_only,
-        }
-        try:
-            harness_mod.detect_harness_layout = lambda _start=None: layout
-            harness_mod.main_sync_status = lambda _repo_root: harness_mod.RefSyncStatus(
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            main_sync_status=lambda _repo_root: harness_mod.RefSyncStatus(
                 local_ref="v4.29.0",
                 upstream_ref="origin/v4.29.0",
                 local_oid="abc",
                 upstream_oid="def",
                 relationship="behind",
-            )
-            harness_mod.current_branch_name = lambda _repo_root: "fix/demo"
-            harness_mod.active_release_branch = lambda _repo_root: "v4.29.0"
-            harness_mod.branch_policy_path = lambda _repo_root: Path("/tmp/worktree/branch-policy.json")
-            harness_mod.default_dev_branch = lambda _repo_root: "v4.29.0"
-            harness_mod.checkout_branch_role = lambda _repo_root: "default_dev"
-            harness_mod.checkout_is_backport_only = lambda _repo_root: False
+            ),
+            current_branch_name=lambda _repo_root: "fix/demo",
+            active_release_branch=lambda _repo_root: "v4.29.0",
+            branch_policy_path=lambda _repo_root: Path("/tmp/worktree/branch-policy.json"),
+            default_dev_branch=lambda _repo_root: "v4.29.0",
+            checkout_branch_role=lambda _repo_root: "default_dev",
+            checkout_is_backport_only=lambda _repo_root: False,
+        ):
             self.assertEqual(harness_mod.command_main_status(args), 1)
-        finally:
-            for name, value in originals.items():
-                setattr(harness_mod, name, value)
 
     def test_release_status_reports_backport_policy_fields(self) -> None:
         args = argparse.Namespace(require_sync=False)
         layout = SimpleNamespace(repo_root=Path("/tmp/repo"), package_root=Path("/tmp/worktree"))
-        originals = {
-            "detect_harness_layout": harness_mod.detect_harness_layout,
-            "main_sync_status": harness_mod.main_sync_status,
-            "current_branch_name": harness_mod.current_branch_name,
-            "active_release_branch": harness_mod.active_release_branch,
-            "branch_policy_path": harness_mod.branch_policy_path,
-            "default_dev_branch": harness_mod.default_dev_branch,
-            "checkout_branch_role": harness_mod.checkout_branch_role,
-            "checkout_is_backport_only": harness_mod.checkout_is_backport_only,
-        }
         out = io.StringIO()
-        try:
-            harness_mod.detect_harness_layout = lambda _start=None: layout
-            harness_mod.main_sync_status = lambda _repo_root: harness_mod.RefSyncStatus(
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            main_sync_status=lambda _repo_root: harness_mod.RefSyncStatus(
                 local_ref="v4.28.0",
                 upstream_ref="origin/v4.28.0",
                 local_oid="abc",
                 upstream_oid="abc",
                 relationship="in_sync",
-            )
-            harness_mod.current_branch_name = lambda _repo_root: "fix/backport"
-            harness_mod.active_release_branch = lambda _repo_root: "v4.28.0"
-            harness_mod.branch_policy_path = lambda _repo_root: Path("/tmp/worktree/branch-policy.json")
-            harness_mod.default_dev_branch = lambda _repo_root: "v4.29.0"
-            harness_mod.checkout_branch_role = lambda _repo_root: "backport"
-            harness_mod.checkout_is_backport_only = lambda _repo_root: True
-
+            ),
+            current_branch_name=lambda _repo_root: "fix/backport",
+            active_release_branch=lambda _repo_root: "v4.28.0",
+            branch_policy_path=lambda _repo_root: Path("/tmp/worktree/branch-policy.json"),
+            default_dev_branch=lambda _repo_root: "v4.29.0",
+            checkout_branch_role=lambda _repo_root: "backport",
+            checkout_is_backport_only=lambda _repo_root: True,
+        ):
             with redirect_stdout(out):
                 self.assertEqual(harness_mod.command_main_status(args), 0)
-        finally:
-            for name, value in originals.items():
-                setattr(harness_mod, name, value)
 
         output = out.getvalue()
         self.assertIn("current_branch=fix/backport", output)
@@ -380,22 +359,17 @@ class BlueprintHarnessCliTests(unittest.TestCase):
     def test_prepare_backports_prints_pending_lines(self) -> None:
         args = argparse.Namespace(exempt=None)
         layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
-        originals = {
-            "detect_harness_layout": harness_mod.detect_harness_layout,
-            "load_branch_policy": harness_mod.load_branch_policy,
-        }
         out = io.StringIO()
-        try:
-            harness_mod.detect_harness_layout = lambda _start=None: layout
-            harness_mod.load_branch_policy = lambda _checkout_root: SimpleNamespace(
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            load_branch_policy=lambda _checkout_root: SimpleNamespace(
                 default_dev_branch="v4.29.0",
                 required_backport_branches=("v4.28.0", "v4.27.0"),
-            )
+            ),
+        ):
             with redirect_stdout(out):
                 self.assertEqual(harness_mod.command_prepare_backports(args), 0)
-        finally:
-            for name, value in originals.items():
-                setattr(harness_mod, name, value)
 
         output = out.getvalue()
         self.assertIn("default_dev_branch=v4.29.0", output)
@@ -406,21 +380,16 @@ class BlueprintHarnessCliTests(unittest.TestCase):
     def test_prepare_backports_rejects_unknown_exemption_branch(self) -> None:
         args = argparse.Namespace(exempt=["v4.27.0=docs-only"])
         layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
-        originals = {
-            "detect_harness_layout": harness_mod.detect_harness_layout,
-            "load_branch_policy": harness_mod.load_branch_policy,
-        }
-        try:
-            harness_mod.detect_harness_layout = lambda _start=None: layout
-            harness_mod.load_branch_policy = lambda _checkout_root: SimpleNamespace(
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            load_branch_policy=lambda _checkout_root: SimpleNamespace(
                 default_dev_branch="v4.29.0",
                 required_backport_branches=("v4.28.0",),
-            )
+            ),
+        ):
             with self.assertRaisesRegex(SystemExit, "unknown required backport branch"):
                 harness_mod.command_prepare_backports(args)
-        finally:
-            for name, value in originals.items():
-                setattr(harness_mod, name, value)
 
     def test_prepare_pr_prints_public_scaffold(self) -> None:
         args = argparse.Namespace(
@@ -431,28 +400,20 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             exempt=None,
         )
         layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
-        originals = {
-            "detect_harness_layout": harness_mod.detect_harness_layout,
-            "load_branch_policy": harness_mod.load_branch_policy,
-            "require_checkout_role": harness_mod.require_checkout_role,
-            "current_branch_name": harness_mod.current_branch_name,
-            "current_commit_subject": harness_mod.current_commit_subject,
-        }
         out = io.StringIO()
-        try:
-            harness_mod.detect_harness_layout = lambda _start=None: layout
-            harness_mod.load_branch_policy = lambda _checkout_root: SimpleNamespace(
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            load_branch_policy=lambda _checkout_root: SimpleNamespace(
                 default_dev_branch="v4.29.0",
                 required_backport_branches=("v4.28.0",),
-            )
-            harness_mod.require_checkout_role = lambda *_args, **_kwargs: None
-            harness_mod.current_branch_name = lambda _checkout_root: "fix/public-pr-scaffold"
-            harness_mod.current_commit_subject = lambda _checkout_root: "fix: tighten public PR scaffolds"
+            ),
+            require_checkout_role=lambda *_args, **_kwargs: None,
+            current_branch_name=lambda _checkout_root: "fix/public-pr-scaffold",
+            current_commit_subject=lambda _checkout_root: "fix: tighten public PR scaffolds",
+        ):
             with redirect_stdout(out):
                 self.assertEqual(harness_mod.command_prepare_pr(args), 0)
-        finally:
-            for name, value in originals.items():
-                setattr(harness_mod, name, value)
 
         output = out.getvalue()
         self.assertIn("repository=leanprover/verso-blueprint", output)
@@ -494,27 +455,19 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             exempt=None,
         )
         layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
-        originals = {
-            "detect_harness_layout": harness_mod.detect_harness_layout,
-            "load_branch_policy": harness_mod.load_branch_policy,
-            "require_checkout_role": harness_mod.require_checkout_role,
-            "current_branch_name": harness_mod.current_branch_name,
-            "current_commit_subject": harness_mod.current_commit_subject,
-        }
-        try:
-            harness_mod.detect_harness_layout = lambda _start=None: layout
-            harness_mod.load_branch_policy = lambda _checkout_root: SimpleNamespace(
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            load_branch_policy=lambda _checkout_root: SimpleNamespace(
                 default_dev_branch="v4.30.0",
                 required_backport_branches=("v4.29.0",),
-            )
-            harness_mod.require_checkout_role = lambda *_args, **_kwargs: None
-            harness_mod.current_branch_name = lambda _checkout_root: "feat/slides"
-            harness_mod.current_commit_subject = lambda _checkout_root: "feat(slides): render Blueprint preview nodes"
+            ),
+            require_checkout_role=lambda *_args, **_kwargs: None,
+            current_branch_name=lambda _checkout_root: "feat/slides",
+            current_commit_subject=lambda _checkout_root: "feat(slides): render Blueprint preview nodes",
+        ):
             with self.assertRaisesRegex(SystemExit, "without type scopes"):
                 harness_mod.command_prepare_pr(args)
-        finally:
-            for name, value in originals.items():
-                setattr(harness_mod, name, value)
 
     def test_prepare_backport_pr_prints_standardized_scaffold(self) -> None:
         args = argparse.Namespace(
@@ -525,28 +478,20 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             source_branch="fix/backport-discipline",
         )
         layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
-        originals = {
-            "detect_harness_layout": harness_mod.detect_harness_layout,
-            "load_branch_policy": harness_mod.load_branch_policy,
-            "default_dev_branch": harness_mod.default_dev_branch,
-            "require_checkout_role": harness_mod.require_checkout_role,
-            "source_commit_series": harness_mod.source_commit_series,
-        }
         out = io.StringIO()
-        try:
-            harness_mod.detect_harness_layout = lambda _start=None: layout
-            harness_mod.load_branch_policy = lambda _checkout_root: SimpleNamespace(
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            load_branch_policy=lambda _checkout_root: SimpleNamespace(
                 default_dev_branch="v4.29.0",
                 required_backport_branches=("v4.28.0",),
-            )
-            harness_mod.default_dev_branch = lambda _checkout_root: "v4.29.0"
-            harness_mod.require_checkout_role = lambda *_args, **_kwargs: None
-            harness_mod.source_commit_series = lambda _repo_root, _source_branch: ["abc123", "def456"]
+            ),
+            default_dev_branch=lambda _checkout_root: "v4.29.0",
+            require_checkout_role=lambda *_args, **_kwargs: None,
+            source_commit_series=lambda _repo_root, _source_branch: ["abc123", "def456"],
+        ):
             with redirect_stdout(out):
                 self.assertEqual(harness_mod.command_prepare_backport_pr(args), 0)
-        finally:
-            for name, value in originals.items():
-                setattr(harness_mod, name, value)
 
         output = out.getvalue()
         self.assertIn("## Local Backport Plan", output)
@@ -578,27 +523,19 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             source_branch="fix/public-pr-title",
         )
         layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
-        originals = {
-            "detect_harness_layout": harness_mod.detect_harness_layout,
-            "load_branch_policy": harness_mod.load_branch_policy,
-            "default_dev_branch": harness_mod.default_dev_branch,
-            "require_checkout_role": harness_mod.require_checkout_role,
-            "source_commit_series": harness_mod.source_commit_series,
-        }
-        try:
-            harness_mod.detect_harness_layout = lambda _start=None: layout
-            harness_mod.load_branch_policy = lambda _checkout_root: SimpleNamespace(
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            load_branch_policy=lambda _checkout_root: SimpleNamespace(
                 default_dev_branch="v4.30.0",
                 required_backport_branches=("v4.28.0",),
-            )
-            harness_mod.default_dev_branch = lambda _checkout_root: "v4.30.0"
-            harness_mod.require_checkout_role = lambda *_args, **_kwargs: None
-            harness_mod.source_commit_series = lambda _repo_root, _source_branch: ["abc123"]
+            ),
+            default_dev_branch=lambda _checkout_root: "v4.30.0",
+            require_checkout_role=lambda *_args, **_kwargs: None,
+            source_commit_series=lambda _repo_root, _source_branch: ["abc123"],
+        ):
             with self.assertRaisesRegex(SystemExit, "without type scopes"):
                 harness_mod.command_prepare_backport_pr(args)
-        finally:
-            for name, value in originals.items():
-                setattr(harness_mod, name, value)
 
     def test_prepare_backport_pr_all_required_prints_multiple_scaffolds(self) -> None:
         args = argparse.Namespace(
@@ -609,28 +546,20 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             source_branch="fix/backport-discipline",
         )
         layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
-        originals = {
-            "detect_harness_layout": harness_mod.detect_harness_layout,
-            "load_branch_policy": harness_mod.load_branch_policy,
-            "default_dev_branch": harness_mod.default_dev_branch,
-            "require_checkout_role": harness_mod.require_checkout_role,
-            "source_commit_series": harness_mod.source_commit_series,
-        }
         out = io.StringIO()
-        try:
-            harness_mod.detect_harness_layout = lambda _start=None: layout
-            harness_mod.load_branch_policy = lambda _checkout_root: SimpleNamespace(
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            load_branch_policy=lambda _checkout_root: SimpleNamespace(
                 default_dev_branch="v4.29.0",
                 required_backport_branches=("v4.28.0", "v4.27.0"),
-            )
-            harness_mod.default_dev_branch = lambda _checkout_root: "v4.29.0"
-            harness_mod.require_checkout_role = lambda *_args, **_kwargs: None
-            harness_mod.source_commit_series = lambda _repo_root, _source_branch: ["abc123"]
+            ),
+            default_dev_branch=lambda _checkout_root: "v4.29.0",
+            require_checkout_role=lambda *_args, **_kwargs: None,
+            source_commit_series=lambda _repo_root, _source_branch: ["abc123"],
+        ):
             with redirect_stdout(out):
                 self.assertEqual(harness_mod.command_prepare_backport_pr(args), 0)
-        finally:
-            for name, value in originals.items():
-                setattr(harness_mod, name, value)
 
         output = out.getvalue()
         self.assertIn("backport_release=v4.28.0", output)
@@ -644,67 +573,46 @@ class BlueprintHarnessCliTests(unittest.TestCase):
     def test_land_main_rejects_unsynced_main(self) -> None:
         args = argparse.Namespace(source="feat/demo", no_push=False, cleanup=False, keep_remote=False)
         layout = SimpleNamespace(repo_root=Path("/tmp/repo"), package_root=Path("/tmp/repo"), in_linked_worktree=False)
-        originals = {
-            "detect_harness_layout": harness_mod.detect_harness_layout,
-            "current_branch_name": harness_mod.current_branch_name,
-            "worktree_is_clean": harness_mod.worktree_is_clean,
-            "main_sync_status": harness_mod.main_sync_status,
-            "active_release_branch": harness_mod.active_release_branch,
-        }
-        try:
-            harness_mod.detect_harness_layout = lambda _start=None: layout
-            harness_mod.current_branch_name = lambda _repo_root: "v4.29.0"
-            harness_mod.worktree_is_clean = lambda _path: True
-            harness_mod.main_sync_status = lambda _repo_root: harness_mod.RefSyncStatus(
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            current_branch_name=lambda _repo_root: "v4.29.0",
+            worktree_is_clean=lambda _path: True,
+            main_sync_status=lambda _repo_root: harness_mod.RefSyncStatus(
                 local_ref="v4.29.0",
                 upstream_ref="origin/v4.29.0",
                 local_oid="abc",
                 upstream_oid="def",
                 relationship="behind",
-            )
-            harness_mod.active_release_branch = lambda _repo_root: "v4.29.0"
+            ),
+            active_release_branch=lambda _repo_root: "v4.29.0",
+        ):
             with self.assertRaisesRegex(SystemExit, "sync `v4.29.0` before landing"):
                 harness_mod.command_land_main(args)
-        finally:
-            for name, value in originals.items():
-                setattr(harness_mod, name, value)
 
     def test_land_main_fast_forwards_and_pushes(self) -> None:
         args = argparse.Namespace(source="feat/demo", no_push=False, cleanup=False, keep_remote=False)
         layout = SimpleNamespace(repo_root=Path("/tmp/repo"), package_root=Path("/tmp/repo"), in_linked_worktree=False)
-        originals = {
-            "detect_harness_layout": harness_mod.detect_harness_layout,
-            "current_branch_name": harness_mod.current_branch_name,
-            "worktree_is_clean": harness_mod.worktree_is_clean,
-            "main_sync_status": harness_mod.main_sync_status,
-            "ref_oid": harness_mod.ref_oid,
-            "is_ancestor": harness_mod.is_ancestor,
-            "preferred_main_ref": harness_mod.preferred_main_ref,
-            "active_release_branch": harness_mod.active_release_branch,
-            "run": harness_mod.run,
-        }
         commands: list[list[str]] = []
-        try:
-            harness_mod.detect_harness_layout = lambda _start=None: layout
-            harness_mod.current_branch_name = lambda _repo_root: "v4.29.0"
-            harness_mod.worktree_is_clean = lambda _path: True
-            harness_mod.main_sync_status = lambda _repo_root: harness_mod.RefSyncStatus(
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            current_branch_name=lambda _repo_root: "v4.29.0",
+            worktree_is_clean=lambda _path: True,
+            main_sync_status=lambda _repo_root: harness_mod.RefSyncStatus(
                 local_ref="v4.29.0",
                 upstream_ref="origin/v4.29.0",
                 local_oid="abc",
                 upstream_oid="abc",
                 relationship="in_sync",
-            )
-            harness_mod.ref_oid = lambda _repo_root, ref: "deadbeef" if ref == "feat/demo" else None
-            harness_mod.is_ancestor = lambda _repo_root, ancestor, descendant: (ancestor, descendant) == ("v4.29.0", "feat/demo")
-            harness_mod.preferred_main_ref = lambda _repo_root: "origin/v4.29.0"
-            harness_mod.active_release_branch = lambda _repo_root: "v4.29.0"
-            harness_mod.run = lambda command, *, cwd: commands.append(command)
-
+            ),
+            ref_oid=lambda _repo_root, ref: "deadbeef" if ref == "feat/demo" else None,
+            is_ancestor=lambda _repo_root, ancestor, descendant: (ancestor, descendant) == ("v4.29.0", "feat/demo"),
+            preferred_main_ref=lambda _repo_root: "origin/v4.29.0",
+            active_release_branch=lambda _repo_root: "v4.29.0",
+            run=lambda command, *, cwd: commands.append(command),
+        ):
             self.assertEqual(harness_mod.command_land_main(args), 0)
-        finally:
-            for name, value in originals.items():
-                setattr(harness_mod, name, value)
 
         self.assertEqual(commands, [["git", "merge", "--ff-only", "feat/demo"], ["git", "push", "origin", "v4.29.0"]])
 
@@ -718,45 +626,31 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             branch="feat/demo",
             root_checkout=False,
         )
-        originals = {
-            "detect_harness_layout": harness_mod.detect_harness_layout,
-            "current_branch_name": harness_mod.current_branch_name,
-            "worktree_is_clean": harness_mod.worktree_is_clean,
-            "main_sync_status": harness_mod.main_sync_status,
-            "ref_oid": harness_mod.ref_oid,
-            "is_ancestor": harness_mod.is_ancestor,
-            "preferred_main_ref": harness_mod.preferred_main_ref,
-            "active_release_branch": harness_mod.active_release_branch,
-            "run": harness_mod.run,
-            "branch_worktrees": harness_mod.branch_worktrees,
-            "local_branch_ref": harness_mod.local_branch_ref,
-            "origin_branch_exists": harness_mod.origin_branch_exists,
-        }
         commands: list[list[str]] = []
-        try:
-            harness_mod.detect_harness_layout = lambda _start=None: layout
-            harness_mod.current_branch_name = lambda _repo_root: "v4.29.0"
-            harness_mod.worktree_is_clean = lambda _path: True
-            harness_mod.main_sync_status = lambda _repo_root: harness_mod.RefSyncStatus(
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            current_branch_name=lambda _repo_root: "v4.29.0",
+            worktree_is_clean=lambda _path: True,
+            main_sync_status=lambda _repo_root: harness_mod.RefSyncStatus(
                 local_ref="v4.29.0",
                 upstream_ref="origin/v4.29.0",
                 local_oid="abc",
                 upstream_oid="abc",
                 relationship="in_sync",
-            )
-            harness_mod.ref_oid = lambda _repo_root, ref: "deadbeef" if ref in {"feat/demo", "refs/heads/feat/demo", "refs/remotes/origin/feat/demo"} else None
-            harness_mod.is_ancestor = lambda _repo_root, ancestor, descendant: (ancestor, descendant) == ("v4.29.0", "feat/demo")
-            harness_mod.preferred_main_ref = lambda _repo_root: "origin/v4.29.0"
-            harness_mod.active_release_branch = lambda _repo_root: "v4.29.0"
-            harness_mod.run = lambda command, *, cwd: commands.append(command)
-            harness_mod.branch_worktrees = lambda _repo_root, branch: [demo_worktree] if branch == "feat/demo" else []
-            harness_mod.local_branch_ref = lambda _repo_root, branch: branch if branch == "feat/demo" else None
-            harness_mod.origin_branch_exists = lambda _repo_root, branch: branch == "feat/demo"
-
+            ),
+            ref_oid=lambda _repo_root, ref: (
+                "deadbeef" if ref in {"feat/demo", "refs/heads/feat/demo", "refs/remotes/origin/feat/demo"} else None
+            ),
+            is_ancestor=lambda _repo_root, ancestor, descendant: (ancestor, descendant) == ("v4.29.0", "feat/demo"),
+            preferred_main_ref=lambda _repo_root: "origin/v4.29.0",
+            active_release_branch=lambda _repo_root: "v4.29.0",
+            run=lambda command, *, cwd: commands.append(command),
+            branch_worktrees=lambda _repo_root, branch: [demo_worktree] if branch == "feat/demo" else [],
+            local_branch_ref=lambda _repo_root, branch: branch if branch == "feat/demo" else None,
+            origin_branch_exists=lambda _repo_root, branch: branch == "feat/demo",
+        ):
             self.assertEqual(harness_mod.command_land_main(args), 0)
-        finally:
-            for name, value in originals.items():
-                setattr(harness_mod, name, value)
 
         self.assertEqual(
             commands,
@@ -791,27 +685,21 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             allow_local_build=False,
         )
         layout = SimpleNamespace(package_root=Path("/tmp/package"), repo_root=Path("/tmp/package"), in_linked_worktree=False)
-        originals = {
-            "detect_harness_layout": reference_harness_mod.detect_harness_layout,
-            "require_safe_root_main": reference_harness_mod.require_safe_root_main,
-        }
         seen: dict[str, object] = {}
-        try:
-            reference_harness_mod.detect_harness_layout = lambda _start=None: layout
 
-            def fake_require(_layout, *, allow_unsafe, command_name):
-                seen["layout"] = _layout
-                seen["allow_unsafe"] = allow_unsafe
-                seen["command_name"] = command_name
-                raise SystemExit("blocked")
+        def fake_require(_layout, *, allow_unsafe, command_name):
+            seen["layout"] = _layout
+            seen["allow_unsafe"] = allow_unsafe
+            seen["command_name"] = command_name
+            raise SystemExit("blocked")
 
-            reference_harness_mod.require_safe_root_main = fake_require
-
+        with patched_attrs(
+            reference_harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            require_safe_root_main=fake_require,
+        ):
             with self.assertRaisesRegex(SystemExit, "blocked"):
                 reference_harness_mod.command_generate(args)
-        finally:
-            for name, value in originals.items():
-                setattr(reference_harness_mod, name, value)
 
         self.assertEqual(seen["layout"], layout)
         self.assertFalse(seen["allow_unsafe"])
@@ -829,67 +717,49 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             allow_local_build=False,
         )
         layout = SimpleNamespace(package_root=Path("/tmp/package"), repo_root=Path("/tmp/package"), in_linked_worktree=False)
-        originals = {
-            "detect_harness_layout": reference_harness_mod.detect_harness_layout,
-            "require_safe_root_main": reference_harness_mod.require_safe_root_main,
-            "resolve_output_root": reference_harness_mod.resolve_output_root,
-            "resolve_manifest_path": reference_harness_mod.resolve_manifest_path,
-            "load_project_catalog": reference_harness_mod.load_project_catalog,
-            "select_release_projects": reference_harness_mod.select_release_projects,
-            "active_release_branch": reference_harness_mod.active_release_branch,
-        }
-        try:
-            reference_harness_mod.detect_harness_layout = lambda _start=None: layout
-            reference_harness_mod.require_safe_root_main = lambda _layout, *, allow_unsafe, command_name: None
-            reference_harness_mod.resolve_output_root = lambda _path_text, _start=None: Path("/tmp/out")
-            reference_harness_mod.resolve_manifest_path = lambda _path_text, _package_root: Path("/tmp/projects.json")
-            reference_harness_mod.load_project_catalog = lambda _manifest_path: SimpleNamespace(projects=(), release_targets=())
-            reference_harness_mod.select_release_projects = lambda _catalog, *, release, project_ids, package_root: ("v4.28.0", [])
-            reference_harness_mod.active_release_branch = lambda _package_root: "v4.29.0"
-
+        with patched_attrs(
+            reference_harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            require_safe_root_main=lambda _layout, *, allow_unsafe, command_name: None,
+            resolve_output_root=lambda _path_text, _start=None: Path("/tmp/out"),
+            resolve_manifest_path=lambda _path_text, _package_root: Path("/tmp/projects.json"),
+            load_project_catalog=lambda _manifest_path: SimpleNamespace(projects=(), release_targets=()),
+            select_release_projects=lambda _catalog, *, release, project_ids, package_root: ("v4.28.0", []),
+            active_release_branch=lambda _package_root: "v4.29.0",
+        ):
             with self.assertRaisesRegex(SystemExit, "Create or switch to a `v4.28.0` checkout first"):
                 reference_harness_mod.command_generate(args)
-        finally:
-            for name, value in originals.items():
-                setattr(reference_harness_mod, name, value)
 
     def test_bump_toolchain_uses_helper(self) -> None:
         args = argparse.Namespace(toolchain="4.29.0", verso_ref=None, skip_validation=False)
         layout = SimpleNamespace(package_root=Path("/tmp/package"))
-        originals = {
-            "detect_harness_layout": harness_mod.detect_harness_layout,
-            "bump_toolchain_checkout": harness_mod.bump_toolchain_checkout,
-            "require_checkout_role": harness_mod.require_checkout_role,
-        }
         seen: dict[str, object] = {}
-        try:
-            harness_mod.detect_harness_layout = lambda _start=None: layout
-            harness_mod.require_checkout_role = lambda checkout_root, *, required_role, operation: seen.update(
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            require_checkout_role=lambda checkout_root, *, required_role, operation: seen.update(
                 {
                     "role_checkout_root": checkout_root,
                     "required_role": required_role,
                     "operation": operation,
                 }
+            ),
+            bump_toolchain_checkout=lambda package_root, toolchain, *, verso_ref, validate: seen.update(
+                {
+                    "package_root": package_root,
+                    "toolchain": toolchain,
+                    "verso_ref": verso_ref,
+                    "validate": validate,
+                }
             )
-
-            def fake_bump(package_root, toolchain, *, verso_ref, validate):
-                seen["package_root"] = package_root
-                seen["toolchain"] = toolchain
-                seen["verso_ref"] = verso_ref
-                seen["validate"] = validate
-                return SimpleNamespace(
-                    lean_ref="v4.29.0",
-                    toolchain_spec="leanprover/lean4:v4.29.0",
-                    verso_ref="v4.29.0",
-                    verso_tag_oid="deadbeef",
-                )
-
-            harness_mod.bump_toolchain_checkout = fake_bump
-
+            or SimpleNamespace(
+                lean_ref="v4.29.0",
+                toolchain_spec="leanprover/lean4:v4.29.0",
+                verso_ref="v4.29.0",
+                verso_tag_oid="deadbeef",
+            ),
+        ):
             self.assertEqual(harness_mod.command_bump_toolchain(args), 0)
-        finally:
-            for name, value in originals.items():
-                setattr(harness_mod, name, value)
 
         self.assertEqual(seen["package_root"], layout.package_root)
         self.assertEqual(seen["role_checkout_root"], layout.package_root)
@@ -956,37 +826,25 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             release_targets=(release,),
             projects=(selected_project, old_project),
         )
-        originals = {
-            "detect_harness_layout": harness_mod.detect_harness_layout,
-            "resolve_manifest_path": harness_mod.resolve_manifest_path,
-            "load_project_catalog_manifest": harness_mod.load_project_catalog_manifest,
-            "resolve_release_target": harness_mod.resolve_release_target,
-            "resolve_projects_for_release": harness_mod.resolve_projects_for_release,
-            "active_release_branch": harness_mod.active_release_branch,
-            "preferred_main_ref": harness_mod.preferred_main_ref,
-            "canonical_test_blueprint_site_dir": harness_mod.canonical_test_blueprint_site_dir,
-            "canonical_reference_project_site_dir": harness_mod.canonical_reference_project_site_dir,
-        }
-        try:
-            harness_mod.detect_harness_layout = lambda _start=None: layout
-            harness_mod.resolve_manifest_path = lambda _path_text, _package_root: Path("/tmp/projects.json")
-            harness_mod.load_project_catalog_manifest = lambda _manifest_path: catalog
-            harness_mod.resolve_release_target = lambda _catalog, _release, _package_root: release
-            harness_mod.resolve_projects_for_release = lambda _catalog, _release, _selected_ids: [selected_project]
-            harness_mod.active_release_branch = lambda _repo_root: "v4.29.0"
-            harness_mod.preferred_main_ref = lambda _repo_root: "origin/v4.29.0"
-            harness_mod.canonical_test_blueprint_site_dir = (
+        buffer = io.StringIO()
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            resolve_manifest_path=lambda _path_text, _package_root: Path("/tmp/projects.json"),
+            load_project_catalog_manifest=lambda _manifest_path: catalog,
+            resolve_release_target=lambda _catalog, _release, _package_root: release,
+            resolve_projects_for_release=lambda _catalog, _release, _selected_ids: [selected_project],
+            active_release_branch=lambda _repo_root: "v4.29.0",
+            preferred_main_ref=lambda _repo_root: "origin/v4.29.0",
+            canonical_test_blueprint_site_dir=(
                 lambda _name, _start=None: Path("/tmp/package/_out/test-blueprints/preview_runtime_showcase/html-multi")
-            )
-            harness_mod.canonical_reference_project_site_dir = (
+            ),
+            canonical_reference_project_site_dir=(
                 lambda project_id, _start=None: Path(f"/tmp/package/_out/reference-blueprints/{project_id}/html-multi")
-            )
-            buffer = io.StringIO()
+            ),
+        ):
             with redirect_stdout(buffer):
                 self.assertEqual(harness_mod.command_paths(args), 0)
-        finally:
-            for name, value in originals.items():
-                setattr(harness_mod, name, value)
 
         output = buffer.getvalue()
         self.assertIn("selected_release_target=v4.29.0", output)
@@ -1002,26 +860,18 @@ class BlueprintHarnessCliTests(unittest.TestCase):
     def test_require_branch_role_returns_nonzero_on_mismatch(self) -> None:
         args = argparse.Namespace(role="default_dev")
         layout = SimpleNamespace(repo_root=Path("/tmp/repo"), package_root=Path("/tmp/worktree"))
-        originals = {
-            "detect_harness_layout": harness_mod.detect_harness_layout,
-            "print_branch_policy_status": harness_mod.print_branch_policy_status,
-            "checkout_branch_role": harness_mod.checkout_branch_role,
-            "active_release_branch": harness_mod.active_release_branch,
-            "default_dev_branch": harness_mod.default_dev_branch,
-        }
         out = io.StringIO()
         err = io.StringIO()
-        try:
-            harness_mod.detect_harness_layout = lambda _start=None: layout
-            harness_mod.print_branch_policy_status = lambda _layout: None
-            harness_mod.checkout_branch_role = lambda _checkout_root: "backport"
-            harness_mod.active_release_branch = lambda _checkout_root: "v4.28.0"
-            harness_mod.default_dev_branch = lambda _checkout_root: "v4.29.0"
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            print_branch_policy_status=lambda _layout: None,
+            checkout_branch_role=lambda _checkout_root: "backport",
+            active_release_branch=lambda _checkout_root: "v4.28.0",
+            default_dev_branch=lambda _checkout_root: "v4.29.0",
+        ):
             with redirect_stdout(out), redirect_stderr(err):
                 self.assertEqual(harness_mod.command_require_branch_role(args), 1)
-        finally:
-            for name, value in originals.items():
-                setattr(harness_mod, name, value)
 
         self.assertEqual(out.getvalue(), "")
         self.assertIn("checkout `v4.28.0` is backport-only", err.getvalue())
@@ -1044,31 +894,23 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         )
         args = argparse.Namespace(manifest=None, project="noperthedron", branch="wip/noperthedron", base="origin/main")
         layout = SimpleNamespace(package_root=Path("/tmp/package"), reference_project_edit_root=Path("/tmp/edit"))
-        originals = {
-            "detect_harness_layout": reference_harness_mod.detect_harness_layout,
-            "resolve_manifest_path": reference_harness_mod.resolve_manifest_path,
-            "load_project_catalog": reference_harness_mod.load_project_catalog,
-            "prepare_reference_edit_checkout": reference_harness_mod.prepare_reference_edit_checkout,
-        }
         seen: dict[str, object] = {}
-        try:
-            reference_harness_mod.detect_harness_layout = lambda _start=None: layout
-            reference_harness_mod.resolve_manifest_path = lambda _path_text, _package_root: Path("/tmp/projects.json")
-            reference_harness_mod.load_project_catalog = lambda _manifest_path: SimpleNamespace(projects=(project,))
 
-            def fake_prepare(_layout, _project, *, branch, base_ref):
-                seen["layout"] = _layout
-                seen["project"] = _project
-                seen["branch"] = branch
-                seen["base_ref"] = base_ref
-                return Path("/tmp/edit/noperthedron"), branch or "wip/noperthedron", base_ref or "origin/main"
+        def fake_prepare(_layout, _project, *, branch, base_ref):
+            seen["layout"] = _layout
+            seen["project"] = _project
+            seen["branch"] = branch
+            seen["base_ref"] = base_ref
+            return Path("/tmp/edit/noperthedron"), branch or "wip/noperthedron", base_ref or "origin/main"
 
-            reference_harness_mod.prepare_reference_edit_checkout = fake_prepare
-
+        with patched_attrs(
+            reference_harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            resolve_manifest_path=lambda _path_text, _package_root: Path("/tmp/projects.json"),
+            load_project_catalog=lambda _manifest_path: SimpleNamespace(projects=(project,)),
+            prepare_reference_edit_checkout=fake_prepare,
+        ):
             self.assertEqual(reference_harness_mod.command_reference_edit(args), 0)
-        finally:
-            for name, value in originals.items():
-                setattr(reference_harness_mod, name, value)
 
         self.assertEqual(seen["layout"], layout)
         self.assertEqual(seen["project"], project)
@@ -1104,61 +946,53 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             commit_message=None,
         )
         layout = SimpleNamespace(package_root=Path("/tmp/package"), artifact_root=Path("/tmp/out"))
-        originals = {
-            "detect_harness_layout": reference_harness_mod.detect_harness_layout,
-            "resolve_manifest_path": reference_harness_mod.resolve_manifest_path,
-            "load_project_catalog": reference_harness_mod.load_project_catalog,
-            "bump_reference_project": reference_harness_mod.bump_reference_project,
-        }
         seen: dict[str, object] = {}
-        try:
-            reference_harness_mod.detect_harness_layout = lambda _start=None: layout
-            reference_harness_mod.resolve_manifest_path = lambda _path_text, _package_root: Path("/tmp/projects.json")
-            reference_harness_mod.load_project_catalog = lambda _manifest_path: SimpleNamespace(projects=(project,))
-            seen["selected_values"] = ["noperthedron"]
 
-            def fake_bump(
-                _layout,
-                _project,
-                *,
-                ref,
-                branch,
-                base_ref,
-                build_project,
-                generate_site,
-                output_root,
-                commit,
-                push,
-                commit_message,
-            ):
-                seen["layout"] = _layout
-                seen["project"] = _project
-                seen["ref"] = ref
-                seen["branch"] = branch
-                seen["base_ref"] = base_ref
-                seen["build_project"] = build_project
-                seen["generate_site"] = generate_site
-                seen["output_root"] = output_root
-                seen["commit"] = commit
-                seen["push"] = push
-                seen["commit_message"] = commit_message
-                return SimpleNamespace(
-                    edit_dir=Path("/tmp/edit/noperthedron"),
-                    branch=branch,
-                    base_ref=base_ref,
-                    previous_ref="old-ref",
-                    changed=True,
-                    committed=False,
-                    pushed=False,
-                    output_dir=output_root / "noperthedron",
-                )
+        def fake_bump(
+            _layout,
+            _project,
+            *,
+            ref,
+            branch,
+            base_ref,
+            build_project,
+            generate_site,
+            output_root,
+            commit,
+            push,
+            commit_message,
+        ):
+            seen["layout"] = _layout
+            seen["project"] = _project
+            seen["ref"] = ref
+            seen["branch"] = branch
+            seen["base_ref"] = base_ref
+            seen["build_project"] = build_project
+            seen["generate_site"] = generate_site
+            seen["output_root"] = output_root
+            seen["commit"] = commit
+            seen["push"] = push
+            seen["commit_message"] = commit_message
+            return SimpleNamespace(
+                edit_dir=Path("/tmp/edit/noperthedron"),
+                branch=branch,
+                base_ref=base_ref,
+                previous_ref="old-ref",
+                changed=True,
+                committed=False,
+                pushed=False,
+                output_dir=output_root / "noperthedron",
+            )
 
-            reference_harness_mod.bump_reference_project = fake_bump
-
+        seen["selected_values"] = ["noperthedron"]
+        with patched_attrs(
+            reference_harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            resolve_manifest_path=lambda _path_text, _package_root: Path("/tmp/projects.json"),
+            load_project_catalog=lambda _manifest_path: SimpleNamespace(projects=(project,)),
+            bump_reference_project=fake_bump,
+        ):
             self.assertEqual(reference_harness_mod.command_reference_bump_blueprint(args), 0)
-        finally:
-            for name, value in originals.items():
-                setattr(reference_harness_mod, name, value)
 
         self.assertEqual(seen["layout"], layout)
         self.assertEqual(seen["project"], project)
@@ -1188,24 +1022,11 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             branch=None,
             root_checkout=False,
         )
-        originals = {
-            "detect_harness_layout": harness_mod.detect_harness_layout,
-            "worktree_record_map": harness_mod.worktree_record_map,
-            "git_worktree_map": harness_mod.git_worktree_map,
-            "preferred_worktree_base_ref": harness_mod.preferred_worktree_base_ref,
-            "ref_merged_into_worktree_base": harness_mod.ref_merged_into_worktree_base,
-            "worktree_is_clean": harness_mod.worktree_is_clean,
-            "local_release_ref": harness_mod.local_release_ref,
-            "run": harness_mod.run,
-            "resolve_manifest_path": harness_mod.resolve_manifest_path,
-            "load_project_catalog": harness_mod.load_project_catalog,
-            "git_worktrees": harness_mod.git_worktrees,
-            "reference_prune_plan": harness_mod.reference_prune_plan,
-        }
         commands: list[list[str]] = []
-        try:
-            harness_mod.detect_harness_layout = lambda _start=None: layout
-            harness_mod.worktree_record_map = lambda _repo_root: (
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            worktree_record_map=lambda _repo_root: (
                 {
                     "reference-edit": SimpleNamespace(
                         name="reference-edit",
@@ -1213,22 +1034,19 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                     )
                 },
                 Path("/tmp/repo/.worktrees/registry.json"),
-            )
-            harness_mod.git_worktree_map = lambda _repo_root: {"reference-edit": detached}
-            harness_mod.preferred_worktree_base_ref = lambda _path: "origin/v4.29.0"
-            harness_mod.ref_merged_into_worktree_base = lambda _repo_root, ref, _path: ref == "abc123"
-            harness_mod.worktree_is_clean = lambda _path: True
-            harness_mod.local_release_ref = lambda _repo_root: "v4.29.0"
-            harness_mod.run = lambda command, *, cwd: commands.append(command)
-            harness_mod.resolve_manifest_path = lambda _path_text, _package_root: Path("/tmp/projects.json")
-            harness_mod.load_project_catalog = lambda _manifest_path: []
-            harness_mod.git_worktrees = lambda _repo_root: []
-            harness_mod.reference_prune_plan = lambda *_args, **_kwargs: []
-
+            ),
+            git_worktree_map=lambda _repo_root: {"reference-edit": detached},
+            preferred_worktree_base_ref=lambda _path: "origin/v4.29.0",
+            ref_merged_into_worktree_base=lambda _repo_root, ref, _path: ref == "abc123",
+            worktree_is_clean=lambda _path: True,
+            local_release_ref=lambda _repo_root: "v4.29.0",
+            run=lambda command, *, cwd: commands.append(command),
+            resolve_manifest_path=lambda _path_text, _package_root: Path("/tmp/projects.json"),
+            load_project_catalog=lambda _manifest_path: [],
+            git_worktrees=lambda _repo_root: [],
+            reference_prune_plan=lambda *_args, **_kwargs: [],
+        ):
             self.assertEqual(harness_mod.command_worktree_retire(args), 0)
-        finally:
-            for name, value in originals.items():
-                setattr(harness_mod, name, value)
 
         self.assertEqual(commands, [["git", "worktree", "remove", str(detached.path)]])
 
@@ -1248,24 +1066,11 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             branch="fix/backport-demo",
             root_checkout=False,
         )
-        originals = {
-            "detect_harness_layout": harness_mod.detect_harness_layout,
-            "worktree_record_map": harness_mod.worktree_record_map,
-            "git_worktree_map": harness_mod.git_worktree_map,
-            "preferred_worktree_base_ref": harness_mod.preferred_worktree_base_ref,
-            "ref_merged_into_worktree_base": harness_mod.ref_merged_into_worktree_base,
-            "worktree_is_clean": harness_mod.worktree_is_clean,
-            "local_release_ref": harness_mod.local_release_ref,
-            "run": harness_mod.run,
-            "resolve_manifest_path": harness_mod.resolve_manifest_path,
-            "load_project_catalog": harness_mod.load_project_catalog,
-            "git_worktrees": harness_mod.git_worktrees,
-            "reference_prune_plan": harness_mod.reference_prune_plan,
-        }
         commands: list[list[str]] = []
-        try:
-            harness_mod.detect_harness_layout = lambda _start=None: layout
-            harness_mod.worktree_record_map = lambda _repo_root: (
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            worktree_record_map=lambda _repo_root: (
                 {
                     "backport-demo": SimpleNamespace(
                         name="backport-demo",
@@ -1273,22 +1078,19 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                     )
                 },
                 Path("/tmp/repo/.worktrees/registry.json"),
-            )
-            harness_mod.git_worktree_map = lambda _repo_root: {"backport-demo": backport}
-            harness_mod.preferred_worktree_base_ref = lambda _path: "origin/v4.28.0"
-            harness_mod.ref_merged_into_worktree_base = lambda _repo_root, ref, _path: ref == "fix/backport-demo"
-            harness_mod.worktree_is_clean = lambda _path: True
-            harness_mod.local_release_ref = lambda _repo_root: "v4.29.0"
-            harness_mod.run = lambda command, *, cwd: commands.append(command)
-            harness_mod.resolve_manifest_path = lambda _path_text, _package_root: Path("/tmp/projects.json")
-            harness_mod.load_project_catalog = lambda _manifest_path: []
-            harness_mod.git_worktrees = lambda _repo_root: []
-            harness_mod.reference_prune_plan = lambda *_args, **_kwargs: []
-
+            ),
+            git_worktree_map=lambda _repo_root: {"backport-demo": backport},
+            preferred_worktree_base_ref=lambda _path: "origin/v4.28.0",
+            ref_merged_into_worktree_base=lambda _repo_root, ref, _path: ref == "fix/backport-demo",
+            worktree_is_clean=lambda _path: True,
+            local_release_ref=lambda _repo_root: "v4.29.0",
+            run=lambda command, *, cwd: commands.append(command),
+            resolve_manifest_path=lambda _path_text, _package_root: Path("/tmp/projects.json"),
+            load_project_catalog=lambda _manifest_path: [],
+            git_worktrees=lambda _repo_root: [],
+            reference_prune_plan=lambda *_args, **_kwargs: [],
+        ):
             self.assertEqual(harness_mod.command_worktree_retire(args), 0)
-        finally:
-            for name, value in originals.items():
-                setattr(harness_mod, name, value)
 
         self.assertEqual(
             commands,
@@ -1305,16 +1107,11 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             package_root=Path("/tmp/package"),
             worktree_name=None,
         )
-        originals = {
-            "detect_harness_layout": harness_mod.detect_harness_layout,
-            "worktree_record_map": harness_mod.worktree_record_map,
-            "git_worktree_map": harness_mod.git_worktree_map,
-            "local_release_ref": harness_mod.local_release_ref,
-        }
-        try:
-            harness_mod.detect_harness_layout = lambda _start=None: layout
-            harness_mod.local_release_ref = lambda _repo_root: "v4.29.0"
-            harness_mod.worktree_record_map = lambda _repo_root: (
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            local_release_ref=lambda _repo_root: "v4.29.0",
+            worktree_record_map=lambda _repo_root: (
                 {
                     "demo": SimpleNamespace(
                         name="demo",
@@ -1322,8 +1119,8 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                     )
                 },
                 Path("/tmp/repo/.worktrees/registry.json"),
-            )
-            harness_mod.git_worktree_map = lambda _repo_root: {
+            ),
+            git_worktree_map=lambda _repo_root: {
                 "demo": GitWorktree(
                     name="demo",
                     path=Path("/tmp/repo/.worktrees/demo"),
@@ -1331,13 +1128,10 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                     branch="feat/demo",
                     root_checkout=False,
                 )
-            }
-
+            },
+        ):
             with self.assertRaisesRegex(SystemExit, "is locked; unlock it before retiring"):
                 harness_mod.command_worktree_retire(args)
-        finally:
-            for name, value in originals.items():
-                setattr(harness_mod, name, value)
 
     def test_generate_projects_does_not_auto_sync_root_lake(self) -> None:
         project = HarnessProject(
@@ -1357,12 +1151,11 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         )
         layout = SimpleNamespace(package_root=Path("/tmp/package"), in_linked_worktree=True)
 
-        original_ensure = reference_harness_mod.ensure_prebuilt_executable
-        original_render = reference_harness_mod.render_in_repo_projects
-        try:
-            reference_harness_mod.ensure_prebuilt_executable = lambda _package_root, _exe_name: Path("/tmp/demo")
-            reference_harness_mod.render_in_repo_projects = lambda _package_root, _output_root, _projects, _serial: None
-
+        with patched_attrs(
+            reference_harness_mod,
+            ensure_prebuilt_executable=lambda _package_root, _exe_name: Path("/tmp/demo"),
+            render_in_repo_projects=lambda _package_root, _output_root, _projects, _serial: None,
+        ):
             generate_projects(
                 layout,
                 Path("/tmp/out"),
@@ -1371,9 +1164,6 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 serial=False,
                 allow_local_build=False,
             )
-        finally:
-            reference_harness_mod.ensure_prebuilt_executable = original_ensure
-            reference_harness_mod.render_in_repo_projects = original_render
 
     def test_validate_run_lean_tests_does_not_auto_sync_root_lake(self) -> None:
         args = argparse.Namespace(
@@ -1391,34 +1181,20 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             stop_on_first_failure=False,
         )
         layout = SimpleNamespace(package_root=Path("/tmp/package"), in_linked_worktree=True)
-        originals = {
-            "detect_harness_layout": reference_harness_mod.detect_harness_layout,
-            "resolve_output_root": reference_harness_mod.resolve_output_root,
-            "resolve_manifest_path": reference_harness_mod.resolve_manifest_path,
-            "load_project_catalog": reference_harness_mod.load_project_catalog,
-            "select_release_projects": reference_harness_mod.select_release_projects,
-            "require_checkout_release": reference_harness_mod.require_checkout_release,
-            "should_use_local_build": reference_harness_mod.should_use_local_build,
-            "find_prebuilt_lean_test_artifact": reference_harness_mod.find_prebuilt_lean_test_artifact,
-            "run_capturing_failure": reference_harness_mod.run_capturing_failure,
-            "generate_projects": reference_harness_mod.generate_projects,
-        }
-        try:
-            reference_harness_mod.detect_harness_layout = lambda _start=None: layout
-            reference_harness_mod.resolve_output_root = lambda _path_text, _start=None: Path("/tmp/out")
-            reference_harness_mod.resolve_manifest_path = lambda _path_text, _package_root: Path("/tmp/projects.json")
-            reference_harness_mod.load_project_catalog = lambda _manifest_path: SimpleNamespace(projects=(), release_targets=())
-            reference_harness_mod.select_release_projects = lambda _catalog, *, release, project_ids, package_root: ("v4.29.0", [])
-            reference_harness_mod.require_checkout_release = lambda _layout, release_id, *, command_name: None
-            reference_harness_mod.should_use_local_build = lambda _layout, _allow_local_build: False
-            reference_harness_mod.find_prebuilt_lean_test_artifact = lambda _package_root: Path("/tmp/VersoBlueprintTests.olean")
-            reference_harness_mod.run_capturing_failure = lambda _step, _command, cwd: None
-            reference_harness_mod.generate_projects = lambda *_args, **_kwargs: None
-
+        with patched_attrs(
+            reference_harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            resolve_output_root=lambda _path_text, _start=None: Path("/tmp/out"),
+            resolve_manifest_path=lambda _path_text, _package_root: Path("/tmp/projects.json"),
+            load_project_catalog=lambda _manifest_path: SimpleNamespace(projects=(), release_targets=()),
+            select_release_projects=lambda _catalog, *, release, project_ids, package_root: ("v4.29.0", []),
+            require_checkout_release=lambda _layout, release_id, *, command_name: None,
+            should_use_local_build=lambda _layout, _allow_local_build: False,
+            find_prebuilt_lean_test_artifact=lambda _package_root: Path("/tmp/VersoBlueprintTests.olean"),
+            run_capturing_failure=lambda _step, _command, cwd: None,
+            generate_projects=lambda *_args, **_kwargs: None,
+        ):
             self.assertEqual(reference_harness_mod.command_validate(args), 0)
-        finally:
-            for name, value in originals.items():
-                setattr(reference_harness_mod, name, value)
 
     def test_reference_validate_rejects_unsafe_root_main_without_override(self) -> None:
         args = argparse.Namespace(
@@ -1436,27 +1212,21 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             stop_on_first_failure=False,
         )
         layout = SimpleNamespace(package_root=Path("/tmp/package"), repo_root=Path("/tmp/package"), in_linked_worktree=False)
-        originals = {
-            "detect_harness_layout": reference_harness_mod.detect_harness_layout,
-            "require_safe_root_main": reference_harness_mod.require_safe_root_main,
-        }
         seen: dict[str, object] = {}
-        try:
-            reference_harness_mod.detect_harness_layout = lambda _start=None: layout
 
-            def fake_require(_layout, *, allow_unsafe, command_name):
-                seen["layout"] = _layout
-                seen["allow_unsafe"] = allow_unsafe
-                seen["command_name"] = command_name
-                raise SystemExit("blocked")
+        def fake_require(_layout, *, allow_unsafe, command_name):
+            seen["layout"] = _layout
+            seen["allow_unsafe"] = allow_unsafe
+            seen["command_name"] = command_name
+            raise SystemExit("blocked")
 
-            reference_harness_mod.require_safe_root_main = fake_require
-
+        with patched_attrs(
+            reference_harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            require_safe_root_main=fake_require,
+        ):
             with self.assertRaisesRegex(SystemExit, "blocked"):
                 reference_harness_mod.command_validate(args)
-        finally:
-            for name, value in originals.items():
-                setattr(reference_harness_mod, name, value)
 
         self.assertEqual(seen["layout"], layout)
         self.assertFalse(seen["allow_unsafe"])
@@ -1478,35 +1248,24 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             reference_project_cache_root=Path("/tmp/cache"),
             reference_project_checkout_root=Path("/tmp/checkouts"),
         )
-        originals = {
-            "detect_harness_layout": reference_harness_mod.detect_harness_layout,
-            "require_safe_root_main": reference_harness_mod.require_safe_root_main,
-            "resolve_manifest_path": reference_harness_mod.resolve_manifest_path,
-            "load_project_catalog": reference_harness_mod.load_project_catalog,
-            "select_release_projects": reference_harness_mod.select_release_projects,
-            "require_checkout_release": reference_harness_mod.require_checkout_release,
-            "sync_reference_blueprints": reference_harness_mod.sync_reference_blueprints,
-        }
         seen: dict[str, object] = {}
-        try:
-            reference_harness_mod.detect_harness_layout = lambda _start=None: layout
 
-            def fake_require(_layout, *, allow_unsafe, command_name):
-                seen["layout"] = _layout
-                seen["allow_unsafe"] = allow_unsafe
-                seen["command_name"] = command_name
+        def fake_require(_layout, *, allow_unsafe, command_name):
+            seen["layout"] = _layout
+            seen["allow_unsafe"] = allow_unsafe
+            seen["command_name"] = command_name
 
-            reference_harness_mod.require_safe_root_main = fake_require
-            reference_harness_mod.resolve_manifest_path = lambda _path_text, _package_root: Path("/tmp/projects.json")
-            reference_harness_mod.load_project_catalog = lambda _manifest_path: SimpleNamespace(projects=(), release_targets=())
-            reference_harness_mod.select_release_projects = lambda _catalog, *, release, project_ids, package_root: ("v4.29.0", [])
-            reference_harness_mod.require_checkout_release = lambda _layout, release_id, *, command_name: None
-            reference_harness_mod.sync_reference_blueprints = lambda *_args, **_kwargs: None
-
+        with patched_attrs(
+            reference_harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            require_safe_root_main=fake_require,
+            resolve_manifest_path=lambda _path_text, _package_root: Path("/tmp/projects.json"),
+            load_project_catalog=lambda _manifest_path: SimpleNamespace(projects=(), release_targets=()),
+            select_release_projects=lambda _catalog, *, release, project_ids, package_root: ("v4.29.0", []),
+            require_checkout_release=lambda _layout, release_id, *, command_name: None,
+            sync_reference_blueprints=lambda *_args, **_kwargs: None,
+        ):
             self.assertEqual(reference_harness_mod.command_reference_sync(args), 0)
-        finally:
-            for name, value in originals.items():
-                setattr(reference_harness_mod, name, value)
 
         self.assertEqual(seen["layout"], layout)
         self.assertTrue(seen["allow_unsafe"])
@@ -1546,36 +1305,26 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             blueprint_ahead=0,
             blueprint_behind=5,
         )
-        originals = {
-            "detect_harness_layout": reference_harness_mod.detect_harness_layout,
-            "resolve_manifest_path": reference_harness_mod.resolve_manifest_path,
-            "load_project_catalog": reference_harness_mod.load_project_catalog,
-            "select_release_projects": reference_harness_mod.select_release_projects,
-            "main_sync_status": reference_harness_mod.main_sync_status,
-            "collect_reference_project_status": reference_harness_mod.collect_reference_project_status,
-            "active_release_branch": reference_harness_mod.active_release_branch,
-        }
         out = io.StringIO()
-        try:
-            reference_harness_mod.detect_harness_layout = lambda _start=None: layout
-            reference_harness_mod.resolve_manifest_path = lambda _path_text, _package_root: Path("/tmp/projects.json")
-            reference_harness_mod.load_project_catalog = lambda _manifest_path: SimpleNamespace(projects=(project,), release_targets=())
-            reference_harness_mod.select_release_projects = lambda _catalog, *, release, project_ids, package_root: ("v4.29.0", [project])
-            reference_harness_mod.main_sync_status = lambda _repo_root: harness_mod.RefSyncStatus(
+        with patched_attrs(
+            reference_harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            resolve_manifest_path=lambda _path_text, _package_root: Path("/tmp/projects.json"),
+            load_project_catalog=lambda _manifest_path: SimpleNamespace(projects=(project,), release_targets=()),
+            select_release_projects=lambda _catalog, *, release, project_ids, package_root: ("v4.29.0", [project]),
+            require_checkout_release=lambda _layout, _release_id, *, command_name: None,
+            main_sync_status=lambda _repo_root: harness_mod.RefSyncStatus(
                 local_ref="v4.29.0",
                 upstream_ref="origin/v4.29.0",
                 local_oid="111",
                 upstream_oid="111",
                 relationship="in_sync",
-            )
-            reference_harness_mod.active_release_branch = lambda _repo_root: "v4.29.0"
-            reference_harness_mod.collect_reference_project_status = lambda _layout, _project: status
-
+            ),
+            active_release_branch=lambda _repo_root: "v4.29.0",
+            collect_reference_project_status=lambda _layout, _project: status,
+        ):
             with redirect_stdout(out):
                 self.assertEqual(reference_harness_mod.command_status(args), 0)
-        finally:
-            for name, value in originals.items():
-                setattr(reference_harness_mod, name, value)
 
         output = out.getvalue()
         self.assertIn("project_manifest=/tmp/projects.json", output)
@@ -1650,53 +1399,45 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         )
         args = argparse.Namespace(manifest=None, project=None, release=None, outdated_only=True)
         layout = SimpleNamespace(package_root=Path("/tmp/package"), repo_root=Path("/tmp/repo"))
-        originals = {
-            "detect_harness_layout": reference_harness_mod.detect_harness_layout,
-            "resolve_manifest_path": reference_harness_mod.resolve_manifest_path,
-            "load_project_catalog": reference_harness_mod.load_project_catalog,
-            "collect_reference_project_status": reference_harness_mod.collect_reference_project_status,
-        }
         out = io.StringIO()
-        try:
-            reference_harness_mod.detect_harness_layout = lambda _start=None: layout
-            reference_harness_mod.resolve_manifest_path = lambda _path_text, _package_root: Path("/tmp/projects.json")
-            reference_harness_mod.load_project_catalog = lambda _manifest_path: catalog
 
-            def fake_collect(_layout, project, *, blueprint_base_ref=None):
-                if project.project_id == "noperthedron":
-                    return reference_harness_mod.ReferenceProjectStatus(
-                        project=project,
-                        catalog_ref="deadbeef",
-                        project_upstream_ref="origin/main",
-                        project_relationship="behind",
-                        project_ahead=0,
-                        project_behind=3,
-                        blueprint_pin=None,
-                        blueprint_relationship=None,
-                        blueprint_ahead=None,
-                        blueprint_behind=None,
-                    )
+        def fake_collect(_layout, project, *, blueprint_base_ref=None):
+            if project.project_id == "noperthedron":
                 return reference_harness_mod.ReferenceProjectStatus(
                     project=project,
-                    catalog_ref=project.ref,
-                    project_upstream_ref="origin/main" if project.git_checkout else None,
-                    project_relationship="in_sync" if project.git_checkout else None,
-                    project_ahead=0 if project.git_checkout else None,
-                    project_behind=0 if project.git_checkout else None,
+                    catalog_ref="deadbeef",
+                    project_upstream_ref="origin/main",
+                    project_relationship="behind",
+                    project_ahead=0,
+                    project_behind=3,
                     blueprint_pin=None,
                     blueprint_relationship=None,
                     blueprint_ahead=None,
                     blueprint_behind=None,
-                    skipped="in_repo_project" if project.in_repo_project else None,
                 )
+            return reference_harness_mod.ReferenceProjectStatus(
+                project=project,
+                catalog_ref=project.ref,
+                project_upstream_ref="origin/main" if project.git_checkout else None,
+                project_relationship="in_sync" if project.git_checkout else None,
+                project_ahead=0 if project.git_checkout else None,
+                project_behind=0 if project.git_checkout else None,
+                blueprint_pin=None,
+                blueprint_relationship=None,
+                blueprint_ahead=None,
+                blueprint_behind=None,
+                skipped="in_repo_project" if project.in_repo_project else None,
+            )
 
-            reference_harness_mod.collect_reference_project_status = fake_collect
-
+        with patched_attrs(
+            reference_harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            resolve_manifest_path=lambda _path_text, _package_root: Path("/tmp/projects.json"),
+            load_project_catalog=lambda _manifest_path: catalog,
+            collect_reference_project_status=fake_collect,
+        ):
             with redirect_stdout(out):
                 self.assertEqual(reference_harness_mod.command_release_status(args), 0)
-        finally:
-            for name, value in originals.items():
-                setattr(reference_harness_mod, name, value)
 
         output = out.getvalue()
         self.assertIn("project_manifest=/tmp/projects.json", output)
@@ -1705,7 +1446,6 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertIn("downstream_pin_drift=0", output)
         self.assertIn("project=noperthedron", output)
         self.assertNotIn("project=spherepackingblueprint", output)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/harness/test_blueprint_harness_manifest.py
+++ b/tests/harness/test_blueprint_harness_manifest.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+
+from scripts.blueprint_harness_manifest import load_json_object
+
+
+class BlueprintHarnessManifestTests(unittest.TestCase):
+    def test_load_json_object_accepts_top_level_object(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = Path(tmp) / "manifest.json"
+            manifest.write_text('{"version": 1}\n', encoding="utf-8")
+
+            self.assertEqual(load_json_object(manifest), {"version": 1})
+
+    def test_load_json_object_rejects_non_object(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = Path(tmp) / "manifest.json"
+            manifest.write_text("[]\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "expected JSON object"):
+                load_json_object(manifest)
+
+    def test_load_json_object_reports_invalid_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = Path(tmp) / "manifest.json"
+            manifest.write_text("{\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "invalid JSON"):
+                load_json_object(manifest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -130,6 +130,14 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(projects[4].repository, "https://github.com/ejgallego/verso-algebraic-combinatorics.git")
         self.assertEqual([target.release for target in projects[4].targets], ["v4.28.0"])
 
+    def test_project_catalog_requires_json_object(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = Path(tmp) / "projects.json"
+            manifest.write_text("[]\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "expected JSON object"):
+                load_project_catalog(manifest)
+
     def test_reference_pages_workflow_stages_every_manifest_project(self) -> None:
         catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
         release = resolve_release_target(catalog, "v4.29.0", PACKAGE_ROOT)

--- a/tests/harness/test_blueprint_test_blueprints.py
+++ b/tests/harness/test_blueprint_test_blueprints.py
@@ -56,6 +56,14 @@ class StandaloneTestBlueprintTests(unittest.TestCase):
             "tests/harness/preview_runtime_showcase/check_blueprint_code_panels.py",
         )
 
+    def test_test_blueprint_catalog_requires_json_object(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = Path(tmp) / "test_blueprints.json"
+            manifest.write_text("[]\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "expected JSON object"):
+                load_test_blueprints_manifest(manifest)
+
     def test_duplicate_fixture_slugs_are_rejected(self) -> None:
         manifest_data = {
             "version": 1,


### PR DESCRIPTION
## Summary
Backport #102 to `v4.29.0`.

## Primary Review
- Primary review: #102
- Keep review comments on #102 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.29.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.