### PR TITLE
[backport v4.29.0] fix: add graph preview controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ Blueprint can render:
 
 The graph page is interactive rather than static: it can expose a view switcher
 for grouped graphs, a legend popover, a `Graph options` control for direction
-and component-packing switches, and the usual Blueprint hover/link previews.
+and component-packing switches, and graph-node previews that can be configured
+as click-pinned or transient hover panels with docked or near-node placement.
 
 Progress is computed automatically from the status of the associated Lean code
 and declarations, so the HTML summary and graph views stay aligned with the

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -151,8 +151,10 @@ The starter template includes:
 - a progress summary with `{blueprint_summary}`
 
 That is the core HTML surface most projects want first. The dependency graph can
-also take `(direction := LR | RL | TB | BT)` and `(pack := true | false)`, and
-grouped projects expose the current graph views through the rendered page's
+also take `(direction := LR | RL | TB | BT)`, `(pack := true | false)`, and
+`(preview := pinned | hover)` with optional
+`(previewPlacement := docked | anchored)`. Grouped projects expose the current
+graph views and preview behavior and placement through the rendered page's
 `View`, `Legend`, and `Graph options` controls.
 
 ## Read the generator entry point

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -500,6 +500,8 @@ or with explicit graph layout options:
 ```lean
 {blueprint_graph (direction := LR)}
 {blueprint_graph (direction := LR) (pack := true)}
+{blueprint_graph (preview := hover)}
+{blueprint_graph (preview := hover) (previewPlacement := anchored)}
 ```
 
 Supported directions are `LR`, `RL`, `TB`, and `BT`. When `(direction := ...)`
@@ -508,6 +510,14 @@ is omitted, the command falls back to the
 The `(pack := true | false)` option controls Graphviz component packing for
 disconnected graph components. It defaults to
 `verso.blueprint.graph.defaultPack`, which is `false`.
+The `(preview := pinned | hover)` option chooses the initial graph-node preview
+behavior. The default is `pinned`: clicking a node opens a persistent preview
+panel that stays open until closed. `hover` opens a transient preview that
+disappears after the pointer leaves the node and preview panel.
+The `(previewPlacement := docked | anchored)` option chooses where the preview
+panel appears. The default is `docked`, so both click-pinned and hover previews
+open in the graph corner unless `anchored` is selected to place the panel near
+the active node.
 
 The rendered graph page is interactive:
 
@@ -515,7 +525,7 @@ The rendered graph page is interactive:
   views
 - a `Legend` button opens the current graph legend in a popover
 - a `Graph options` button exposes runtime graph options such as direction and
-  component packing
+  component packing, plus the graph-node preview behavior and placement
 - when grouped metadata produces multiple children for the same parent, the
   selector includes a synthetic group overview plus one subgraph view per group
 
@@ -524,7 +534,8 @@ The command-side options and the runtime graph controls are compatible:
 - `(direction := ...)` chooses the initial graph direction when the page first
   loads
 - the rendered `Graph options` control lets readers switch among the supported
-  directions and toggle component packing without regenerating the site
+  directions, toggle component packing, and choose between click-pinned and
+  hover previews and docked or near-node placement without regenerating the site
 
 Group metadata may be used to organize the presentation, but grouping does not
 change dependency edges.
@@ -765,6 +776,15 @@ prefixes with document-order block counts.
   - default: `false`
   - sets the fallback Graphviz component packing behavior for
     `blueprint_graph` when `(pack := ...)` is omitted
+- `verso.blueprint.graph.defaultPreviewMode`
+  - default: `pinned`
+  - sets the fallback graph-node preview behavior for `blueprint_graph` when
+    `(preview := ...)` is omitted; accepts `pinned`/`click` and `hover`
+- `verso.blueprint.graph.defaultPreviewPlacement`
+  - default: `docked`
+  - sets the fallback graph-node preview placement for `blueprint_graph` when
+    `(previewPlacement := ...)` is omitted; accepts `docked`/`fixed` and
+    `anchored`/`near-node`
 - `verso.blueprint.debug.commands`
   - default: `false`
   - emits debug info logs while elaborating Blueprint graph, summary, and

--- a/src/VersoBlueprint/Commands/Graph.lean
+++ b/src/VersoBlueprint/Commands/Graph.lean
@@ -55,6 +55,16 @@ register_option verso.blueprint.graph.defaultPack : Bool := {
   descr := "Default Graphviz component packing for `blueprint_graph` when `(pack := ...)` is omitted"
 }
 
+register_option verso.blueprint.graph.defaultPreviewMode : String := {
+  defValue := "pinned"
+  descr := "Default preview behavior for `blueprint_graph` when `(preview := ...)` is omitted (`pinned`/`click` or `hover`)"
+}
+
+register_option verso.blueprint.graph.defaultPreviewPlacement : String := {
+  defValue := "docked"
+  descr := "Default preview panel placement for `blueprint_graph` when `(previewPlacement := ...)` is omitted (`docked`/`fixed` or `anchored`/`near-node`)"
+}
+
 structure GraphOptions where
   direction : GraphDirection := .TB
   /--
@@ -67,11 +77,26 @@ deriving Inhabited, BEq, FromJson, ToJson, Quote
 structure GraphBlockData where
   graph : Graph
   options : GraphOptions := {}
+  previewMode : Informal.HoverRender.PreviewMode := .pinned
+  previewPlacement : Informal.HoverRender.PreviewPlacement := .docked
   groupTitles : Array (Name × String) := #[]
 deriving Inhabited, FromJson, ToJson, Quote
 
 def graphPackAttr (pack : Bool) : String :=
   if pack then "true" else "false"
+
+def parseGraphPreviewMode? (s : String) : Option Informal.HoverRender.PreviewMode :=
+  match s.trimAscii.toString.toLower with
+  | "hover" | "transient" => some .hover
+  | "pinned" | "pin" | "click" | "click-to-pin" | "click-and-stay" | "click-to-stay" =>
+      some .pinned
+  | _ => none
+
+def parseGraphPreviewPlacement? (s : String) : Option Informal.HoverRender.PreviewPlacement :=
+  match s.trimAscii.toString.toLower with
+  | "docked" | "dock" | "fixed" | "panel" => some .docked
+  | "anchored" | "anchor" | "near" | "near-node" | "node" => some .anchored
+  | _ => none
 
 /-- Common DOT header for rendered Blueprint graphs.
 
@@ -504,41 +529,20 @@ block_extension Block.graph (graphData : GraphBlockData) where
             (note? := some Informal.Graph.graphLegendGroupViewNote) (hidden := true)
         else
           .empty
-      let graphViewSelectId : String :=
-        let attrs := s.htmlId id
-        match attrs.findSome? fun
-            | ("id", value) => some s!"{value}--view"
+      let graphHtmlAttrs := s.htmlId id
+      let graphControlId (suffix : String) : String :=
+        match graphHtmlAttrs.findSome? fun
+            | ("id", value) => some s!"{value}{suffix}"
             | _ => Option.none with
         | some value => value
-        | Option.none => fallbackGraphControlId id "--view"
-      let graphDirectionSelectId : String :=
-        let attrs := s.htmlId id
-        match attrs.findSome? fun
-            | ("id", value) => some s!"{value}--direction"
-            | _ => Option.none with
-        | some value => value
-        | Option.none => fallbackGraphControlId id "--direction"
-      let graphPackInputId : String :=
-        let attrs := s.htmlId id
-        match attrs.findSome? fun
-            | ("id", value) => some s!"{value}--pack"
-            | _ => Option.none with
-        | some value => value
-        | Option.none => fallbackGraphControlId id "--pack"
-      let graphLegendPanelId : String :=
-        let attrs := s.htmlId id
-        match attrs.findSome? fun
-            | ("id", value) => some s!"{value}--legend"
-            | _ => Option.none with
-        | some value => value
-        | Option.none => fallbackGraphControlId id "--legend"
-      let graphOptionsPanelId : String :=
-        let attrs := s.htmlId id
-        match attrs.findSome? fun
-            | ("id", value) => some s!"{value}--options"
-            | _ => Option.none with
-        | some value => value
-        | Option.none => fallbackGraphControlId id "--options"
+        | Option.none => fallbackGraphControlId id suffix
+      let graphViewSelectId : String := graphControlId "--view"
+      let graphDirectionSelectId : String := graphControlId "--direction"
+      let graphPackInputId : String := graphControlId "--pack"
+      let graphPreviewModeSelectId : String := graphControlId "--preview-mode"
+      let graphPreviewPlacementSelectId : String := graphControlId "--preview-placement"
+      let graphLegendPanelId : String := graphControlId "--legend"
+      let graphOptionsPanelId : String := graphControlId "--options"
       let graphDirectionOptions : Array Output.Html :=
         allGraphDirections.map fun direction =>
           if direction == graphData.options.direction then
@@ -548,11 +552,36 @@ block_extension Block.graph (graphData : GraphBlockData) where
       let graphPackChecked : Array (String × String) :=
         if graphData.options.pack then #[("checked", "checked")] else #[]
       let graphPackDefault : String := graphPackAttr graphData.options.pack
+      let previewModeDefault : String := graphData.previewMode.dataValue
+      let graphPreviewModeOptions : Array Output.Html := #[
+        if graphData.previewMode == .pinned then
+          {{ <option value="pinned" selected>"Click to pin"</option> }}
+        else
+          {{ <option value="pinned">"Click to pin"</option> }},
+        if graphData.previewMode == .hover then
+          {{ <option value="hover" selected>"Hover"</option> }}
+        else
+          {{ <option value="hover">"Hover"</option> }}
+      ]
+      let previewPlacementDefault : String := graphData.previewPlacement.dataValue
+      let graphPreviewPlacementOptions : Array Output.Html := #[
+        if graphData.previewPlacement == .docked then
+          {{ <option value="docked" selected>"Docked"</option> }}
+        else
+          {{ <option value="docked">"Docked"</option> }},
+        if graphData.previewPlacement == .anchored then
+          {{ <option value="anchored" selected>"Near node"</option> }}
+        else
+          {{ <option value="anchored">"Near node"</option> }}
+      ]
       let fallbackDot : String :=
         match graphVariants[0]? with
         | some variant => variant.dot
         | Option.none => graphToDot graphData.graph graphData.options resolveHref resolveGroupTitle
-      let previewUi := Informal.HoverRender.graphPreviewUi
+      let previewUi :=
+        Informal.HoverRender.graphPreviewUi
+          graphData.previewMode
+          graphData.previewPlacement
       let groupHoverUi := Informal.HoverRender.graphGroupPreviewUi
       return {{
         <div class="bp_graph_fullwidth">
@@ -617,6 +646,22 @@ block_extension Block.graph (graphData : GraphBlockData) where
                   {{graphPackChecked}}/>
                 <span>"Pack disconnected components"</span>
               </label>
+              <label class="bp_graph_controls_label" for={{graphPreviewModeSelectId}}>"Preview"</label>
+              <select
+                id={{graphPreviewModeSelectId}}
+                class="bp_graph_controls_select bp_graph_preview_mode_select"
+                data-bp-graph-default-preview-mode={{previewModeDefault}}
+              >
+                {{graphPreviewModeOptions}}
+              </select>
+              <label class="bp_graph_controls_label" for={{graphPreviewPlacementSelectId}}>"Position"</label>
+              <select
+                id={{graphPreviewPlacementSelectId}}
+                class="bp_graph_controls_select bp_graph_preview_placement_select"
+                data-bp-graph-default-preview-placement={{previewPlacementDefault}}
+              >
+                {{graphPreviewPlacementOptions}}
+              </select>
             </div>
           </div>
           <div
@@ -666,15 +711,53 @@ instance : FromArgVal GraphDirection Verso.Doc.Elab.PartElabM where
         throwError "Expected a direction identifier or string, got {toMessageData other}"
   }
 
+instance : FromArgVal Informal.HoverRender.PreviewMode Verso.Doc.Elab.PartElabM where
+  fromArgVal := {
+    description := doc!"graph preview mode (`pinned`/`click` or `hover`)"
+    signature := CanMatch.Ident ∪ CanMatch.String
+    get := fun
+      | .name id =>
+        match parseGraphPreviewMode? id.getId.toString with
+        | some mode => pure mode
+        | none => throwErrorAt id "Expected `pinned`, `click`, or `hover`"
+      | .str s =>
+        match parseGraphPreviewMode? s.getString with
+        | some mode => pure mode
+        | none => throwErrorAt s "Expected \"pinned\", \"click\", or \"hover\""
+      | other =>
+        throwError "Expected a preview mode identifier or string, got {toMessageData other}"
+  }
+
+instance : FromArgVal Informal.HoverRender.PreviewPlacement Verso.Doc.Elab.PartElabM where
+  fromArgVal := {
+    description := doc!"graph preview placement (`docked`/`fixed` or `anchored`/`near-node`)"
+    signature := CanMatch.Ident ∪ CanMatch.String
+    get := fun
+      | .name id =>
+        match parseGraphPreviewPlacement? id.getId.toString with
+        | some placement => pure placement
+        | none => throwErrorAt id "Expected `docked`, `fixed`, `anchored`, or `near-node`"
+      | .str s =>
+        match parseGraphPreviewPlacement? s.getString with
+        | some placement => pure placement
+        | none => throwErrorAt s "Expected \"docked\", \"fixed\", \"anchored\", or \"near-node\""
+      | other =>
+        throwError "Expected a preview placement identifier or string, got {toMessageData other}"
+  }
+
 structure BlueprintGraphConfig where
   direction : Option GraphDirection := none
   pack : Option Bool := none
+  preview : Option Informal.HoverRender.PreviewMode := none
+  previewPlacement : Option Informal.HoverRender.PreviewPlacement := none
 
 instance : FromArgs BlueprintGraphConfig Verso.Doc.Elab.PartElabM where
   fromArgs :=
     BlueprintGraphConfig.mk <$>
       .named' `direction true <*>
-      .named' `pack true
+      .named' `pack true <*>
+      .named' `preview true <*>
+      .named' `previewPlacement true
 
 def parseGraphDirection (cfg : BlueprintGraphConfig) : Verso.Doc.Elab.PartElabM GraphDirection := do
   match cfg.direction with
@@ -699,8 +782,40 @@ def parseGraphOptions (cfg : BlueprintGraphConfig) : Verso.Doc.Elab.PartElabM Gr
         verso.blueprint.graph.defaultPack.defValue
   pure { direction, pack }
 
+def parseGraphPreviewMode
+    (cfg : BlueprintGraphConfig) : Verso.Doc.Elab.PartElabM Informal.HoverRender.PreviewMode := do
+  match cfg.preview with
+  | none =>
+    let configured :=
+      (← getOptions).get
+        verso.blueprint.graph.defaultPreviewMode.name
+        verso.blueprint.graph.defaultPreviewMode.defValue
+    match parseGraphPreviewMode? configured with
+    | some mode => pure mode
+    | none =>
+      logWarning m!"Invalid value '{configured}' for option 'verso.blueprint.graph.defaultPreviewMode'; expected pinned, click, or hover. Falling back to pinned."
+      pure .pinned
+  | some mode => pure mode
+
+def parseGraphPreviewPlacement
+    (cfg : BlueprintGraphConfig) : Verso.Doc.Elab.PartElabM Informal.HoverRender.PreviewPlacement := do
+  match cfg.previewPlacement with
+  | none =>
+    let configured :=
+      (← getOptions).get
+        verso.blueprint.graph.defaultPreviewPlacement.name
+        verso.blueprint.graph.defaultPreviewPlacement.defValue
+    match parseGraphPreviewPlacement? configured with
+    | some placement => pure placement
+    | none =>
+      logWarning m!"Invalid value '{configured}' for option 'verso.blueprint.graph.defaultPreviewPlacement'; expected docked, fixed, anchored, or near-node. Falling back to docked."
+      pure .docked
+  | some placement => pure placement
+
 open Verso Doc Elab Syntax in
-def mkGraphPart (stx : Syntax) (endPos : String.Pos.Raw) (options : GraphOptions := {}) :
+def mkGraphPart (stx : Syntax) (endPos : String.Pos.Raw) (options : GraphOptions := {})
+    (previewMode : Informal.HoverRender.PreviewMode := .pinned)
+    (previewPlacement : Informal.HoverRender.PreviewPlacement := .docked) :
     PartElabM FinishedPart := do
   let titlePreview := "Dependency Graph"
   let titleInlines ← `(inline | "Dependency Graph")
@@ -709,7 +824,7 @@ def mkGraphPart (stx : Syntax) (endPos : String.Pos.Raw) (options : GraphOptions
   let (graph, groupTitles) ← buildAll
   if verso.blueprint.debug.commands.get (← Lean.getOptions) then
     logInfo m!"Adding {graph.size} nodes"
-  let graphData : GraphBlockData := { graph, options, groupTitles }
+  let graphData : GraphBlockData := { graph, options, previewMode, previewPlacement, groupTitles }
   let block ← ``(Verso.Doc.Block.other (Informal.Commands.Block.graph $(quote graphData)) #[])
   let subParts := #[]
   pure <| FinishedPart.mk stx expandedTitle titlePreview metadata #[block] subParts endPos
@@ -720,9 +835,11 @@ public meta def depGraph : PartCommand
   | stx@`(block|command{blueprint_graph $args*}) => do
     let cfg ← Verso.ArgParse.parseThe BlueprintGraphConfig (← parseArgs args)
     let options ← parseGraphOptions cfg
+    let previewMode ← parseGraphPreviewMode cfg
+    let previewPlacement ← parseGraphPreviewPlacement cfg
     let endPos := stx.getTailPos?.get!
     closePartsUntil 1 endPos
-    addPart (← mkGraphPart stx endPos options)
+    addPart (← mkGraphPart stx endPos options previewMode previewPlacement)
   | _ => (Lean.Elab.throwUnsupportedSyntax : PartElabM Unit)
 
 end Informal.Commands

--- a/src/VersoBlueprint/Commands/graph.css
+++ b/src/VersoBlueprint/Commands/graph.css
@@ -211,7 +211,9 @@
   min-width: min(100%, 15rem);
 }
 
-.bp_graph_direction_select {
+.bp_graph_direction_select,
+.bp_graph_preview_mode_select,
+.bp_graph_preview_placement_select {
   display: inline-block;
   width: max-content;
   min-width: 0;

--- a/src/VersoBlueprint/Commands/graph.js
+++ b/src/VersoBlueprint/Commands/graph.js
@@ -38,6 +38,45 @@
     return true;
   }
 
+  function normalizePreviewMode(rawMode) {
+    const mode = String(rawMode || "").trim().toLowerCase();
+    if (mode === "hover" || mode === "transient") return "hover";
+    return "pinned";
+  }
+
+  function normalizePreviewPlacement(rawPlacement) {
+    const placement = String(rawPlacement || "").trim().toLowerCase();
+    if (
+      placement === "anchored" ||
+      placement === "anchor" ||
+      placement === "near" ||
+      placement === "near-node" ||
+      placement === "node"
+    ) {
+      return "anchored";
+    }
+    return "docked";
+  }
+
+  function previewBehaviorForMode(previewUtils, mode, placement) {
+    const normalized = normalizePreviewMode(mode);
+    const normalizedPlacement = normalizePreviewPlacement(placement);
+    if (previewUtils && typeof previewUtils.readPanelBehavior === "function") {
+      return previewUtils.readPanelBehavior(null, {
+        mode: normalized,
+        placement: normalizedPlacement
+      });
+    }
+    return {
+      mode: normalized,
+      placement: normalizedPlacement,
+      isPinned: normalized === "pinned",
+      isHover: normalized === "hover",
+      isAnchored: normalizedPlacement === "anchored",
+      isDocked: normalizedPlacement === "docked"
+    };
+  }
+
   function normalizeGraphOptions(rawOptions) {
     const options = rawOptions && typeof rawOptions === "object" ? rawOptions : {};
     return {
@@ -353,8 +392,17 @@
     return controller;
   }
 
-  function makeHtmlPanelPositioner(behavior) {
+  function readBehaviorSource(behaviorSource) {
+    if (typeof behaviorSource === "function") {
+      const behavior = behaviorSource();
+      return behavior && typeof behavior === "object" ? behavior : null;
+    }
+    return behaviorSource && typeof behaviorSource === "object" ? behaviorSource : null;
+  }
+
+  function makeHtmlPanelPositioner(behaviorSource) {
     return function (panel, anchorNode) {
+      const behavior = readBehaviorSource(behaviorSource);
       const previewUtils = window.bpPreviewUtils;
       if (
         behavior &&
@@ -406,6 +454,10 @@
       return;
     }
     if (behavior && behavior.isPinned) {
+      closeButton.hidden = false;
+      closeButton.style.display = "";
+      closeButton.setAttribute("aria-hidden", "false");
+      closeButton.tabIndex = 0;
       if (previewUtils && typeof previewUtils.bindCloseOnce === "function") {
         previewUtils.bindCloseOnce(closeButton, hidePanel);
       } else if (closeButton.getAttribute("data-bp-bound") !== "1") {
@@ -432,7 +484,6 @@
       }
     };
     if (!controller || !(controller.panel instanceof Element)) return noop;
-    if (!controller.behavior || !controller.behavior.isHover) return noop;
     const panel = controller.panel;
     const attr =
       typeof boundAttr === "string" && boundAttr.length > 0
@@ -448,6 +499,7 @@
     }
 
     function scheduleHide() {
+      if (!controller.behavior || !controller.behavior.isHover) return;
       cancelHide();
       hideTimer = window.setTimeout(function () {
         hideTimer = null;
@@ -522,11 +574,15 @@
       graphState.previewActiveNode = anchorNode instanceof Element ? anchorNode : null;
       previewController.show(label, html, graphState.previewActiveNode);
     };
-    svg.querySelectorAll("g.node").forEach(function (node) {
+    const canPreviewNode = function (node) {
+      if (!(node instanceof Element)) return false;
       const label = graphNodeLabel(node);
       const nodeId = graphNodeId(node);
       const previewKey = nodeId ? (previewKeys.get(nodeId) || "") : "";
-      if (!label || (!previewMap.has(label) && !(canResolveHtmlCache && previewKey))) return;
+      return !!label && (previewMap.has(label) || !!(canResolveHtmlCache && previewKey));
+    };
+    svg.querySelectorAll("g.node").forEach(function (node) {
+      if (!canPreviewNode(node)) return;
       node.style.cursor = "pointer";
       node.setAttribute("tabindex", "0");
       const titleNode = node.querySelector("title");
@@ -541,39 +597,52 @@
       });
     });
     const showFromTarget = function (target) {
-      if (!(target instanceof Element)) return;
+      if (!(target instanceof Element)) return false;
       const node = target.closest("g.node");
-      if (!node) return;
-       if (graphState.previewActiveNode === node && !previewController.panel.hidden) {
+      if (!node || !canPreviewNode(node)) return false;
+      if (graphState.previewActiveNode === node && !previewController.panel.hidden) {
         hoverLifetime.cancelHide();
         previewController.position(node);
-        return;
+        return true;
       }
       const label = graphNodeLabel(node);
       if (label) show(label, node);
+      return !!label;
     };
     if (svg.getAttribute("data-bp-preview-bound") === "1") return;
     svg.setAttribute("data-bp-preview-bound", "1");
     svg.addEventListener("mouseover", function (ev) {
+      if (!previewController.behavior || !previewController.behavior.isHover) return;
       showFromTarget(ev.target);
     });
     svg.addEventListener("focusin", function (ev) {
+      if (!previewController.behavior || !previewController.behavior.isHover) return;
       showFromTarget(ev.target);
     });
-    if (previewController.behavior && previewController.behavior.isHover) {
-      const hideIfLeaving = function (ev) {
-        if (
-          previewUtils &&
-          typeof previewUtils.shouldKeepOpen === "function" &&
-          previewUtils.shouldKeepOpen(ev.relatedTarget, graphState.previewActiveNode, previewController.panel)
-        ) {
-          return;
-        }
-        hoverLifetime.scheduleHide();
-      };
-      svg.addEventListener("mouseout", hideIfLeaving);
-      svg.addEventListener("focusout", hideIfLeaving);
-    }
+    svg.addEventListener("click", function (ev) {
+      if (!previewController.behavior || !previewController.behavior.isPinned) return;
+      if (!showFromTarget(ev.target)) return;
+      ev.preventDefault();
+    });
+    svg.addEventListener("keydown", function (ev) {
+      if (ev.key !== "Enter" && ev.key !== " ") return;
+      if (!previewController.behavior || !previewController.behavior.isPinned) return;
+      if (!showFromTarget(ev.target)) return;
+      ev.preventDefault();
+    });
+    const hideIfLeaving = function (ev) {
+      if (!previewController.behavior || !previewController.behavior.isHover) return;
+      if (
+        previewUtils &&
+        typeof previewUtils.shouldKeepOpen === "function" &&
+        previewUtils.shouldKeepOpen(ev.relatedTarget, graphState.previewActiveNode, previewController.panel)
+      ) {
+        return;
+      }
+      hoverLifetime.scheduleHide();
+    };
+    svg.addEventListener("mouseout", hideIfLeaving);
+    svg.addEventListener("focusout", hideIfLeaving);
   }
 
   function attachVariantSelectors(graphContainer, variantsByKey, activeVariant, onSelect, onHover, onHoverLeave) {
@@ -771,6 +840,8 @@
         const selector = graphBlock.querySelector(".bp_graph_view_select");
         const directionSelector = graphBlock.querySelector(".bp_graph_direction_select");
         const packInput = graphBlock.querySelector(".bp_graph_pack_input");
+        const previewModeSelector = graphBlock.querySelector(".bp_graph_preview_mode_select");
+        const previewPlacementSelector = graphBlock.querySelector(".bp_graph_preview_placement_select");
         const previewMap = collectPreviewTemplates(graphBlock);
         const previewPanelNode = graphBlock.querySelector(".bp_graph_preview");
         const previewClose = previewPanelNode
@@ -781,7 +852,8 @@
           previewUtils && typeof previewUtils.readPanelBehavior === "function"
             ? previewUtils.readPanelBehavior(previewPanelNode, { mode: "pinned", placement: "docked" })
             : { mode: "pinned", placement: "docked", isPinned: true, isHover: false, isAnchored: false, isDocked: true };
-        const previewController = createPanelController(
+        let previewController = null;
+        previewController = createPanelController(
           previewPanelNode,
           previewPanelBehavior,
           ".bp_graph_preview_title",
@@ -795,7 +867,9 @@
               }
               renderMath(body);
             },
-            positionPanel: makeHtmlPanelPositioner(previewPanelBehavior),
+            positionPanel: makeHtmlPanelPositioner(function () {
+              return previewController ? previewController.behavior : previewPanelBehavior;
+            }),
             onHide: function () {
               graphState.previewRequestToken += 1;
               graphState.previewActiveNode = null;
@@ -803,9 +877,45 @@
           }
         );
         graphState.previewController = previewController;
-        configurePanelCloseButton(previewUtils, previewClose, function () {
-          if (previewController) previewController.hide();
-        }, previewPanelBehavior);
+        const readPreviewMode = function () {
+          if (previewModeSelector) return previewModeSelector.value;
+          if (previewController && previewController.behavior) return previewController.behavior.mode;
+          return previewPanelBehavior.mode || "pinned";
+        };
+        const readPreviewPlacement = function () {
+          if (previewPlacementSelector) return previewPlacementSelector.value;
+          if (previewController && previewController.behavior) return previewController.behavior.placement;
+          return previewPanelBehavior.placement || "docked";
+        };
+        const setPreviewBehavior = function (nextMode, nextPlacement, options) {
+          const opts = options && typeof options === "object" ? options : {};
+          const mode = normalizePreviewMode(nextMode);
+          const placement = normalizePreviewPlacement(nextPlacement);
+          if (previewPanelNode) {
+            previewPanelNode.setAttribute("data-bp-preview-mode", mode);
+            previewPanelNode.setAttribute("data-bp-preview-placement", placement);
+          }
+          if (previewModeSelector) previewModeSelector.value = mode;
+          if (previewPlacementSelector) previewPlacementSelector.value = placement;
+          const behavior = previewBehaviorForMode(previewUtils, mode, placement);
+          if (previewController) {
+            previewController.behavior = behavior;
+            configurePanelCloseButton(previewUtils, previewClose, function () {
+              if (previewController) previewController.hide();
+            }, behavior);
+            if (!opts.keepOpen) previewController.hide();
+          }
+          return behavior;
+        };
+        setPreviewBehavior(
+          previewModeSelector
+            ? (previewModeSelector.getAttribute("data-bp-graph-default-preview-mode") || previewModeSelector.value)
+            : (previewPanelBehavior.mode || "pinned"),
+          previewPlacementSelector
+            ? (previewPlacementSelector.getAttribute("data-bp-graph-default-preview-placement") || previewPlacementSelector.value)
+            : (previewPanelBehavior.placement || "docked"),
+          { keepOpen: true }
+        );
 
         const rawVariants = collectGraphVariants(graphContainer);
         if (!Array.isArray(rawVariants) || rawVariants.length === 0) return;
@@ -1103,6 +1213,16 @@
         if (packInput) {
           packInput.addEventListener("change", function () {
             switchPack(packInput.checked);
+          });
+        }
+        if (previewModeSelector) {
+          previewModeSelector.addEventListener("change", function () {
+            setPreviewBehavior(previewModeSelector.value, readPreviewPlacement());
+          });
+        }
+        if (previewPlacementSelector) {
+          previewPlacementSelector.addEventListener("change", function () {
+            setPreviewBehavior(readPreviewMode(), previewPlacementSelector.value);
           });
         }
 

--- a/src/VersoBlueprint/Lib/HoverRender.lean
+++ b/src/VersoBlueprint/Lib/HoverRender.lean
@@ -30,7 +30,7 @@ Preview visibility behavior:
 inductive PreviewMode where
   | hover
   | pinned
-deriving Inhabited, Repr, BEq, ToJson, FromJson
+deriving Inhabited, Repr, BEq, ToJson, FromJson, Quote
 
 def PreviewMode.dataValue : PreviewMode → String
   | .hover => "hover"
@@ -44,7 +44,7 @@ Preview placement behavior:
 inductive PreviewPlacement where
   | anchored
   | docked
-deriving Inhabited, Repr, BEq, ToJson, FromJson
+deriving Inhabited, Repr, BEq, ToJson, FromJson, Quote
 
 def PreviewPlacement.dataValue : PreviewPlacement → String
   | .anchored => "anchored"

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
@@ -25,6 +25,34 @@ Base statement for an explicit left-to-right graph.
 {blueprint_graph (direction := LR) (pack := false)}
 :::::::
 
+#docs (Genre.Manual) hoverPreviewGraphDoc "Blueprint Hover Preview Graph" :=
+:::::::
+:::definition "def:graph.hover.base"
+Base statement for an explicit hover-preview graph with the default docked panel.
+:::
+
+{blueprint_graph (preview := hover)}
+:::::::
+
+#docs (Genre.Manual) anchoredHoverPreviewGraphDoc "Blueprint Anchored Hover Preview Graph" :=
+:::::::
+:::definition "def:graph.hover.anchored.base"
+Base statement for an explicit anchored hover-preview graph.
+:::
+
+{blueprint_graph (preview := hover) (previewPlacement := anchored)}
+:::::::
+
+set_option verso.blueprint.graph.defaultPreviewMode "hover" in
+#docs (Genre.Manual) optionHoverPreviewGraphDoc "Blueprint Option Hover Preview Graph" :=
+:::::::
+:::definition "def:graph.option.hover.base"
+Base statement for graph preview mode option coverage.
+:::
+
+{blueprint_graph}
+:::::::
+
 /-- info: true -/
 #guard_msgs in
 #eval
@@ -38,6 +66,18 @@ Base statement for an explicit left-to-right graph.
       hasSubstr out "class=\"bp_graph_preview bp_preview_panel\"" &&
       hasSubstr out "data-bp-preview-mode=\"pinned\"" &&
       hasSubstr out "data-bp-preview-placement=\"docked\"" &&
+      hasSubstr out "class=\"bp_graph_controls_select bp_graph_preview_mode_select\"" &&
+      hasSubstr out "data-bp-graph-default-preview-mode=\"pinned\"" &&
+      hasSubstr out "class=\"bp_graph_controls_select bp_graph_preview_placement_select\"" &&
+      hasSubstr out "data-bp-graph-default-preview-placement=\"docked\"" &&
+      hasSubstr out "value=\"pinned\"" &&
+      hasSubstr out "Click to pin" &&
+      hasSubstr out "value=\"hover\"" &&
+      hasSubstr out "Hover" &&
+      hasSubstr out "value=\"docked\"" &&
+      hasSubstr out "Docked" &&
+      hasSubstr out "value=\"anchored\"" &&
+      hasSubstr out "Near node" &&
       !hasSubstr out "class=\"bp_graph_preview_store\"" &&
       !hasSubstr out "class=\"bp_graph_preview_tpl\"" &&
       hasSubstr out "class=\"bp_group_hover_preview bp_preview_panel\"" &&
@@ -62,10 +102,14 @@ Base statement for an explicit left-to-right graph.
       | some graphJs =>
         hasSubstr graphJs "return utils.readPreviewTemplate(entry);" &&
         hasSubstr graphJs "function layoutGraphCanvas(graphRoot, graphState)" &&
+        hasSubstr graphJs "function normalizePreviewMode(rawMode)" &&
+        hasSubstr graphJs "function normalizePreviewPlacement(rawPlacement)" &&
         hasSubstr graphJs "function ensureGraphBlockState(graphBlock)" &&
         hasSubstr graphJs "function createPanelController(panel, behavior, titleSelector, bodySelector, options)" &&
         hasSubstr graphJs "function bindHoverablePanelLifetime(previewUtils, controller, getActiveAnchor, boundAttr)" &&
         hasSubstr graphJs "function configurePanelCloseButton(previewUtils, closeButton, hidePanel, behavior)" &&
+        hasSubstr graphJs "const previewModeSelector = graphBlock.querySelector(\".bp_graph_preview_mode_select\");" &&
+        hasSubstr graphJs "const previewPlacementSelector = graphBlock.querySelector(\".bp_graph_preview_placement_select\");" &&
         hasSubstr graphJs "const previewKey = nodeId ? (previewKeys.get(nodeId) || \"\") : \"\";" &&
         hasSubstr graphJs "previewUtils.loadBlueprintHtmlCacheEntry(previewKey)" &&
         hasSubstr graphJs "previewUtils.readPanelBehavior(previewPanelNode, { mode: \"pinned\", placement: \"docked\" })" &&
@@ -73,6 +117,10 @@ Base statement for an explicit left-to-right graph.
         hasSubstr graphJs "previewUtils.readPanelBehavior(groupHoverPanel, { mode: \"pinned\", placement: \"docked\" })" &&
         hasSubstr graphJs "attachPreviewHandlers(graphBlock, graphContainer, previewMap, previewController, previewKeyByNodeId)" &&
         hasSubstr graphJs "graphState.previewActiveNode === node && !previewController.panel.hidden" &&
+        hasSubstr graphJs "if (!previewController.behavior || !previewController.behavior.isHover) return;" &&
+        hasSubstr graphJs "if (!previewController.behavior || !previewController.behavior.isPinned) return;" &&
+        hasSubstr graphJs "setPreviewBehavior(previewModeSelector.value, readPreviewPlacement());" &&
+        hasSubstr graphJs "setPreviewBehavior(readPreviewMode(), previewPlacementSelector.value);" &&
         hasSubstr graphJs "configurePanelCloseButton(previewUtils, previewClose" &&
         hasSubstr graphJs "configurePanelCloseButton(previewUtils, groupHoverClose" &&
         hasSubstr graphJs "previewKeyByNodeId: new Map(previewKeyByNodeId)" &&
@@ -101,6 +149,50 @@ Base statement for an explicit left-to-right graph.
         hasSubstr graphJs ".fit(true)" &&
         hasSubstr graphJs "syncLegend(graphBlock, activeKey)"
       | none => false
+    )
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (out, _) ← renderManualDocHtmlStringAndState manualImpls hoverPreviewGraphDoc
+    pure (
+      hasSubstr out "data-bp-preview-mode=\"hover\"" &&
+      hasSubstr out "data-bp-preview-placement=\"docked\"" &&
+      hasSubstr out "data-bp-graph-default-preview-mode=\"hover\"" &&
+      hasSubstr out "data-bp-graph-default-preview-placement=\"docked\"" &&
+      hasSubstr out "value=\"pinned\"" &&
+      hasSubstr out "Click to pin" &&
+      hasSubstr out "value=\"hover\"" &&
+      hasSubstr out "Hover" &&
+      hasSubstr out "value=\"docked\"" &&
+      hasSubstr out "Docked" &&
+      hasSubstr out "value=\"anchored\"" &&
+      hasSubstr out "Near node"
+    )
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (out, _) ← renderManualDocHtmlStringAndState manualImpls anchoredHoverPreviewGraphDoc
+    pure (
+      hasSubstr out "data-bp-preview-mode=\"hover\"" &&
+      hasSubstr out "data-bp-preview-placement=\"anchored\"" &&
+      hasSubstr out "data-bp-graph-default-preview-mode=\"hover\"" &&
+      hasSubstr out "data-bp-graph-default-preview-placement=\"anchored\""
+    )
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (out, _) ← renderManualDocHtmlStringAndState manualImpls optionHoverPreviewGraphDoc
+    pure (
+      hasSubstr out "data-bp-preview-mode=\"hover\"" &&
+      hasSubstr out "data-bp-preview-placement=\"docked\"" &&
+      hasSubstr out "data-bp-graph-default-preview-mode=\"hover\"" &&
+      hasSubstr out "data-bp-graph-default-preview-placement=\"docked\""
     )
 
 /-- info: true -/

--- a/tests/browser/test_graph_layout_runtime.py
+++ b/tests/browser/test_graph_layout_runtime.py
@@ -1,4 +1,4 @@
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 
 
 def wait_for_graph(page: Page):
@@ -117,6 +117,12 @@ def assert_graph_is_well_placed(page: Page):
     assert metrics is not None
     assert metrics["graphTop"] < metrics["canvasTop"] + 0.35 * metrics["canvasHeight"]
     assert metrics["graphBottom"] > metrics["canvasTop"] + 0.5 * metrics["canvasHeight"]
+
+
+def first_preview_node(page: Page):
+    node = page.locator(".bp_graph_canvas svg g.node[tabindex='0']").first
+    node.wait_for()
+    return node
 
 
 class TestGraphLayoutRuntime:
@@ -267,6 +273,104 @@ class TestGraphLayoutRuntime:
         assert switched["activePack"] == "true"
         assert switched["width"] > switched["height"]
         assert_graph_is_well_placed(page)
+
+    def test_graph_preview_defaults_to_click_to_pin(self, server: str, page: Page):
+        page.set_viewport_size({"width": 1400, "height": 900})
+        page.goto(f"{server}/Dependency-Graph/")
+        wait_for_graph(page)
+
+        panel = page.locator(".bp_graph_preview").first
+        node = first_preview_node(page)
+
+        assert panel.get_attribute("data-bp-preview-mode") == "pinned"
+        assert panel.get_attribute("data-bp-preview-placement") == "docked"
+
+        node.hover()
+        page.wait_for_timeout(250)
+        assert panel.evaluate("el => el.hidden") is True
+
+        node.click()
+        page.wait_for_function(
+            """() => {
+                const panel = document.querySelector(".bp_graph_preview");
+                return !!panel && !panel.hidden && panel.getAttribute("data-bp-preview-mode") === "pinned";
+            }"""
+        )
+        page.mouse.move(20, 20)
+        page.wait_for_timeout(250)
+        assert panel.evaluate("el => el.hidden") is False
+
+        page.locator(".bp_graph_preview_close").first.click()
+        page.wait_for_function(
+            """() => {
+                const panel = document.querySelector(".bp_graph_preview");
+                return !!panel && panel.hidden;
+            }"""
+        )
+
+    def test_graph_preview_can_switch_to_hover_autohide(self, server: str, page: Page):
+        page.set_viewport_size({"width": 1400, "height": 900})
+        page.goto(f"{server}/Dependency-Graph/")
+        wait_for_graph(page)
+
+        options_button = page.locator(".bp_graph_options_button").first
+        preview_selector = page.locator(".bp_graph_preview_mode_select").first
+        placement_selector = page.locator(".bp_graph_preview_placement_select").first
+        panel = page.locator(".bp_graph_preview").first
+        node = first_preview_node(page)
+
+        options_button.click()
+        expect(placement_selector).to_have_value("docked")
+        preview_selector.select_option("hover")
+        page.locator(".bp_graph_options_popover_close").first.click()
+
+        page.wait_for_function(
+            """() => {
+                const panel = document.querySelector(".bp_graph_preview");
+                const selector = document.querySelector(".bp_graph_preview_mode_select");
+                return (
+                    !!panel &&
+                    !!selector &&
+                    panel.hidden &&
+                    selector.value === "hover" &&
+                    panel.getAttribute("data-bp-preview-mode") === "hover" &&
+                    panel.getAttribute("data-bp-preview-placement") === "docked"
+                );
+            }"""
+        )
+
+        node.hover()
+        page.wait_for_function(
+            """() => {
+                const panel = document.querySelector(".bp_graph_preview");
+                return !!panel && !panel.hidden;
+            }"""
+        )
+        page.mouse.move(1390, 890)
+        page.wait_for_function(
+            """() => {
+                const panel = document.querySelector(".bp_graph_preview");
+                return !!panel && panel.hidden;
+            }"""
+        )
+
+        options_button.click()
+        placement_selector.select_option("anchored")
+        page.locator(".bp_graph_options_popover_close").first.click()
+        page.wait_for_function(
+            """() => {
+                const panel = document.querySelector(".bp_graph_preview");
+                const selector = document.querySelector(".bp_graph_preview_placement_select");
+                return (
+                    !!panel &&
+                    !!selector &&
+                    panel.hidden &&
+                    selector.value === "anchored" &&
+                    panel.getAttribute("data-bp-preview-mode") === "hover" &&
+                    panel.getAttribute("data-bp-preview-placement") === "anchored"
+                );
+            }"""
+        )
 
     def test_graph_page_does_not_force_extra_vertical_scroll(self, server: str, page: Page):
         page.set_viewport_size({"width": 1400, "height": 900})


### PR DESCRIPTION
## Summary
Backport #107 to `v4.29.0`.

## Primary Review
- Primary review: #107
- Keep review comments on #107 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.29.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.