### PR TITLE
[backport v4.29.0] refactor: clarify relation panel config helpers

### DIFF
--- a/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
+++ b/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
@@ -104,11 +104,11 @@ private structure UsesScopeText where
   lowercase : String
   titlecase : String
 
-private def usesScopeText (isProof : Bool) : UsesScopeText :=
-  if isProof then
-    { lowercase := "proof", titlecase := "Proof" }
-  else
-    { lowercase := "statement", titlecase := "Statement" }
+private def statementUsesScopeText : UsesScopeText :=
+  { lowercase := "statement", titlecase := "Statement" }
+
+private def proofUsesScopeText : UsesScopeText :=
+  { lowercase := "proof", titlecase := "Proof" }
 
 /-- Standard reverse-dependency panel presentation. -/
 def usedByPanelConfig (targetLabel? : Option Data.Label := none) : PanelConfig := {
@@ -127,10 +127,9 @@ def usedByPanelConfig (targetLabel? : Option Data.Label := none) : PanelConfig :
   previewEmptyText := "Reverse dependency preview content is loaded from the Blueprint HTML cache."
 }
 
-/-- Standard forward-dependency panel presentation for statement and proof uses. -/
-def usesPanelConfig (sourceLabel : Data.Label) (isProof : Bool) : PanelConfig :=
-  let scope := usesScopeText isProof
-  {
+/-- Standard forward-dependency panel presentation for one dependency scope. -/
+private def usesPanelConfigForScope (sourceLabel : Data.Label) (scope : UsesScopeText) :
+    PanelConfig := {
   chipText := fun n => s!"uses {n}"
   chipTitle := fun n =>
     if n == 0 then
@@ -150,6 +149,20 @@ def usesPanelConfig (sourceLabel : Data.Label) (isProof : Bool) : PanelConfig :=
   chipClass := "bp_relation_chip bp_uses_chip"
   emptyChipClass := "bp_relation_chip bp_relation_chip_empty bp_uses_chip"
 }
+
+/-- Standard forward-dependency panel presentation for statement dependencies. -/
+def statementUsesPanelConfig (sourceLabel : Data.Label) : PanelConfig :=
+  usesPanelConfigForScope sourceLabel statementUsesScopeText
+
+/-- Standard forward-dependency panel presentation for proof dependencies. -/
+def proofUsesPanelConfig (sourceLabel : Data.Label) : PanelConfig :=
+  usesPanelConfigForScope sourceLabel proofUsesScopeText
+
+/-- Standard forward-dependency panel presentation for a concrete informal block. -/
+def usesPanelConfigForBlock (data : BlockData) : PanelConfig :=
+  match data.kind with
+  | .proof => proofUsesPanelConfig data.label
+  | .statement _ => statementUsesPanelConfig data.label
 
 private def groupChipClass (declared : Bool) : String :=
   if declared then
@@ -567,10 +580,6 @@ def renderUsesExtra {m}
     (data : BlockData) :
     Verso.Doc.Html.HtmlT Verso.Genre.Manual m Output.Html := do
   let entries := collectUsesEntries ctx data
-  let isProof :=
-    match data.kind with
-    | .proof => true
-    | .statement _ => false
   let panelEntries ← entries.mapM fun entry => do
     let badgesHtml := {{
       {{renderUseAxisBadges entry}}
@@ -585,7 +594,7 @@ def renderUsesExtra {m}
       mkLabelEntry ctx entry.label
         (usesPreviewId data.label entry.label)
         (badgesHtml := badgesHtml)
-  pure <| renderPanel (usesPanelConfig data.label isProof) panelEntries
+  pure <| renderPanel (usesPanelConfigForBlock data) panelEntries
 
 /-- Render the group-membership header extra, if the block belongs to a group. -/
 def renderGroupExtra {m}

--- a/src/VersoBlueprint/PreviewManifest/BlockRender.lean
+++ b/src/VersoBlueprint/PreviewManifest/BlockRender.lean
@@ -139,6 +139,28 @@ private def renderRelatedPanel
     Informal.PreviewManifest.relatedPanelEntries entries currentLabel (cfg.idPrefix kind entry)
   Informal.RelatedPanel.renderPanel (cfg.apply kind panelCfg) panelEntries
 
+/--
+Render a preview-manifest relation panel as a header extra.
+
+Most relation kinds disappear when they have no entries; undeclared groups are
+the exception, because their empty warning chip is the whole signal.
+-/
+private def renderRelatedPanelExtra?
+    (cfg : RelationPanelsConfig)
+    (kind : RelationPanelKind)
+    (panelCfg : Informal.RelatedPanel.PanelConfig)
+    (entries : Array RelatedEntry)
+    (entry : Entry)
+    (currentLabel : Name)
+    (toExtra : Html → Informal.HeaderExtra)
+    (showWhenEmpty : Bool := false) :
+    Option Informal.HeaderExtra :=
+  if entries.isEmpty && !showWhenEmpty then
+    none
+  else
+    some <| toExtra <|
+      renderRelatedPanel cfg kind panelCfg entries entry currentLabel
+
 private def renderGroupExtra?
     (cfg : RelationPanelsConfig)
     (entry : Entry) :
@@ -146,33 +168,34 @@ private def renderGroupExtra?
   match entry.group with
   | none => none
   | some group =>
-      if group.declared && group.entries.isEmpty then
-        none
-      else
-        some <| Informal.HeaderExtra.group <|
-          renderRelatedPanel
-            cfg
-            .group
-            (Informal.RelatedPanel.groupPanelConfig group.label group.title group.declared)
-            group.entries
-            entry
-            entry.label
+    renderRelatedPanelExtra?
+      cfg
+      .group
+      (Informal.RelatedPanel.groupPanelConfig group.label group.title group.declared)
+      group.entries
+      entry
+      entry.label
+      Informal.HeaderExtra.group
+      (showWhenEmpty := !group.declared)
+
+/-- Select the uses-panel wording from the manifest entry facet. -/
+private def usesPanelConfigForEntry (entry : Entry) : Informal.RelatedPanel.PanelConfig :=
+  match entryBlockKind entry with
+  | .proof => Informal.RelatedPanel.proofUsesPanelConfig entry.label
+  | .statement _ => Informal.RelatedPanel.statementUsesPanelConfig entry.label
 
 private def renderUsesExtra?
     (cfg : RelationPanelsConfig)
     (entry : Entry) :
     Option Informal.HeaderExtra :=
-  if entry.uses.isEmpty then
-    none
-  else
-    some <| Informal.HeaderExtra.uses <|
-      renderRelatedPanel
-        cfg
-        .uses
-        (Informal.RelatedPanel.usesPanelConfig entry.label (entry.facet == .proof))
-        entry.uses
-        entry
-        Name.anonymous
+  renderRelatedPanelExtra?
+    cfg
+    .uses
+    (usesPanelConfigForEntry entry)
+    entry.uses
+    entry
+    Name.anonymous
+    Informal.HeaderExtra.uses
 
 private def renderCodeExtra? (entry : Entry) (blockData : Informal.BlockData) :
     Option Informal.HeaderExtra :=
@@ -187,17 +210,14 @@ private def renderUsedByExtra?
     (cfg : RelationPanelsConfig)
     (entry : Entry) :
     Option Informal.HeaderExtra :=
-  if entry.usedBy.isEmpty then
-    none
-  else
-    some <| Informal.HeaderExtra.usedBy <|
-      renderRelatedPanel
-        cfg
-        .usedBy
-        Informal.RelatedPanel.usedByPanelConfig
-        entry.usedBy
-        entry
-        Name.anonymous
+  renderRelatedPanelExtra?
+    cfg
+    .usedBy
+    Informal.RelatedPanel.usedByPanelConfig
+    entry.usedBy
+    entry
+    Name.anonymous
+    Informal.HeaderExtra.usedBy
 
 private def renderHeaderExtras
     (cfg : RelationPanelsConfig)

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
@@ -4,12 +4,34 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Emilio J. Gallego Arias
 -/
 
+import VersoBlueprint.Informal.Block.RelatedPanel
 import VersoBlueprintTests.BlueprintPreviewWiring.Shared
 
 namespace Verso.VersoBlueprintTests.BlueprintPreviewWiring.RelatedPanel
 
 open Verso.VersoBlueprintTests.Blueprint.Support
 open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
+
+private def samplePanelEntry : Informal.RelatedPanel.PanelEntry := {
+  previewId := "preview"
+  previewKey := "preview-key"
+  previewTitle := "Target"
+  label := Lean.Name.mkSimple "target"
+}
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    let source := Lean.Name.mkSimple "source"
+    let statementCfg := Informal.RelatedPanel.statementUsesPanelConfig source
+    let proofCfg := Informal.RelatedPanel.proofUsesPanelConfig source
+    statementCfg.panelTitle 2 == "Statement uses 2" &&
+      statementCfg.chipTitle 1 == "Statement dependencies used by source" &&
+      statementCfg.singleTitle samplePanelEntry == "Statement dependency: Target" &&
+      proofCfg.panelTitle 2 == "Proof uses 2" &&
+      proofCfg.chipTitle 1 == "Proof dependencies used by source" &&
+      proofCfg.singleTitle samplePanelEntry == "Proof dependency: Target"
 
 /-- info: true -/
 #guard_msgs in


### PR DESCRIPTION
## Summary
Backport #103 to `v4.29.0`.

## Primary Review
- Primary review: #103
- Keep review comments on #103 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.29.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.