### PR TITLE
[backport v4.29.0] fix: deprecate preview manifest compatibility alias

### DIFF
--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -1576,4 +1576,14 @@ def manualMainWithPreviewData
     (extraSteps : List ExtraStep := []) : IO UInt32 :=
   blueprintMainWithPreviewData text options extensionImpls config extraSteps
 
+-- Compatibility for reference generators pinned before preview data was renamed.
+@[deprecated manualMainWithPreviewData (since := "2026-06-08")]
+def manualMainWithSharedPreviewManifest
+    (text : Part Manual)
+    (options : List String)
+    (extensionImpls : ExtensionImpls)
+    (config : RenderConfig := {})
+    (extraSteps : List ExtraStep := []) : IO UInt32 :=
+  manualMainWithPreviewData text options extensionImpls config extraSteps
+
 end Informal.PreviewManifest


### PR DESCRIPTION
## Summary
Release-line compatibility fix for #111 on `v4.29.0`.

## Primary Review
- Related default-development PR: #111
- Keep review comments on #111 unless this release-line fix diverges materially.

## Scope
- Add the legacy `Informal.PreviewManifest.manualMainWithSharedPreviewManifest` compatibility wrapper that already exists on `v4.30.0`.
- Mark that wrapper deprecated with an automatic replacement pointing to `Informal.PreviewManifest.manualMainWithPreviewData`.
- Keep this PR limited to the `v4.29.0` compatibility gap that broke the sphere-packing reference generator.

## Backport Delta
- This is intentionally not a patch-id-identical paired backport: `v4.30.0` already had the wrapper and only needed the deprecation attribute, while `v4.29.0` lacked the wrapper entirely.
- The wrapper forwards to `Informal.PreviewManifest.manualMainWithPreviewData`, matching the default-development compatibility behavior.
