### PR TITLE
chore: centralize reference release policy

### DIFF
--- a/.github/workflows/reference-blueprints.yml
+++ b/.github/workflows/reference-blueprints.yml
@@ -43,15 +43,15 @@ jobs:
       - name: Show resolved release target
         run: |
           echo "release_id=${{ needs.resolve-reference-release.outputs.release_id }}"
-          echo "rc=${{ needs.resolve-reference-release.outputs.rc }}"
-          echo "toolchain=${{ needs.resolve-reference-release.outputs.toolchain }}"
-          echo "verso_ref=${{ needs.resolve-reference-release.outputs.verso_ref }}"
+          echo "rc=${{ matrix.rc }}"
+          echo "toolchain=${{ matrix.toolchain }}"
+          echo "verso_ref=${{ matrix.verso_ref }}"
           echo "blueprint=${{ matrix.project_id }}"
           echo "hash=${{ matrix.hash }}"
           echo "reference_cache_key=${{ matrix.reference_cache_key }}"
       - name: Match reference target toolchain
-        if: ${{ needs.resolve-reference-release.outputs.rc != '' }}
-        run: printf 'leanprover/lean4:${{ needs.resolve-reference-release.outputs.toolchain }}\n' > lean-toolchain
+        if: ${{ matrix.rc != '' }}
+        run: printf 'leanprover/lean4:${{ matrix.toolchain }}\n' > lean-toolchain
       - name: Install elan
         run: |
           curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
@@ -62,9 +62,9 @@ jobs:
           path: |
             .lake/packages/mathlib
             .lake/packages/verso
-          key: ${{ runner.os }}-lake-packages-v2-${{ needs.resolve-reference-release.outputs.toolchain }}-${{ hashFiles('lake-manifest.json') }}
+          key: ${{ runner.os }}-lake-packages-v2-${{ matrix.toolchain }}-${{ hashFiles('lake-manifest.json') }}
           restore-keys: |
-            ${{ runner.os }}-lake-packages-v2-${{ needs.resolve-reference-release.outputs.toolchain }}-
+            ${{ runner.os }}-lake-packages-v2-${{ matrix.toolchain }}-
             ${{ runner.os }}-lake-packages-v2-
       - name: Restore Lake dependency build cache
         uses: actions/cache@v4
@@ -72,9 +72,9 @@ jobs:
           path: |
             .lake/packages/mathlib/.lake/build
             .lake/packages/verso/.lake/build
-          key: ${{ runner.os }}-lake-deps-${{ needs.resolve-reference-release.outputs.toolchain }}-${{ hashFiles('lake-manifest.json') }}
+          key: ${{ runner.os }}-lake-deps-${{ matrix.toolchain }}-${{ hashFiles('lake-manifest.json') }}
           restore-keys: |
-            ${{ runner.os }}-lake-deps-${{ needs.resolve-reference-release.outputs.toolchain }}-
+            ${{ runner.os }}-lake-deps-${{ matrix.toolchain }}-
             ${{ runner.os }}-lake-deps-
       - name: Restore external reference dependency cache
         if: ${{ matrix.reference_cache_key != '' }}

--- a/README.md
+++ b/README.md
@@ -197,8 +197,6 @@ you want to enable it.
 The repository also tracks larger reference blueprints.
 
 - [project_template/](./project_template/), the in-repo starter template
-- [`ejgallego/verso-algebraic-combinatorics`](https://github.com/ejgallego/verso-algebraic-combinatorics),
-  [rendered site](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.28.0/algebraic-combinatorics/)
 - [`ejgallego/verso-sphere-packing`](https://github.com/ejgallego/verso-sphere-packing),
   [rendered site](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.29.0/spherepackingblueprint/)
 - [`ejgallego/verso-noperthedron`](https://github.com/ejgallego/verso-noperthedron),

--- a/branch-policy.json
+++ b/branch-policy.json
@@ -1,5 +1,21 @@
 {
-  "version": 1,
+  "version": 2,
   "default_dev_branch": "v4.30.0",
-  "required_backport_branches": ["v4.29.0"]
+  "required_backport_branches": ["v4.29.0"],
+  "release_targets": [
+    {
+      "id": "v4.29.0",
+      "toolchain": "v4.29.0",
+      "verso_ref": "v4.29.0",
+      "branch": "v4.29.0",
+      "deploy_pages": true
+    },
+    {
+      "id": "v4.30.0",
+      "toolchain": "v4.30.0",
+      "verso_ref": "v4.30.0",
+      "branch": "v4.30.0",
+      "deploy_pages": true
+    }
+  ]
 }

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -49,7 +49,8 @@ python3 -m scripts.blueprint_test_blueprints --help
 
 The two generated artifact families serve different purposes:
 
-- reference blueprints are the release-facing validation catalog declared in
+- reference blueprints are the release-facing validation catalog selected from
+  release targets in `branch-policy.json` and project targets in
   `tests/harness/projects.json`
 - test blueprints are local rendering and browser-regression fixtures declared
   in `tests/VersoBlueprintTests/TestBlueprintRegistry.lean` and
@@ -243,19 +244,20 @@ Run this from the new local branch, for example `v4.30.0`. The command:
   committed manifests for the root package, `project_template`, and the
   preview showcase
 - updates `branch-policy.json` so the new branch is the default-development
-  line and the previous default-development branch becomes a required backport
-  target
-- adds the new release target to `tests/harness/projects.json`
+  line, the previous default-development branch becomes a required backport
+  target, and the new release target is recorded
 - enables the in-repo reference projects, currently `project-template`, on the
   new release target
 
 For release candidates, use the official short RC name such as `4.30-rc2`.
 The branch name remains the stable release branch, for example `v4.30.0`, while
-the harness records the RC metadata and pins `v4.30.0-rc2` internally.
+the command pins the managed root-package files to `v4.30.0-rc2`.
 
 External reference projects are not auto-pinned for a new release line. Add
 their release-target refs only after those repositories have been updated and
-validated on the new Lean release.
+validated on the new Lean release. If one project target still needs a release
+candidate, put the short RC name, for example `"rc": "4.30-rc2"`, on that
+specific project target in `tests/harness/projects.json`.
 
 Do not backport the branch-start commit to older release lines: that commit
 changes the actual Lean toolchain. Instead, update only the tracked branch
@@ -602,7 +604,7 @@ template-owned CI path.
 `reference-blueprints.yml` is the shared build workflow. On pull requests,
 pushes to release branches named like `v4.29.0`, and manual dispatch, it:
 
-- resolves the current branch's release target from `tests/harness/projects.json`
+- resolves the current branch's release target from `branch-policy.json`
 - builds only project targets for that release that set
   `publish_reference: true`
 - builds the local `test-blueprints/` artifact set, including
@@ -628,14 +630,15 @@ the project id, release, pinned ref, and publication flag. For each deploy
 matrix entry, the workflow writes a small one-project manifest from that
 default-development catalog and passes it to the release-branch harness with
 `--manifest`; the deploy job therefore does not rely on stale branch-local
-`projects.json` refs.
+`projects.json` refs. The per-project target entry also owns any RC override,
+so two projects in the same release line can deploy against different release
+candidate tags when needed.
 
 At the moment that means:
 
 - `v4.30.0` deploys Pages for `noperthedron`, `verso-flt`, and
   `verso-carleson`
 - `v4.29.0` deploys Pages for `spherepackingblueprint`
-- `v4.28.0` also deploys Pages for `algebraic-combinatorics`
 
 The branch-local site artifact produced by `reference-blueprints.yml` for one
 release includes:
@@ -671,13 +674,15 @@ The staging helper is:
 
 The harness is now project-driven rather than hardcoded to one project.
 
-- the default catalog is declared in `tests/harness/projects.json`
+- release targets, branch names, and deploy flags are declared in
+  `branch-policy.json`
+- the default project catalog is declared in `tests/harness/projects.json`
 - catalog entries can also describe ephemeral `git_checkout` projects hosted
   outside this repository
 - external `projects` entries declare the repository plus the build and
   generation commands needed after checkout
-- each project target owns its release ref, and `publish_reference: true` marks
-  the target as part of the release-facing published catalog
+- each project target owns its release ref, optional RC metadata, and
+  `publish_reference: true` marker for the release-facing published catalog
 - prefer a build command that targets only the Lean library or formalization
   artifacts needed by the document, followed by a `lake env lean --run ...`
   generation command; do not build the generator executable unless that native

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -154,8 +154,8 @@ workflow details in user-facing docs.
 
 Work:
 
-1. keep `branch-policy.json` as the source of truth for default-development and
-   backport behavior
+1. keep `branch-policy.json` as the source of truth for release targets,
+   default-development, and backport behavior
 2. keep linked worktree metadata local under `.worktrees/`
 3. keep shell wrappers thin; keep Python harness modules as the source of truth
    for orchestration, path logic, release checks, and project catalogs

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -61,6 +61,7 @@ python3 -m scripts.blueprint_test_blueprints list-json
 Reference blueprints and test blueprints are distinct artifact families:
 
 - reference blueprints are the release-facing validation catalog selected from
+  release targets in [`branch-policy.json`](../branch-policy.json) and
   `publish_reference: true` project targets in
   [`tests/harness/projects.json`](../tests/harness/projects.json)
 - test blueprints are local rendering/browser fixtures selected from
@@ -100,10 +101,17 @@ script map, not a second command reference.
 - `blueprint_harness_manifest.py`
   Shared JSON manifest loading, path resolution, and field validators used by
   the harness catalog loaders.
+- `blueprint_harness_releases.py`
+  Lean release-ref and release-candidate normalization helpers shared across
+  branch policy, toolchain, and reference-project code.
+- `blueprint_harness_branches.py`
+  Branch-policy loading, checkout role checks, and release-branch ref
+  resolution.
 - `blueprint_harness_projects.py`
   Project-manifest loader and schema checks for
   [`tests/harness/projects.json`](../tests/harness/projects.json), including
-  the external reference dependency-cache key.
+  branch-policy release-target inheritance and the external reference
+  dependency-cache key.
 - `blueprint_harness_references.py`
   Reference-blueprint checkout, editable-clone setup, local override,
   dependency-package cache warm-up, and prune helpers shared by the reference
@@ -135,9 +143,10 @@ python3 -m scripts.blueprint_reference_harness status
 python3 -m scripts.blueprint_harness paths
 ```
 
-The active project catalog lives in
-[`tests/harness/projects.json`](../tests/harness/projects.json). The current
-workflow and flag semantics live in
+The active release policy lives in
+[`branch-policy.json`](../branch-policy.json), and the active project catalog
+lives in [`tests/harness/projects.json`](../tests/harness/projects.json). The
+current workflow and flag semantics live in
 [`doc/MAINTAINER_GUIDE.md`](../doc/MAINTAINER_GUIDE.md).
 
 The local HTML-producing test fixtures use a second metadata source:

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 
 from scripts.blueprint_harness_branches import (
+    BranchPolicyReleaseTarget,
     CHECKOUT_ROLE_CHOICES,
     ROOT_WORKTREE_NAME,
     active_release_branch,
@@ -19,14 +20,16 @@ from scripts.blueprint_harness_branches import (
     checkout_is_backport_only,
     load_branch_policy,
     local_release_ref,
-    normalize_lean_release_ref,
     preferred_release_ref,
-    release_branch_from_lean_ref,
-    release_candidate_name_or_none,
     require_checkout_role,
     resolve_git_ref,
     root_checkout_namespace,
     write_branch_policy,
+)
+from scripts.blueprint_harness_releases import (
+    normalize_lean_release_ref,
+    release_branch_from_lean_ref,
+    release_candidate_name_or_none,
 )
 from scripts.blueprint_harness_cli import add_optional_worktree_name_argument
 from scripts.blueprint_harness_manifest import load_json_object
@@ -437,43 +440,11 @@ def update_release_line_project_manifest(
     manifest_path: Path,
     *,
     release_id: str,
-    release_toolchain: str,
-    release_verso_ref: str,
-    branch: str,
-    rc: str | None,
-    deploy_pages: bool,
 ) -> None:
     try:
         raw = load_json_object(manifest_path)
     except ValueError as err:
         raise SystemExit(f"[blueprint-harness] invalid project manifest: {err}") from err
-
-    release_targets = raw.get("release_targets")
-    if not isinstance(release_targets, list):
-        raise SystemExit(f"[blueprint-harness] invalid project manifest `{manifest_path}`: expected `release_targets` list")
-
-    entry = {
-        "id": release_id,
-        "toolchain": release_toolchain,
-        "verso_ref": release_verso_ref,
-    }
-    if rc is not None:
-        entry["rc"] = rc
-    entry.update(
-        {
-            "branch": branch,
-            "deploy_pages": deploy_pages,
-        }
-    )
-
-    replaced = False
-    for index, candidate in enumerate(release_targets):
-        if isinstance(candidate, dict) and release_branch_from_lean_ref(str(candidate.get("id", ""))) == release_id:
-            release_targets[index] = entry
-            replaced = True
-            break
-    if not replaced:
-        release_targets.append(entry)
 
     projects = raw.get("projects")
     if not isinstance(projects, list):
@@ -498,6 +469,19 @@ def update_release_line_project_manifest(
             targets.append({"release": release_id})
 
     write_json(manifest_path, raw)
+
+
+def upsert_release_target(
+    targets: tuple[BranchPolicyReleaseTarget, ...],
+    target: BranchPolicyReleaseTarget,
+) -> tuple[BranchPolicyReleaseTarget, ...]:
+    updated = list(targets)
+    for index, candidate in enumerate(updated):
+        if candidate.release_id == target.release_id:
+            updated[index] = target
+            return tuple(updated)
+    updated.append(target)
+    return tuple(updated)
 
 
 def command_start_release_line(args: argparse.Namespace) -> int:
@@ -531,20 +515,27 @@ def command_start_release_line(args: argparse.Namespace) -> int:
             f"got `{result.verso_ref}`"
         )
 
+    release_targets = upsert_release_target(
+        old_policy.release_targets,
+        BranchPolicyReleaseTarget(
+            release_id=release_id,
+            release_toolchain=release_toolchain,
+            release_verso_ref=release_verso_ref,
+            branch=release_id,
+            deploy_pages=args.deploy_pages,
+        ),
+    )
     new_policy = write_branch_policy(
         layout.package_root,
         default_dev_branch=release_id,
         required_backport_branches=required_backports,
+        release_targets=release_targets,
+        version=max(old_policy.version, 2),
     )
     manifest_path = resolve_manifest_path(None, layout.package_root)
     update_release_line_project_manifest(
         manifest_path,
         release_id=release_id,
-        release_toolchain=release_toolchain,
-        release_verso_ref=release_verso_ref,
-        branch=release_id,
-        rc=rc,
-        deploy_pages=args.deploy_pages,
     )
 
     print(f"package_root={layout.package_root}")
@@ -569,6 +560,7 @@ def command_set_default_dev_branch(args: argparse.Namespace) -> int:
         layout.package_root,
         default_dev_branch=args.branch,
         required_backport_branches=old_policy.required_backport_branches,
+        release_targets=old_policy.release_targets,
         version=old_policy.version,
     )
     print(f"branch_policy={new_policy.source_path}")

--- a/scripts/blueprint_harness_branches.py
+++ b/scripts/blueprint_harness_branches.py
@@ -2,21 +2,37 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-import re
 import subprocess
 from pathlib import Path
 
+from scripts.blueprint_harness_releases import (
+    normalize_lean_release_ref,
+    release_branch_from_lean_ref,
+)
+
 
 BRANCH_POLICY_FILENAME = "branch-policy.json"
-LEAN_TOOLCHAIN_PREFIX = "leanprover/lean4:"
 ROOT_WORKTREE_NAME = "root"
 CHECKOUT_ROLE_DEFAULT_DEV = "default_dev"
 CHECKOUT_ROLE_BACKPORT = "backport"
 CHECKOUT_ROLE_CHOICES = (CHECKOUT_ROLE_DEFAULT_DEV, CHECKOUT_ROLE_BACKPORT)
-NUMERIC_LEAN_RELEASE_PATTERN = re.compile(r"^v?\d+\.\d+\.\d+$")
-LEAN_RELEASE_CANDIDATE_PATTERN = re.compile(
-    r"^v?(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?-rc(?P<rc>\d+)$"
-)
+
+
+@dataclass(frozen=True)
+class BranchPolicyReleaseTarget:
+    release_id: str
+    release_toolchain: str
+    release_verso_ref: str
+    branch: str
+    deploy_pages: bool
+
+    @property
+    def toolchain(self) -> str:
+        return self.release_toolchain
+
+    @property
+    def verso_ref(self) -> str:
+        return self.release_verso_ref
 
 
 @dataclass(frozen=True)
@@ -24,91 +40,8 @@ class BranchPolicy:
     version: int
     default_dev_branch: str
     required_backport_branches: tuple[str, ...]
+    release_targets: tuple[BranchPolicyReleaseTarget, ...]
     source_path: Path
-
-
-def clean_lean_ref(raw_ref: str) -> str:
-    ref = raw_ref.strip()
-    if ref.startswith(LEAN_TOOLCHAIN_PREFIX):
-        ref = ref[len(LEAN_TOOLCHAIN_PREFIX) :]
-    if not ref or any(char.isspace() for char in ref) or any(char in ref for char in {'"', "\n", "\r"}):
-        raise SystemExit("[blueprint-harness] expected a Lean release ref without whitespace, quotes, or newlines")
-    return ref
-
-
-def normalize_release_candidate_name(raw_ref: str) -> str:
-    ref = clean_lean_ref(raw_ref)
-    match = LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(ref)
-    if match is None:
-        raise SystemExit("[blueprint-harness] expected an official Lean release candidate name like `4.30-rc2`")
-
-    major = match.group("major")
-    minor = match.group("minor")
-    patch = match.group("patch")
-    rc = match.group("rc")
-    if patch is None or patch == "0":
-        return f"{major}.{minor}-rc{rc}"
-    return f"{major}.{minor}.{patch}-rc{rc}"
-
-
-def release_candidate_name_or_none(raw_ref: str) -> str | None:
-    ref = clean_lean_ref(raw_ref)
-    if LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(ref) is None:
-        return None
-    return normalize_release_candidate_name(ref)
-
-
-def release_candidate_ref(raw_ref: str) -> str:
-    name = normalize_release_candidate_name(raw_ref)
-    match = LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(name)
-    if match is None:
-        raise AssertionError(f"normalized release candidate did not parse: {name}")
-
-    patch = match.group("patch") or "0"
-    return f"v{match.group('major')}.{match.group('minor')}.{patch}-rc{match.group('rc')}"
-
-
-def normalize_lean_release_ref(raw_ref: str) -> str:
-    ref = clean_lean_ref(raw_ref)
-    if LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(ref) is not None:
-        return release_candidate_ref(ref)
-    if NUMERIC_LEAN_RELEASE_PATTERN.fullmatch(ref) is not None and not ref.startswith("v"):
-        ref = f"v{ref}"
-    return ref
-
-
-def release_branch_from_lean_ref(raw_ref: str) -> str:
-    ref = normalize_lean_release_ref(raw_ref)
-    match = LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(ref)
-    if match is not None:
-        patch = match.group("patch") or "0"
-        return f"v{match.group('major')}.{match.group('minor')}.{patch}"
-    return ref
-
-
-def lean_release_order_key(raw_ref: str) -> tuple[int, int, int, int] | None:
-    ref = normalize_lean_release_ref(raw_ref)
-    if NUMERIC_LEAN_RELEASE_PATTERN.fullmatch(ref) is not None:
-        version = ref[1:] if ref.startswith("v") else ref
-        major, minor, patch = (int(part) for part in version.split("."))
-        return major, minor, patch, 1_000_000
-
-    match = LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(ref)
-    if match is None:
-        return None
-
-    patch = int(match.group("patch") or "0")
-    return int(match.group("major")), int(match.group("minor")), patch, int(match.group("rc"))
-
-
-def lean_toolchain_spec(lean_ref: str) -> str:
-    return f"{LEAN_TOOLCHAIN_PREFIX}{lean_ref}"
-
-
-def rewrite_lean_toolchain(path: Path, lean_ref: str) -> None:
-    existing = path.read_text(encoding="utf-8")
-    suffix = "\n" if existing.endswith("\n") else ""
-    path.write_text(f"{lean_toolchain_spec(lean_ref)}{suffix}", encoding="utf-8")
 
 
 def active_release_branch(repo_root: Path) -> str:
@@ -122,20 +55,34 @@ def branch_policy_path(checkout_root: Path) -> Path:
     return checkout_root / BRANCH_POLICY_FILENAME
 
 
+def _format_release_target(target: BranchPolicyReleaseTarget) -> dict[str, object]:
+    entry: dict[str, object] = {
+        "id": target.release_id,
+        "toolchain": target.release_toolchain,
+        "verso_ref": target.release_verso_ref,
+    }
+    entry["branch"] = target.branch
+    entry["deploy_pages"] = target.deploy_pages
+    return entry
+
+
 def format_branch_policy(
     *,
     default_dev_branch: str,
     required_backport_branches: tuple[str, ...] | list[str],
+    release_targets: tuple[BranchPolicyReleaseTarget, ...] | list[BranchPolicyReleaseTarget] = (),
     version: int = 1,
 ) -> str:
-    backports = ", ".join(f'"{release_branch_from_lean_ref(branch)}"' for branch in required_backport_branches)
-    return (
-        "{\n"
-        f'  "version": {version},\n'
-        f'  "default_dev_branch": "{release_branch_from_lean_ref(default_dev_branch)}",\n'
-        f'  "required_backport_branches": [{backports}]\n'
-        "}\n"
-    )
+    data: dict[str, object] = {
+        "version": version,
+        "default_dev_branch": release_branch_from_lean_ref(default_dev_branch),
+        "required_backport_branches": [
+            release_branch_from_lean_ref(branch) for branch in required_backport_branches
+        ],
+    }
+    if release_targets:
+        data["release_targets"] = [_format_release_target(target) for target in release_targets]
+    return json.dumps(data, indent=2) + "\n"
 
 
 def write_branch_policy(
@@ -143,12 +90,14 @@ def write_branch_policy(
     *,
     default_dev_branch: str,
     required_backport_branches: tuple[str, ...] | list[str],
+    release_targets: tuple[BranchPolicyReleaseTarget, ...] | list[BranchPolicyReleaseTarget] = (),
     version: int = 1,
 ) -> BranchPolicy:
     path = branch_policy_path(checkout_root)
     text = format_branch_policy(
         default_dev_branch=default_dev_branch,
         required_backport_branches=required_backport_branches,
+        release_targets=release_targets,
         version=version,
     )
     path.write_text(text, encoding="utf-8")
@@ -162,6 +111,7 @@ def load_branch_policy(checkout_root: Path) -> BranchPolicy:
             version=1,
             default_dev_branch=active_release_branch(checkout_root),
             required_backport_branches=(),
+            release_targets=(),
             source_path=path,
         )
 
@@ -188,12 +138,85 @@ def load_branch_policy(checkout_root: Path) -> BranchPolicy:
     if not isinstance(raw_version, int):
         raise SystemExit(f"[blueprint-harness] invalid branch policy file `{path}`: `version` must be an integer")
 
+    release_targets = load_branch_policy_release_targets(data, path)
+    release_ids = {target.release_id for target in release_targets}
+    if release_ids and release_branch_from_lean_ref(raw_default) not in release_ids:
+        raise SystemExit(
+            f"[blueprint-harness] invalid branch policy file `{path}`: "
+            f"default development branch `{release_branch_from_lean_ref(raw_default)}` is not a release target"
+        )
+    for branch in raw_backports:
+        normalized = release_branch_from_lean_ref(branch)
+        if release_ids and normalized not in release_ids:
+            raise SystemExit(
+                f"[blueprint-harness] invalid branch policy file `{path}`: "
+                f"required backport branch `{normalized}` is not a release target"
+            )
+
     return BranchPolicy(
         version=raw_version,
         default_dev_branch=release_branch_from_lean_ref(raw_default),
         required_backport_branches=tuple(release_branch_from_lean_ref(item) for item in raw_backports),
+        release_targets=release_targets,
         source_path=path,
     )
+
+
+def _require_policy_string(entry: dict, field: str, *, context: str) -> str:
+    value = entry.get(field)
+    if not isinstance(value, str) or not value:
+        raise SystemExit(f"[blueprint-harness] invalid branch policy file `{context}`: missing string `{field}`")
+    return value
+
+
+def load_branch_policy_release_targets(data: dict, path: Path) -> tuple[BranchPolicyReleaseTarget, ...]:
+    entries = data.get("release_targets", [])
+    if entries is None:
+        entries = []
+    if not isinstance(entries, list):
+        raise SystemExit(f"[blueprint-harness] invalid branch policy file `{path}`: `release_targets` must be a list")
+
+    targets: list[BranchPolicyReleaseTarget] = []
+    seen_ids: set[str] = set()
+    for index, entry in enumerate(entries, start=1):
+        if not isinstance(entry, dict):
+            raise SystemExit(
+                f"[blueprint-harness] invalid branch policy file `{path}`: release target #{index} must be an object"
+            )
+        context = f"{path}: release target #{index}"
+        release_id = release_branch_from_lean_ref(_require_policy_string(entry, "id", context=context))
+        if release_id in seen_ids:
+            raise SystemExit(
+                f"[blueprint-harness] invalid branch policy file `{path}`: duplicate release target `{release_id}`"
+            )
+        seen_ids.add(release_id)
+
+        if "rc" in entry:
+            raise SystemExit(
+                f"[blueprint-harness] invalid branch policy file `{context}`: "
+                "`rc` belongs on project targets, not release targets"
+            )
+
+        deploy_pages = entry.get("deploy_pages", False)
+        if not isinstance(deploy_pages, bool):
+            raise SystemExit(
+                f"[blueprint-harness] invalid branch policy file `{context}`: expected boolean `deploy_pages`"
+            )
+
+        targets.append(
+            BranchPolicyReleaseTarget(
+                release_id=release_id,
+                release_toolchain=normalize_lean_release_ref(
+                    _require_policy_string(entry, "toolchain", context=context)
+                ),
+                release_verso_ref=normalize_lean_release_ref(
+                    _require_policy_string(entry, "verso_ref", context=context)
+                ),
+                branch=release_branch_from_lean_ref(_require_policy_string(entry, "branch", context=context)),
+                deploy_pages=deploy_pages,
+            )
+        )
+    return tuple(targets)
 
 
 def default_dev_branch(checkout_root: Path) -> str:

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -7,11 +7,16 @@ from pathlib import Path
 import re
 
 from scripts.blueprint_harness_branches import (
+    BranchPolicyReleaseTarget as HarnessReleaseTarget,
     active_release_branch,
+    branch_policy_path,
+    load_branch_policy,
+)
+from scripts.blueprint_harness_releases import (
     normalize_lean_release_ref,
     normalize_release_candidate_name,
-    release_branch_from_lean_ref,
     release_candidate_ref,
+    release_branch_from_lean_ref,
 )
 from scripts.blueprint_harness_manifest import (
     load_json_object,
@@ -29,28 +34,11 @@ REFERENCE_CACHE_KEY_DIGEST_LENGTH = 12
 
 
 @dataclass(frozen=True)
-class HarnessReleaseTarget:
-    release_id: str
-    release_toolchain: str
-    release_verso_ref: str
-    branch: str
-    deploy_pages: bool
-    rc: str | None = None
-
-    @property
-    def toolchain(self) -> str:
-        return release_candidate_ref(self.rc) if self.rc is not None else self.release_toolchain
-
-    @property
-    def verso_ref(self) -> str:
-        return release_candidate_ref(self.rc) if self.rc is not None else self.release_verso_ref
-
-
-@dataclass(frozen=True)
 class HarnessProjectTarget:
     release: str
     ref: str | None
     publish_reference: bool = False
+    rc: str | None = None
 
 
 @dataclass(frozen=True)
@@ -83,6 +71,7 @@ class HarnessProject:
     description: str | None
     targets: tuple[HarnessProjectTarget, ...] = ()
     selected_release: str | None = None
+    selected_rc: str | None = None
 
     @property
     def in_repo_project(self) -> bool:
@@ -156,8 +145,27 @@ def resolve_manifest_path(path_text: str | None, package_root: Path) -> Path:
     return resolve_manifest_file_path(path_text, default_project_manifest(package_root))
 
 
+def _package_root_for_manifest(manifest_path: Path | str) -> Path | None:
+    path = Path(manifest_path)
+    candidates = path.parents if path.suffix else (path, *path.parents)
+    for parent in candidates:
+        if branch_policy_path(parent).exists():
+            return parent
+    return None
+
+
 def _load_release_targets(raw: dict, manifest_path: Path | str) -> tuple[HarnessReleaseTarget, ...]:
     entries = raw.get("release_targets")
+    if entries is None:
+        package_root = _package_root_for_manifest(manifest_path)
+        if package_root is None:
+            raise ValueError(
+                f"{manifest_path}: expected top-level `release_targets` list or nearby `branch-policy.json`"
+            )
+        targets = load_branch_policy(package_root).release_targets
+        if not targets:
+            raise ValueError(f"{branch_policy_path(package_root)}: expected non-empty `release_targets` list")
+        return targets
     if not isinstance(entries, list) or not entries:
         raise ValueError(f"{manifest_path}: expected non-empty top-level `release_targets` list")
 
@@ -177,9 +185,7 @@ def _load_release_targets(raw: dict, manifest_path: Path | str) -> tuple[Harness
         deploy_pages = _optional_bool(entry, "deploy_pages", default=False, context=context)
         rc = entry.get("rc")
         if rc is not None:
-            if not isinstance(rc, str):
-                raise ValueError(f"{context}: expected string field `rc`")
-            rc = normalize_release_candidate_name(rc)
+            raise ValueError(f"{context}: `rc` belongs on project targets, not release targets")
         targets.append(
             HarnessReleaseTarget(
                 release_id=release_id,
@@ -187,7 +193,6 @@ def _load_release_targets(raw: dict, manifest_path: Path | str) -> tuple[Harness
                 release_verso_ref=verso_ref,
                 branch=branch,
                 deploy_pages=deploy_pages,
-                rc=rc,
             )
         )
     return tuple(targets)
@@ -223,11 +228,19 @@ def _load_project_targets(
             raise ValueError(f"{target_context}: in-repo project targets must not declare `ref`")
         if "publish" in raw_target:
             raise ValueError(f"{target_context}: `publish` is no longer supported; use `publish_reference`")
+        rc = raw_target.get("rc")
+        if rc is not None:
+            if not isinstance(rc, str):
+                raise ValueError(f"{target_context}: expected string field `rc`")
+            rc = normalize_release_candidate_name(rc)
+            if release_branch_from_lean_ref(rc) != release:
+                raise ValueError(f"{target_context}: `rc` `{rc}` does not belong to release `{release}`")
         targets.append(
             HarnessProjectTarget(
                 release=release,
                 ref=ref,
                 publish_reference=_optional_bool(raw_target, "publish_reference", default=False, context=target_context),
+                rc=rc,
             )
         )
     return tuple(targets)
@@ -409,6 +422,7 @@ def resolve_projects_for_release(
                 project,
                 ref=target.ref,
                 selected_release=release,
+                selected_rc=target.rc,
             )
         )
     return resolved
@@ -440,11 +454,29 @@ def reference_artifact_path(project: HarnessProject) -> str:
     return f"_out/reference-blueprints/{project.project_id}"
 
 
-def reference_build_matrix(projects: list[HarnessProject]) -> dict[str, list[dict[str, object]]]:
+def project_target_rc(project: HarnessProject) -> str:
+    return project.selected_rc or ""
+
+
+def project_target_toolchain(release_target: HarnessReleaseTarget, project: HarnessProject) -> str:
+    return release_candidate_ref(project.selected_rc) if project.selected_rc is not None else release_target.toolchain
+
+
+def project_target_verso_ref(release_target: HarnessReleaseTarget, project: HarnessProject) -> str:
+    return release_candidate_ref(project.selected_rc) if project.selected_rc is not None else release_target.verso_ref
+
+
+def reference_build_matrix(
+    projects: list[HarnessProject],
+    release_target: HarnessReleaseTarget,
+) -> dict[str, list[dict[str, object]]]:
     return {
         "include": [
             {
                 "project_id": project.project_id,
+                "rc": project_target_rc(project),
+                "toolchain": project_target_toolchain(release_target, project),
+                "verso_ref": project_target_verso_ref(release_target, project),
                 "project_root": project.project_root,
                 "hash": project.ref,
                 "reference_cache_key": reference_dependency_cache_key(project) if project.git_checkout else "",

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -7,7 +7,7 @@ import subprocess
 from pathlib import Path
 import tomllib
 
-from scripts.blueprint_harness_branches import (
+from scripts.blueprint_harness_releases import (
     lean_release_order_key,
     lean_toolchain_spec,
     normalize_lean_release_ref,

--- a/scripts/blueprint_harness_releases.py
+++ b/scripts/blueprint_harness_releases.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+LEAN_TOOLCHAIN_PREFIX = "leanprover/lean4:"
+NUMERIC_LEAN_RELEASE_PATTERN = re.compile(r"^v?\d+\.\d+\.\d+$")
+LEAN_RELEASE_CANDIDATE_PATTERN = re.compile(
+    r"^v?(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?-rc(?P<rc>\d+)$"
+)
+
+
+def clean_lean_ref(raw_ref: str) -> str:
+    ref = raw_ref.strip()
+    if ref.startswith(LEAN_TOOLCHAIN_PREFIX):
+        ref = ref[len(LEAN_TOOLCHAIN_PREFIX) :]
+    if not ref or any(char.isspace() for char in ref) or any(char in ref for char in {'"', "\n", "\r"}):
+        raise SystemExit("[blueprint-harness] expected a Lean release ref without whitespace, quotes, or newlines")
+    return ref
+
+
+def normalize_release_candidate_name(raw_ref: str) -> str:
+    ref = clean_lean_ref(raw_ref)
+    match = LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(ref)
+    if match is None:
+        raise SystemExit("[blueprint-harness] expected an official Lean release candidate name like `4.30-rc2`")
+
+    major = match.group("major")
+    minor = match.group("minor")
+    patch = match.group("patch")
+    rc = match.group("rc")
+    if patch is None or patch == "0":
+        return f"{major}.{minor}-rc{rc}"
+    return f"{major}.{minor}.{patch}-rc{rc}"
+
+
+def release_candidate_name_or_none(raw_ref: str) -> str | None:
+    ref = clean_lean_ref(raw_ref)
+    if LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(ref) is None:
+        return None
+    return normalize_release_candidate_name(ref)
+
+
+def release_candidate_ref(raw_ref: str) -> str:
+    name = normalize_release_candidate_name(raw_ref)
+    match = LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(name)
+    if match is None:
+        raise AssertionError(f"normalized release candidate did not parse: {name}")
+
+    patch = match.group("patch") or "0"
+    return f"v{match.group('major')}.{match.group('minor')}.{patch}-rc{match.group('rc')}"
+
+
+def normalize_lean_release_ref(raw_ref: str) -> str:
+    ref = clean_lean_ref(raw_ref)
+    if LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(ref) is not None:
+        return release_candidate_ref(ref)
+    if NUMERIC_LEAN_RELEASE_PATTERN.fullmatch(ref) is not None and not ref.startswith("v"):
+        ref = f"v{ref}"
+    return ref
+
+
+def release_branch_from_lean_ref(raw_ref: str) -> str:
+    ref = normalize_lean_release_ref(raw_ref)
+    match = LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(ref)
+    if match is not None:
+        patch = match.group("patch") or "0"
+        return f"v{match.group('major')}.{match.group('minor')}.{patch}"
+    return ref
+
+
+def lean_release_order_key(raw_ref: str) -> tuple[int, int, int, int] | None:
+    ref = normalize_lean_release_ref(raw_ref)
+    if NUMERIC_LEAN_RELEASE_PATTERN.fullmatch(ref) is not None:
+        version = ref[1:] if ref.startswith("v") else ref
+        major, minor, patch = (int(part) for part in version.split("."))
+        return major, minor, patch, 1_000_000
+
+    match = LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(ref)
+    if match is None:
+        return None
+
+    patch = int(match.group("patch") or "0")
+    return int(match.group("major")), int(match.group("minor")), patch, int(match.group("rc"))
+
+
+def lean_toolchain_spec(lean_ref: str) -> str:
+    return f"{LEAN_TOOLCHAIN_PREFIX}{lean_ref}"
+
+
+def rewrite_lean_toolchain(path: Path, lean_ref: str) -> None:
+    existing = path.read_text(encoding="utf-8")
+    suffix = "\n" if existing.endswith("\n") else ""
+    path.write_text(f"{lean_toolchain_spec(lean_ref)}{suffix}", encoding="utf-8")

--- a/scripts/blueprint_harness_toolchains.py
+++ b/scripts/blueprint_harness_toolchains.py
@@ -5,7 +5,7 @@ import re
 import subprocess
 from pathlib import Path
 
-from scripts.blueprint_harness_branches import (
+from scripts.blueprint_harness_releases import (
     lean_toolchain_spec,
     normalize_lean_release_ref,
     release_branch_from_lean_ref,

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -21,7 +21,14 @@ from scripts.blueprint_harness_cli import (
     selected_output_root,
 )
 from scripts.blueprint_harness_paths import detect_harness_layout, resolve_output_root
-from scripts.blueprint_harness_projects import HarnessProject, resolve_manifest_path
+from scripts.blueprint_harness_projects import (
+    HarnessProject,
+    HarnessReleaseTarget,
+    project_target_rc,
+    project_target_toolchain,
+    project_target_verso_ref,
+    resolve_manifest_path,
+)
 from scripts.blueprint_harness_projects import (
     HarnessProjectCatalog,
     load_project_catalog as load_project_catalog_manifest,
@@ -319,7 +326,18 @@ def collect_reference_project_status(layout, project: HarnessProject, *, bluepri
     )
 
 
-def print_reference_project_status(status: ReferenceProjectStatus) -> None:
+def project_target_status_fields(release_target: HarnessReleaseTarget, project: HarnessProject) -> list[str]:
+    return [
+        f"rc={project_target_rc(project)}",
+        f"toolchain={project_target_toolchain(release_target, project)}",
+        f"verso_ref={project_target_verso_ref(release_target, project)}",
+    ]
+
+
+def print_reference_project_status(
+    status: ReferenceProjectStatus,
+    release_target: HarnessReleaseTarget | None = None,
+) -> None:
     project = status.project
     source = f"in_repo:{project.project_root}" if project.in_repo_project else f"git:{project.repository}@{project.ref}"
     fields = [
@@ -339,6 +357,8 @@ def print_reference_project_status(status: ReferenceProjectStatus) -> None:
         f"skip={text_or_blank(status.skipped)}",
         f"error={text_or_blank(status.error)}",
     ]
+    if release_target is not None:
+        fields[2:2] = project_target_status_fields(release_target, project)
     print("\t".join(fields))
 
 
@@ -379,13 +399,14 @@ def print_release_target_summary(status: ReleaseTargetStatus) -> None:
     )
 
 
-def print_release_target_project_status(release_id: str, status: ReferenceProjectStatus) -> None:
+def print_release_target_project_status(release_target: HarnessReleaseTarget, status: ReferenceProjectStatus) -> None:
     project = status.project
     source = f"in_repo:{project.project_root}" if project.in_repo_project else f"git:{project.repository}@{project.ref}"
     fields = [
-        f"release={release_id}",
+        f"release={release_target.release_id}",
         f"project={project.project_id}",
         f"source={source}",
+        *project_target_status_fields(release_target, project),
         f"catalog_ref={text_or_blank(status.catalog_ref)}",
         f"project_upstream_ref={text_or_blank(status.project_upstream_ref)}",
         f"catalog_status={text_or_blank(status.project_relationship)}",
@@ -744,6 +765,7 @@ def command_projects(args: argparse.Namespace) -> int:
         project_ids=args.project,
         package_root=layout.package_root,
     )
+    release_target = resolve_release_target(catalog, release_id, layout.package_root)
     print(f"project_manifest={manifest_path}")
     print(f"release_target={release_id}")
     for project in projects:
@@ -757,7 +779,13 @@ def command_projects(args: argparse.Namespace) -> int:
         if project.browser_tests_path is not None:
             validations.append("browser")
         validation_text = ",".join(validations) if validations else "none"
-        print(f"{project.project_id}\tsource={source}\tvalidations={validation_text}")
+        fields = [
+            project.project_id,
+            f"source={source}",
+            *project_target_status_fields(release_target, project),
+            f"validations={validation_text}",
+        ]
+        print("\t".join(fields))
     return 0
 
 
@@ -801,7 +829,7 @@ def command_status(args: argparse.Namespace) -> int:
                 blueprint_behind=None,
                 error=str(err),
             )
-        print_reference_project_status(status)
+        print_reference_project_status(status, release_target)
     return 0
 
 
@@ -872,7 +900,7 @@ def command_release_status(args: argparse.Namespace) -> int:
         for status in summary.project_statuses:
             if args.outdated_only and not status_has_catalog_issue(status):
                 continue
-            print_release_target_project_status(release_target.release_id, status)
+            print_release_target_project_status(release_target, status)
     return 0
 
 

--- a/scripts/emit_reference_deploy_matrix.py
+++ b/scripts/emit_reference_deploy_matrix.py
@@ -17,6 +17,9 @@ from scripts.blueprint_harness_projects import (
     deploy_project_artifact_name,
     deploy_project_artifact_path,
     load_project_catalog,
+    project_target_rc,
+    project_target_toolchain,
+    project_target_verso_ref,
     reference_dependency_cache_key,
     resolve_manifest_path,
     resolve_projects_for_release,
@@ -41,16 +44,13 @@ def parse_args() -> argparse.Namespace:
 
 
 def release_target_manifest_entry(target: HarnessReleaseTarget) -> dict[str, object]:
-    entry: dict[str, object] = {
+    return {
         "id": target.release_id,
         "toolchain": target.release_toolchain,
         "verso_ref": target.release_verso_ref,
         "branch": target.branch,
         "deploy_pages": target.deploy_pages,
     }
-    if target.rc is not None:
-        entry["rc"] = target.rc
-    return entry
 
 
 def project_manifest_entry(project: HarnessProject) -> dict[str, object]:
@@ -67,6 +67,8 @@ def project_manifest_entry(project: HarnessProject) -> dict[str, object]:
     target: dict[str, object] = {"release": project.selected_release}
     if project.ref is not None:
         target["ref"] = project.ref
+    if project.selected_rc is not None:
+        target["rc"] = project.selected_rc
 
     entry: dict[str, object] = {
         "id": project.project_id,
@@ -118,9 +120,9 @@ def deploy_matrix_from_controller_catalog(
             include.append(
                 {
                     "release_id": target.release_id,
-                    "rc": target.rc,
-                    "toolchain": target.toolchain,
-                    "verso_ref": target.verso_ref,
+                    "rc": project_target_rc(project),
+                    "toolchain": project_target_toolchain(target, project),
+                    "verso_ref": project_target_verso_ref(target, project),
                     "branch": target.branch,
                     "project_id": project.project_id,
                     "project_root": project.project_root,

--- a/scripts/emit_reference_release_matrix.py
+++ b/scripts/emit_reference_release_matrix.py
@@ -50,13 +50,13 @@ def payload(args: argparse.Namespace) -> dict[str, object]:
     return {
         "manifest_path": str(manifest_path),
         "release_id": release_target.release_id,
-        "rc": release_target.rc,
+        "rc": "",
         "toolchain": release_target.toolchain,
         "verso_ref": release_target.verso_ref,
         "branch": release_target.branch,
         "deploy_pages": release_target.deploy_pages,
         "reference_project_count": len(projects),
-        "reference_matrix": reference_build_matrix(projects),
+        "reference_matrix": reference_build_matrix(projects, release_target),
     }
 
 

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -1,29 +1,5 @@
 {
   "version": 2,
-  "release_targets": [
-    {
-      "id": "v4.28.0",
-      "toolchain": "v4.28.0",
-      "verso_ref": "v4.28.0",
-      "branch": "v4.28.0",
-      "deploy_pages": true
-    },
-    {
-      "id": "v4.29.0",
-      "toolchain": "v4.29.0",
-      "verso_ref": "v4.29.0",
-      "branch": "v4.29.0",
-      "deploy_pages": true
-    },
-    {
-      "id": "v4.30.0",
-      "toolchain": "v4.30.0",
-      "verso_ref": "v4.30.0",
-      "rc": "4.30-rc2",
-      "branch": "v4.30.0",
-      "deploy_pages": true
-    }
-  ],
   "projects": [
     {
       "id": "project-template",
@@ -33,9 +9,6 @@
         "project_root": "project_template"
       },
       "targets": [
-        {
-          "release": "v4.28.0"
-        },
         {
           "release": "v4.29.0"
         },
@@ -63,6 +36,7 @@
         {
           "release": "v4.30.0",
           "ref": "122abfd41c841ce5932114eb060dc1ee5c4c1425",
+          "rc": "4.30-rc2",
           "publish_reference": true
         }
       ],
@@ -105,6 +79,7 @@
         {
           "release": "v4.30.0",
           "ref": "bd848824b43c95ba9ae490321a70086d4f511984",
+          "rc": "4.30-rc2",
           "publish_reference": true
         }
       ],
@@ -124,29 +99,11 @@
         {
           "release": "v4.30.0",
           "ref": "260f2f7309da4916508a93f9754c0c766eb39b9b",
+          "rc": "4.30-rc2",
           "publish_reference": true
         }
       ],
       "build_command": ["lake", "build", "CarlesonBlueprint"],
-      "generate_command": ["lake", "env", "lean", "--run", "BlueprintMain.lean", "--output", "{output_dir}"],
-      "site_subdir": "html-multi"
-    },
-    {
-      "id": "algebraic-combinatorics",
-      "description": "External algebraic combinatorics blueprint project currently maintained on the v4.28.0 line.",
-      "source": {
-        "kind": "git_checkout",
-        "repository": "https://github.com/ejgallego/verso-algebraic-combinatorics.git",
-        "project_root": "."
-      },
-      "targets": [
-        {
-          "release": "v4.28.0",
-          "ref": "96d34747d1654bd0ded13a222bb99b3513f71927",
-          "publish_reference": true
-        }
-      ],
-      "build_command": ["lake", "build", "AlgebraicCombinatoricsBlueprint"],
       "generate_command": ["lake", "env", "lean", "--run", "BlueprintMain.lean", "--output", "{output_dir}"],
       "site_subdir": "html-multi"
     }

--- a/tests/harness/test_blueprint_harness_branches.py
+++ b/tests/harness/test_blueprint_harness_branches.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 import subprocess
 import tempfile
 import unittest
 
 import scripts.blueprint_harness_branches as branches_mod
+import scripts.blueprint_harness_releases as releases_mod
 
 
 class BlueprintHarnessBranchPolicyTests(unittest.TestCase):
@@ -35,25 +37,28 @@ class BlueprintHarnessBranchPolicyTests(unittest.TestCase):
             self.assertEqual(policy.source_path, root / "branch-policy.json")
 
     def test_release_candidate_names_normalize_to_tags_and_branch_ids(self) -> None:
-        self.assertEqual(branches_mod.normalize_release_candidate_name("4.30-rc2"), "4.30-rc2")
-        self.assertEqual(branches_mod.normalize_release_candidate_name("v4.30.0-rc2"), "4.30-rc2")
-        self.assertEqual(branches_mod.release_candidate_name_or_none("v4.30.0-rc2"), "4.30-rc2")
-        self.assertIsNone(branches_mod.release_candidate_name_or_none("v4.30.0"))
-        self.assertEqual(branches_mod.release_candidate_ref("4.30-rc2"), "v4.30.0-rc2")
-        self.assertEqual(branches_mod.normalize_lean_release_ref("4.30-rc2"), "v4.30.0-rc2")
-        self.assertEqual(branches_mod.release_branch_from_lean_ref("leanprover/lean4:v4.30.0-rc2"), "v4.30.0")
+        self.assertEqual(releases_mod.normalize_release_candidate_name("4.30-rc2"), "4.30-rc2")
+        self.assertEqual(releases_mod.normalize_release_candidate_name("v4.30.0-rc2"), "4.30-rc2")
+        self.assertEqual(releases_mod.release_candidate_name_or_none("v4.30.0-rc2"), "4.30-rc2")
+        self.assertIsNone(releases_mod.release_candidate_name_or_none("v4.30.0"))
+        self.assertEqual(releases_mod.release_candidate_ref("4.30-rc2"), "v4.30.0-rc2")
+        self.assertEqual(releases_mod.normalize_lean_release_ref("4.30-rc2"), "v4.30.0-rc2")
+        self.assertEqual(releases_mod.release_branch_from_lean_ref("leanprover/lean4:v4.30.0-rc2"), "v4.30.0")
 
     def test_lean_release_order_key_orders_release_candidates_before_final_release(self) -> None:
         self.assertLess(
-            branches_mod.lean_release_order_key("v4.30.0-rc1"),
-            branches_mod.lean_release_order_key("v4.30.0-rc2"),
+            releases_mod.lean_release_order_key("v4.30.0-rc1"),
+            releases_mod.lean_release_order_key("v4.30.0-rc2"),
         )
         self.assertLess(
-            branches_mod.lean_release_order_key("v4.30.0-rc2"),
-            branches_mod.lean_release_order_key("v4.30.0"),
+            releases_mod.lean_release_order_key("v4.30.0-rc2"),
+            releases_mod.lean_release_order_key("v4.30.0"),
         )
-        self.assertEqual(branches_mod.lean_release_order_key("v4.30-rc2"), branches_mod.lean_release_order_key("v4.30.0-rc2"))
-        self.assertIsNone(branches_mod.lean_release_order_key("nightly-testing"))
+        self.assertEqual(
+            releases_mod.lean_release_order_key("v4.30-rc2"),
+            releases_mod.lean_release_order_key("v4.30.0-rc2"),
+        )
+        self.assertIsNone(releases_mod.lean_release_order_key("nightly-testing"))
 
     def test_rewrite_lean_toolchain_preserves_existing_final_newline_style(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -63,8 +68,8 @@ class BlueprintHarnessBranchPolicyTests(unittest.TestCase):
             self.write(with_newline, "leanprover/lean4:v4.29.0\n")
             self.write(without_newline, "leanprover/lean4:v4.29.0")
 
-            branches_mod.rewrite_lean_toolchain(with_newline, "v4.30.0")
-            branches_mod.rewrite_lean_toolchain(without_newline, "v4.30.0")
+            releases_mod.rewrite_lean_toolchain(with_newline, "v4.30.0")
+            releases_mod.rewrite_lean_toolchain(without_newline, "v4.30.0")
 
             self.assertEqual(with_newline.read_text(encoding="utf-8"), "leanprover/lean4:v4.30.0\n")
             self.assertEqual(without_newline.read_text(encoding="utf-8"), "leanprover/lean4:v4.30.0")
@@ -87,6 +92,68 @@ class BlueprintHarnessBranchPolicyTests(unittest.TestCase):
             policy = branches_mod.load_branch_policy(root)
 
             self.assertEqual(policy.required_backport_branches, ("v4.28.0",))
+
+    def test_load_branch_policy_reads_release_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write(
+                root / "branch-policy.json",
+                json.dumps(
+                    {
+                        "version": 2,
+                        "default_dev_branch": "v4.30.0",
+                        "required_backport_branches": ["v4.29.0"],
+                        "release_targets": [
+                            {
+                                "id": "v4.29.0",
+                                "toolchain": "v4.29.0",
+                                "verso_ref": "v4.29.0",
+                                "branch": "v4.29.0",
+                                "deploy_pages": True,
+                            },
+                            {
+                                "id": "v4.30.0",
+                                "toolchain": "v4.30.0",
+                                "verso_ref": "v4.30.0",
+                                "branch": "v4.30.0",
+                                "deploy_pages": True,
+                            },
+                        ],
+                    }
+                ),
+            )
+
+            policy = branches_mod.load_branch_policy(root)
+
+            self.assertEqual(policy.version, 2)
+            self.assertEqual([target.release_id for target in policy.release_targets], ["v4.29.0", "v4.30.0"])
+            self.assertEqual(policy.release_targets[1].toolchain, "v4.30.0")
+
+    def test_load_branch_policy_rejects_release_target_rc(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write(
+                root / "branch-policy.json",
+                json.dumps(
+                    {
+                        "version": 2,
+                        "default_dev_branch": "v4.30.0",
+                        "release_targets": [
+                            {
+                                "id": "v4.30.0",
+                                "toolchain": "v4.30.0",
+                                "verso_ref": "v4.30.0",
+                                "rc": "4.30-rc2",
+                                "branch": "v4.30.0",
+                                "deploy_pages": True,
+                            }
+                        ],
+                    }
+                ),
+            )
+
+            with self.assertRaisesRegex(SystemExit, "`rc` belongs on project targets"):
+                branches_mod.load_branch_policy(root)
 
     def test_resolve_git_ref_prefers_branch_over_same_named_tag(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -121,7 +188,7 @@ class BlueprintHarnessBranchPolicyTests(unittest.TestCase):
             self.assertEqual(policy.required_backport_branches, ("v4.29.0", "v4.28.0"))
             self.assertEqual(
                 (root / "branch-policy.json").read_text(encoding="utf-8"),
-                '{\n  "version": 1,\n  "default_dev_branch": "v4.30.0",\n  "required_backport_branches": ["v4.29.0", "v4.28.0"]\n}\n',
+                '{\n  "version": 1,\n  "default_dev_branch": "v4.30.0",\n  "required_backport_branches": [\n    "v4.29.0",\n    "v4.28.0"\n  ]\n}\n',
             )
 
     def test_load_branch_policy_falls_back_to_active_release_branch(self) -> None:

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -883,16 +883,19 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             (root / "branch-policy.json").write_text(
-                '{\n  "version": 1,\n  "default_dev_branch": "v4.29.0",\n  "required_backport_branches": ["v4.28.0"]\n}\n',
-                encoding="utf-8",
-            )
-            manifest_path = root / "tests" / "harness" / "projects.json"
-            manifest_path.parent.mkdir(parents=True)
-            manifest_path.write_text(
                 json.dumps(
                     {
                         "version": 2,
+                        "default_dev_branch": "v4.29.0",
+                        "required_backport_branches": ["v4.28.0"],
                         "release_targets": [
+                            {
+                                "id": "v4.28.0",
+                                "toolchain": "v4.28.0",
+                                "verso_ref": "v4.28.0",
+                                "branch": "v4.28.0",
+                                "deploy_pages": False,
+                            },
                             {
                                 "id": "v4.29.0",
                                 "toolchain": "v4.29.0",
@@ -901,6 +904,16 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                                 "deploy_pages": True,
                             }
                         ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            manifest_path = root / "tests" / "harness" / "projects.json"
+            manifest_path.parent.mkdir(parents=True)
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "version": 2,
                         "projects": [
                             {
                                 "id": "project-template",
@@ -955,13 +968,38 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             self.assertEqual(seen["toolchain"], "4.30-rc2")
             self.assertFalse(seen["validate"])
             self.assertEqual(
-                (root / "branch-policy.json").read_text(encoding="utf-8"),
-                '{\n  "version": 1,\n  "default_dev_branch": "v4.30.0",\n  "required_backport_branches": ["v4.29.0", "v4.28.0"]\n}\n',
+                json.loads((root / "branch-policy.json").read_text(encoding="utf-8")),
+                {
+                    "version": 2,
+                    "default_dev_branch": "v4.30.0",
+                    "required_backport_branches": ["v4.29.0", "v4.28.0"],
+                    "release_targets": [
+                        {
+                            "id": "v4.28.0",
+                            "toolchain": "v4.28.0",
+                            "verso_ref": "v4.28.0",
+                            "branch": "v4.28.0",
+                            "deploy_pages": False,
+                        },
+                        {
+                            "id": "v4.29.0",
+                            "toolchain": "v4.29.0",
+                            "verso_ref": "v4.29.0",
+                            "branch": "v4.29.0",
+                            "deploy_pages": True,
+                        },
+                        {
+                            "id": "v4.30.0",
+                            "toolchain": "v4.30.0",
+                            "verso_ref": "v4.30.0",
+                            "branch": "v4.30.0",
+                            "deploy_pages": False,
+                        },
+                    ],
+                },
             )
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-            self.assertEqual(manifest["release_targets"][1]["id"], "v4.30.0")
-            self.assertEqual(manifest["release_targets"][1]["rc"], "4.30-rc2")
-            self.assertFalse(manifest["release_targets"][1]["deploy_pages"])
+            self.assertNotIn("release_targets", manifest)
             self.assertEqual(
                 [target["release"] for target in manifest["projects"][0]["targets"]],
                 ["v4.29.0", "v4.30.0"],
@@ -992,7 +1030,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
 
             self.assertEqual(
                 (root / "branch-policy.json").read_text(encoding="utf-8"),
-                '{\n  "version": 1,\n  "default_dev_branch": "v4.30.0",\n  "required_backport_branches": ["v4.28.0"]\n}\n',
+                '{\n  "version": 1,\n  "default_dev_branch": "v4.30.0",\n  "required_backport_branches": [\n    "v4.28.0"\n  ]\n}\n',
             )
             self.assertIn("checkout_role=backport", out.getvalue())
 
@@ -1641,6 +1679,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         )
         args = argparse.Namespace(manifest=None, project=None, release=None)
         layout = SimpleNamespace(package_root=Path("/tmp/package"), repo_root=Path("/tmp/repo"))
+        release = HarnessReleaseTarget("v4.29.0", "v4.29.0", "v4.29.0", "v4.29.0", True)
         status = reference_harness_mod.ReferenceProjectStatus(
             project=project,
             catalog_ref="abc123",
@@ -1665,7 +1704,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             load_project_catalog=lambda _manifest_path: SimpleNamespace(projects=(project,), release_targets=()),
             select_release_projects=lambda _catalog, *, release, project_ids, package_root: ("v4.29.0", [project]),
             require_checkout_release=lambda _layout, _release_id, *, command_name: None,
-            resolve_release_target=lambda _catalog, _release, _package_root: SimpleNamespace(branch="v4.29.0"),
+            resolve_release_target=lambda _catalog, _release, _package_root: release,
             ref_sync_status=lambda _repo_root, _local_ref, _upstream_ref: harness_mod.RefSyncStatus(
                 local_ref="v4.29.0",
                 upstream_ref="origin/v4.29.0",
@@ -1683,6 +1722,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertIn("release_relationship=in_sync", output)
         self.assertIn("verso_blueprint_ref=v4.29.0", output)
         self.assertIn("noperthedron\tsource=git:https://github.com/example/noperthedron.git@abc123", output)
+        self.assertIn("rc=\ttoolchain=v4.29.0\tverso_ref=v4.29.0", output)
         self.assertIn("catalog_status=behind", output)
         self.assertIn("catalog_behind=12", output)
         self.assertIn("blueprint_pin_source=lake-manifest.json", output)

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -77,6 +77,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
 
         expected_projects: list[str] = []
         expected_refs: dict[str, str | None] = {}
+        expected_rcs: dict[str, str | None] = {}
         published_targets = [
             (project, target)
             for project in catalog.projects
@@ -86,6 +87,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             for project, target in published_targets:
                 expected_projects.append(project.project_id)
                 expected_refs[project.project_id] = target.ref
+                expected_rcs[project.project_id] = target.rc
         else:
             for project in catalog.projects:
                 target = next((target for target in project.targets if target.release == release.release_id), None)
@@ -93,24 +95,34 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                     continue
                 expected_projects.append(project.project_id)
                 expected_refs[project.project_id] = target.ref
+                expected_rcs[project.project_id] = target.rc
 
         self.assertEqual([project.project_id for project in projects], expected_projects)
         for project in projects:
             self.assertEqual(project.selected_release, release.release_id)
+            self.assertEqual(project.selected_rc, expected_rcs[project.project_id])
             expected_ref = expected_refs[project.project_id]
             if expected_ref is not None:
                 self.assertEqual(project.ref, expected_ref)
 
     def test_default_manifest_contains_current_external_projects(self) -> None:
         manifest = default_project_manifest(PACKAGE_ROOT)
+        manifest_data = json.loads(manifest.read_text(encoding="utf-8"))
+        self.assertNotIn("release_targets", manifest_data)
         catalog = load_project_catalog(manifest)
         projects = list(catalog.projects)
 
         self.assertEqual(
             [project.project_id for project in projects],
-            ["project-template", "noperthedron", "spherepackingblueprint", "verso-flt", "verso-carleson", "algebraic-combinatorics"],
+            [
+                "project-template",
+                "noperthedron",
+                "spherepackingblueprint",
+                "verso-flt",
+                "verso-carleson",
+            ],
         )
-        self.assertEqual([target.release_id for target in catalog.release_targets], ["v4.28.0", "v4.29.0", "v4.30.0"])
+        self.assertEqual([target.release_id for target in catalog.release_targets], ["v4.29.0", "v4.30.0"])
         self.assertTrue(projects[0].in_repo_project)
         self.assertTrue(projects[0].in_repo_command_project)
         self.assertEqual(projects[0].project_root, "project_template")
@@ -119,20 +131,20 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             projects[0].generate_command,
             ("lake", "env", "lean", "--run", "ProjectTemplateMain.lean", "--output", "{output_dir}"),
         )
-        self.assertEqual([target.release for target in projects[0].targets], ["v4.28.0", "v4.29.0", "v4.30.0"])
+        self.assertEqual([target.release for target in projects[0].targets], ["v4.29.0", "v4.30.0"])
         release_430 = catalog.release_target("v4.30.0")
         self.assertIsNotNone(release_430)
         assert release_430 is not None
-        self.assertEqual(release_430.rc, "4.30-rc2")
         self.assertEqual(release_430.release_toolchain, "v4.30.0")
-        self.assertEqual(release_430.toolchain, "v4.30.0-rc2")
-        self.assertEqual(release_430.verso_ref, "v4.30.0-rc2")
+        self.assertEqual(release_430.toolchain, "v4.30.0")
+        self.assertEqual(release_430.verso_ref, "v4.30.0")
         self.assertTrue(release_430.deploy_pages)
         self.assertTrue(projects[1].git_checkout)
         self.assertEqual(projects[1].repository, "https://github.com/ejgallego/verso-noperthedron.git")
         self.assertEqual([target.release for target in projects[1].targets], ["v4.29.0", "v4.30.0"])
         self.assertFalse(projects[1].targets[0].publish_reference)
         self.assertTrue(projects[1].targets[1].publish_reference)
+        self.assertEqual(projects[1].targets[1].rc, "4.30-rc2")
         self.assertEqual(projects[1].build_command, ("lake", "build", "Contents"))
         self.assertEqual(
             projects[1].generate_command,
@@ -140,21 +152,23 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         )
         self.assertEqual(projects[1].browser_tests_path, None)
         self.assertEqual(projects[1].panel_regression_script, None)
+        self.assertEqual(projects[2].repository, "https://github.com/ejgallego/verso-sphere-packing.git")
+        self.assertEqual([target.release for target in projects[2].targets], ["v4.29.0"])
+        self.assertTrue(projects[2].targets[0].publish_reference)
         self.assertEqual(projects[3].repository, "https://github.com/ejgallego/verso-flt.git")
         self.assertEqual([target.release for target in projects[3].targets], ["v4.29.0", "v4.30.0"])
         self.assertFalse(projects[3].targets[0].publish_reference)
         self.assertTrue(projects[3].targets[1].publish_reference)
+        self.assertEqual(projects[3].targets[1].rc, "4.30-rc2")
         self.assertEqual(projects[4].repository, "https://github.com/ejgallego/verso-carleson.git")
         self.assertEqual([target.release for target in projects[4].targets], ["v4.30.0"])
         self.assertTrue(projects[4].targets[0].publish_reference)
+        self.assertEqual(projects[4].targets[0].rc, "4.30-rc2")
         self.assertEqual(projects[4].build_command, ("lake", "build", "CarlesonBlueprint"))
         self.assertEqual(
             projects[4].generate_command,
             ("lake", "env", "lean", "--run", "BlueprintMain.lean", "--output", "{output_dir}"),
         )
-        self.assertEqual(projects[5].repository, "https://github.com/ejgallego/verso-algebraic-combinatorics.git")
-        self.assertEqual([target.release for target in projects[5].targets], ["v4.28.0"])
-        self.assertTrue(projects[5].targets[0].publish_reference)
 
     def test_project_catalog_requires_json_object(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -292,7 +306,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
         release = resolve_release_target(catalog, "v4.29.0", PACKAGE_ROOT)
         projects = resolve_projects_for_release(catalog, release.release_id, None)
-        matrix = reference_build_matrix(projects)
+        matrix = reference_build_matrix(projects, release)
         workflow_text = (PACKAGE_ROOT / ".github" / "workflows" / "reference-blueprints.yml").read_text(
             encoding="utf-8"
         )
@@ -373,6 +387,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                                 {
                                     "release": "v4.29.0",
                                     "ref": "new-controller-ref",
+                                    "rc": "4.29-rc1",
                                     "publish_reference": True,
                                 }
                             ],
@@ -390,6 +405,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                                 {
                                     "release": "v4.29.0",
                                     "ref": "new-second-controller-ref",
+                                    "rc": "v4.29.0-rc2",
                                     "publish_reference": True,
                                 }
                             ],
@@ -431,11 +447,24 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             "old-controller",
         )
         self.assertEqual(matrix_by_project["old-release-project"]["project_root"], "old-controller")
+        self.assertEqual(matrix_by_project["old-release-project"]["rc"], "")
+        self.assertEqual(matrix_by_project["old-release-project"]["toolchain"], "v4.28.0")
         self.assertTrue(matrix_by_project["old-release-project"]["reference_cache_key"].startswith("old-release-project-"))
         self.assertEqual(
             manifest_by_project["new-release-project"]["projects"][0]["targets"],
-            [{"release": "v4.29.0", "ref": "new-controller-ref"}],
+            [{"release": "v4.29.0", "ref": "new-controller-ref", "rc": "4.29-rc1"}],
         )
+        self.assertNotIn("rc", manifest_by_project["new-release-project"]["release_targets"][0])
+        self.assertEqual(matrix_by_project["new-release-project"]["rc"], "4.29-rc1")
+        self.assertEqual(matrix_by_project["new-release-project"]["toolchain"], "v4.29.0-rc1")
+        self.assertEqual(matrix_by_project["new-release-project"]["verso_ref"], "v4.29.0-rc1")
+        self.assertEqual(
+            manifest_by_project["new-release-second-project"]["projects"][0]["targets"],
+            [{"release": "v4.29.0", "ref": "new-second-controller-ref", "rc": "4.29-rc2"}],
+        )
+        self.assertEqual(matrix_by_project["new-release-second-project"]["rc"], "4.29-rc2")
+        self.assertEqual(matrix_by_project["new-release-second-project"]["toolchain"], "v4.29.0-rc2")
+        self.assertEqual(matrix_by_project["new-release-second-project"]["verso_ref"], "v4.29.0-rc2")
 
     def test_git_checkout_project_is_supported(self) -> None:
         manifest_data = {
@@ -523,10 +552,10 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(projects[0].generate_command, ("lake", "exe", "blueprint-gen", "--output", "{output_dir}"))
 
     def test_resolve_projects_for_release_filters_to_matching_targets(self) -> None:
-        self.assert_resolved_projects_match_manifest("v4.29.0")
+        self.assert_resolved_projects_match_manifest("v4.30.0")
 
     def test_resolve_projects_for_older_release_uses_matching_targets(self) -> None:
-        self.assert_resolved_projects_match_manifest("v4.28.0")
+        self.assert_resolved_projects_match_manifest("v4.29.0")
 
     def test_publish_reference_targets_select_default_release_catalog(self) -> None:
         catalog = load_project_catalog_text(

--- a/tests/harness/test_prepare_reference_blueprints_pages.py
+++ b/tests/harness/test_prepare_reference_blueprints_pages.py
@@ -174,7 +174,6 @@ class PrepareReferenceBlueprintPagesTests(unittest.TestCase):
         self.assertNotIn("reference-blueprints/verso-flt/", readme)
         self.assertNotIn("reference-blueprints/verso-carleson/", readme)
 
-        self.assertIn("reference-blueprints/v4.28.0/algebraic-combinatorics/", readme)
         self.assertIn("reference-blueprints/v4.29.0/spherepackingblueprint/", readme)
         self.assertIn("reference-blueprints/v4.30.0/noperthedron/", readme)
         self.assertIn("reference-blueprints/v4.30.0/verso-flt/", readme)


### PR DESCRIPTION
This PR makes `branch-policy.json` the source of truth for release targets while removing obsolete v4.28.0 reference blueprint coverage from the active catalog. Project target entries remain the source of truth for project refs, publication flags, and any per-project RC override.

- Move release target metadata from `tests/harness/projects.json` into `branch-policy.json`.
- Keep v4.30 published project targets explicitly pinned to `4.30-rc2`, so the release id stays `v4.30.0` while each selected project row resolves to `v4.30.0-rc2`.
- Update the reference release/deploy matrices and maintainer outputs to carry per-project `rc`, `toolchain`, and `verso_ref` fields.
- Drop v4.28.0 and algebraic-combinatorics from the active reference catalog.

Backport v4.29.0: exempt: v4.30 catalog maintenance