### PR TITLE
fix: deprecate preview manifest compatibility alias

### DIFF
--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -1577,6 +1577,7 @@ def manualMainWithPreviewData
   blueprintMainWithPreviewData text options extensionImpls config extraSteps
 
 -- Compatibility for reference generators pinned before preview data was renamed.
+@[deprecated manualMainWithPreviewData (since := "2026-06-08")]
 def manualMainWithSharedPreviewManifest
     (text : Part Manual)
     (options : List String)


### PR DESCRIPTION
This PR marks the old shared-preview manifest generator entry point as deprecated now that `manualMainWithPreviewData` is the preferred API.

- Deprecated `Informal.PreviewManifest.manualMainWithSharedPreviewManifest` with an automatic replacement pointing to `manualMainWithPreviewData`.

Backport v4.29.0: exempt: the release line did not yet contain the compatibility wrapper; the v4.29-specific fix is tracked separately in #112.


