### PR TITLE
refactor: share informal block render model

### DIFF
--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -152,18 +152,17 @@ block_extension Block.informal (data : BlockData) where
               usedBy? := some <| HeaderExtra.usedBy usedByEntry
               code? := some <| HeaderExtra.code codeEntry
             }
-        let informalBlock :=
-          renderInformalBlockHtml data {
-            numberText := data.displayNumber s
-            captionText? :=
-              match data.kind with
-              | .proof => some (data.displayTitle s)
-              | .statement _ => none
-            attrs
-            headerExtras
-            folded := foldInformalBlock
-          } content
-        return .seq #[informalBlock, externalPanel]
+        return renderInformalBlockModel {
+          data
+          context := InformalBlockRenderContext.forBlock data
+            (data.displayNumber s)
+            (proofCaption? := some (data.displayTitle s))
+            (attrs := attrs)
+            (headerExtras := headerExtras)
+            (folded := foldInformalBlock)
+          content
+          companionPanels := #[externalPanel]
+        }
 
 private def expanderImpl (kind : Data.NodeKind) (isProof : Bool := false) : DirectiveExpanderOf Config
   | cfg, contents => do

--- a/src/VersoBlueprint/Informal/Block/Render.lean
+++ b/src/VersoBlueprint/Informal/Block/Render.lean
@@ -340,6 +340,53 @@ structure InformalBlockRenderContext where
   folded : Bool := false
 
 /--
+Build shell context for a concrete informal block.
+
+Statement and proof headings use different fallback captions. This helper keeps
+that policy out of phase-specific renderers: callers provide the caption they
+resolved for each block kind, and the shared renderer chooses the one that
+matches the block.
+-/
+def InformalBlockRenderContext.forBlock
+    (data : BlockData)
+    (numberText : String)
+    (statementCaption? : Option String := none)
+    (proofCaption? : Option String := none)
+    (attrs : Array (String × String) := #[])
+    (titleRowAttrs? : Option (Array (String × String)) := none)
+    (headerExtras : HeaderExtras := {})
+    (folded : Bool := false) :
+    InformalBlockRenderContext :=
+  let captionText? :=
+    match data.kind with
+    | .proof => proofCaption?
+    | .statement _ => statementCaption?
+  {
+    numberText
+    captionText?
+    attrs
+    titleRowAttrs?
+    headerExtras
+    folded
+  }
+
+/--
+Complete render model for one informal Blueprint block.
+
+The block shell is shared by normal Manual rendering and manifest-backed
+renderers such as slides. Phase-specific callers still own data lookup and body
+rendering, but the final assembly order is centralized here: the informal block
+shell first, followed by any rendered companion panels, optionally wrapped for a
+particular embedding surface.
+-/
+structure InformalBlockRenderModel where
+  data : BlockData
+  context : InformalBlockRenderContext
+  content : Array Verso.Output.Html := #[]
+  companionPanels : Array Verso.Output.Html := #[]
+  wrapperClass? : Option String := none
+
+/--
 Genre-neutral inputs for the reusable Blueprint informal-block shell.
 
 Callers own phase-specific data lookup and body rendering. This shell owns the
@@ -424,5 +471,17 @@ def renderInformalBlockHtml (data : BlockData) (ctx : InformalBlockRenderContext
       folded := ctx.folded
     }
     (.seq content)
+
+/-- HTML attributes for an optional CSS class string. -/
+def htmlClassAttrs (className : String) : Array (String × String) :=
+  if className.isEmpty then #[] else #[("class", className)]
+
+/-- Render a complete informal block model, including companion panels. -/
+def renderInformalBlockModel (model : InformalBlockRenderModel) : Verso.Output.Html :=
+  let blockHtml := renderInformalBlockHtml model.data model.context model.content
+  let html := Verso.Output.Html.seq (#[blockHtml] ++ model.companionPanels)
+  match model.wrapperClass? with
+  | some className => Verso.Output.Html.tag "div" (htmlClassAttrs className) html
+  | none => html
 
 end Informal

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -577,6 +577,52 @@ structure Entry where
   effort : Option String := none
 deriving Inhabited, Repr, ToJson, FromJson
 
+/-- Structured heading text for renderers that rebuild an informal block shell. -/
+structure EntryHeading where
+  /-- Heading caption, such as "Definition" or "Theorem". -/
+  caption : String
+  /-- Heading label/number text. -/
+  label : String
+deriving Inhabited, Repr
+
+/-- Informal block kind represented by this manifest entry. -/
+def Entry.blockKind (entry : Entry) : Informal.Data.InProgressKind :=
+  match entry.facet with
+  | .proof => .proof
+  | .statement => .statement (entry.kind.getD .theorem)
+
+/-- Convert manifest entry metadata to the shared informal block model. -/
+def Entry.blockData (entry : Entry) : Informal.BlockData := {
+  kind := entry.blockKind
+  codeData := entry.codeData
+  label := entry.label
+  parent := entry.parent
+  count := 0
+  statementUses := entry.statementUses
+  proofUses := entry.proofUses
+  ownerDisplayName := entry.ownerDisplayName
+  tags := entry.tags
+  effort := entry.effort
+  priority := entry.priority
+}
+
+/--
+Heading text for manifest-backed block rendering.
+
+The optional override is used by embedding surfaces such as slides that want a
+local display label without mutating the manifest entry.
+-/
+def Entry.heading (entry : Entry) (displayLabelOverride? : Option String := none) :
+    EntryHeading :=
+  let kindText :=
+    match entry.kind with
+    | some kind => toString kind
+    | none => "Blueprint"
+  let caption := (entry.displayCaption.getD kindText).trimAscii.toString
+  let fallbackLabel := entry.label.toString
+  let label := ((displayLabelOverride? <|> entry.displayLabel).getD fallbackLabel).trimAscii.toString
+  { caption, label }
+
 structure File where
   /-- Semantic preview entries keyed by `PreviewCache`, Lean preview key, or citation key. -/
   previews : Array Entry := #[]

--- a/src/VersoBlueprint/PreviewManifest/BlockRender.lean
+++ b/src/VersoBlueprint/PreviewManifest/BlockRender.lean
@@ -89,44 +89,6 @@ def RenderedContent.ofHtmlStrings (bodyHtml : String) (codeHtml : Array String :
     codeBodies := codeHtml.map htmlFragment
   }
 
-private structure EntryTitle where
-  caption : String
-  label : String
-
-private def entryTitle
-    (entry : Entry)
-    (displayLabelOverride? : Option String) :
-    EntryTitle :=
-  let kindText :=
-    match entry.kind with
-    | some kind => toString kind
-    | none => "Blueprint"
-  let caption := (entry.displayCaption.getD kindText).trimAscii.toString
-  let fallbackLabel := entry.label.toString
-  let label := ((displayLabelOverride? <|> entry.displayLabel).getD fallbackLabel).trimAscii.toString
-  { caption, label }
-
-private def entryBlockKind (entry : Entry) : Informal.Data.InProgressKind :=
-  if entry.facet == .proof then
-    .proof
-  else
-    .statement (entry.kind.getD .theorem)
-
-private def entryBlockData (entry : Entry) : Informal.BlockData :=
-  {
-    kind := entryBlockKind entry
-    codeData := entry.codeData
-    label := entry.label
-    parent := entry.parent
-    count := 0
-    statementUses := entry.statementUses
-    proofUses := entry.proofUses
-    ownerDisplayName := entry.ownerDisplayName
-    tags := entry.tags
-    effort := entry.effort
-    priority := entry.priority
-  }
-
 private def renderRelatedPanel
     (cfg : RelationPanelsConfig)
     (kind : RelationPanelKind)
@@ -180,7 +142,7 @@ private def renderGroupExtra?
 
 /-- Select the uses-panel wording from the manifest entry facet. -/
 private def usesPanelConfigForEntry (entry : Entry) : Informal.RelatedPanel.PanelConfig :=
-  match entryBlockKind entry with
+  match entry.blockKind with
   | .proof => Informal.RelatedPanel.proofUsesPanelConfig entry.label
   | .statement _ => Informal.RelatedPanel.statementUsesPanelConfig entry.label
 
@@ -231,12 +193,9 @@ private def renderHeaderExtras
     usedBy? := renderUsedByExtra? cfg entry
   }
 
-private def attrsForClass (className : String) : Array (String × String) :=
-  if className.isEmpty then #[] else #[("class", className)]
-
 private def renderCodePanel
     (cfg : RenderConfig)
-    (title : EntryTitle)
+    (title : EntryHeading)
     (entry : Entry)
     (codeBodies : Array Html) :
     Html :=
@@ -248,7 +207,7 @@ private def renderCodePanel
       { source := entry.codeData }
       (fun _ => none)
     let codeHtml := .seq codeBodies
-    let body := Html.tag "div" (attrsForClass cfg.codeBodyClass) codeHtml
+    let body := Html.tag "div" (Informal.htmlClassAttrs cfg.codeBodyClass) codeHtml
     Informal.mkCodePanel
       { caption := s!"Lean code for {title.caption}", number? := some title.label }
       panelSummary.summaryTitle
@@ -262,26 +221,24 @@ def renderWithRenderedContent
     (content : RenderedContent)
     (opts : RenderOptions := {}) :
     Html :=
-    let blockData := entryBlockData entry
-    let title := entryTitle entry opts.displayLabelOverride?
-    let blockShell :=
-      Informal.renderInformalBlockHtml
-        blockData
-        {
-          numberText := title.label
-          captionText? :=
-            match blockData.kind with
-            | .proof => some entry.title
-            | .statement _ => some title.caption
-          titleRowAttrs? := cfg.titleRowAttrs? entry
-          headerExtras := renderHeaderExtras cfg.relationPanels entry blockData
-        }
-        #[content.body]
+    let blockData := entry.blockData
+    let title := entry.heading opts.displayLabelOverride?
     let codePanel :=
       if opts.compact then
         .empty
       else
         renderCodePanel cfg title entry content.codeBodies
-    Html.tag "div" (attrsForClass cfg.wrapperClass) (.seq #[blockShell, codePanel])
+    Informal.renderInformalBlockModel {
+      data := blockData
+      context := Informal.InformalBlockRenderContext.forBlock blockData
+        title.label
+        (statementCaption? := some title.caption)
+        (proofCaption? := some entry.title)
+        (titleRowAttrs? := cfg.titleRowAttrs? entry)
+        (headerExtras := renderHeaderExtras cfg.relationPanels entry blockData)
+      content := #[content.body]
+      companionPanels := #[codePanel]
+      wrapperClass? := some cfg.wrapperClass
+    }
 
 end Informal.PreviewManifest.BlockRender


### PR DESCRIPTION
This PR centralizes informal block final assembly behind a shared render model so normal Manual rendering and manifest-backed renderers use the same block-shell, companion-panel, and wrapper path.

It also moves manifest entry-to-block semantics onto `PreviewManifest.Entry` helpers and shares the CSS-class attribute helper used by block renderers.

Backport v4.29.0: #108