### PR TITLE
[backport v4.29.0] feat: infer blueprint dependencies from Lean declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ theorem nat_add_zero_right (n : Nat) : n + 0 = n := by
   simp
 ```
 
+Add `(autoDeps := true)` when a tagged declaration, labeled inline Lean block,
+or `(lean := "...")` statement should infer statement/proof dependency edges to
+directly referenced Lean declarations that are already associated with Blueprint
+labels. You can also set `set_option verso.blueprint.autoDeps true` for a file
+or section, with local `(autoDeps := false)` available as an override. Inferred
+edges are recorded with origin `"automatic"`; explicit `uses` and `proofUses`
+entries remain manual unless written through the usual Blueprint dependency
+syntax. Manual `{uses ...}` links remain available for prose-first Blueprint
+nodes.
+
 ```md
 :::theorem "addition_assoc" (lean := "Nat.add_assoc, Nat.add_comm")
 This informal node is linked to existing compiled Lean declarations.

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -133,8 +133,10 @@ code block:
 
 1. `Informal/Code.lean` elaborates the Lean block and records
    `InlineCodeData`.
-2. `Informal/Block.lean` resolves block-level code source precedence during
-   HTML rendering, preferring inline code over any external-code hint.
+2. `Informal/Block.lean` keeps semantic Lean associations accumulated across
+   inline and external sources. Heading summaries prefer inline code when they
+   need one compact status badge, while external declaration panels still render
+   from the statement block's external references.
 3. `Informal/CodeSummary.lean` computes the heading badge, summary hover body,
    and code-panel indicator from that resolved source.
 4. `Informal/Block/Common.lean` provides the shared panel/header helpers used

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -35,7 +35,9 @@ Those labels are the key to the whole system. They are used to:
 - point at a node without adding a dependency edge with `{bpref "addition_spec"}[]`
 - attach inline Lean code with a labeled `lean` code block
 - attach raw TeX source for porting with a `tex` code block
-- tag compiled declarations with `@[blueprint "label"]`
+- tag compiled declarations with `@[blueprint "label"]`, optionally using
+  `(autoDeps := true)` or `set_option verso.blueprint.autoDeps true` to infer
+  edges to directly referenced Lean declarations associated with Blueprint labels
 
 If you pick stable labels early, the rest of the project structure becomes much
 easier to maintain.

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -287,6 +287,77 @@ manual Markdown path when possible, and richer internal docstring structures are
 converted into Manual blocks directly. If no docstring is available, the node is
 still registered, but there is no imported informal statement body.
 
+Automatic dependency inference is opt-in. Enable it locally with
+`(autoDeps := true)`, or set the file/section default with:
+
+```lean
+set_option verso.blueprint.autoDeps true
+```
+
+The local argument wins over the option, so `(autoDeps := false)` disables
+inference for one node even when the file default is enabled.
+
+For a compiled declaration tagged with `@[blueprint]`, write:
+
+```lean
+/-- Associativity of addition. -/
+@[blueprint "addition_assoc_compiled" (autoDeps := true)]
+theorem addition_assoc_compiled (a b c : Nat) : (a + b) + c = a + (b + c) := by
+  simpa [Nat.add_assoc]
+```
+
+The same local option is accepted on labeled inline Lean blocks and on informal
+statement blocks that use `(lean := "...")`:
+
+````md
+:::theorem "addition_assoc" (lean := "Nat.add_assoc") (autoDeps := true)
+For all natural numbers, addition is associative.
+:::
+
+```lean "addition_assoc_local" (autoDeps := true)
+theorem addition_assoc_local (a b c : Nat) : (a + b) + c = a + (b + c) := by
+  simpa [Nat.add_assoc]
+```
+````
+
+When inference is enabled, Blueprint scans the direct Lean constants mentioned
+by the declaration's type and compiled body. Declarations associated with
+Blueprint labels and used directly by the type become statement dependencies;
+declarations associated with Blueprint labels and used directly by the body
+become proof dependencies. A Lean declaration is associated with a Blueprint
+label by `@[blueprint "..."]`, by a labeled inline Lean code block, or by an
+informal statement block with `(lean := "...")`. Untagged Lean constants are
+ignored and are not expanded to search for transitive tagged dependencies. Use
+string labels for ordinary Blueprint-only nodes. Inferred edges are stored with origin
+`"automatic"` so relationship panels can distinguish them from author-written
+edges. If the same label is both inferred and explicitly listed on the same
+axis, the edge is emitted once with manual origin. If the same label is inferred
+on both axes, the statement edge wins and the automatic proof edge is
+suppressed; an explicit `proofUses` entry can still put the label on the proof
+axis when that is what the Blueprint should say.
+
+Manual attribute dependencies can be merged with or excluded from the inferred
+set:
+
+```lean
+@[blueprint "addition_assoc_compiled"
+  (autoDeps := true)
+  (uses := ["addition_right_identity", -"addition_zero"])
+  (proofUses := [nat_add_zero_right])]
+theorem addition_assoc_compiled (a b c : Nat) : (a + b) + c = a + (b + c) := by
+  simpa [Nat.add_assoc]
+```
+
+`uses` affects statement dependencies and `proofUses` affects proof
+dependencies. Each list accepts Lean declaration names or Blueprint label
+strings. Prefix an entry with `-` to remove that inferred or explicit edge from
+the same axis after inference and manual entries have been resolved.
+
+A tagged declaration can still receive a prose statement or proof block with the
+same Blueprint label. If the attribute has only created dependency metadata for
+that statement or proof, the later block fills in the rendered body and keeps
+the inferred dependency edges.
+
 ### Existing Lean declarations
 
 Use `(lean := "Nat.add_assoc")` when Lean already owns the declaration and you
@@ -306,6 +377,8 @@ Notes:
 - `(lean := "Nat.add_assoc")` points at Lean-owned declaration names
 - `(lean := "Nat.add, Nat.succ")` supports comma-separated declaration lists
 - `@[blueprint "addition_assoc_compiled"]` registers a Lean-owned Blueprint node
+- `(autoDeps := true)` is accepted by `@[blueprint]`, labeled inline Lean blocks,
+  and statement blocks with `(lean := "...")`
 - Blueprint labels are Blueprint-owned metadata
 - Blueprint label conventions do not rewrite external Lean names
 

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -297,6 +297,15 @@ set_option verso.blueprint.autoDeps true
 The local argument wins over the option, so `(autoDeps := false)` disables
 inference for one node even when the file default is enabled.
 
+This is LeanArchitect-style automatic dependency inference: dependency edges are
+derived from Lean's compiled declarations instead of duplicated by hand.
+Verso Blueprint's variant is document-first and direct. LeanArchitect expands
+through untagged Lean helpers until it reaches blueprint-tagged declarations;
+Verso Blueprint scans only direct constants and then maps those constants to
+their associated Blueprint labels. This keeps immediate Blueprint edges
+predictable while still removing the routine `uses` duplication around formal
+declarations.
+
 For a compiled declaration tagged with `@[blueprint]`, write:
 
 ```lean
@@ -326,15 +335,22 @@ Blueprint labels and used directly by the type become statement dependencies;
 declarations associated with Blueprint labels and used directly by the body
 become proof dependencies. A Lean declaration is associated with a Blueprint
 label by `@[blueprint "..."]`, by a labeled inline Lean code block, or by an
-informal statement block with `(lean := "...")`. Untagged Lean constants are
-ignored and are not expanded to search for transitive tagged dependencies. Use
-string labels for ordinary Blueprint-only nodes. Inferred edges are stored with origin
-`"automatic"` so relationship panels can distinguish them from author-written
-edges. If the same label is both inferred and explicitly listed on the same
-axis, the edge is emitted once with manual origin. If the same label is inferred
-on both axes, the statement edge wins and the automatic proof edge is
-suppressed; an explicit `proofUses` entry can still put the label on the proof
-axis when that is what the Blueprint should say.
+informal statement block with `(lean := "...")`.
+
+Lean associations are many-to-many. One Blueprint label may be associated with
+several Lean code items, and one Lean declaration may be associated with several
+Blueprint labels. Automatic dependency inference emits all associated labels and
+then deduplicates edges by label.
+
+Untagged Lean constants are ignored and are not expanded to search for
+transitive tagged dependencies. Use string labels for ordinary Blueprint-only
+nodes. Inferred edges are stored with origin `"automatic"` so relationship
+panels can distinguish them from author-written edges. If the same label is
+both inferred and explicitly listed on the same axis, the edge is emitted once
+with manual origin. If the same label is inferred on both axes, the statement
+edge wins and the automatic proof edge is suppressed; an explicit `proofUses`
+entry can still put the label on the proof axis when that is what the Blueprint
+should say.
 
 Manual attribute dependencies can be merged with or excluded from the inferred
 set:
@@ -371,6 +387,11 @@ For all natural numbers $`a`, $`b`, and $`c`, addition is associative.
 
 This links the Blueprint entry to an existing Lean declaration without copying
 the declaration body into the chapter.
+
+If the same Blueprint label also has a labeled inline Lean block, Blueprint
+keeps both Lean associations. External declaration references render with the
+informal statement block, while inline Lean blocks render at their source
+location.
 
 Notes:
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -22,6 +22,7 @@ lean_lib VersoBlueprintTests where
   srcDir := "tests"
   roots := #[
     `VersoBlueprintTests.Blueprint.Support,
+    `VersoBlueprintTests.BlueprintAutoDeps,
     `VersoBlueprintTests.BlueprintAttribute,
     `VersoBlueprintTests.BlueprintCodeRenderMatrix,
     `VersoBlueprintTests.BlueprintImportedDuplicates.Direct,

--- a/src/VersoBlueprint.lean
+++ b/src/VersoBlueprint.lean
@@ -23,6 +23,7 @@ import VersoBlueprint.Macros
 import VersoBlueprint.Math
 import VersoBlueprint.Rust
 import VersoBlueprint.Environment
+import VersoBlueprint.DependencyAnalysis
 import VersoBlueprint.Attribute
 import VersoBlueprint.Cite
 import VersoBlueprint.Commands.Graph

--- a/src/VersoBlueprint/Attribute.lean
+++ b/src/VersoBlueprint/Attribute.lean
@@ -310,8 +310,8 @@ private def registerLeanOnlyDecl (decl : Name) (cfg : BlueprintAttrConfig) (ref 
   let extRef ←
     externalRefSnapshotAtCurrentDir opts (Data.ExternalRef.ofName decl .blueprintAttr)
 
-  Environment.modifyM fun state => do
-    let data ← state.data.registerCodeRef label (.external #[extRef])
+  Environment.modifyDataForLabel label fun data => do
+    let data ← data.registerCodeRef label (.external #[extRef])
     let data :=
       match data.get? label with
       | some node =>
@@ -325,13 +325,7 @@ private def registerLeanOnlyDecl (decl : Name) (cfg : BlueprintAttrConfig) (ref 
         let node := { node with statement, proof }
         data.insert label node
       | none => data
-    let localData :=
-      match data.get? label with
-      | some node => state.localData.insert label node
-      | none => state.localData
-    let labels := state.leanNameLabels.getD decl #[]
-    let leanNameLabels := state.leanNameLabels.insert decl (pushLabelUnique labels label)
-    return { state with data, localData, leanNameLabels }
+    return data
 
 open Lean in
 initialize

--- a/src/VersoBlueprint/Attribute.lean
+++ b/src/VersoBlueprint/Attribute.lean
@@ -7,6 +7,7 @@ Author: Emilio J. Gallego Arias
 import Lean
 import Lean.DocString.Extension
 import VersoManual
+import VersoBlueprint.DependencyAnalysis
 import VersoBlueprint.Environment
 import VersoBlueprint.ExternalRefSnapshot
 import VersoBlueprint.LabelNameParsing
@@ -16,13 +17,101 @@ namespace Informal
 
 open Lean
 
-syntax (name := blueprint) "blueprint" ppSpace str : attr
+syntax blueprintDepTerm := "-"? (ident <|> str)
+syntax blueprintDepList := "[" blueprintDepTerm,* "]"
+declare_syntax_cat blueprintAttrOption
+syntax (name := blueprintAutoDepsAttrOption) "(" &"autoDeps" " := " ident ")" : blueprintAttrOption
+syntax (name := blueprintUsesAttrOption) "(" &"uses" " := " blueprintDepList ")" : blueprintAttrOption
+syntax (name := blueprintProofUsesAttrOption) "(" &"proofUses" " := " blueprintDepList ")" : blueprintAttrOption
+syntax (name := blueprint) "blueprint" ppSpace str (ppSpace blueprintAttrOption)* : attr
+
+private inductive AutoDepTarget where
+  | label (label : Data.Label)
+  | decl (decl : Name)
+deriving Repr
+
+private structure AutoDepEntries where
+  add : Array AutoDepTarget := #[]
+  exclude : Array AutoDepTarget := #[]
+deriving Inhabited, Repr
+
+private def AutoDepEntries.append (current incoming : AutoDepEntries) : AutoDepEntries :=
+  {
+    add := current.add ++ incoming.add
+    exclude := current.exclude ++ incoming.exclude
+  }
+
+private structure BlueprintAttrConfig where
+  label : Data.Label
+  autoDeps : Option Bool := none
+  uses : AutoDepEntries := {}
+  proofUses : AutoDepEntries := {}
+deriving Inhabited, Repr
 
 private def classifyDeclKind (decl : Name) (info : ConstantInfo) : CoreM Data.NodeKind :=
   match Informal.Data.ConstantInfo.blueprintNodeKind? info with
   | some kind => pure kind
   | none =>
     throwError "invalid '[blueprint]' target '{decl}': expected a definition-like declaration or theorem, got {Informal.Data.ConstantInfo.blueprintKindText info}"
+
+private def pushLabelUnique (labels : Array Data.Label) (label : Data.Label) : Array Data.Label :=
+  if labels.contains label then labels else labels.push label
+
+private def manualUseRef (label : Data.Label) : Data.UseRef :=
+  { label }
+
+private def pushTargetUnique (targets : Array AutoDepTarget) (target : AutoDepTarget) :
+    Array AutoDepTarget :=
+  match target with
+  | .label label =>
+    if targets.any (fun
+      | .label existing => existing == label
+      | _ => false) then targets else targets.push target
+  | .decl decl =>
+    let decl := decl.eraseMacroScopes
+    if targets.any (fun
+      | .decl existing => existing.eraseMacroScopes == decl
+      | _ => false) then targets else targets.push (.decl decl)
+
+private def parseLabel (label : String) : Data.Label :=
+  LabelNameParsing.parse label
+
+private def parseDepList : TSyntax ``blueprintDepList → CoreM AutoDepEntries
+  | `(blueprintDepList| [$[$deps:blueprintDepTerm],*]) => do
+    deps.foldlM (init := {}) fun cfg dep => do
+      match dep with
+      | `(blueprintDepTerm| $id:ident) =>
+        let decl ← Lean.Elab.realizeGlobalConstNoOverloadWithInfo id
+        return { cfg with add := pushTargetUnique cfg.add (.decl decl) }
+      | `(blueprintDepTerm| -$id:ident) =>
+        let decl ← Lean.Elab.realizeGlobalConstNoOverloadWithInfo id
+        return { cfg with exclude := pushTargetUnique cfg.exclude (.decl decl) }
+      | `(blueprintDepTerm| $label:str) =>
+        return { cfg with add := pushTargetUnique cfg.add (.label (parseLabel label.getString)) }
+      | `(blueprintDepTerm| -$label:str) =>
+        return { cfg with exclude := pushTargetUnique cfg.exclude (.label (parseLabel label.getString)) }
+      | _ => throwError "unsupported dependency syntax in '[blueprint]' attribute"
+  | _ => throwError "unsupported dependency list syntax in '[blueprint]' attribute"
+
+private def elabBlueprintConfig : Syntax → CoreM BlueprintAttrConfig
+  | `(attr| blueprint $label:str $[$opts:blueprintAttrOption]*) => do
+    let mut cfg : BlueprintAttrConfig := { label := parseLabel label.getString }
+    for opt in opts do
+      match opt with
+      | `(blueprintAttrOption| (autoDeps := $value:ident)) =>
+        match value.getId.eraseMacroScopes with
+        | `true => cfg := { cfg with autoDeps := some true }
+        | `false => cfg := { cfg with autoDeps := some false }
+        | _ => throwErrorAt value "'autoDeps' expects 'true' or 'false'"
+      | `(blueprintAttrOption| (uses := $deps:blueprintDepList)) =>
+        let deps ← parseDepList deps
+        cfg := { cfg with uses := cfg.uses.append deps }
+      | `(blueprintAttrOption| (proofUses := $deps:blueprintDepList)) =>
+        let deps ← parseDepList deps
+        cfg := { cfg with proofUses := cfg.proofUses.append deps }
+      | _ => throwError "unsupported option syntax in '[blueprint]' attribute"
+    return cfg
+  | _ => throwError "invalid syntax for '[blueprint]' attribute"
 
 mutual
 
@@ -139,13 +228,84 @@ private def statementFromDocstring? (decl : Name) (ref : Syntax) : CoreM (Option
       elabStx := elabStx.map (·.raw)
     }
 
-private def registerLeanOnlyDecl (decl label : Name) (ref : Syntax) : CoreM Unit := do
+private structure ResolvedAutoDeps where
+  statement : Array Data.UseRef := #[]
+  proof : Array Data.UseRef := #[]
+deriving Inhabited, Repr
+
+private def labelsForManualTarget
+    (currentDecl currentLabel : Name) (target : AutoDepTarget) : CoreM (Array Data.Label) := do
+  match target with
+  | .label label => return #[label]
+  | .decl decl =>
+    let decl := decl.eraseMacroScopes
+    if decl == currentDecl.eraseMacroScopes then
+      return #[currentLabel]
+    let labels ← Environment.labelsForLeanDecl decl
+    if labels.isEmpty then
+      throwError
+        "Blueprint dependency declaration '{decl}' does not have a registered Blueprint label; use a string label or tag that declaration with '[blueprint]' first"
+    return labels
+
+private def resolveManualTargets
+    (currentDecl currentLabel : Name) (targets : Array AutoDepTarget) : CoreM (Array Data.Label) := do
+  targets.foldlM (init := #[]) fun acc target => do
+    let labels ← labelsForManualTarget currentDecl currentLabel target
+    return labels.foldl pushLabelUnique acc
+
+private def mergeAxisDeps
+    (currentDecl currentLabel : Name) (inferred : Array Data.Label) (manual : AutoDepEntries) :
+    CoreM (Array Data.UseRef) := do
+  let explicit ← resolveManualTargets currentDecl currentLabel manual.add
+  let excluded ← resolveManualTargets currentDecl currentLabel manual.exclude
+  let excluded := pushLabelUnique excluded currentLabel
+  let mut out := #[]
+  for label in DependencyAnalysis.sortLabels inferred do
+    if !excluded.contains label then
+      out := Data.UseRef.pushMergeByLabel out (DependencyAnalysis.automaticUseRef label)
+  for label in explicit do
+    if !excluded.contains label then
+      out := Data.UseRef.pushMergeByLabel out (manualUseRef label)
+  return out
+
+private def resolveAutoDeps
+    (decl : Name) (label : Data.Label) (info : ConstantInfo) (cfg : BlueprintAttrConfig) :
+    CoreM ResolvedAutoDeps := do
+  let inferred ←
+    if DependencyAnalysis.enabled (← getOptions) cfg.autoDeps then
+      DependencyAnalysis.infer decl info
+    else
+      pure {}
+  let statement ← mergeAxisDeps decl label inferred.statement cfg.uses
+  let statementLabels := Data.UseRef.labels statement
+  let proofInferred := inferred.proof.filter fun label => !statementLabels.contains label
+  let proof ← mergeAxisDeps decl label proofInferred cfg.proofUses
+  return { statement, proof }
+
+private def payloadWithDeps
+    (ref : Syntax) (deps : Array Data.UseRef) (incoming? existing? : Option Data.InformalData) :
+    Option Data.InformalData :=
+  let mergeDeps (payload : Data.InformalData) : Data.InformalData :=
+    { payload with deps := deps.foldl Data.UseRef.pushMergeByLabel payload.deps }
+  match existing? with
+  | some payload => some (mergeDeps payload)
+  | none =>
+    match incoming? with
+    | some payload => some (mergeDeps payload)
+    | none =>
+      if deps.isEmpty then
+        none
+      else
+        some { stx := ref, deps }
+
+private def registerLeanOnlyDecl (decl : Name) (cfg : BlueprintAttrConfig) (ref : Syntax) : CoreM Unit := do
   let decl := decl.eraseMacroScopes
-  let label := label.eraseMacroScopes
+  let label := cfg.label.eraseMacroScopes
   let some info := (← getEnv).find? decl
     | throwError "unknown declaration '{decl}'"
   let declKind ← classifyDeclKind decl info
   let statement? ← statementFromDocstring? decl ref
+  let deps ← resolveAutoDeps decl label info cfg
   let opts ← getOptions
   let extRef ←
     externalRefSnapshotAtCurrentDir opts (Data.ExternalRef.ofName decl .blueprintAttr)
@@ -160,22 +320,18 @@ private def registerLeanOnlyDecl (decl label : Name) (ref : Syntax) : CoreM Unit
             { node with kind := declKind }
           else
             node
-        let node :=
-          match statement?, node.statement with
-          | some statement, none => { node with statement := some statement }
-          | _, _ => node
+        let statement := payloadWithDeps ref deps.statement statement? node.statement
+        let proof := payloadWithDeps ref deps.proof none node.proof
+        let node := { node with statement, proof }
         data.insert label node
       | none => data
     let localData :=
       match data.get? label with
       | some node => state.localData.insert label node
       | none => state.localData
-    return { state with data, localData }
-
-private def labelFromAttr (stx : Syntax) : CoreM Name := do
-  match stx with
-  | `(attr| blueprint $lbl:str) => pure (LabelNameParsing.parse lbl.getString)
-  | _ => throwError "invalid syntax for '[blueprint]' attribute"
+    let labels := state.leanNameLabels.getD decl #[]
+    let leanNameLabels := state.leanNameLabels.insert decl (pushLabelUnique labels label)
+    return { state with data, localData, leanNameLabels }
 
 open Lean in
 initialize
@@ -188,9 +344,9 @@ initialize
         throwError "invalid attribute '[blueprint]', must be global"
       unless ((← getEnv).getModuleIdxFor? decl).isNone do
         throwError "invalid attribute '[blueprint]', declaration is in an imported module"
-      let label ← labelFromAttr stx
-      registerLeanOnlyDecl decl label stx
-    descr := "Registers a definition/theorem as a Lean-only blueprint node; argument sets the node label (string literal)"
+      let cfg ← elabBlueprintConfig stx
+      registerLeanOnlyDecl decl cfg stx
+    descr := "Registers a definition/theorem as a Lean-only blueprint node; supports opt-in automatic dependency inference"
   }
 
 end Informal

--- a/src/VersoBlueprint/Commands/Summary.lean
+++ b/src/VersoBlueprint/Commands/Summary.lean
@@ -245,27 +245,117 @@ private def mkIndexItem (label : Name) (kind : Data.NodeKind) (leanObjects : Lis
   { label, kind := toString kind, leanObjects }
 
 private def nodeLeanObjects (node : Data.Node) : List Name :=
-  match node.code with
-  | some (.external decls) => (decls.map (·.canonical)).toList
-  | some (.literate code) => (code.definedDefs.map (·.name) ++ code.definedTheorems.map (·.name)).toList
-  | _ => []
+  let externalNames :=
+    node.externalRefs.foldl (init := #[]) fun acc decl =>
+      pushUniqueName acc decl.canonical
+  let allNames :=
+    node.literateCodes.foldl (init := externalNames) fun acc code =>
+      code.definedDeclNames.foldl pushUniqueName acc
+  allNames.toList
+
+private def codeDeclCount (code : Data.Code) : Nat :=
+  code.definedDefs.size + code.definedTheorems.size
+
+private def codeSorryCount (code : Data.Code) : Nat :=
+  countSorries code.definedDefs (fun (d : Data.LiterateDef) => d.provedStatus) +
+  countSorries code.definedTheorems (fun (d : Data.LiterateThm) => d.provedStatus)
+
+private def codeSorryDetails (label : Name) (kind : String) (code : Data.Code) : List SorryItem :=
+  collectSorries label kind code.definedDefs
+    (fun (d : Data.LiterateDef) => d.name)
+    (fun (d : Data.LiterateDef) => d.provedStatus)
+    (fun _ => false) ++
+  collectSorries label kind code.definedTheorems
+    (fun (d : Data.LiterateThm) => d.name)
+    (fun (d : Data.LiterateThm) => d.provedStatus)
+    (fun _ => true)
+
+private structure NodeLeanSummary where
+  leanDecls : Nat := 0
+  sorries : Nat := 0
+  leanObjects : List Name := []
+  sorryDetails : List SorryItem := []
+  missingLeanDecls : List MissingLeanDeclItem := []
+  renderFailures : List RenderFailureItem := []
+deriving Inhabited
+
+private def nodeLeanSummary (label : Name) (node : Data.Node) : NodeLeanSummary :=
+  if !node.hasAssociatedCode then
+    {}
+  else
+    let kind := toString node.kind
+    let externalDecls := node.externalRefs
+    let missingLeanDecls :=
+      externalDecls.foldl (init := []) fun acc decl =>
+        if !decl.present then
+          {
+            label
+            kind
+            written := decl.written
+            canonical := decl.canonical
+          } :: acc
+        else
+          acc
+    let incompleteExternalDecls :=
+      externalDecls.foldl (init := #[]) fun acc decl =>
+        if !decl.present then
+          acc
+        else
+          let status := decl.provedStatus
+          if status.isIncomplete then
+            acc.push (decl.canonical, status)
+          else
+            acc
+    let externalSorryDetails :=
+      incompleteExternalDecls.toList.map fun (decl, status) =>
+        {
+          label
+          kind
+          decl
+          isTheorem :=
+            (externalDecls.find? (fun d => d.canonical == decl)).map (·.kind.isTheoremLike) |>.getD false
+          status
+        }
+    let renderFailures :=
+      (externalRenderFailures externalDecls).toList.map fun failure =>
+        {
+          label
+          kind
+          written := failure.decl.written
+          canonical := failure.decl.canonical
+          message := failure.message
+        }
+    let (inlineDecls, inlineSorries, inlineSorryDetails) :=
+      node.literateCodes.foldl
+        (init := (0, 0, ([] : List SorryItem)))
+        fun (decls, sorryCount, details) code =>
+          (
+            decls + codeDeclCount code,
+            sorryCount + codeSorryCount code,
+            codeSorryDetails label kind code ++ details
+          )
+    {
+      leanDecls := externalDecls.size + inlineDecls
+      sorries := incompleteExternalDecls.size + inlineSorries
+      leanObjects := nodeLeanObjects node
+      sorryDetails := externalSorryDetails ++ inlineSorryDetails
+      missingLeanDecls
+      renderFailures
+    }
 
 private def nodeMissingLeanDeclCount (external : Informal.Graph.ExternalCodeStatus) (node : Data.Node) : Nat :=
   (Informal.Graph.nodeExternalDecls node).foldl (init := 0) fun acc decl =>
     acc + (if Informal.Graph.externalDeclMissing external decl then 1 else 0)
 
 private def nodeIncompleteLeanDeclCount (external : Informal.Graph.ExternalCodeStatus) (node : Data.Node) : Nat :=
-  match node.code with
-  | some (.external decls) =>
-    decls.foldl (init := 0) fun acc decl =>
+  let externalCount :=
+    node.externalRefs.foldl (init := 0) fun acc decl =>
       if Informal.Graph.externalDeclMissing external decl then
         acc
       else
         acc + (if decl.provedStatus.isIncomplete then 1 else 0)
-  | some (.literate code) =>
-      countSorries code.definedDefs (fun (d : Data.LiterateDef) => d.provedStatus) +
-      countSorries code.definedTheorems (fun (d : Data.LiterateThm) => d.provedStatus)
-  | _ => 0
+  externalCount + node.literateCodes.foldl (init := 0) fun acc code =>
+    acc + codeSorryCount code
 
 private def ownerDisplayName (state : Environment.State) (node : Data.Node) : Option String :=
   match node.owner with
@@ -365,89 +455,27 @@ def buildSummary : CoreM Summary := do
   let summary := entries.foldl (init := ({} : Summary)) fun acc (label, node) =>
       let hasStatement := node.statement.isSome
       let hasProof := node.proof.isSome
-      let hasCode := node.code.isSome
+      let hasCode := Informal.Graph.nodeHasAssociatedCode node
       let statusFlags := entryStatusFlags state external node
-      let (leanDecls, sorries, leanObjects, sorryDetails, missingLeanDecls, renderFailures) :=
-        match node.code with
-        | none => (0, 0, ([] : List Name), ([] : List SorryItem), ([] : List MissingLeanDeclItem), ([] : List RenderFailureItem))
-        | some (.external decls) =>
-          let leanObjects := nodeLeanObjects node
-          let missingDecls :=
-            decls.foldl (init := []) fun acc decl =>
-              if !decl.present then
-                {
-                  label
-                  kind := toString node.kind
-                  written := decl.written
-                  canonical := decl.canonical
-                } :: acc
-              else
-                acc
-          let incompleteDecls :=
-            decls.foldl (init := #[]) fun acc decl =>
-              if !decl.present then
-                acc
-              else
-                let status := decl.provedStatus
-                if status.isIncomplete then
-                  acc.push (decl.canonical, status)
-                else
-                  acc
-          let sorryDetails :=
-            incompleteDecls.toList.map fun (decl, status) =>
-              {
-                label
-                kind := toString node.kind
-                decl
-                isTheorem :=
-                  (decls.find? (fun d => d.canonical == decl)).map (·.kind.isTheoremLike) |>.getD false
-                status
-              }
-          let renderFailures :=
-            (externalRenderFailures decls).toList.map fun failure =>
-              {
-                label
-                kind := toString node.kind
-                written := failure.decl.written
-                canonical := failure.decl.canonical
-                message := failure.message
-              }
-          (decls.size, incompleteDecls.size, leanObjects, sorryDetails, missingDecls, renderFailures)
-        | some (.literate code) =>
-          let kind := toString node.kind
-          let leanObjects := nodeLeanObjects node
-          let leanDecls := code.definedDefs.size + code.definedTheorems.size
-          let sorries :=
-            countSorries code.definedDefs (fun (d : Data.LiterateDef) => d.provedStatus) +
-            countSorries code.definedTheorems (fun (d : Data.LiterateThm) => d.provedStatus)
-          let sorryDetails :=
-            collectSorries label kind code.definedDefs
-              (fun (d : Data.LiterateDef) => d.name)
-              (fun (d : Data.LiterateDef) => d.provedStatus)
-              (fun _ => false) ++
-            collectSorries label kind code.definedTheorems
-              (fun (d : Data.LiterateThm) => d.name)
-              (fun (d : Data.LiterateThm) => d.provedStatus)
-              (fun _ => true)
-          (leanDecls, sorries, leanObjects, sorryDetails, ([] : List MissingLeanDeclItem), ([] : List RenderFailureItem))
+      let leanSummary := nodeLeanSummary label node
       let pendingInformalEntries : List PendingInformalItem :=
         if hasCode && ((node.kind.isTheoremLike && !hasProof) || !hasStatement) then
-          mkIndexItem label node.kind leanObjects :: acc.pendingInformalEntries
+          mkIndexItem label node.kind leanSummary.leanObjects :: acc.pendingInformalEntries
         else
           acc.pendingInformalEntries
       let definitionIndex : List IndexItem :=
         if node.kind == Data.NodeKind.definition then
-          mkIndexItem label node.kind leanObjects :: acc.definitionIndex
+          mkIndexItem label node.kind leanSummary.leanObjects :: acc.definitionIndex
         else
           acc.definitionIndex
       let theoremLikeIndex : List IndexItem :=
         if node.kind.isTheoremLike then
-          mkIndexItem label node.kind leanObjects :: acc.theoremLikeIndex
+          mkIndexItem label node.kind leanSummary.leanObjects :: acc.theoremLikeIndex
         else
           acc.theoremLikeIndex
       let axiomIndex : List IndexItem :=
         if statusFlags.hasAxiomLike then
-          mkIndexItem label node.kind leanObjects :: acc.axiomIndex
+          mkIndexItem label node.kind leanSummary.leanObjects :: acc.axiomIndex
         else
           acc.axiomIndex
       let acc := { acc with
@@ -456,11 +484,11 @@ def buildSummary : CoreM Summary := do
         informalOnlyEntries := acc.informalOnlyEntries + (if hasStatement && !hasCode then 1 else 0)
         totalStatus := bumpEntryStatus acc.totalStatus statusFlags
         pendingInformalEntries
-        leanDecls := acc.leanDecls + leanDecls
-        sorries := acc.sorries + sorries
-        sorryDetails := sorryDetails ++ acc.sorryDetails
-        missingLeanDecls := missingLeanDecls ++ acc.missingLeanDecls
-        renderFailures := renderFailures ++ acc.renderFailures
+        leanDecls := acc.leanDecls + leanSummary.leanDecls
+        sorries := acc.sorries + leanSummary.sorries
+        sorryDetails := leanSummary.sorryDetails ++ acc.sorryDetails
+        missingLeanDecls := leanSummary.missingLeanDecls ++ acc.missingLeanDecls
+        renderFailures := leanSummary.renderFailures ++ acc.renderFailures
         definitionIndex
         theoremLikeIndex
         axiomIndex
@@ -591,7 +619,7 @@ def buildSummary : CoreM Summary := do
   let coverageSplit :=
     entries.foldl (init := ({} : CoverageSplit)) fun acc (label, node) =>
       let hasStatement := node.statement.isSome
-      let hasCode := node.code.isSome
+      let hasCode := Informal.Graph.nodeHasAssociatedCode node
       let statusFlags := entryStatusFlags state external node
       let statementStatus := Informal.Graph.statementStatus external state label node
       let proofStatus := Informal.Graph.proofStatus external state label node

--- a/src/VersoBlueprint/Data.lean
+++ b/src/VersoBlueprint/Data.lean
@@ -420,6 +420,31 @@ inductive CodeRef where
   | literate (code : Code)
 deriving Repr, Inhabited
 
+private def pushNameUnique (names : Array Name) (name : Name) : Array Name :=
+  let name := name.eraseMacroScopes
+  if names.contains name then names else names.push name
+
+def Code.definedDeclNames (code : Code) : Array Name :=
+  (code.definedDefs.map (·.name) ++ code.definedTheorems.map (·.name)).foldl
+    pushNameUnique #[]
+
+def CodeRef.externalRefs : CodeRef → Array ExternalRef
+  | .external refs => refs
+  | .literate _ => #[]
+
+def CodeRef.literateCodes : CodeRef → Array Code
+  | .external _ => #[]
+  | .literate code => #[code]
+
+def CodeRef.leanDecls : CodeRef → Array Name
+  | .external refs =>
+    refs.foldl (init := #[]) fun acc ref =>
+      if ref.present then
+        pushNameUnique acc ref.canonical
+      else
+        acc
+  | .literate code => code.definedDeclNames
+
 structure InformalData where
   stx : Syntax
   /-- Structured dependency edges declared from this informal payload. -/
@@ -439,7 +464,8 @@ structure Node where
   count : Nat := 0
   statement : Option InformalData := none -- Informal Object statement
   proof : Option InformalData := none -- Informal Object proof
-  code : Option CodeRef := none -- Informal Object associated code status
+  /-- Lean code associations for this informal object. -/
+  leanCode : Array CodeRef := #[]
   rustCode : Option RustInlineCode := none -- Informal object associated Rust code
   texSources : Array (String × TexSource) := #[] -- Raw TeX witnesses keyed by slot
   parent : Option Parent := none -- Optional parent group for summaries/graphs
@@ -457,6 +483,32 @@ deriving Repr, Inhabited
 /-- We can state a theorem if all its deps are done, and the theorem isn't "not ready" -/
 def Data.empty : Data := Std.TreeMap.empty
 
+private def pushExternalRefUnique (refs : Array ExternalRef) (ref : ExternalRef) : Array ExternalRef :=
+  let canonical := ref.canonical.eraseMacroScopes
+  if refs.any (fun current => current.canonical.eraseMacroScopes == canonical) then
+    refs.map fun current =>
+      if current.canonical.eraseMacroScopes == canonical && !current.present && ref.present then
+        { ref with canonical }
+      else
+        current
+  else
+    refs.push { ref with canonical }
+
+def Node.externalRefs (node : Node) : Array ExternalRef :=
+  node.leanCode.foldl (init := #[]) fun acc codeRef =>
+    codeRef.externalRefs.foldl pushExternalRefUnique acc
+
+def Node.literateCodes (node : Node) : Array Code :=
+  node.leanCode.foldl (init := #[]) fun acc codeRef =>
+    acc ++ codeRef.literateCodes
+
+def Node.leanDecls (node : Node) : Array Name :=
+  node.leanCode.foldl (init := #[]) fun acc codeRef =>
+    codeRef.leanDecls.foldl pushNameUnique acc
+
+def Node.hasAssociatedCode (node : Node) : Bool :=
+  !node.leanCode.isEmpty
+
 def Data.parentChildren (data : Data) : LabelMap (Array Label) :=
   data.foldl (init := (Std.TreeMap.empty : LabelMap (Array Label))) fun acc child node =>
     match node.parent with
@@ -469,21 +521,28 @@ section
 
 variable [Monad m] [MonadLog m] [AddMessageContext m] [MonadOptions m]
 
-private def mergeCodeRef (label : Label) (current : Option CodeRef) (incoming : CodeRef) : m (Option CodeRef) := do
-  match current, incoming with
-  | none, incoming => return some incoming
-  | some (.external _), .external _ =>
-    logError m!"Label {label} has multiple external Lean reference declarations; external merging is not supported"
-    return current
-  | some (.literate _), .literate _ =>
-    logError m!"Label {label} already has code"
-    return current
-  | some (.external _), .literate code =>
-    logError m!"Label {label} has both '(lean := ...)' and an associated Lean code block; preferring inline code"
-    return some (.literate code)
-  | some (.literate _), .external _ =>
-    logError m!"Label {label} has both an associated Lean code block and '(lean := ...)'; preferring inline code"
-    return current
+private def mergeAssociatedCodeRefs (current : Array CodeRef) (incoming : CodeRef) : Array CodeRef :=
+  match incoming with
+  | .external incomingRefs =>
+    let currentExternalRefs :=
+      current.foldl (init := #[]) fun refs codeRef =>
+        codeRef.externalRefs.foldl pushExternalRefUnique refs
+    let externalRefs := incomingRefs.foldl pushExternalRefUnique currentExternalRefs
+    let nonExternal := current.filter fun
+      | .external _ => false
+      | .literate _ => true
+    if externalRefs.isEmpty then
+      nonExternal
+    else
+      nonExternal.push (.external externalRefs)
+  | .literate code =>
+    current.push (.literate code)
+
+private def Node.withCodeRef (node : Node) (codeRef : CodeRef) : Node :=
+  {
+    node with
+      leanCode := mergeAssociatedCodeRefs node.leanCode codeRef
+  }
 
 private def mergeRustCode (label : Label) (current : Option RustInlineCode) (incoming : RustInlineCode) :
     m (Option RustInlineCode) := do
@@ -593,27 +652,26 @@ private def mergeTexSource (label : Label) (slot : String)
 def Data.registerCodeRef (data : Data) (label : Label) (codeRef : CodeRef) : m Data := do
   match data.get? label with
   | none =>
-    return data.insert label { code := some codeRef }
+    return data.insert label (({} : Node).withCodeRef codeRef)
   | some node =>
-    let code ← mergeCodeRef label node.code codeRef
-    return data.insert label { node with code }
+    return data.insert label (node.withCodeRef codeRef)
 
 def Data.register (data : Data) (label : Label) (kind : InProgressKind) (payload : InformalData)
     (codeHint : Option CodeRef := none) (parent : Option Parent := none) (priority : Option String := none)
     (owner : Option AuthorId := none) (tags : Array String := #[]) (effort : Option String := none)
     (prUrl : Option String := none) : m Data := do
   let applyHints (node : Node) : m Node := do
-    let code ←
+    let node :=
       match codeHint with
-      | none => pure node.code
-      | some hint => mergeCodeRef label node.code hint
+      | none => node
+      | some hint => node.withCodeRef hint
     let parent ← mergeParent label node.parent parent
     let priority ← mergePriority label node.priority priority
     let owner ← mergeOwner label node.owner owner
     let effort ← mergeEffort label node.effort effort
     let prUrl ← mergePrUrl label node.prUrl prUrl
     let tags := mergeTags node.tags tags
-    return { node with code, parent, priority, owner, tags, effort, prUrl }
+    return { node with parent, priority, owner, tags, effort, prUrl }
   let nextCount := data.nextCount
   match data.get? label, kind with
   -- First statement for a fresh label.
@@ -667,10 +725,9 @@ def Data.registerCode (data : Data) (label : Label) (code : Syntax)
   let literate : CodeRef := .literate { stx := code, definedDefs, definedTheorems }
   match data.get? label with
   | none =>
-    return data.insert label { code := some literate }
+    return data.insert label (({} : Node).withCodeRef literate)
   | some node =>
-    let code ← mergeCodeRef label node.code literate
-    return data.insert label { node with code }
+    return data.insert label (node.withCodeRef literate)
 
 def Data.registerRustCode (data : Data) (label : Label) (code : RustInlineCode) : m Data := do
   match data.get? label with

--- a/src/VersoBlueprint/Data.lean
+++ b/src/VersoBlueprint/Data.lean
@@ -105,6 +105,30 @@ deriving Repr, Inhabited, DecidableEq, ToJson, FromJson, Quote
 def UseRef.labels (uses : Array UseRef) : Array Label :=
   uses.map (·.label)
 
+/--
+Merge duplicate dependency refs for the same label.
+
+An explicit manual edge is preferred over an inferred automatic duplicate.
+Otherwise, the existing ref is kept so order and earlier metadata remain stable.
+-/
+def UseRef.mergeSameLabel (current incoming : UseRef) : UseRef :=
+  match current.origin, incoming.origin with
+  | .automatic, .manual => incoming
+  | _, _ => current
+
+def UseRef.pushMergeByLabel (uses : Array UseRef) (useRef : UseRef) : Array UseRef :=
+  if uses.any (·.label == useRef.label) then
+    uses.map fun current =>
+      if current.label == useRef.label then
+        current.mergeSameLabel useRef
+      else
+        current
+  else
+    uses.push useRef
+
+def UseRef.mergeByLabel (current incoming : Array UseRef) : Array UseRef :=
+  incoming.foldl UseRef.pushMergeByLabel current
+
 structure AuthorInfo where
   displayName : String
   url : Option String := none
@@ -404,6 +428,9 @@ structure InformalData where
   elabStx : Array Syntax := #[] -- Syntax is going to have type Verso.Block ...
 deriving Repr, Inhabited
 
+def InformalData.hasBody (data : InformalData) : Bool :=
+  !data.previewBlocks.isEmpty || !data.elabStx.isEmpty
+
 def InformalData.dependencyLabels (data : InformalData) : Array Label :=
   data.deps.map (·.label)
 
@@ -535,6 +562,25 @@ private def mergeTags (current incoming : Array String) : Array String :=
   incoming.foldl (init := current) fun acc tag =>
     if acc.contains tag then acc else acc.push tag
 
+private def fillBodylessPayload (current incoming : InformalData) : InformalData :=
+  { incoming with deps := UseRef.mergeByLabel current.deps incoming.deps }
+
+private def fillPayload? (current? : Option InformalData) (incoming : InformalData) :
+    Option InformalData :=
+  match current? with
+  | none => some incoming
+  | some current =>
+    if current.hasBody then
+      none
+    else
+      some (fillBodylessPayload current incoming)
+
+private def Data.nextCount (data : Data) : Nat :=
+  data.foldl (init := 0) (fun count _label node => max count node.count) + 1
+
+private def Node.countOrNext (node : Node) (nextCount : Nat) : Nat :=
+  if node.count == 0 then nextCount else node.count
+
 private def mergeTexSource (label : Label) (slot : String)
     (current : Array (String × TexSource)) (incoming : TexSource)
     : m (Array (String × TexSource)) := do
@@ -568,7 +614,7 @@ def Data.register (data : Data) (label : Label) (kind : InProgressKind) (payload
     let prUrl ← mergePrUrl label node.prUrl prUrl
     let tags := mergeTags node.tags tags
     return { node with code, parent, priority, owner, tags, effort, prUrl }
-  let nextCount := data.size + 1
+  let nextCount := data.nextCount
   match data.get? label, kind with
   -- First statement for a fresh label.
   | none, .statement nodeKind =>
@@ -585,32 +631,35 @@ def Data.register (data : Data) (label : Label) (kind : InProgressKind) (payload
     return data
   -- Late statement fill for an existing placeholder node.
   | some node, .statement nodeKind =>
-    if node.statement.isNone then
-      let count := if node.count == 0 then nextCount else node.count
+    match fillPayload? node.statement payload with
+    | some statement =>
+      let count := node.countOrNext nextCount
       let node ← applyHints {
         node with
           kind := nodeKind
           count
-          statement := some payload
+          statement := some statement
       }
       return data.insert label node
-    else
+    | none =>
       -- logError m!"Duplicated entry for {label}"
       return data
   -- Register proof for an existing statement.
   | some node, .proof =>
-    if node.proof.isSome then
-      -- logError m!"{label} already has a proof"
-      return data
-    else if node.statement.isNone then
+    if node.statement.isNone then
       logError m!"Cannot register proof for {label}: statement dependencies are missing"
       return data
     else
-      let node ← applyHints {
-        node with
-          proof := some payload
-      }
-      return data.insert label node
+      match fillPayload? node.proof payload with
+      | some proof =>
+        let node ← applyHints {
+          node with
+            proof := some proof
+        }
+        return data.insert label node
+      | none =>
+        -- logError m!"{label} already has a proof"
+        return data
 
 /-- Register Lean code and code metadata for an informal object label. -/
 def Data.registerCode (data : Data) (label : Label) (code : Syntax)

--- a/src/VersoBlueprint/DependencyAnalysis.lean
+++ b/src/VersoBlueprint/DependencyAnalysis.lean
@@ -7,6 +7,15 @@ Author: Emilio J. Gallego Arias
 import Lean
 import VersoBlueprint.Environment
 
+/-!
+LeanArchitect-style automatic dependency inference for Verso Blueprint.
+
+LeanArchitect recursively expands untagged Lean constants until it reaches
+blueprint nodes. Verso Blueprint uses a document-first variant: it scans direct
+constants from compiled declarations and maps each associated Lean declaration
+to its Blueprint labels.
+-/
+
 namespace Informal
 
 open Lean
@@ -141,22 +150,18 @@ def attachInferredUseRefs (label : Data.Label) (ref : Syntax) (useRefs : Inferre
   if useRefs.statement.isEmpty && useRefs.proof.isEmpty then
     pure ()
   else
-    Environment.modifyM fun state => do
+    Environment.modifyDataForLabel label fun data => do
       let data :=
-        match state.data.get? label with
+        match data.get? label with
         | some node =>
           let statement := payloadWithUseRefs ref useRefs.statement node.statement
           let proof := payloadWithUseRefs ref useRefs.proof node.proof
-          state.data.insert label { node with statement, proof }
+          data.insert label { node with statement, proof }
         | none =>
           let statement := payloadWithUseRefs ref useRefs.statement none
           let proof := payloadWithUseRefs ref useRefs.proof none
-          state.data.insert label { statement, proof }
-      let localData :=
-        match data.get? label with
-        | some node => state.localData.insert label node
-        | none => state.localData
-      return { state with data, localData }
+          data.insert label { statement, proof }
+      return data
 
 end DependencyAnalysis
 

--- a/src/VersoBlueprint/DependencyAnalysis.lean
+++ b/src/VersoBlueprint/DependencyAnalysis.lean
@@ -1,0 +1,163 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import Lean
+import VersoBlueprint.Environment
+
+namespace Informal
+
+open Lean
+
+namespace DependencyAnalysis
+
+register_option verso.blueprint.autoDeps : Bool := {
+  defValue := false
+  descr := "Enable automatic Blueprint dependency inference by default"
+}
+
+/--
+Dependency labels inferred from a compiled Lean declaration.
+
+The analysis is intentionally direct: it scans constants mentioned by the
+declaration's type and body, but it does not recursively expand untagged helper
+declarations. Untagged constants are implementation details unless authors tag
+them with `@[blueprint]` or add a manual dependency edge.
+-/
+structure InferredDeps where
+  statement : Array Data.Label := #[]
+  proof : Array Data.Label := #[]
+deriving Inhabited, Repr
+
+structure InferredUseRefs where
+  statement : Array Data.UseRef := #[]
+  proof : Array Data.UseRef := #[]
+deriving Inhabited, Repr
+
+def enabled (opts : Options) (local? : Option Bool) : Bool :=
+  local?.getD (verso.blueprint.autoDeps.get opts)
+
+def pushLabelUnique (labels : Array Data.Label) (label : Data.Label) :
+    Array Data.Label :=
+  if labels.contains label then labels else labels.push label
+
+def automaticUseRef (label : Data.Label) : Data.UseRef :=
+  { label, origin := .automatic }
+
+def sortLabels (labels : Array Data.Label) : Array Data.Label :=
+  labels.qsort fun a b => a.toString < b.toString
+
+def InferredDeps.merge (current incoming : InferredDeps) : InferredDeps :=
+  {
+    statement := incoming.statement.foldl pushLabelUnique current.statement
+    proof := incoming.proof.foldl pushLabelUnique current.proof
+  }
+
+private def automaticUseRefs (labels : Array Data.Label) : Array Data.UseRef :=
+  (sortLabels labels).foldl (init := #[]) fun acc label =>
+    Data.UseRef.pushMergeByLabel acc (automaticUseRef label)
+
+private def removeSelfLabel (currentLabel? : Option Data.Label) (labels : Array Data.Label) :
+    Array Data.Label :=
+  match currentLabel? with
+  | none => labels
+  | some currentLabel => labels.filter (· != currentLabel)
+
+def InferredDeps.toUseRefs (deps : InferredDeps)
+    (statementManual : Array Data.UseRef := #[]) (currentLabel? : Option Data.Label := none) :
+    InferredUseRefs :=
+  let statementLabels := removeSelfLabel currentLabel? deps.statement
+  let proofLabels := removeSelfLabel currentLabel? deps.proof
+  let statement := Data.UseRef.mergeByLabel (automaticUseRefs statementLabels) statementManual
+  let statementLabels := Data.UseRef.labels statement
+  let proofLabels := proofLabels.filter fun label => !statementLabels.contains label
+  {
+    statement
+    proof := automaticUseRefs proofLabels
+  }
+
+private def directLabelsForExpr (root : Name) (expr : Expr) : CoreM (Array Data.Label) := do
+  let root := root.eraseMacroScopes
+  expr.getUsedConstants.foldlM (init := #[]) fun labels decl => do
+    let decl := decl.eraseMacroScopes
+    if decl == root then
+      return labels
+    else
+      let declLabels ← Environment.labelsForLeanDecl decl
+      return declLabels.foldl pushLabelUnique labels
+
+private def directBodyLabels (root : Name) (info : ConstantInfo) : CoreM (Array Data.Label) := do
+  match info with
+  | .axiomInfo _ => return #[]
+  | .defnInfo info => directLabelsForExpr root info.value
+  | .thmInfo info => directLabelsForExpr root info.value
+  | .opaqueInfo info => directLabelsForExpr root info.value
+  | .quotInfo _ => return #[]
+  | .ctorInfo info => directLabelsForExpr root info.type
+  | .recInfo info => directLabelsForExpr root info.type
+  | .inductInfo info =>
+    info.ctors.foldlM (init := #[]) fun labels ctor => do
+      match (← getEnv).find? ctor with
+      | some (.ctorInfo ctorInfo) =>
+        let ctorLabels ← directLabelsForExpr root ctorInfo.type
+        return ctorLabels.foldl pushLabelUnique labels
+      | _ => return labels
+
+def infer (decl : Name) (info : ConstantInfo) : CoreM InferredDeps := do
+  let decl := decl.eraseMacroScopes
+  let statement ← directLabelsForExpr decl info.type
+  let proof ← directBodyLabels decl info
+  return { statement, proof }
+
+def inferDecl? (decl : Name) : CoreM InferredDeps := do
+  let decl := decl.eraseMacroScopes
+  match (← getEnv).find? decl with
+  | some info => infer decl info
+  | none => pure {}
+
+def inferDecls (decls : Array Name) : CoreM InferredDeps :=
+  decls.foldlM (init := {}) fun acc decl => do
+    return acc.merge (← inferDecl? decl)
+
+def inferExternalRefs (refs : Array Data.ExternalRef) : CoreM InferredDeps :=
+  inferDecls (refs.filter (·.present) |>.map (·.canonical))
+
+private def payloadWithUseRefs
+    (ref : Syntax) (useRefs : Array Data.UseRef) (current? : Option Data.InformalData) :
+    Option Data.InformalData :=
+  if useRefs.isEmpty then
+    current?
+  else
+    match current? with
+    | some payload =>
+      some { payload with deps := Data.UseRef.mergeByLabel payload.deps useRefs }
+    | none =>
+      some { stx := ref, deps := useRefs }
+
+def attachInferredUseRefs (label : Data.Label) (ref : Syntax) (useRefs : InferredUseRefs) :
+    CoreM Unit := do
+  if useRefs.statement.isEmpty && useRefs.proof.isEmpty then
+    pure ()
+  else
+    Environment.modifyM fun state => do
+      let data :=
+        match state.data.get? label with
+        | some node =>
+          let statement := payloadWithUseRefs ref useRefs.statement node.statement
+          let proof := payloadWithUseRefs ref useRefs.proof node.proof
+          state.data.insert label { node with statement, proof }
+        | none =>
+          let statement := payloadWithUseRefs ref useRefs.statement none
+          let proof := payloadWithUseRefs ref useRefs.proof none
+          state.data.insert label { statement, proof }
+      let localData :=
+        match data.get? label with
+        | some node => state.localData.insert label node
+        | none => state.localData
+      return { state with data, localData }
+
+end DependencyAnalysis
+
+end Informal

--- a/src/VersoBlueprint/Environment.lean
+++ b/src/VersoBlueprint/Environment.lean
@@ -49,6 +49,7 @@ structure State where
   localGroups : NameMap String := {}
   authors : NameMap AuthorInfo := {}
   localAuthors : NameMap AuthorInfo := {}
+  leanNameLabels : NameMap (Array Label) := {}
   importedConflicts : Array ImportedConflict := #[]
   importedConflictsReported : Bool := false
   stack : List InProgress := []
@@ -82,6 +83,48 @@ inductive Entry where
   | author (label : Name) (info : AuthorInfo)
 deriving Inhabited, Repr
 
+private def pushLabelUnique (labels : Array Label) (label : Label) : Array Label :=
+  if labels.contains label then labels else labels.push label
+
+private def pushDeclUnique (decls : Array Name) (decl : Name) : Array Name :=
+  let decl := decl.eraseMacroScopes
+  if decls.contains decl then decls else decls.push decl
+
+private def codeRefDecls : CodeRef → Array Name
+  | .external refs =>
+    refs.foldl (init := #[]) fun acc ref =>
+      if ref.present then
+        pushDeclUnique acc ref.canonical
+      else
+        acc
+  | .literate code =>
+    (code.definedDefs.map (·.name) ++ code.definedTheorems.map (·.name)).foldl
+      pushDeclUnique #[]
+
+private def nodeLeanDecls (node : Node) : Array Name :=
+  match node.code with
+  | some code => codeRefDecls code
+  | none => #[]
+
+private def addLeanDeclLabel
+    (leanNameLabels : NameMap (Array Label)) (decl label : Name) : NameMap (Array Label) :=
+  let decl := decl.eraseMacroScopes
+  let labels := leanNameLabels.getD decl #[]
+  leanNameLabels.insert decl (pushLabelUnique labels label)
+
+private def addNodeLeanDeclLabels
+    (leanNameLabels : NameMap (Array Label)) (label : Name) (node : Node) :
+    NameMap (Array Label) :=
+  (nodeLeanDecls node).foldl (init := leanNameLabels) fun acc decl =>
+    addLeanDeclLabel acc decl label
+
+private def addRegisteredNodeLeanDeclLabels
+    (leanNameLabels : NameMap (Array Label)) (data : Data) (label : Name) :
+    NameMap (Array Label) :=
+  match data.get? label with
+  | some node => addNodeLeanDeclLabels leanNameLabels label node
+  | none => leanNameLabels
+
 initialize informalExt : PersistentEnvExtension Entry Entry State ←
   registerPersistentEnvExtension {
     mkInitial := pure {}
@@ -90,6 +133,7 @@ initialize informalExt : PersistentEnvExtension Entry Entry State ←
         { state with
           data := state.data.insert label node
           localData := state.localData.insert label node
+          leanNameLabels := addNodeLeanDeclLabels state.leanNameLabels label node
         }
       | .group label header =>
         { state with
@@ -102,26 +146,33 @@ initialize informalExt : PersistentEnvExtension Entry Entry State ←
           localAuthors := state.localAuthors.insert label info
         }
     addImportedFn entries := do
-      let (data, groups, authors, importedConflicts) := entries.foldl
-          (init := (({} : NameMap Node), ({} : NameMap String), ({} : NameMap AuthorInfo), (#[] : Array ImportedConflict))) fun acc entry =>
-        entry.foldl (init := acc) fun (dataAcc, groupAcc, authorAcc, conflictsAcc) item =>
+      let (data, groups, authors, leanNameLabels, importedConflicts) := entries.foldl
+          (init := (
+            ({} : NameMap Node),
+            ({} : NameMap String),
+            ({} : NameMap AuthorInfo),
+            ({} : NameMap (Array Label)),
+            (#[] : Array ImportedConflict)
+          )) fun acc entry =>
+        entry.foldl (init := acc) fun (dataAcc, groupAcc, authorAcc, leanNameAcc, conflictsAcc) item =>
           match item with
           | .node label node =>
             if dataAcc.contains label then
-              (dataAcc, groupAcc, authorAcc, pushImportedConflict conflictsAcc .node label)
+              (dataAcc, groupAcc, authorAcc, leanNameAcc, pushImportedConflict conflictsAcc .node label)
             else
-              (dataAcc.insert label node, groupAcc, authorAcc, conflictsAcc)
+              let leanNameAcc := addNodeLeanDeclLabels leanNameAcc label node
+              (dataAcc.insert label node, groupAcc, authorAcc, leanNameAcc, conflictsAcc)
           | .group label header =>
             if groupAcc.contains label then
-              (dataAcc, groupAcc, authorAcc, pushImportedConflict conflictsAcc .group label)
+              (dataAcc, groupAcc, authorAcc, leanNameAcc, pushImportedConflict conflictsAcc .group label)
             else
-              (dataAcc, groupAcc.insert label header, authorAcc, conflictsAcc)
+              (dataAcc, groupAcc.insert label header, authorAcc, leanNameAcc, conflictsAcc)
           | .author label info =>
             if authorAcc.contains label then
-              (dataAcc, groupAcc, authorAcc, pushImportedConflict conflictsAcc .author label)
+              (dataAcc, groupAcc, authorAcc, leanNameAcc, pushImportedConflict conflictsAcc .author label)
             else
-              (dataAcc, groupAcc, authorAcc.insert label info, conflictsAcc)
-      pure { data, groups, authors, importedConflicts := sortImportedConflicts importedConflicts }
+              (dataAcc, groupAcc, authorAcc.insert label info, leanNameAcc, conflictsAcc)
+      pure { data, groups, authors, leanNameLabels, importedConflicts := sortImportedConflicts importedConflicts }
     -- Strip transient elaboration cache before exporting nodes to the environment.
     exportEntriesFnEx env := fun state _level =>
       let nodeEntries := state.localData.toArray.map fun (name, node) =>
@@ -160,19 +211,26 @@ def reportImportedConflicts : m Unit := do
       logError conflict.message
     return { state with importedConflictsReported := true }
 
--- XXX: needs: test
 def checkLabelAndNesting (label : Label) (kind : Data.InProgressKind) : m Bool := do
   let { data, stack, .. } := informalExt.getState (← getEnv)
   match (kind, data.get? label, stack.isEmpty) with
   | (.statement _, none, true) => return true
   | (.statement _, some node, true) =>
-    if node.statement.isNone then
+    let statementCanBeFilled :=
+      match node.statement with
+      | none => true
+      | some statement => !statement.hasBody
+    if statementCanBeFilled then
       return true
     else do
       logError m!"Label {label} already defined"
       return false
   | (.proof, some node, true) =>
-    if node.proof.isSome then
+    let proofCanBeFilled :=
+      match node.proof with
+      | none => true
+      | some proof => !proof.hasBody
+    if !proofCanBeFilled then
       logError m!"Label {label} already has a proof"
       return false
     else if node.statement.isNone then
@@ -215,6 +273,7 @@ def State.popNested? (state : State) : Option State :=
   | [] => none
 
 def pop (ref : Syntax) : m Nat := do
+  let label? := (informalExt.getState (← getEnv)).stack.head?.map (·.label)
   modifyM fun state => do
     if let some state := state.popNested? then
       return state
@@ -236,8 +295,14 @@ def pop (ref : Syntax) : m Nat := do
           match data.get? cur.label with
           | some node => state.localData.insert cur.label node
           | none => state.localData
-        return { state with data, localData, stack }
-  getCount
+        let leanNameLabels := addRegisteredNodeLeanDeclLabels state.leanNameLabels data cur.label
+        return { state with data, localData, leanNameLabels, stack }
+  let state := informalExt.getState (← getEnv)
+  match label? with
+  | some label =>
+    return (state.data.get? label).map (·.count) |>.getD state.data.size
+  | none =>
+    return state.data.size
 
 def peek : m (Option InProgress) := do
   return (informalExt.getState (← getEnv)).stack.head?
@@ -286,7 +351,8 @@ def registerCode (label : Label) (code : Syntax)
       match data.get? label with
       | some node => state.localData.insert label node
       | none => state.localData
-    return { state with data, localData }
+    let leanNameLabels := addRegisteredNodeLeanDeclLabels state.leanNameLabels data label
+    return { state with data, localData, leanNameLabels }
 
 def registerRustCode (label : Label) (code : RustInlineCode) : m Unit := do
   modifyM fun state => do
@@ -308,6 +374,9 @@ def registerTexSource (label : Label) (slot : String) (texSource : TexSource) : 
 
 def getNode? (label : Label) : m (Option Node) := do
   return (informalExt.getState (← getEnv)).data.get? label
+
+def labelsForLeanDecl (decl : Name) : m (Array Label) := do
+  return (informalExt.getState (← getEnv)).leanNameLabels.getD decl.eraseMacroScopes #[]
 
 def registerGroup (label : Label) (header : String) : m Unit := do
   reportImportedConflicts

--- a/src/VersoBlueprint/Environment.lean
+++ b/src/VersoBlueprint/Environment.lean
@@ -86,25 +86,8 @@ deriving Inhabited, Repr
 private def pushLabelUnique (labels : Array Label) (label : Label) : Array Label :=
   if labels.contains label then labels else labels.push label
 
-private def pushDeclUnique (decls : Array Name) (decl : Name) : Array Name :=
-  let decl := decl.eraseMacroScopes
-  if decls.contains decl then decls else decls.push decl
-
-private def codeRefDecls : CodeRef → Array Name
-  | .external refs =>
-    refs.foldl (init := #[]) fun acc ref =>
-      if ref.present then
-        pushDeclUnique acc ref.canonical
-      else
-        acc
-  | .literate code =>
-    (code.definedDefs.map (·.name) ++ code.definedTheorems.map (·.name)).foldl
-      pushDeclUnique #[]
-
 private def nodeLeanDecls (node : Node) : Array Name :=
-  match node.code with
-  | some code => codeRefDecls code
-  | none => #[]
+  node.leanDecls
 
 private def addLeanDeclLabel
     (leanNameLabels : NameMap (Array Label)) (decl label : Name) : NameMap (Array Label) :=
@@ -124,6 +107,28 @@ private def addRegisteredNodeLeanDeclLabels
   match data.get? label with
   | some node => addNodeLeanDeclLabels leanNameLabels label node
   | none => leanNameLabels
+
+private def removeLeanDeclLabel
+    (leanNameLabels : NameMap (Array Label)) (label : Name) : NameMap (Array Label) :=
+  leanNameLabels.foldl (init := ({} : NameMap (Array Label))) fun acc decl labels =>
+    let labels := labels.filter (· != label)
+    if labels.isEmpty then
+      acc
+    else
+      acc.insert decl labels
+
+private def reindexRegisteredNodeLeanDeclLabels
+    (leanNameLabels : NameMap (Array Label)) (data : Data) (label : Name) :
+    NameMap (Array Label) :=
+  addRegisteredNodeLeanDeclLabels (removeLeanDeclLabel leanNameLabels label) data label
+
+private def State.commitDataForLabel (state : State) (label : Name) (data : Data) : State :=
+  let localData :=
+    match data.get? label with
+    | some node => state.localData.insert label node
+    | none => state.localData
+  let leanNameLabels := reindexRegisteredNodeLeanDeclLabels state.leanNameLabels data label
+  { state with data, localData, leanNameLabels }
 
 initialize informalExt : PersistentEnvExtension Entry Entry State ←
   registerPersistentEnvExtension {
@@ -199,6 +204,11 @@ def modifyM (f : State -> m State) : m Unit := do
   let st := informalExt.getState (← getEnv)
   let st ← f st
   modifyEnv (informalExt.setState · st)
+
+def modifyDataForLabel (label : Label) (f : Data -> m Data) : m Unit := do
+  modifyM fun state => do
+    let data ← f state.data
+    return state.commitDataForLabel label data
 
 def importedConflicts : m (Array ImportedConflict) := do
   return (informalExt.getState (← getEnv)).importedConflicts
@@ -291,12 +301,7 @@ def pop (ref : Syntax) : m Nat := do
         }
         let data ← state.data.register
           cur.label cur.kind payload cur.codeHint cur.parent cur.priority cur.owner cur.tags cur.effort cur.prUrl
-        let localData :=
-          match data.get? cur.label with
-          | some node => state.localData.insert cur.label node
-          | none => state.localData
-        let leanNameLabels := addRegisteredNodeLeanDeclLabels state.leanNameLabels data cur.label
-        return { state with data, localData, leanNameLabels, stack }
+        return { state.commitDataForLabel cur.label data with stack }
   let state := informalExt.getState (← getEnv)
   match label? with
   | some label =>
@@ -345,32 +350,16 @@ def setPreviewBlocks (blocks : Array (Verso.Doc.Block Verso.Genre.Manual)) : m U
 
 def registerCode (label : Label) (code : Syntax)
     (definedDefs : Array LiterateDef := #[]) (definedTheorems : Array LiterateThm := #[]) : m Unit := do
-  modifyM fun state => do
-    let data ← state.data.registerCode label code definedDefs definedTheorems
-    let localData :=
-      match data.get? label with
-      | some node => state.localData.insert label node
-      | none => state.localData
-    let leanNameLabels := addRegisteredNodeLeanDeclLabels state.leanNameLabels data label
-    return { state with data, localData, leanNameLabels }
+  modifyDataForLabel label fun data =>
+    data.registerCode label code definedDefs definedTheorems
 
 def registerRustCode (label : Label) (code : RustInlineCode) : m Unit := do
-  modifyM fun state => do
-    let data ← state.data.registerRustCode label code
-    let localData :=
-      match data.get? label with
-      | some node => state.localData.insert label node
-      | none => state.localData
-    return { state with data, localData }
+  modifyDataForLabel label fun data =>
+    data.registerRustCode label code
 
 def registerTexSource (label : Label) (slot : String) (texSource : TexSource) : m Unit := do
-  modifyM fun state => do
-    let data ← state.data.registerTexSource label slot texSource
-    let localData :=
-      match data.get? label with
-      | some node => state.localData.insert label node
-      | none => state.localData
-    return { state with data, localData }
+  modifyDataForLabel label fun data =>
+    data.registerTexSource label slot texSource
 
 def getNode? (label : Label) : m (Option Node) := do
   return (informalExt.getState (← getEnv)).data.get? label

--- a/src/VersoBlueprint/Graph.lean
+++ b/src/VersoBlueprint/Graph.lean
@@ -293,6 +293,20 @@ private def CodeHealth.bump (health : CodeHealth) (kind : Data.NodeKind) (status
       hasAxiomLike := health.hasAxiomLike || status.isAxiomLike
   }
 
+private def CodeHealth.merge (left right : CodeHealth) : CodeHealth :=
+  {
+    hasAssociatedCode := left.hasAssociatedCode || right.hasAssociatedCode
+    totalDecls := left.totalDecls + right.totalDecls
+    presentDecls := left.presentDecls + right.presentDecls
+    missingDecls := left.missingDecls + right.missingDecls
+    statementAxisCount := left.statementAxisCount + right.statementAxisCount
+    proofAxisCount := left.proofAxisCount + right.proofAxisCount
+    statementBlockCount := left.statementBlockCount + right.statementBlockCount
+    proofBlockCount := left.proofBlockCount + right.proofBlockCount
+    anyGapCount := left.anyGapCount + right.anyGapCount
+    hasAxiomLike := left.hasAxiomLike || right.hasAxiomLike
+  }
+
 private def codeHealthOfInlineDecls (kind : Data.NodeKind) (statuses : Array Data.ProvedStatus) : CodeHealth :=
   statuses.foldl
       (init := { hasAssociatedCode := true, totalDecls := statuses.size, presentDecls := statuses.size })
@@ -310,15 +324,19 @@ def codeHealthOfExternalDecls (kind : Data.NodeKind) (external : ExternalCodeSta
       let health := health.bump kind status
       { health with presentDecls := health.presentDecls + 1 }
 
-def codeHealthOfCodeRef (kind : Data.NodeKind) (external : ExternalCodeStatus)
-    (codeRef? : Option Data.CodeRef) : CodeHealth :=
-  match codeRef? with
-  | none => {}
-  | some (.external decls) => codeHealthOfExternalDecls kind external decls
-  | some (.literate code) =>
+private def codeHealthOfOneCodeRef (kind : Data.NodeKind) (external : ExternalCodeStatus)
+    (codeRef : Data.CodeRef) : CodeHealth :=
+  match codeRef with
+  | .external decls => codeHealthOfExternalDecls kind external decls
+  | .literate code =>
     let statuses :=
       (code.definedDefs.map (·.provedStatus)) ++ (code.definedTheorems.map (·.provedStatus))
     codeHealthOfInlineDecls kind statuses
+
+def codeHealthOfLeanCode (kind : Data.NodeKind) (external : ExternalCodeStatus)
+    (leanCode : Array Data.CodeRef) : CodeHealth :=
+  leanCode.foldl (init := {}) fun health codeRef =>
+    health.merge (codeHealthOfOneCodeRef kind external codeRef)
 
 def codeHealthOfBlockSource (kind : Data.NodeKind) (external : ExternalCodeStatus)
     (source? : Option Informal.BlockCodeData) : CodeHealth :=
@@ -331,7 +349,7 @@ def codeHealthOfBlockSource (kind : Data.NodeKind) (external : ExternalCodeStatu
     codeHealthOfInlineDecls kind statuses
 
 def nodeCodeHealth (external : ExternalCodeStatus) (node : Data.Node) : CodeHealth :=
-  codeHealthOfCodeRef node.kind external node.code
+  codeHealthOfLeanCode node.kind external node.leanCode
 
 def CodeHealth.hasMissingExternalDecls (health : CodeHealth) : Bool :=
   health.missingDecls > 0
@@ -363,12 +381,10 @@ def CodeHealth.localFormalized (health : CodeHealth) (kind : Data.NodeKind) : Bo
     false
 
 def nodeExternalDecls (node : Data.Node) : Array Data.ExternalRef :=
-  match node.code with
-  | some (.external decls) => decls
-  | _ => #[]
+  node.externalRefs
 
 def nodeHasAssociatedCode (node : Data.Node) : Bool :=
-  node.code.isSome
+  node.hasAssociatedCode
 
 def externalDeclMissing (external : ExternalCodeStatus) (decl : Data.ExternalRef) : Bool :=
   !decl.present || external.isMissing decl.canonical

--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -100,6 +100,7 @@ block_extension Block.informal (data : BlockData) where
           | .proof => none
           | .statement _ => data.codeData
         let codeSource := BlockCodeData.ofHintAndInline codeHint? codeData?
+        let externalDecls := codeHint?.map (·.externalDecls) |>.getD #[]
         let getDeclHref (decl : Name) : Option String :=
           Resolve.resolveInformalDeclHref? s data.label decl
         let getDeclAnchorAttrs (decl : Data.ExternalRef) : Array (String × String) :=
@@ -108,27 +109,30 @@ block_extension Block.informal (data : BlockData) where
           codeHref
           source := codeSource
         }
-        let panelSummary := CodeSummary.renderPanelIndicator data.label cdata getDeclHref
         let headingParts? : Option CodeSummary.RenderParts :=
           match data.kind with
           | .statement _ => some <| CodeSummary.renderParts data cdata getDeclHref
           | .proof => none
         let externalParts? : Option ExternalCode.RenderParts ←
-          match data.kind, codeSource with
-          | .statement _, some (.external decls) =>
-            if decls.isEmpty then
+          match data.kind with
+          | .statement _ =>
+            if externalDecls.isEmpty then
               pure none
             else
+              let externalCdata : CodeSummary.ComputedData := {
+                source := some (.external externalDecls)
+              }
+              let externalSummary := CodeSummary.renderPanelIndicator data.label externalCdata getDeclHref
               let panelHeader := codePanelHeader data (data.displayNumber s)
               some <$> ExternalCode.renderPartsWithPageHovers
                 panelHeader
-                panelSummary.summaryTitle
-                panelSummary.indicator
-                decls
+                externalSummary.summaryTitle
+                externalSummary.indicator
+                externalDecls
                 getDeclHref
                 getDeclAnchorAttrs
                 (folded := data.foldCodeBlock)
-          | _, _ => pure none
+          | .proof => pure none
         let externalPanel := (externalParts?.map (·.externalCodePanel)).getD .empty
         let content := (← blocks.mapM goB)
         let codeEntry := (headingParts?.map (·.codeEntry)).getD .empty
@@ -180,7 +184,6 @@ private def expanderImpl (kind : Data.NodeKind) (isProof : Bool := false) : Dire
     let count ← Environment.pop blockRef
     liftM <| DependencyAnalysis.attachInferredUseRefs label blockRef { proof := resolved.proofUses }
     let node? ← Environment.getNode? label
-    let nodeCodeRef? := node?.bind (·.code)
     let blockKind : Data.InProgressKind ←
       if isProof then
         pure .proof
@@ -195,7 +198,9 @@ private def expanderImpl (kind : Data.NodeKind) (isProof : Bool := false) : Dire
     let codeData :=
       match blockKind with
       | .proof => none
-      | .statement _ => BlockCodeData.ofCodeRefHint nodeCodeRef?
+      | .statement _ =>
+        let externalRefs := node?.map (·.externalRefs) |>.getD #[]
+        BlockCodeData.ofExternalRefs externalRefs
     let statementPayload? := node?.bind (·.statement)
     let proofPayload? := node?.bind (·.proof)
     let statementUses := statementPayload?.map (·.deps) |>.getD #[]

--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -171,13 +171,14 @@ private def expanderImpl (kind : Data.NodeKind) (isProof : Bool := false) : Dire
     let label := resolved.label
     let accepted ← Environment.push
       label resolved.envKind resolved.codeHint resolved.parent resolved.priority
-      resolved.owner resolved.tags resolved.effort resolved.prUrl resolved.metadataUses
+      resolved.owner resolved.tags resolved.effort resolved.prUrl resolved.statementUses
     let contents ← contents.mapM elabBlock
     if !accepted then
       return ← ``(Block.concat #[$contents,*])
     let previewBlocks ← liftM <| Informal.evalElaboratedBlocks (contents.map (·.raw))
     Environment.setPreviewBlocks previewBlocks
     let count ← Environment.pop blockRef
+    liftM <| DependencyAnalysis.attachInferredUseRefs label blockRef { proof := resolved.proofUses }
     let node? ← Environment.getNode? label
     let nodeCodeRef? := node?.bind (·.code)
     let blockKind : Data.InProgressKind ←

--- a/src/VersoBlueprint/Informal/Block/Config.lean
+++ b/src/VersoBlueprint/Informal/Block/Config.lean
@@ -7,6 +7,7 @@ Author: Emilio J. Gallego Arias
 import Lean.Elab.InfoTree.Types
 import VersoManual
 import VersoBlueprint.Data
+import VersoBlueprint.DependencyAnalysis
 import VersoBlueprint.DirectiveArgParsing
 import VersoBlueprint.Environment
 import VersoBlueprint.Informal.ExternalCode
@@ -38,6 +39,8 @@ structure Config where
   labelSyntax : Syntax := Syntax.missing
   /-- Optional Lean/external-code references associated with statement blocks. -/
   lean : Option String := none
+  /-- Optional local override for automatic dependency inference. -/
+  autoDeps : Option Bool := none
   /-- Optional parent node label. -/
   parent : Option Data.Parent := none
   /-- Raw priority option, normalized during directive resolution. -/
@@ -82,10 +85,11 @@ private def normalizeTags (raw : String) : Array String :=
     |>.foldl (init := #[]) fun acc tag => if acc.contains tag then acc else acc.push tag
 
 section
-variable [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m] [MonadFileMap m]
+variable [Monad m] [MonadInfoTree m] [MonadResolveName m] [MonadLiftT CoreM m] [MonadEnv m]
+    [MonadError m] [MonadFileMap m] [MonadLog m] [AddMessageContext m] [MonadOptions m]
 
 def Config.parse : ArgParse m Config :=
-  (fun (labelArg : Verso.ArgParse.WithSyntax String) lean parent priority owner tags effort prUrl
+  (fun (labelArg : Verso.ArgParse.WithSyntax String) lean autoDeps parent priority owner tags effort prUrl
       uses usesOrigin usesIntent =>
     let (externalCode, invalidExternalCode) := ExternalCode.parseExternalCodeList lean
     let parsedLabel := LabelArg.parse labelArg
@@ -94,6 +98,7 @@ def Config.parse : ArgParse m Config :=
       label := parsedLabel.label
       labelSyntax := parsedLabel.labelSyntax
       lean := lean
+      autoDeps := autoDeps
       parent := parent.map LabelNameParsing.parse
       priority := priority
       owner := owner.map LabelNameParsing.parse
@@ -106,6 +111,7 @@ def Config.parse : ArgParse m Config :=
       externalCode := externalCode
       invalidExternalCode := invalidExternalCode
     }) <$> .positional `label (.withSyntax .string) <*> .named `lean .string true
+        <*> .named' `autoDeps true
         <*> .named `parent .string true <*> .named `priority .string true <*> .named `owner .string true
         <*> .named `tags .string true <*> .named `effort .string true <*> .named `pr_url .string true
         <*> .named `uses .string true <*> .named `uses_origin .string true <*> .named `uses_intent .string true
@@ -127,7 +133,8 @@ structure ResolvedConfig where
   tags : Array String := #[]
   effort : Option String := none
   prUrl : Option String := none
-  metadataUses : Array Data.UseRef := #[]
+  statementUses : Array Data.UseRef := #[]
+  proofUses : Array Data.UseRef := #[]
 
 private def resolvePriority? {m}
     [Monad m] [MonadOptions m] [MonadLog m] [AddMessageContext m] [MonadFileMap m]
@@ -238,6 +245,12 @@ def Config.resolveForDirective {m}
   let tags ← resolveTags cfg isProof
   let prUrl ← resolvePrUrl? cfg isProof
   let hasExternal := hasExternalRaw && !isProof
+  let inferredDeps ←
+    if hasExternal && DependencyAnalysis.enabled (← getOptions) cfg.autoDeps then
+      liftM <| DependencyAnalysis.inferExternalRefs resolvedExternalCode
+    else
+      pure {}
+  let inferredUseRefs := inferredDeps.toUseRefs cfg.metadataUses (some cfg.label)
   let codeHint : Option Data.CodeRef :=
     if isProof then
       none
@@ -256,7 +269,8 @@ def Config.resolveForDirective {m}
     tags
     effort
     prUrl
-    metadataUses := cfg.metadataUses
+    statementUses := inferredUseRefs.statement
+    proofUses := inferredUseRefs.proof
   }
 
 end Informal

--- a/src/VersoBlueprint/Informal/Block/Model.lean
+++ b/src/VersoBlueprint/Informal/Block/Model.lean
@@ -106,6 +106,8 @@ structure InlineCodeData where
   label : Data.Label
   definedDefs : Array CodeDeclData := #[]
   definedTheorems : Array CodeDeclData := #[]
+  statementUses : Array Data.UseRef := #[]
+  proofUses : Array Data.UseRef := #[]
   foldCodeBlock : Bool := false
   foldProofs : Bool := true
 deriving Repr, Inhabited, FromJson, ToJson, Quote

--- a/src/VersoBlueprint/Informal/Block/Model.lean
+++ b/src/VersoBlueprint/Informal/Block/Model.lean
@@ -127,11 +127,11 @@ inductive BlockCodeData where
   | external (decls : Array Data.ExternalRef)
 deriving Repr, Inhabited, FromJson, ToJson, Quote
 
-/-- Projection from environment-level `Data.CodeRef` into JSON-safe block payload hints. -/
-def BlockCodeData.ofCodeRefHint (codeRef? : Option Data.CodeRef) : Option BlockCodeData :=
-  match codeRef? with
-  | some (.external decls) => some (.external decls)
-  | _ => none
+def BlockCodeData.ofExternalRefs (decls : Array Data.ExternalRef) : Option BlockCodeData :=
+  if decls.isEmpty then
+    none
+  else
+    some (.external decls)
 
 /-- Resolve inline precedence at render time by combining optional hint + inline payload. -/
 def BlockCodeData.ofHintAndInline (hint? : Option BlockCodeData) (inline? : Option InlineCodeData)

--- a/src/VersoBlueprint/Informal/Block/Store.lean
+++ b/src/VersoBlueprint/Informal/Block/Store.lean
@@ -129,10 +129,6 @@ def resolveStoredNodeData? (st : TraverseState) (label : Data.Label) : Option St
 def resolveStoredBlockData? (st : TraverseState) (label : Data.Label) : Option BlockData :=
   (resolveStoredNodeData? st label).map (·.toBlockData)
 
-private def mergeUseRefs (xs ys : Array Data.UseRef) : Array Data.UseRef :=
-  ys.foldl (init := xs) fun acc useRef =>
-    if acc.contains useRef then acc else acc.push useRef
-
 private def mergeStringArrays (xs ys : Array String) : Array String :=
   ys.foldl (init := xs) fun acc value =>
     if acc.contains value then acc else acc.push value
@@ -155,8 +151,8 @@ def mergeStoredBlockData (existing incoming : StoredBlockData) : StoredBlockData
       parent := existing.parent <|> incoming.parent
       partPrefix := existing.partPrefix <|> incoming.partPrefix
       globalCount := existing.globalCount <|> incoming.globalCount
-      statementUses := mergeUseRefs existing.statementUses incoming.statementUses
-      proofUses := mergeUseRefs existing.proofUses incoming.proofUses
+      statementUses := Data.UseRef.mergeByLabel existing.statementUses incoming.statementUses
+      proofUses := Data.UseRef.mergeByLabel existing.proofUses incoming.proofUses
       owner := existing.owner <|> incoming.owner
       ownerDisplayName := existing.ownerDisplayName <|> incoming.ownerDisplayName
       ownerUrl := existing.ownerUrl <|> incoming.ownerUrl

--- a/src/VersoBlueprint/Informal/Code.lean
+++ b/src/VersoBlueprint/Informal/Code.lean
@@ -5,6 +5,7 @@ Author: Emilio J. Gallego Arias
 -/
 
 import VersoManual
+import VersoBlueprint.DependencyAnalysis
 import VersoBlueprint.Environment
 import VersoBlueprint.Informal.Block.Assets
 import VersoBlueprint.Informal.Block
@@ -53,12 +54,21 @@ private partial def previewCodeBlocks
 block_extension Block.informalCode (data : InlineCodeData) where
   data := toJson data
   traverse id data _contents := do
-    let .ok cdata@{ label, definedDefs := _, definedTheorems := _, foldCodeBlock := _, foldProofs := _ } := fromJson? (α := InlineCodeData) data
+    let .ok cdata := fromJson? (α := InlineCodeData) data
       | logError s!"Malformed data: {data}"
         pure none
+    let label := cdata.label
     if let .some _d := Informal.TraversalIndex.InlineCode.object? (← get) label then
       pure none
     else
+      if !cdata.statementUses.isEmpty || !cdata.proofUses.isEmpty then
+        if let some existing := Informal.TraversalIndex.Nodes.storedData? (← get) label then
+          let updated := {
+            existing with
+              statementUses := Data.UseRef.mergeByLabel existing.statementUses cdata.statementUses
+              proofUses := Data.UseRef.mergeByLabel existing.proofUses cdata.proofUses
+          }
+          modify fun s => Informal.TraversalIndex.Nodes.saveData s label (toJson updated)
       let previewBlocks := previewCodeBlocks id _contents
       let previewTargets :=
         (cdata.definedDefs.map (·.name)) ++ (cdata.definedTheorems.map (·.name))
@@ -83,7 +93,7 @@ block_extension Block.informalCode (data : InlineCodeData) where
     open Verso.Doc.Html in
     open Verso.Output.Html in
     some <| fun _goI goB id data blocks => do
-      let .ok { label, definedDefs, definedTheorems, foldCodeBlock, foldProofs } := fromJson? (α := InlineCodeData) data
+      let .ok { label, definedDefs, definedTheorems, statementUses := _, proofUses := _, foldCodeBlock, foldProofs } := fromJson? (α := InlineCodeData) data
         | HtmlT.logError s!"Malformed data: {data}"
           pure .empty
       let s ← HtmlT.state
@@ -111,20 +121,24 @@ block_extension Block.informalCode (data : InlineCodeData) where
 structure CodeConfig where
   label : Data.Label
   leanLabel : Name
+  autoDeps : Option Bool := none
   labelSyntax : Syntax := Syntax.missing
 
 section
-variable [Monad m] [MonadError m] [MonadOptions m]
+variable [Monad m] [MonadInfoTree m] [MonadResolveName m] [MonadLiftT CoreM m] [MonadEnv m]
+    [MonadError m] [MonadOptions m] [MonadLog m] [AddMessageContext m]
 
 def CodeConfig.parse : ArgParse m CodeConfig :=
-  (fun (labelArg : Verso.ArgParse.WithSyntax String) opts =>
+  (fun (labelArg : Verso.ArgParse.WithSyntax String) autoDeps opts =>
     let label := LabelNameParsing.parse labelArg.val
     let leanLabel := LabelNameParsing.parse labelArg.val (some opts)
     {
       label
       leanLabel
+      autoDeps
       labelSyntax := labelArg.syntax
     }) <$> .positional `label (.withSyntax .string)
+      <*> .named' `autoDeps true
       <*> .lift "current elaboration options" getOptions
 
 instance : FromArgs CodeConfig m where
@@ -176,15 +190,23 @@ private def leanImpl : CodeBlockExpanderOf CodeConfig
     let codeBlock := res.block
     let definedDefs := res.definedDefs.map CodeDeclData.ofLiterateDef
     let definedTheorems := res.definedTheorems.map CodeDeclData.ofLiterateThm
+    let mut inferredUseRefs : DependencyAnalysis.InferredUseRefs := {}
+    let codeRef ← getRef
+    Environment.registerCode cfg.label codeRef res.definedDefs res.definedTheorems
+    if DependencyAnalysis.enabled (← getOptions) cfg.autoDeps then
+      let decls := (res.definedDefs.map (·.name)) ++ (res.definedTheorems.map (·.name))
+      let deps ← liftM <| DependencyAnalysis.inferDecls decls
+      inferredUseRefs := deps.toUseRefs (currentLabel? := some cfg.label)
+      liftM <| DependencyAnalysis.attachInferredUseRefs cfg.label codeRef inferredUseRefs
     let data : InlineCodeData := {
       label := cfg.label
       definedDefs
       definedTheorems
+      statementUses := inferredUseRefs.statement
+      proofUses := inferredUseRefs.proof
       foldCodeBlock := verso.blueprint.foldCodeBlocks.get (← getOptions)
       foldProofs := verso.blueprint.foldProofs.get (← getOptions)
     }
-    let codeRef ← getRef
-    Environment.registerCode cfg.label codeRef res.definedDefs res.definedTheorems
     ``(Block.other (Block.informalCode $(quote data)) #[$codeBlock])
 
 @[code_block]

--- a/src/VersoBlueprint/Informal/CodeSummary.lean
+++ b/src/VersoBlueprint/Informal/CodeSummary.lean
@@ -35,19 +35,20 @@ Public API:
 -/
 
 /--
-Canonical inputs used to compute Lean summary UI for one informal block.
+Presentation inputs used to compute Lean summary UI for one informal block.
 
-`source` is the resolved optional code source for this block (`none` / `some inline` /
-`some external`).
-Inline declaration summaries come from `.inline`; `codeHref` is used for heading link rendering.
+`source` is the optional source selected for this particular heading or panel
+summary (`none` / `some inline` / `some external`). It is not the complete set of
+Lean associations owned by the label; semantic association data lives in
+`Data.Node.leanCode`.
 
-Callers should pass `source` after applying code-source precedence
-(typically via `BlockCodeData.ofHintAndInline`).
+Callers that need a single heading source should pass `source` after applying
+the presentation selection rule, typically via `BlockCodeData.ofHintAndInline`.
 -/
 structure ComputedData where
   /-- URL to the rendered Lean panel for this block, when available. -/
   codeHref : Option String := none
-  /-- Canonical resolved source used for status and tooltip semantics. -/
+  /-- Presentation source used for status and tooltip semantics. -/
   source : Option BlockCodeData := none
 
 /--

--- a/tests/VersoBlueprintTests/Blueprint.lean
+++ b/tests/VersoBlueprintTests/Blueprint.lean
@@ -5,6 +5,7 @@ Author: Emilio J. Gallego Arias
 -/
 
 import VersoBlueprintTests.BlueprintAttribute
+import VersoBlueprintTests.BlueprintAutoDeps
 import VersoBlueprintTests.BlueprintBlockFolding
 import VersoBlueprintTests.BlueprintCodeRenderMatrix
 import VersoBlueprintTests.BlueprintImportedDuplicates.Direct

--- a/tests/VersoBlueprintTests/BlueprintAttribute.lean
+++ b/tests/VersoBlueprintTests/BlueprintAttribute.lean
@@ -22,8 +22,8 @@ private def importedNodeInLocalData (label : String) : CoreM Bool := do
 
 private def isBlueprintAttrRef (expectedDecl : Name) (expectedKind : Informal.Data.NodeKind)
     (node : Informal.Data.Node) : Bool :=
-  match node.code with
-  | some (.external #[ref]) =>
+  match node.externalRefs with
+  | #[ref] =>
     ref.origin == .blueprintAttr &&
       ref.present &&
       ref.written == expectedDecl &&
@@ -45,16 +45,16 @@ private def isBlueprintAttrRef (expectedDecl : Name) (expectedKind : Informal.Da
       | return false
     pure (
       theoremNode.kind == .theorem &&
-      theoremNode.code.isSome &&
+      theoremNode.hasAssociatedCode &&
       theoremNode.statement.isSome &&
       definitionNode.kind == .definition &&
-      definitionNode.code.isSome &&
+      definitionNode.hasAssociatedCode &&
       definitionNode.statement.isSome &&
       inductiveNode.kind == .definition &&
-      inductiveNode.code.isSome &&
+      inductiveNode.hasAssociatedCode &&
       inductiveNode.statement.isSome &&
       undocumentedNode.kind == .definition &&
-      undocumentedNode.code.isSome
+      undocumentedNode.hasAssociatedCode
     )
 
 /-- info: true -/

--- a/tests/VersoBlueprintTests/BlueprintAutoDeps.lean
+++ b/tests/VersoBlueprintTests/BlueprintAutoDeps.lean
@@ -1,0 +1,9 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoBlueprintTests.BlueprintAutoDeps.Consumer
+import VersoBlueprintTests.BlueprintAutoDeps.Controls
+import VersoBlueprintTests.BlueprintAutoDeps.Preview

--- a/tests/VersoBlueprintTests/BlueprintAutoDeps/Consumer.lean
+++ b/tests/VersoBlueprintTests/BlueprintAutoDeps/Consumer.lean
@@ -124,6 +124,26 @@ private def expectedUsesMatrix : Array ExpectedUses :=
 #guard_msgs in
 #eval
   show CoreM Bool from do
+    let sharedLabels ←
+      Environment.labelsForLeanDecl
+        `Verso.VersoBlueprintTests.BlueprintAutoDeps.Provider.sharedSource
+    let sharedUses ← statementUses "auto.shared.target"
+    let expectedLabels := labels #[
+      "auto.shared.source.primary",
+      "auto.shared.source.secondary"
+    ]
+    pure <|
+      sharedLabels.size == expectedLabels.size &&
+      expectedLabels.all (fun label => sharedLabels.contains label) &&
+      sharedUses.size == expectedLabels.size &&
+      expectedLabels.all (fun label =>
+        sharedUses.any fun useRef =>
+          useRef.label == label && useRef.origin == .automatic)
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show CoreM Bool from do
     let providerLabels ←
       Environment.labelsForLeanDecl
         `Verso.VersoBlueprintTests.BlueprintAutoDeps.Provider.typeSource

--- a/tests/VersoBlueprintTests/BlueprintAutoDeps/Consumer.lean
+++ b/tests/VersoBlueprintTests/BlueprintAutoDeps/Consumer.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoBlueprintTests.BlueprintAutoDeps.Reexport
+import VersoBlueprintTests.BlueprintAutoDeps.Support
+
+open Lean
+open Informal
+open Verso.VersoBlueprintTests.BlueprintAutoDeps.Support
+
+namespace Verso.VersoBlueprintTests.BlueprintAutoDeps.Consumer
+
+@[blueprint "auto.imported.target" (autoDeps := true)]
+theorem importedTarget :
+    Verso.VersoBlueprintTests.BlueprintAutoDeps.Provider.typeSource := by
+  trivial
+
+@[blueprint "auto.imported.manual_decl"
+  (uses := [Verso.VersoBlueprintTests.BlueprintAutoDeps.Provider.manualExtra])]
+theorem importedManualDeclTarget : True := by
+  trivial
+
+private def expectedUsesMatrix : Array ExpectedUses :=
+  #[
+    -- Automatic inference by dependency axis.
+    {
+      labelText := "auto.type.target",
+      statement := #[useRef "auto.type.source" .automatic]
+    },
+    {
+      labelText := "auto.proof.target",
+      proof := #[useRef "auto.proof.source" .automatic]
+    },
+    {
+      labelText := "auto.def.target",
+      proof := #[useRef "auto.def.source" .automatic]
+    },
+    {
+      labelText := "auto.imported.target",
+      statement := #[useRef "auto.type.source" .automatic]
+    },
+    -- Manual dependencies and imported declarations.
+    {
+      labelText := "auto.imported.manual_decl",
+      statement := #[useRef "auto.manual.extra"]
+    },
+    -- Untagged declarations do not create edges or expose transitive tagged dependencies.
+    {
+      labelText := "auto.untagged.target"
+    },
+    {
+      labelText := "auto.untagged.type_target"
+    },
+    {
+      labelText := "auto.untagged.proof_target"
+    },
+    {
+      labelText := "auto.duplicate_axis.target",
+      statement := #[useRef "auto.def.source" .automatic]
+    },
+    -- Manual entries, exclusions, duplicate-axis suppression, and manual precedence.
+    {
+      labelText := "auto.manual.target",
+      statement := #[useRef "auto.manual.extra"]
+    },
+    {
+      labelText := "auto.manual.same_axis",
+      statement := #[useRef "auto.type.source"]
+    },
+    {
+      labelText := "auto.add_exclude.same_axis"
+    },
+    {
+      labelText := "auto.overlap.target",
+      statement := #[useRef "auto.type.source" .automatic],
+      proof := #[useRef "auto.type.source"]
+    },
+    {
+      labelText := "auto.decl.manual_no_auto",
+      statement := #[useRef "auto.type.source"]
+    },
+    -- String labels and proof-only manual entries.
+    {
+      labelText := "auto.string.target",
+      statement := #[useRef "auto.synthetic.label"]
+    },
+    {
+      labelText := "auto.string.proof_only",
+      proof := #[useRef "auto.synthetic.proof"]
+    },
+    {
+      labelText := "auto.manual.proof_only",
+      proof := #[useRef "auto.proof.source"]
+    },
+    -- Self edges are always suppressed.
+    {
+      labelText := "auto.self.string_target"
+    },
+    {
+      labelText := "auto.self.decl_target"
+    }
+  ]
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  let auto := dataUseRef "auto.merge.target" .automatic
+  let manual := dataUseRef "auto.merge.target"
+  let other := dataUseRef "auto.merge.other" .automatic
+  Data.UseRef.mergeByLabel #[auto] #[manual] == #[manual] &&
+  Data.UseRef.mergeByLabel #[manual] #[auto] == #[manual] &&
+  Data.UseRef.mergeByLabel #[auto] #[other] == #[auto, other]
+
+/-- info: #[] -/
+#guard_msgs in
+#eval
+  show CoreM (Array String) from do
+    expectedUsesFailures expectedUsesMatrix
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show CoreM Bool from do
+    let providerLabels ←
+      Environment.labelsForLeanDecl
+        `Verso.VersoBlueprintTests.BlueprintAutoDeps.Provider.typeSource
+    let env ← getEnv
+    let some reexportIdx := env.getModuleIdx? `VersoBlueprintTests.BlueprintAutoDeps.Reexport
+      | return false
+    let reexportEntries := Environment.informalExt.getModuleEntries env reexportIdx
+    pure <|
+      providerLabels == labels #["auto.type.source"] &&
+      reexportEntries.isEmpty
+
+end Verso.VersoBlueprintTests.BlueprintAutoDeps.Consumer

--- a/tests/VersoBlueprintTests/BlueprintAutoDeps/Controls.lean
+++ b/tests/VersoBlueprintTests/BlueprintAutoDeps/Controls.lean
@@ -1,0 +1,258 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoBlueprintTests.BlueprintAutoDeps.Support
+
+open Lean
+open Verso
+open Verso.Genre.Manual
+open Informal
+open Verso.VersoBlueprintTests.BlueprintAutoDeps.Support
+
+namespace Verso.VersoBlueprintTests.BlueprintAutoDeps.Controls
+
+set_option doc.verso true
+
+@[blueprint "auto.controls.type_source"]
+def controlsTypeSource : Prop := True
+
+@[blueprint "auto.controls.proof_source"]
+theorem controlsProofSource : True := by
+  trivial
+
+@[blueprint "auto.controls.attr.local_true" (autoDeps := true)]
+theorem attrLocalTrue : controlsTypeSource := by
+  trivial
+
+set_option verso.blueprint.autoDeps true
+
+@[blueprint "auto.controls.attr.global_default"]
+theorem attrGlobalDefault : controlsTypeSource := by
+  trivial
+
+@[blueprint "auto.controls.attr.local_false" (autoDeps := false)]
+theorem attrLocalFalse : controlsTypeSource := by
+  trivial
+
+set_option verso.blueprint.autoDeps false
+
+theorem externalLocalTrueDecl : controlsTypeSource := by
+  exact controlsProofSource
+
+theorem externalManualSameAxisDecl : controlsTypeSource := by
+  exact controlsProofSource
+
+theorem externalUnionStatementDecl : controlsTypeSource := by
+  trivial
+
+theorem externalUnionProofDecl : True := by
+  exact controlsProofSource
+
+def externalSourceDecl : Prop := True
+
+#docs (Genre.Manual) autoDepsLocalControlsDoc "Auto Dependency Local Controls" :=
+:::::::
+:::theorem "auto.controls.external.local_true" (lean := "externalLocalTrueDecl") (autoDeps := true)
+External declaration inference can be enabled locally.
+:::
+
+:::theorem "auto.controls.external.manual_same_axis" (lean := "externalManualSameAxisDecl") (autoDeps := true) (uses := "auto.controls.type_source")
+Block-level manual dependencies take precedence over same-axis automatic edges.
+:::
+
+:::theorem "auto.controls.external.union" (lean := "externalUnionStatementDecl, externalUnionProofDecl") (autoDeps := true)
+External declaration inference unions multiple compiled Lean references.
+:::
+
+:::definition "auto.controls.inline.local_true"
+Inline Lean inference can be enabled locally.
+:::
+
+```lean "auto.controls.inline.local_true" (autoDeps := true)
+theorem inlineLocalTrueDecl : controlsTypeSource := by
+  exact controlsProofSource
+```
+
+:::definition "auto.controls.inline.manual_same_axis" (uses := "auto.controls.type_source")
+Statement-level manual dependencies take precedence over inline-code automatic edges.
+:::
+
+```lean "auto.controls.inline.manual_same_axis" (autoDeps := true)
+theorem inlineManualSameAxisDecl : controlsTypeSource := by
+  exact controlsProofSource
+```
+
+:::definition "auto.controls.external.source" (lean := "externalSourceDecl")
+An ordinary `(lean := ...)` declaration association seeds the Lean-name lookup.
+:::
+
+:::definition "auto.controls.inline.source"
+An inline Lean declaration association seeds the Lean-name lookup.
+:::
+
+```lean "auto.controls.inline.source"
+def inlineSourceDecl : Prop := True
+```
+:::::::
+
+set_option verso.blueprint.autoDeps true
+
+theorem externalGlobalDefaultDecl : controlsTypeSource := by
+  exact controlsProofSource
+
+theorem externalLocalFalseDecl : controlsTypeSource := by
+  exact controlsProofSource
+
+#docs (Genre.Manual) autoDepsGlobalControlsDoc "Auto Dependency Global Controls" :=
+:::::::
+:::theorem "auto.controls.external.global_default" (lean := "externalGlobalDefaultDecl")
+External declaration inference follows the file option when the local option is omitted.
+:::
+
+:::theorem "auto.controls.external.local_false" (lean := "externalLocalFalseDecl") (autoDeps := false)
+External declaration inference can be disabled locally.
+:::
+
+:::definition "auto.controls.inline.global_default"
+Inline Lean inference follows the file option when the local option is omitted.
+:::
+
+```lean "auto.controls.inline.global_default"
+theorem inlineGlobalDefaultDecl : controlsTypeSource := by
+  exact controlsProofSource
+```
+
+:::definition "auto.controls.inline.local_false"
+Inline Lean inference can be disabled locally.
+:::
+
+```lean "auto.controls.inline.local_false" (autoDeps := false)
+theorem inlineLocalFalseDecl : controlsTypeSource := by
+  exact controlsProofSource
+```
+:::::::
+
+set_option verso.blueprint.autoDeps false
+
+@[blueprint "auto.controls.external.source_target" (autoDeps := true)]
+theorem externalSourceTarget : externalSourceDecl := by
+  trivial
+
+@[blueprint "auto.controls.inline.source_target" (autoDeps := true)]
+theorem inlineSourceTarget : inlineSourceDecl := by
+  trivial
+
+private def expectedControlUses : Array ExpectedUses :=
+  #[
+    -- Attribute-level controls.
+    {
+      labelText := "auto.controls.attr.local_true",
+      statement := #[useRef "auto.controls.type_source" .automatic]
+    },
+    {
+      labelText := "auto.controls.attr.global_default",
+      statement := #[useRef "auto.controls.type_source" .automatic]
+    },
+    {
+      labelText := "auto.controls.attr.local_false"
+    },
+    -- `(lean := ...)` controls.
+    {
+      labelText := "auto.controls.external.local_true",
+      statement := #[useRef "auto.controls.type_source" .automatic],
+      proof := #[useRef "auto.controls.proof_source" .automatic]
+    },
+    {
+      labelText := "auto.controls.external.global_default",
+      statement := #[useRef "auto.controls.type_source" .automatic],
+      proof := #[useRef "auto.controls.proof_source" .automatic]
+    },
+    {
+      labelText := "auto.controls.external.local_false"
+    },
+    {
+      labelText := "auto.controls.external.manual_same_axis",
+      statement := #[useRef "auto.controls.type_source"],
+      proof := #[useRef "auto.controls.proof_source" .automatic]
+    },
+    {
+      labelText := "auto.controls.external.union",
+      statement := #[useRef "auto.controls.type_source" .automatic],
+      proof := #[useRef "auto.controls.proof_source" .automatic]
+    },
+    -- Inline Lean controls.
+    {
+      labelText := "auto.controls.inline.local_true",
+      statement := #[useRef "auto.controls.type_source" .automatic],
+      proof := #[useRef "auto.controls.proof_source" .automatic]
+    },
+    {
+      labelText := "auto.controls.inline.global_default",
+      statement := #[useRef "auto.controls.type_source" .automatic],
+      proof := #[useRef "auto.controls.proof_source" .automatic]
+    },
+    {
+      labelText := "auto.controls.inline.local_false"
+    },
+    {
+      labelText := "auto.controls.inline.manual_same_axis",
+      statement := #[useRef "auto.controls.type_source"],
+      proof := #[useRef "auto.controls.proof_source" .automatic]
+    },
+    -- Lookup seeding from non-attribute Lean associations.
+    {
+      labelText := "auto.controls.external.source_target",
+      statement := #[useRef "auto.controls.external.source" .automatic]
+    },
+    {
+      labelText := "auto.controls.inline.source_target",
+      statement := #[useRef "auto.controls.inline.source" .automatic]
+    }
+  ]
+
+/-- info: #[] -/
+#guard_msgs in
+#eval
+  show CoreM (Array String) from do
+    expectedUsesFailures expectedControlUses
+
+/--
+error: Expected 'true' or 'false'
+-/
+#guard_msgs in
+#docs (Genre.Manual) invalidBlockAutoDepsDoc "Invalid Block AutoDeps" :=
+:::::::
+:::definition "auto.controls.invalid.block" (autoDeps := Nat)
+Invalid block autoDeps option.
+:::
+:::::::
+
+/--
+error: Expected 'true' or 'false'
+-/
+#guard_msgs in
+#docs (Genre.Manual) invalidInlineAutoDepsDoc "Invalid Inline AutoDeps" :=
+:::::::
+```lean "auto.controls.invalid.inline" (autoDeps := Nat)
+def invalidInlineAutoDepsDecl : Nat := 0
+```
+:::::::
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show CoreM Bool from do
+    let externalLabels ←
+      Environment.labelsForLeanDecl
+        `Verso.VersoBlueprintTests.BlueprintAutoDeps.Controls.externalSourceDecl
+    let inlineLabels ←
+      Environment.labelsForLeanDecl
+        `Verso.VersoBlueprintTests.BlueprintAutoDeps.Controls.inlineSourceDecl
+    pure <|
+      externalLabels == labels #["auto.controls.external.source"] &&
+      inlineLabels == labels #["auto.controls.inline.source"]
+
+end Verso.VersoBlueprintTests.BlueprintAutoDeps.Controls

--- a/tests/VersoBlueprintTests/BlueprintAutoDeps/Preview.lean
+++ b/tests/VersoBlueprintTests/BlueprintAutoDeps/Preview.lean
@@ -1,0 +1,264 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoBlueprintTests.Blueprint.Support
+
+namespace Verso.VersoBlueprintTests.BlueprintAutoDeps.Preview
+
+open Verso
+open Verso.Genre.Manual
+open Lean
+open Informal
+open Verso.VersoBlueprintTests.Blueprint.Support
+
+set_option doc.verso true
+
+def manualImpls : ExtensionImpls := extension_impls%
+
+private def label (s : String) : Name :=
+  Name.mkSimple s
+
+@[blueprint "auto.demo.type_source"]
+def autoDemoTypeSource : Prop := True
+
+@[blueprint "auto.demo.proof_source"]
+theorem autoDemoProofSource : True := by
+  trivial
+
+@[blueprint "auto.demo.manual_extra"]
+theorem autoDemoManualExtra : True := by
+  trivial
+
+@[blueprint "auto.demo.statement_target"
+  (autoDeps := true)
+  (uses := ["auto.demo.manual_extra"])]
+theorem autoDemoStatementTarget : autoDemoTypeSource := by
+  trivial
+
+@[blueprint "auto.demo.proof_target"
+  (autoDeps := true)
+  (proofUses := [autoDemoManualExtra])]
+theorem autoDemoProofTarget : True := by
+  exact autoDemoProofSource
+
+@[blueprint "auto.demo.excluded_target"
+  (autoDeps := true)
+  (uses := [-"auto.demo.type_source", "auto.demo.manual_extra"])]
+theorem autoDemoExcludedTarget : autoDemoTypeSource := by
+  trivial
+
+theorem autoDemoExternalTargetDecl : autoDemoTypeSource := by
+  exact autoDemoProofSource
+
+theorem autoDemoExternalOptOutDecl : autoDemoTypeSource := by
+  exact autoDemoProofSource
+
+set_option verso.blueprint.autoDeps true
+
+#docs (Genre.Manual) autoDepsPreviewDoc "Lean Auto Dependencies" :=
+:::::::
+Inspect `auto.demo.statement_target` for a statement panel with one automatic
+edge and one manual edge, `auto.demo.proof_target` for the same split on a
+proof panel, and `auto.demo.excluded_target` for an automatic edge removed by
+an attribute exclusion. This file also enables
+`set_option verso.blueprint.autoDeps true` for the examples that use
+`(lean := "...")` and inline Lean code.
+
+:::definition "auto.demo.type_source"
+Tagged source declaration used by another declaration's type. Edges to this
+node are inferred only when a target's statement mentions the Lean declaration.
+:::
+
+:::theorem "auto.demo.proof_source"
+Tagged source theorem used by another declaration's proof. Edges to this node
+should appear on proof dependency chips, not statement dependency chips.
+:::
+
+:::theorem "auto.demo.manual_extra"
+Manual comparison dependency. This edge is written in the attribute options, so
+it should stay manual while inferred edges are marked automatic.
+:::
+
+:::theorem "auto.demo.statement_target"
+The Lean statement has type `autoDemoTypeSource`, so automatic dependency
+inference adds `auto.demo.type_source`. The attribute also adds
+`auto.demo.manual_extra` manually, making the statement dependency panel show
+both origins side by side.
+:::
+
+:::theorem "auto.demo.proof_target"
+The Lean statement is just `True`, so there is no inferred statement dependency.
+The proof below uses `autoDemoProofSource`.
+:::
+
+:::proof "auto.demo.proof_target"
+The Lean proof body references `autoDemoProofSource`, so automatic dependency
+inference adds `auto.demo.proof_source` to the proof dependencies. The attribute
+also adds `auto.demo.manual_extra` manually for comparison.
+:::
+
+:::theorem "auto.demo.excluded_target"
+The Lean statement mentions `autoDemoTypeSource`, but the attribute excludes
+`auto.demo.type_source`. Only the manually listed `auto.demo.manual_extra`
+dependency remains.
+:::
+
+:::theorem "auto.demo.external_target" (lean := "autoDemoExternalTargetDecl")
+This node points at an existing compiled Lean declaration with `(lean := ...)`.
+The file option enables automatic dependencies, so the declaration's type and
+proof body provide statement and proof edges.
+:::
+
+:::definition "auto.demo.inline_target"
+This node has an inline Lean block. The file option also enables automatic
+dependencies for the declarations defined in the block.
+:::
+
+```lean "auto.demo.inline_target"
+theorem autoDemoInlineTargetDecl : autoDemoTypeSource := by
+  exact autoDemoProofSource
+```
+
+:::theorem "auto.demo.external_opt_out" (lean := "autoDemoExternalOptOutDecl") (autoDeps := false)
+This node points at a compiled Lean declaration, but locally disables automatic
+dependency inference.
+:::
+
+:::theorem "auto.demo.viewer"
+A prose-first node links to the inferred targets with ordinary manual
+dependencies: {uses "auto.demo.statement_target"}[],
+{uses "auto.demo.proof_target"}[], {uses "auto.demo.external_target"}[], and
+{uses "auto.demo.inline_target"}[].
+:::
+
+{blueprint_graph}
+
+{blueprint_summary}
+:::::::
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show CoreM Bool from do
+    let some node ← Environment.getNode? (label "auto.demo.statement_target")
+      | return false
+    let some statement := node.statement
+      | return false
+    pure <|
+      statement.hasBody &&
+      statement.deps ==
+        #[
+          { label := label "auto.demo.type_source", origin := .automatic },
+          { label := label "auto.demo.manual_extra" }
+        ]
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show CoreM Bool from do
+    let some node ← Environment.getNode? (label "auto.demo.proof_target")
+      | return false
+    let some proof := node.proof
+      | return false
+    pure <|
+      proof.hasBody &&
+      proof.deps ==
+        #[
+          { label := label "auto.demo.proof_source", origin := .automatic },
+          { label := label "auto.demo.manual_extra" }
+        ]
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show CoreM Bool from do
+    let some node ← Environment.getNode? (label "auto.demo.excluded_target")
+      | return false
+    let some statement := node.statement
+      | return false
+    pure <|
+      statement.hasBody &&
+      statement.deps == #[{ label := label "auto.demo.manual_extra" }]
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show CoreM Bool from do
+    let some node ← Environment.getNode? (label "auto.demo.external_target")
+      | return false
+    let some statement := node.statement
+      | return false
+    let some proof := node.proof
+      | return false
+    pure <|
+      statement.deps == #[{ label := label "auto.demo.type_source", origin := .automatic }] &&
+      proof.deps == #[{ label := label "auto.demo.proof_source", origin := .automatic }]
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show CoreM Bool from do
+    let some node ← Environment.getNode? (label "auto.demo.inline_target")
+      | return false
+    let some statement := node.statement
+      | return false
+    let some proof := node.proof
+      | return false
+    pure <|
+      statement.deps == #[{ label := label "auto.demo.type_source", origin := .automatic }] &&
+      proof.deps == #[{ label := label "auto.demo.proof_source", origin := .automatic }]
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show CoreM Bool from do
+    let some node ← Environment.getNode? (label "auto.demo.external_opt_out")
+      | return false
+    let statementDeps := node.statement.map (·.deps) |>.getD #[]
+    let proofDeps := node.proof.map (·.deps) |>.getD #[]
+    pure <| statementDeps.isEmpty && proofDeps.isEmpty
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show CoreM Bool from do
+    let labels :=
+      #[
+        "auto.demo.type_source",
+        "auto.demo.proof_source",
+        "auto.demo.manual_extra",
+        "auto.demo.statement_target",
+        "auto.demo.proof_target",
+        "auto.demo.excluded_target",
+        "auto.demo.external_target",
+        "auto.demo.inline_target",
+        "auto.demo.external_opt_out",
+        "auto.demo.viewer"
+      ]
+    let counts ← labels.mapM fun labelText => do
+      let some node ← Environment.getNode? (label labelText)
+        | return 0
+      return node.count
+    pure <| counts == #[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let out ← renderManualDocHtmlString manualImpls autoDepsPreviewDoc
+    pure <|
+      hasSubstr out "auto.demo.type_source" &&
+      hasSubstr out "auto.demo.statement_target" &&
+      hasSubstr out "auto.demo.proof_target" &&
+      hasSubstr out "auto.demo.excluded_target" &&
+      hasSubstr out "auto.demo.external_target" &&
+      hasSubstr out "auto.demo.inline_target" &&
+      hasSubstr out "auto.demo.external_opt_out" &&
+      hasSubstr out "Statement uses 2" &&
+      hasSubstr out "Proof uses 2" &&
+      hasSubstr out "Origin: automatic"
+
+end Verso.VersoBlueprintTests.BlueprintAutoDeps.Preview

--- a/tests/VersoBlueprintTests/BlueprintAutoDeps/Provider.lean
+++ b/tests/VersoBlueprintTests/BlueprintAutoDeps/Provider.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoBlueprint
+
+namespace Verso.VersoBlueprintTests.BlueprintAutoDeps.Provider
+
+/-- Source declaration used from another theorem's type. -/
+@[blueprint "auto.type.source"]
+def typeSource : Prop := True
+
+/-- Source declaration used from another theorem's proof. -/
+@[blueprint "auto.proof.source"]
+theorem proofSource : True := by
+  trivial
+
+/-- Source declaration used from another definition's body. -/
+@[blueprint "auto.def.source"]
+def defSource : Nat := 1
+
+/-- Extra explicit dependency target. -/
+@[blueprint "auto.manual.extra"]
+theorem manualExtra : True := by
+  trivial
+
+/-- The type mentions a tagged Blueprint declaration. -/
+@[blueprint "auto.type.target" (autoDeps := true)]
+theorem typeTarget : typeSource := by
+  trivial
+
+@[blueprint "auto.proof.target" (autoDeps := true)]
+theorem proofTarget : True := by
+  exact proofSource
+
+@[blueprint "auto.def.target" (autoDeps := true)]
+def defTarget : Nat := defSource + 1
+
+theorem untaggedSource : True := by
+  trivial
+
+@[blueprint "auto.untagged.target" (autoDeps := true)]
+theorem untaggedTarget : True := by
+  exact untaggedSource
+
+def untaggedTypeAlias : Prop := typeSource
+
+@[blueprint "auto.untagged.type_target" (autoDeps := true)]
+theorem untaggedTypeTarget : untaggedTypeAlias := by
+  trivial
+
+def untaggedProofHelper : True := proofSource
+
+@[blueprint "auto.untagged.proof_target" (autoDeps := true)]
+theorem untaggedProofTarget : True := by
+  exact untaggedProofHelper
+
+@[blueprint "auto.duplicate_axis.target" (autoDeps := true)]
+def duplicateAxisTarget : { n : Nat // n = defSource } :=
+  ⟨defSource, rfl⟩
+
+@[blueprint "auto.manual.target"
+  (autoDeps := true)
+  (uses := ["auto.manual.extra", -"auto.type.source"])
+  (proofUses := [proofSource, -"auto.proof.source"])]
+theorem manualTarget : typeSource := by
+  exact proofSource
+
+@[blueprint "auto.manual.same_axis"
+  (autoDeps := true)
+  (uses := [typeSource])]
+theorem manualSameAxisTarget : typeSource := by
+  trivial
+
+@[blueprint "auto.add_exclude.same_axis"
+  (autoDeps := true)
+  (uses := [typeSource, -typeSource])]
+theorem addExcludeSameAxisTarget : typeSource := by
+  trivial
+
+@[blueprint "auto.overlap.target" (autoDeps := true) (proofUses := [typeSource])]
+theorem overlapTarget : typeSource := by
+  trivial
+
+@[blueprint "auto.decl.manual_no_auto" (uses := [typeSource])]
+theorem declManualNoAuto : True := by
+  trivial
+
+@[blueprint "auto.string.target" (uses := ["auto.synthetic.label"])]
+theorem stringTarget : True := by
+  trivial
+
+@[blueprint "auto.string.proof_only" (proofUses := ["auto.synthetic.proof"])]
+theorem stringProofOnly : True := by
+  trivial
+
+@[blueprint "auto.manual.proof_only" (proofUses := [proofSource])]
+theorem manualProofOnly : True := by
+  trivial
+
+@[blueprint "auto.self.string_target" (uses := ["auto.self.string_target"])]
+theorem selfStringTarget : True := by
+  trivial
+
+@[blueprint "auto.self.decl_target" (uses := [selfDeclTarget])]
+theorem selfDeclTarget : True := by
+  trivial
+
+end Verso.VersoBlueprintTests.BlueprintAutoDeps.Provider

--- a/tests/VersoBlueprintTests/BlueprintAutoDeps/Provider.lean
+++ b/tests/VersoBlueprintTests/BlueprintAutoDeps/Provider.lean
@@ -21,6 +21,10 @@ theorem proofSource : True := by
 @[blueprint "auto.def.source"]
 def defSource : Nat := 1
 
+/-- Source declaration intentionally associated with two Blueprint labels. -/
+@[blueprint "auto.shared.source.primary", blueprint "auto.shared.source.secondary"]
+def sharedSource : Prop := True
+
 /-- Extra explicit dependency target. -/
 @[blueprint "auto.manual.extra"]
 theorem manualExtra : True := by
@@ -37,6 +41,10 @@ theorem proofTarget : True := by
 
 @[blueprint "auto.def.target" (autoDeps := true)]
 def defTarget : Nat := defSource + 1
+
+@[blueprint "auto.shared.target" (autoDeps := true)]
+theorem sharedTarget : sharedSource := by
+  trivial
 
 theorem untaggedSource : True := by
   trivial

--- a/tests/VersoBlueprintTests/BlueprintAutoDeps/Reexport.lean
+++ b/tests/VersoBlueprintTests/BlueprintAutoDeps/Reexport.lean
@@ -1,0 +1,14 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoBlueprintTests.BlueprintAutoDeps.Provider
+
+namespace Verso.VersoBlueprintTests.BlueprintAutoDeps.Reexport
+
+def importedValue : Nat :=
+  Verso.VersoBlueprintTests.BlueprintAutoDeps.Provider.defSource
+
+end Verso.VersoBlueprintTests.BlueprintAutoDeps.Reexport

--- a/tests/VersoBlueprintTests/BlueprintAutoDeps/Support.lean
+++ b/tests/VersoBlueprintTests/BlueprintAutoDeps/Support.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoBlueprint
+
+open Lean
+open Informal
+
+namespace Verso.VersoBlueprintTests.BlueprintAutoDeps.Support
+
+def label (s : String) : Name :=
+  Name.mkSimple s
+
+def state : CoreM Environment.State := do
+  pure <| Environment.informalExt.getState (← getEnv)
+
+def node? (labelText : String) : CoreM (Option Data.Node) := do
+  pure <| (← state).data.get? (label labelText)
+
+def statementUses (labelText : String) : CoreM (Array Data.UseRef) := do
+  let some node ← node? labelText
+    | return #[]
+  pure <| (node.statement.map (·.deps)).getD #[]
+
+def proofUses (labelText : String) : CoreM (Array Data.UseRef) := do
+  let some node ← node? labelText
+    | return #[]
+  pure <| (node.proof.map (·.deps)).getD #[]
+
+def useRefSummary (useRefs : Array Data.UseRef) :
+    Array (Name × Data.UseOrigin × Data.UseIntent) :=
+  useRefs.map fun useRef => (useRef.label, useRef.origin, useRef.intent)
+
+def useRef
+    (labelText : String) (origin : Data.UseOrigin := .manual)
+    (intent : Data.UseIntent := .regular) : Name × Data.UseOrigin × Data.UseIntent :=
+  (label labelText, origin, intent)
+
+def dataUseRef
+    (labelText : String) (origin : Data.UseOrigin := .manual)
+    (intent : Data.UseIntent := .regular) : Data.UseRef :=
+  { label := label labelText, origin, intent }
+
+def labels (items : Array String) : Array Name :=
+  items.map label
+
+structure ExpectedUses where
+  labelText : String
+  statement : Array (Name × Data.UseOrigin × Data.UseIntent) := #[]
+  proof : Array (Name × Data.UseOrigin × Data.UseIntent) := #[]
+
+def summaryString
+    (summary : Array (Name × Data.UseOrigin × Data.UseIntent)) : String :=
+  let itemString : Name × Data.UseOrigin × Data.UseIntent → String
+    | (label, origin, intent) => s!"({label}, {origin}, {intent})"
+  "#[" ++ String.intercalate ", " (summary.toList.map itemString) ++ "]"
+
+def expectedUsesFailure? (expected : ExpectedUses) : CoreM (Option String) := do
+  let actualStatement := useRefSummary (← statementUses expected.labelText)
+  let actualProof := useRefSummary (← proofUses expected.labelText)
+  if actualStatement == expected.statement && actualProof == expected.proof then
+    return none
+  else
+    return some <|
+      s!"{expected.labelText}: statement expected {summaryString expected.statement}, " ++
+      s!"got {summaryString actualStatement}; proof expected {summaryString expected.proof}, " ++
+      s!"got {summaryString actualProof}"
+
+def expectedUsesFailures (expectedUses : Array ExpectedUses) : CoreM (Array String) := do
+  let mut failures := #[]
+  for expected in expectedUses do
+    if let some failure ← expectedUsesFailure? expected then
+      failures := failures.push failure
+  pure failures
+
+end Verso.VersoBlueprintTests.BlueprintAutoDeps.Support

--- a/tests/VersoBlueprintTests/BlueprintGraph/NodeStatus.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraph/NodeStatus.lean
@@ -20,7 +20,7 @@ def stateStatus : Environment.State := mkState [
     {
       kind := .definition
       statement := some (mkInformal #[])
-      code := some (mkDefCode `def_formal_decl)
+      leanCode := #[mkDefCode `def_formal_decl]
     }),
   (`def_ready,
     {
@@ -40,19 +40,19 @@ def stateStatus : Environment.State := mkState [
   (`lean_only,
     {
       kind := .definition
-      code := some (mkDefCode `lean_only_decl)
+      leanCode := #[mkDefCode `lean_only_decl]
     }),
   (`local_sorry,
     {
       kind := .theorem
       statement := some (mkInformal #[])
-      code := some (mkTheoremCode `local_sorry_decl false true)
+      leanCode := #[mkTheoremCode `local_sorry_decl false true]
     }),
   (`thm_type_sorry,
     {
       kind := .theorem
       statement := some (mkInformal #[])
-      code := some (mkTheoremCode `thm_type_sorry_decl true false)
+      leanCode := #[mkTheoremCode `thm_type_sorry_decl true false]
     })
 ]
 
@@ -109,19 +109,19 @@ def stateAncestorsOk : Environment.State := mkState [
     {
       kind := .definition
       statement := some (mkInformal #[])
-      code := some (mkDefCode `def_ok_decl)
+      leanCode := #[mkDefCode `def_ok_decl]
     }),
   (`thm_dep_ok,
     {
       kind := .theorem
       statement := some (mkInformal #[`def_ok])
-      code := some (mkTheoremCode `thm_dep_ok_decl)
+      leanCode := #[mkTheoremCode `thm_dep_ok_decl]
     }),
   (`thm_top_ok,
     {
       kind := .theorem
       statement := some (mkInformal #[`thm_dep_ok])
-      code := some (mkTheoremCode `thm_top_ok_decl)
+      leanCode := #[mkTheoremCode `thm_top_ok_decl]
     })
 ]
 
@@ -144,13 +144,13 @@ def stateAncestorsBad : Environment.State := mkState [
     {
       kind := .theorem
       statement := some (mkInformal #[`def_unfinished])
-      code := some (mkTheoremCode `thm_dep_bad_decl)
+      leanCode := #[mkTheoremCode `thm_dep_bad_decl]
     }),
   (`thm_top_bad,
     {
       kind := .theorem
       statement := some (mkInformal #[`thm_dep_bad])
-      code := some (mkTheoremCode `thm_top_bad_decl)
+      leanCode := #[mkTheoremCode `thm_top_bad_decl]
     })
 ]
 
@@ -171,34 +171,34 @@ def stateExternalCode : Environment.State := mkState [
     {
       kind := .definition
       statement := some (mkInformal #[])
-      code := some (.external #[
+      leanCode := #[.external #[
         { (Data.ExternalRef.ofName `Ext.good) with
           present := true
           provedStatus := .proved
         }
-      ])
+      ]]
     }),
   (`def_ext_bad,
     {
       kind := .definition
       statement := some (mkInformal #[])
-      code := some (.external #[
+      leanCode := #[.external #[
         { (Data.ExternalRef.ofName `Ext.bad) with
           present := true
           provedStatus := .containsSorry #[{ location := .statement }, { location := .proof }]
         }
-      ])
+      ]]
     }),
   (`def_ext_missing,
     {
       kind := .definition
       statement := some (mkInformal #[])
-      code := some (.external #[
+      leanCode := #[.external #[
         { (Data.ExternalRef.ofName `Ext.missing) with
           present := false
           provedStatus := .proved
         }
-      ])
+      ]]
     })
 ]
 
@@ -244,23 +244,23 @@ def stateExternalOverride : Environment.State := mkState [
     {
       kind := .definition
       statement := some (mkInformal #[])
-      code := some (.external #[
+      leanCode := #[.external #[
         { (Data.ExternalRef.ofName `Ext.override_bad) with
           present := true
           provedStatus := .proved
         }
-      ])
+      ]]
     }),
   (`def_ext_override_missing,
     {
       kind := .definition
       statement := some (mkInformal #[])
-      code := some (.external #[
+      leanCode := #[.external #[
         { (Data.ExternalRef.ofName `Ext.override_missing) with
           present := true
           provedStatus := .proved
         }
-      ])
+      ]]
     })
 ]
 
@@ -285,12 +285,12 @@ def stateLeanOnlyExternalMissing : Environment.State := mkState [
   (`lean_only_ext_missing,
     {
       kind := .definition
-      code := some (.external #[
+      leanCode := #[.external #[
         { (Data.ExternalRef.ofName `Ext.missing) with
           present := false
           provedStatus := .proved
         }
-      ])
+      ]]
     })
 ]
 

--- a/tests/VersoBlueprintTests/BlueprintInformal/LeanRefs.lean
+++ b/tests/VersoBlueprintTests/BlueprintInformal/LeanRefs.lean
@@ -5,13 +5,17 @@ Author: Emilio J. Gallego Arias
 -/
 
 import VersoBlueprintTests.BlueprintInformal.Shared
+import VersoBlueprintTests.Blueprint.Support
 
 open Lean
 open Verso Genre Manual
 open Informal
+open Verso.VersoBlueprintTests.Blueprint.Support
 open Verso.VersoBlueprintTests.BlueprintInformal.Shared
 
 namespace Verso.VersoBlueprintTests.BlueprintInformal.LeanRefs
+
+private def manualImpls : ExtensionImpls := extension_impls%
 
 private def attachedInductiveName : Name :=
   `Verso.VersoBlueprintTests.BlueprintInformal.LeanRefs.AttachedInductive
@@ -83,10 +87,6 @@ Proof body.
 :::
 :::::::
 
-/--
-error: Label «conflict.ext.inline» has both '(lean := ...)' and an associated Lean code block; preferring inline code
--/
-#guard_msgs in
 #docs (Manual) conflictExternalThenInline "Conflict External Then Inline" :=
 :::::::
 :::definition "conflict.ext.inline" (lean := "Nat.add")
@@ -98,10 +98,6 @@ def conflictExternalThenInlineValue : Nat := Nat.succ 0
 ```
 :::::::
 
-/--
-error: Label «conflict.inline.ext» has both an associated Lean code block and '(lean := ...)'; preferring inline code
--/
-#guard_msgs in
 #docs (Manual) conflictInlineThenExternal "Conflict Inline Then External" :=
 :::::::
 ```lean "conflict.inline.ext"
@@ -112,6 +108,53 @@ def conflictInlineThenExternalValue : Nat := Nat.succ 1
 Simple body.
 :::
 :::::::
+
+private def hasLabel (labels : Array Informal.Data.Label) (label : String) : Bool :=
+  labels.contains (Name.mkSimple label)
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show CoreM Bool from do
+    let natAddLabels ← Environment.labelsForLeanDecl `Nat.add
+    let extInlineLabels ←
+      Environment.labelsForLeanDecl
+        `Verso.VersoBlueprintTests.BlueprintInformal.LeanRefs.conflictExternalThenInlineValue
+    let inlineExtLabels ←
+      Environment.labelsForLeanDecl
+        `Verso.VersoBlueprintTests.BlueprintInformal.LeanRefs.conflictInlineThenExternalValue
+    let state ← currentState
+    let some extInlineNode := state.data.get? (Name.mkSimple "conflict.ext.inline")
+      | pure false
+    let some inlineExtNode := state.data.get? (Name.mkSimple "conflict.inline.ext")
+      | pure false
+    pure <|
+      hasLabel natAddLabels "conflict.ext.inline" &&
+      hasLabel natAddLabels "conflict.inline.ext" &&
+      hasLabel extInlineLabels "conflict.ext.inline" &&
+      hasLabel inlineExtLabels "conflict.inline.ext" &&
+      extInlineNode.externalRefs.any (fun ref => ref.canonical == `Nat.add) &&
+      inlineExtNode.externalRefs.any (fun ref => ref.canonical == `Nat.add) &&
+      extInlineNode.literateCodes.size == 1 &&
+      inlineExtNode.literateCodes.size == 1
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let extInlineOut ← renderManualDocHtmlString manualImpls conflictExternalThenInline
+    let inlineExtOut ← renderManualDocHtmlString manualImpls conflictInlineThenExternal
+    pure <|
+      hasSubstr extInlineOut "bp_external_decl_rendered" &&
+      hasSubstr extInlineOut "Nat.add" &&
+      hasSubstr extInlineOut "conflictExternalThenInlineValue" &&
+      appearsBefore extInlineOut "Simple body." "bp_external_decl_rendered" &&
+      appearsBefore extInlineOut "bp_external_decl_rendered" "conflictExternalThenInlineValue" &&
+      hasSubstr inlineExtOut "bp_external_decl_rendered" &&
+      hasSubstr inlineExtOut "Nat.add" &&
+      hasSubstr inlineExtOut "conflictInlineThenExternalValue" &&
+      appearsBefore inlineExtOut "conflictInlineThenExternalValue" "Simple body." &&
+      appearsBefore inlineExtOut "Simple body." "bp_external_decl_rendered"
 
 #docs (Manual) inductiveLeanRefAccepted "Inductive Lean Ref Accepted" :=
 :::::::
@@ -129,8 +172,8 @@ Simple body.
       | pure false
     pure <|
       node.kind == .definition &&
-      match node.code with
-      | some (.external #[ref]) =>
+      match node.externalRefs with
+      | #[ref] =>
         ref.present &&
         ref.kind == .definition &&
         ref.canonical == `Verso.VersoBlueprintTests.BlueprintInformal.LeanRefs.AttachedInductive &&
@@ -170,7 +213,7 @@ Simple body.
     let state ← currentState
     let some node := state.data.get? (Name.mkSimple "trim.external.name")
       | pure false
-    pure node.code.isNone
+    pure !node.hasAssociatedCode
 
 set_option verso.blueprint.trimTeXLabelPrefix false
 

--- a/tests/VersoBlueprintTests/BlueprintInlinePrecision.lean
+++ b/tests/VersoBlueprintTests/BlueprintInlinePrecision.lean
@@ -40,15 +40,13 @@ theorem inline_main_complete : True := by
     | some node =>
       let external : ExternalCodeStatus := {}
       let helperProofGapOnly :=
-        match node.code with
-        | some (.literate code) =>
+        node.literateCodes.any fun code =>
           code.definedDefs.any fun decl =>
             let (typeRefs, proofRefs) := decl.provedStatus.sorryRefCounts
             decl.provedStatus.hasProofGap &&
             !decl.provedStatus.hasTypeGap &&
             typeRefs == 0 &&
             proofRefs > 0
-        | _ => false
       pure <|
         node.kind == .theorem &&
         nodeLocalStatementFormalized external node &&
@@ -77,12 +75,11 @@ private def literateDeclNamesFor? (label : Name) : CoreM (Option (Array String))
   match state.data.get? label with
   | none => pure none
   | some node =>
-    match node.code with
-    | some (.literate code) =>
-      pure <| some <|
-        (code.definedDefs.map (·.name.toString)) ++
-        (code.definedTheorems.map (·.name.toString))
-    | _ => pure none
+    let names :=
+      node.literateCodes.foldl (init := #[]) fun acc code =>
+        acc ++ (code.definedDefs.map (·.name.toString)) ++
+          (code.definedTheorems.map (·.name.toString))
+    pure <| if names.isEmpty then none else some names
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/VersoBlueprintTests/BlueprintSummaryStatus.lean
+++ b/tests/VersoBlueprintTests/BlueprintSummaryStatus.lean
@@ -70,7 +70,7 @@ def definitionWithProofGap : Node :=
   {
     kind := .definition
     statement := some (mkInformal #[])
-    code := some <| mkLiterateCode #[mkDefDecl `def_with_proof_gap 0 1] #[]
+    leanCode := #[mkLiterateCode #[mkDefDecl `def_with_proof_gap 0 1] #[]]
   }
 
 /-- info: true -/
@@ -86,9 +86,9 @@ def theoremWithHelperDefProofGap : Node :=
   {
     kind := .theorem
     statement := some (mkInformal #[])
-    code := some <| mkLiterateCode
+    leanCode := #[mkLiterateCode
       #[mkDefDecl `helper_def_with_proof_gap 0 1]
-      #[mkThmDecl `main_theorem 0 0]
+      #[mkThmDecl `main_theorem 0 0]]
   }
 
 /-- info: true -/
@@ -104,7 +104,7 @@ def theoremWithProofGapOnly : Node :=
   {
     kind := .theorem
     statement := some (mkInformal #[])
-    code := some <| mkLiterateCode #[] #[mkThmDecl `theorem_with_proof_gap 0 1]
+    leanCode := #[mkLiterateCode #[] #[mkThmDecl `theorem_with_proof_gap 0 1]]
   }
 
 /-- info: true -/

--- a/tests/VersoBlueprintTests/TestBlueprintRegistry.lean
+++ b/tests/VersoBlueprintTests/TestBlueprintRegistry.lean
@@ -24,15 +24,6 @@ open Verso.Genre.Manual
 open Lean
 open Verso.VersoBlueprintTests.TestBlueprintRegistryMeta
 
-structure CuratedTestBlueprint where
-  slug : String
-  title : String
-  category : String
-  summary : String
-  tags : Array String := #[]
-  doc : Doc.VersoDoc Genre.Manual
-deriving Inhabited
-
 def manualImpls : ExtensionImpls := extension_impls%
 
 private def curatedTestBlueprintDoc? (slug : String) : Option (Doc.VersoDoc Genre.Manual) :=
@@ -61,35 +52,10 @@ private def curatedTestBlueprintDoc? (slug : String) : Option (Doc.VersoDoc Genr
   | "single-declared-group" => some Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared.singleDeclaredGroupDoc
   | _ => none
 
-def curatedTestBlueprints : Array CuratedTestBlueprint :=
-  curatedTestBlueprintMetas.map (fun entry =>
-    match curatedTestBlueprintDoc? entry.slug with
-    | some doc =>
-        {
-          slug := entry.slug
-          title := entry.title
-          category := entry.category
-          summary := entry.summary
-          tags := entry.tags
-          doc := doc
-        }
-    | none =>
-        panic! s!"missing curated test blueprint doc for slug `{entry.slug}`")
-
 def curatedTestBlueprintDocSlugs : Array String :=
-  curatedTestBlueprints.map (·.slug)
+  curatedTestBlueprintMetas.map (·.slug)
 
 def findCuratedTestBlueprintDoc? (slug : String) : Option (Doc.VersoDoc Genre.Manual) :=
-  (curatedTestBlueprints.find? fun entry => entry.slug == slug).map (·.doc)
-
-def CuratedTestBlueprint.meta (doc : CuratedTestBlueprint) : CuratedTestBlueprintMeta :=
-  {
-    slug := doc.slug
-    title := doc.title
-    category := doc.category
-    summary := doc.summary
-    tags := doc.tags
-    kind := "curated_doc"
-  }
+  curatedTestBlueprintDoc? slug
 
 end Verso.VersoBlueprintTests.TestBlueprintRegistry

--- a/tests/VersoBlueprintTests/TestBlueprintRegistry.lean
+++ b/tests/VersoBlueprintTests/TestBlueprintRegistry.lean
@@ -6,6 +6,7 @@ Author: Emilio J. Gallego Arias
 
 import VersoBlueprintTests.BlueprintImportedDuplicates.Direct
 import VersoBlueprintTests.BlueprintImportedDuplicates.Transitive
+import VersoBlueprintTests.BlueprintAutoDeps.Preview
 import VersoBlueprintTests.BlueprintLinkHover
 import VersoBlueprintTests.BlueprintMetadataPanel
 import VersoBlueprintTests.BlueprintPreviewSource.Provider
@@ -45,6 +46,7 @@ private def curatedTestBlueprintDoc? (slug : String) : Option (Doc.VersoDoc Genr
   | "direct-imported-duplicates" => some Verso.VersoBlueprintTests.BlueprintImportedDuplicates.Direct.directImportedDuplicateDoc
   | "transitive-imported-duplicates" => some Verso.VersoBlueprintTests.BlueprintImportedDuplicates.Transitive.transitiveImportedDuplicateDoc
   | "imported-preview-source" => some Verso.VersoBlueprintTests.BlueprintPreviewSource.Provider.importedPreviewSourceDoc
+  | "lean-auto-deps" => some Verso.VersoBlueprintTests.BlueprintAutoDeps.Preview.autoDepsPreviewDoc
   | "state-showcase" => some Verso.VersoBlueprintTests.BlueprintPreviewWiring.StateShowcase.stateShowcaseDoc
   | "external-summary-links" => some Verso.VersoBlueprintTests.BlueprintSummaryLinks.Shared.externalSummaryLinksDoc
   | "summary-blockers" => some Verso.VersoBlueprintTests.BlueprintSummaryLinks.Shared.summaryBlockersDoc

--- a/tests/VersoBlueprintTests/TestBlueprintRegistryMeta.lean
+++ b/tests/VersoBlueprintTests/TestBlueprintRegistryMeta.lean
@@ -91,6 +91,14 @@ def curatedTestBlueprintMetas : Array CuratedTestBlueprintMeta := #[
     kind := "curated_doc"
   },
   {
+    slug := "lean-auto-deps"
+    title := "Lean Auto Dependencies"
+    category := "Relationships"
+    summary := "Lean declaration dependency inference with generated graph and summary output."
+    tags := #["lean", "relationships", "automatic"]
+    kind := "curated_doc"
+  },
+  {
     slug := "state-showcase"
     title := "Blueprint Graph State Showcase"
     category := "Graph"


### PR DESCRIPTION
## Summary
Backport #73 to `v4.29.0`.

## Primary Review
- Primary review: #73
- Keep review comments on #73 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.29.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.
