### PR TITLE
[backport v4.29.0] chore: reduce reference CI package duplication

### DIFF
--- a/.github/workflows/reference-blueprints-deploy.yml
+++ b/.github/workflows/reference-blueprints-deploy.yml
@@ -102,6 +102,7 @@ jobs:
             --release ${{ matrix.release_id }} \
             --project ${{ matrix.project_id }} \
             --allow-local-build \
+            --reference-package-mode move \
             --serial \
             _out/reference-blueprints/${{ matrix.release_id }}
       - name: Report disk usage after reference generation

--- a/.github/workflows/reference-blueprints-deploy.yml
+++ b/.github/workflows/reference-blueprints-deploy.yml
@@ -65,6 +65,8 @@ jobs:
           echo "branch=${{ matrix.branch }}"
           echo "project_id=${{ matrix.project_id }}"
           echo "hash=${{ matrix.hash }}"
+      - name: Report disk usage before cache restore
+        run: ./scripts/report-ci-disk-usage.sh "before cache restore" --artifact-path "${{ matrix.artifact_path }}"
       - name: Install elan
         run: |
           curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
@@ -87,6 +89,8 @@ jobs:
           key: ${{ runner.os }}-reference-deploy-lake-deps-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-${{ matrix.release_id }}
           restore-keys: |
             ${{ runner.os }}-reference-deploy-lake-deps-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-
+      - name: Report disk usage after Lake cache restore
+        run: ./scripts/report-ci-disk-usage.sh "after Lake cache restore" --artifact-path "${{ matrix.artifact_path }}"
       - name: Show tool versions
         run: |
           lean --version
@@ -100,6 +104,9 @@ jobs:
             --allow-local-build \
             --serial \
             _out/reference-blueprints/${{ matrix.release_id }}
+      - name: Report disk usage after reference generation
+        if: ${{ always() }}
+        run: ./scripts/report-ci-disk-usage.sh "after reference generation" --artifact-path "${{ matrix.artifact_path }}"
       - name: Upload release reference artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/reference-blueprints.yml
+++ b/.github/workflows/reference-blueprints.yml
@@ -80,7 +80,7 @@ jobs:
           lake --version
           python3 --version
       - name: Generate reference blueprint
-        run: ./scripts/generate-reference-blueprints.sh --allow-unsafe-root-release --project ${{ matrix.project_id }}
+        run: ./scripts/generate-reference-blueprints.sh --allow-unsafe-root-release --reference-package-mode move --project ${{ matrix.project_id }}
       - name: Report disk usage after reference generation
         if: ${{ always() }}
         run: ./scripts/report-ci-disk-usage.sh "after reference generation" --artifact-path "${{ matrix.artifact_path }}"

--- a/.github/workflows/reference-blueprints.yml
+++ b/.github/workflows/reference-blueprints.yml
@@ -48,6 +48,8 @@ jobs:
           echo "verso_ref=${{ needs.resolve-reference-release.outputs.verso_ref }}"
           echo "blueprint=${{ matrix.project_id }}"
           echo "hash=${{ matrix.hash }}"
+      - name: Report disk usage before cache restore
+        run: ./scripts/report-ci-disk-usage.sh "before cache restore" --artifact-path "${{ matrix.artifact_path }}"
       - name: Install elan
         run: |
           curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
@@ -70,13 +72,18 @@ jobs:
           key: ${{ runner.os }}-lake-deps-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}
           restore-keys: |
             ${{ runner.os }}-lake-deps-
+      - name: Report disk usage after Lake cache restore
+        run: ./scripts/report-ci-disk-usage.sh "after Lake cache restore" --artifact-path "${{ matrix.artifact_path }}"
       - name: Show tool versions
         run: |
           lean --version
           lake --version
           python3 --version
       - name: Generate reference blueprint
-        run: ./scripts/generate-reference-blueprints.sh --project ${{ matrix.project_id }}
+        run: ./scripts/generate-reference-blueprints.sh --allow-unsafe-root-release --project ${{ matrix.project_id }}
+      - name: Report disk usage after reference generation
+        if: ${{ always() }}
+        run: ./scripts/report-ci-disk-usage.sh "after reference generation" --artifact-path "${{ matrix.artifact_path }}"
       - name: Upload reference blueprint artifact
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -32,6 +32,9 @@ from scripts.blueprint_harness_utils import lean_low_priority_command, run
 
 
 COMMIT_HASH_PATTERN = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
+REFERENCE_PACKAGE_MODE_COPY = "copy"
+REFERENCE_PACKAGE_MODE_MOVE = "move"
+REFERENCE_PACKAGE_MODES = (REFERENCE_PACKAGE_MODE_COPY, REFERENCE_PACKAGE_MODE_MOVE)
 GITHUB_SUBMODULE_URL_REWRITE_ARGS = (
     "-c",
     "url.https://github.com/.insteadOf=git@github.com:",
@@ -174,6 +177,36 @@ def reconcile_reference_toolchains(package_root: Path, project_dir: Path) -> Ref
         release_branch=common_branch,
         changed_paths=tuple(changed_paths),
     )
+
+
+def validate_reference_package_mode(mode: str) -> str:
+    if mode not in REFERENCE_PACKAGE_MODES:
+        expected = ", ".join(REFERENCE_PACKAGE_MODES)
+        raise ValueError(f"unknown reference package mode `{mode}`; expected one of: {expected}")
+    return mode
+
+
+def discard_lake_packages(project_dir: Path) -> Path | None:
+    packages = lake_packages_dir(project_dir)
+    if not packages.exists() and not packages.is_symlink():
+        return None
+    if packages.is_symlink() or packages.is_file():
+        packages.unlink()
+    else:
+        shutil.rmtree(packages)
+    return packages
+
+
+def move_lake_packages(source_project_dir: Path, destination_project_dir: Path, *, action: str) -> Path | None:
+    source_packages = lake_packages_dir(source_project_dir)
+    if not source_packages.exists() and not source_packages.is_symlink():
+        return None
+    destination_packages = lake_packages_dir(destination_project_dir)
+    discard_lake_packages(destination_project_dir)
+    destination_packages.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(source_packages), str(destination_packages))
+    print(f"[blueprint-harness] {action} {destination_packages}")
+    return destination_packages
 
 
 def short_git_ref(ref: str) -> str:
@@ -575,7 +608,14 @@ def bump_reference_project(
     )
 
 
-def sync_reference_cache_checkout(layout, project: HarnessProject, *, warm_build: bool) -> Path:
+def sync_reference_cache_checkout(
+    layout,
+    project: HarnessProject,
+    *,
+    warm_build: bool,
+    package_mode: str = REFERENCE_PACKAGE_MODE_COPY,
+) -> Path:
+    package_mode = validate_reference_package_mode(package_mode)
     cache_dir = reference_cache_checkout_dir(layout, project)
     cache_dir.parent.mkdir(parents=True, exist_ok=True)
     if not cache_dir.exists():
@@ -592,23 +632,61 @@ def sync_reference_cache_checkout(layout, project: HarnessProject, *, warm_build
     return cache_dir
 
 
-def sync_reference_local_checkout(layout, project: HarnessProject, cache_dir: Path) -> Path:
+def sync_reference_local_checkout(
+    layout,
+    project: HarnessProject,
+    cache_dir: Path,
+    *,
+    package_mode: str = REFERENCE_PACKAGE_MODE_COPY,
+) -> Path:
+    package_mode = validate_reference_package_mode(package_mode)
     local_dir = reference_local_checkout_dir(layout, project)
     local_dir.parent.mkdir(parents=True, exist_ok=True)
     if not local_dir.exists():
         clone_git_project(project, local_dir, cwd=layout.package_root, source=str(cache_dir))
     else:
         update_git_checkout(project, local_dir)
-    bootstrap_reference_checkout(project_dir=local_dir / project.project_root)
+    cache_project_dir = cache_dir / project.project_root
+    local_project_dir = local_dir / project.project_root
+    bootstrap_reference_checkout(project_dir=local_project_dir)
 
-    cache_lake = cache_dir / ".lake"
+    cache_lake = cache_project_dir / ".lake"
     if cache_lake.exists():
         # Seed dependency state from the shared cache, but preserve the
         # worktree-local project's own build products. Those artifacts are
         # produced after rewriting the reference project to depend on the local
         # VersoBlueprint checkout, so deleting them defeats the local cache.
+        if package_mode == REFERENCE_PACKAGE_MODE_MOVE:
+            moved_packages = move_lake_packages(
+                cache_project_dir,
+                local_project_dir,
+                action="moved reference cache packages into",
+            )
+            try:
+                run(
+                    [
+                        "rsync",
+                        "-a",
+                        "--exclude",
+                        "/build/",
+                        "--exclude",
+                        "/packages/",
+                        f"{cache_lake}/",
+                        f"{local_project_dir / '.lake'}/",
+                    ],
+                    cwd=layout.package_root,
+                )
+            except Exception:
+                if moved_packages is not None:
+                    move_lake_packages(
+                        local_project_dir,
+                        cache_project_dir,
+                        action="restored reference cache packages to",
+                    )
+                raise
+            return local_dir
         run(
-            ["rsync", "-a", "--exclude", "/build/", f"{cache_lake}/", f"{local_dir / '.lake'}/"],
+            ["rsync", "-a", "--exclude", "/build/", f"{cache_lake}/", f"{local_project_dir / '.lake'}/"],
             cwd=layout.package_root,
         )
     return local_dir
@@ -652,50 +730,82 @@ def generate_in_repo_command_project(layout, output_root: Path, project: Harness
         restore_tracked_project_manifest(original_manifest)
 
 
-def generate_git_project(layout, output_root: Path, project: HarnessProject, *, skip_build: bool) -> None:
+def generate_git_project(
+    layout,
+    output_root: Path,
+    project: HarnessProject,
+    *,
+    skip_build: bool,
+    package_mode: str = REFERENCE_PACKAGE_MODE_COPY,
+) -> None:
+    package_mode = validate_reference_package_mode(package_mode)
     rebuild_and_log_embedded_asset_owners(layout.package_root)
-    cache_dir = sync_reference_cache_checkout(layout, project, warm_build=False)
-    checkout_root = sync_reference_local_checkout(layout, project, cache_dir)
+    cache_dir = sync_reference_cache_checkout(layout, project, warm_build=False, package_mode=package_mode)
+    cache_project_dir = cache_dir / project.project_root
+    cache_packages = lake_packages_dir(cache_project_dir)
+    cache_packages_available = cache_packages.exists() or cache_packages.is_symlink()
+    checkout_root = sync_reference_local_checkout(layout, project, cache_dir, package_mode=package_mode)
     project_dir = checkout_root / project.project_root
-    discard_untracked_project_manifest(project_dir)
-    output_dir = output_dir_for(project, output_root)
-    output_dir.mkdir(parents=True, exist_ok=True)
-    bootstrap_reference_checkout(project_dir=project_dir)
-    with local_blueprint_dependency_override(layout.package_root, project_dir, restore_lakefile=False, log=True):
-        run_project_update_build_generate(
-            layout.package_root,
-            project_dir,
-            update_project=lambda: run_reference_lake_update(
+    borrowed_packages = (
+        package_mode == REFERENCE_PACKAGE_MODE_MOVE
+        and cache_packages_available
+        and lake_packages_dir(project_dir).exists()
+    )
+    try:
+        discard_untracked_project_manifest(project_dir)
+        output_dir = output_dir_for(project, output_root)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        bootstrap_reference_checkout(project_dir=project_dir)
+        with local_blueprint_dependency_override(layout.package_root, project_dir, restore_lakefile=False, log=True):
+            run_project_update_build_generate(
                 layout.package_root,
                 project_dir,
-                reconcile_toolchains=True,
-            ),
-            build_command=project.build_command,
-            generate_command=project.generate_command or (),
-            format_command=lambda command: format_project_command(
-                command,
-                reference_command_placeholders(
-                    project,
-                    package_root=layout.package_root,
-                    checkout_root=checkout_root,
-                    project_dir=project_dir,
-                    output_dir=output_dir,
+                update_project=lambda: run_reference_lake_update(
+                    layout.package_root,
+                    project_dir,
+                    reconcile_toolchains=True,
                 ),
-            ),
-            skip_build=skip_build,
-        )
+                build_command=project.build_command,
+                generate_command=project.generate_command or (),
+                format_command=lambda command: format_project_command(
+                    command,
+                    reference_command_placeholders(
+                        project,
+                        package_root=layout.package_root,
+                        checkout_root=checkout_root,
+                        project_dir=project_dir,
+                        output_dir=output_dir,
+                    ),
+                ),
+                skip_build=skip_build,
+            )
+    finally:
+        if borrowed_packages:
+            move_lake_packages(
+                project_dir,
+                cache_project_dir,
+                action="restored reference cache packages to",
+            )
 
 
-def sync_reference_blueprints(layout, projects: list[HarnessProject], *, warm_build: bool, prepare_local_checkout: bool) -> None:
+def sync_reference_blueprints(
+    layout,
+    projects: list[HarnessProject],
+    *,
+    warm_build: bool,
+    prepare_local_checkout: bool,
+    package_mode: str = REFERENCE_PACKAGE_MODE_COPY,
+) -> None:
+    package_mode = validate_reference_package_mode(package_mode)
     git_projects = [project for project in projects if project.git_checkout]
     if not git_projects:
         return
     if shutil.which("rsync") is None:
         raise SystemExit("[blueprint-harness] `rsync` is required for reference blueprint cache sync.")
     for project in git_projects:
-        cache_dir = sync_reference_cache_checkout(layout, project, warm_build=warm_build)
+        cache_dir = sync_reference_cache_checkout(layout, project, warm_build=warm_build, package_mode=package_mode)
         if prepare_local_checkout:
-            local_dir = sync_reference_local_checkout(layout, project, cache_dir)
+            local_dir = sync_reference_local_checkout(layout, project, cache_dir, package_mode=package_mode)
             print(f"[blueprint-harness] prepared local reference checkout: {local_dir}")
 
 

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -30,6 +30,8 @@ from scripts.blueprint_harness_projects import (
 )
 from scripts.blueprint_harness_project_commands import OFFICIAL_BLUEPRINT_URL_PATTERNS
 from scripts.blueprint_harness_references import (
+    REFERENCE_PACKAGE_MODE_COPY,
+    REFERENCE_PACKAGE_MODES,
     bump_reference_project,
     clone_git_project,
     generate_in_repo_command_project,
@@ -92,6 +94,18 @@ BLUEPRINT_REQUIRE_PATTERN = re.compile(
     re.MULTILINE | re.DOTALL,
 )
 REFERENCE_HARNESS_PREFIX = "[blueprint-reference-harness]"
+
+
+def add_reference_package_mode_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--reference-package-mode",
+        choices=REFERENCE_PACKAGE_MODES,
+        default=REFERENCE_PACKAGE_MODE_COPY,
+        help=(
+            "How external reference projects receive warmed `.lake/packages` trees. "
+            "`copy` keeps the local default; `move` avoids duplicate package trees and is intended for CI."
+        ),
+    )
 
 
 def text_or_blank(value: object | None) -> str:
@@ -564,6 +578,7 @@ def generate_projects(
     skip_build: bool,
     serial: bool,
     allow_local_build: bool,
+    reference_package_mode: str = REFERENCE_PACKAGE_MODE_COPY,
 ) -> None:
     in_repo_projects = [project for project in projects if project.in_repo_project]
     in_repo_target_projects = [project for project in in_repo_projects if project.in_repo_target_project]
@@ -602,7 +617,13 @@ def generate_projects(
 
     for project in git_projects:
         print(f"[blueprint-reference-harness] reference checkout: {project.project_id}")
-        generate_git_project(layout, output_root, project, skip_build=skip_build)
+        generate_git_project(
+            layout,
+            output_root,
+            project,
+            skip_build=skip_build,
+            package_mode=reference_package_mode,
+        )
 
 
 def command_generate(args: argparse.Namespace) -> int:
@@ -626,6 +647,7 @@ def command_generate(args: argparse.Namespace) -> int:
         skip_build=args.skip_build,
         serial=args.serial,
         allow_local_build=args.allow_local_build,
+        reference_package_mode=getattr(args, "reference_package_mode", REFERENCE_PACKAGE_MODE_COPY),
     )
 
     print(f"[blueprint-reference-harness] project manifest: {manifest_path}")
@@ -689,6 +711,7 @@ def command_validate(args: argparse.Namespace) -> int:
             skip_build=False,
             serial=args.serial,
             allow_local_build=args.allow_local_build,
+            reference_package_mode=getattr(args, "reference_package_mode", REFERENCE_PACKAGE_MODE_COPY),
         )
     except SystemExit as err:
         failures.append(StepFailure("generate projects", str(err)))
@@ -1026,6 +1049,7 @@ def build_parser() -> argparse.ArgumentParser:
         generate,
         help_text="Permit `lake build` in a linked worktree instead of requiring synced root executables.",
     )
+    add_reference_package_mode_argument(generate)
     generate.set_defaults(func=command_generate)
 
     validate = subparsers.add_parser(
@@ -1068,6 +1092,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Stop validation as soon as one phase fails instead of collecting later failures.",
     )
+    add_reference_package_mode_argument(validate)
     validate.set_defaults(func=command_validate)
 
     projects = subparsers.add_parser(

--- a/scripts/report-ci-disk-usage.sh
+++ b/scripts/report-ci-disk-usage.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/report-ci-disk-usage.sh LABEL [options]
+
+Print a compact disk-usage report for CI reference blueprint jobs.
+
+Options:
+  --reference-cache-key KEY   Include per-reference cache paths for KEY.
+  --artifact-path PATH        Include the generated artifact path.
+  -h, --help                  Show this help.
+EOF
+}
+
+label=""
+reference_cache_key=""
+artifact_path=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --reference-cache-key)
+      if [[ $# -lt 2 ]]; then
+        echo "missing value for --reference-cache-key" >&2
+        exit 2
+      fi
+      reference_cache_key="$2"
+      shift 2
+      ;;
+    --artifact-path)
+      if [[ $# -lt 2 ]]; then
+        echo "missing value for --artifact-path" >&2
+        exit 2
+      fi
+      artifact_path="$2"
+      shift 2
+      ;;
+    -*)
+      echo "unknown option: $1" >&2
+      exit 2
+      ;;
+    *)
+      if [[ -n "$label" ]]; then
+        echo "unexpected argument: $1" >&2
+        exit 2
+      fi
+      label="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$label" ]]; then
+  usage >&2
+  exit 2
+fi
+
+begin_group() {
+  if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    printf '::group::%s\n' "$1"
+  else
+    printf '## %s\n' "$1"
+  fi
+}
+
+end_group() {
+  if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    printf '::endgroup::\n'
+  fi
+}
+
+report_df() {
+  local paths=(".")
+  if [[ -n "${RUNNER_TEMP:-}" ]]; then
+    paths+=("$RUNNER_TEMP")
+  fi
+  if [[ -n "${HOME:-}" ]]; then
+    paths+=("$HOME")
+  fi
+  paths+=("/tmp")
+
+  printf '[ci-disk] filesystems\n'
+  df -h "${paths[@]}" | awk '!seen[$0]++'
+}
+
+report_du() {
+  local path
+  local paths=(
+    ".lake"
+    ".lake/packages"
+    ".lake/build"
+    ".lake/packages/mathlib"
+    ".lake/packages/mathlib/.lake/build"
+    ".lake/packages/verso"
+    ".lake/packages/verso/.lake/build"
+    ".worktrees/_reference-blueprints"
+    ".worktrees/_reference-blueprints/cache"
+    ".worktrees/_reference-blueprints/deps"
+    ".worktrees/_reference-blueprints/by-worktree"
+    "_out"
+    "_out/reference-blueprints"
+  )
+
+  if [[ -n "$reference_cache_key" ]]; then
+    paths+=(
+      ".worktrees/_reference-blueprints/cache/$reference_cache_key"
+      ".worktrees/_reference-blueprints/deps/$reference_cache_key"
+      ".worktrees/_reference-blueprints/deps/$reference_cache_key/packages"
+    )
+
+    shopt -s nullglob
+    local local_checkouts=(.worktrees/_reference-blueprints/by-worktree/*/"$reference_cache_key")
+    shopt -u nullglob
+    paths+=("${local_checkouts[@]}")
+  fi
+
+  if [[ -n "$artifact_path" ]]; then
+    paths+=("$artifact_path")
+  fi
+
+  printf '[ci-disk] selected paths\n'
+  for path in "${paths[@]}"; do
+    if [[ -e "$path" || -L "$path" ]]; then
+      du -sh "$path"
+    else
+      printf 'missing\t%s\n' "$path"
+    fi
+  done
+}
+
+report_reference_children() {
+  local root=".worktrees/_reference-blueprints"
+  if [[ -d "$root" ]]; then
+    printf '[ci-disk] reference cache children\n'
+    du -sh "$root"/* 2>/dev/null | sort -h || true
+  fi
+
+  if [[ -n "$reference_cache_key" ]]; then
+    local packages=".worktrees/_reference-blueprints/deps/$reference_cache_key/packages"
+    if [[ -d "$packages" ]]; then
+      printf '[ci-disk] packages for %s\n' "$reference_cache_key"
+      du -sh "$packages"/* 2>/dev/null | sort -h || true
+    fi
+  fi
+}
+
+begin_group "Disk usage: $label"
+printf '[ci-disk] label=%s\n' "$label"
+if [[ -n "$reference_cache_key" ]]; then
+  printf '[ci-disk] reference_cache_key=%s\n' "$reference_cache_key"
+fi
+if [[ -n "$artifact_path" ]]; then
+  printf '[ci-disk] artifact_path=%s\n' "$artifact_path"
+fi
+report_df
+report_du
+report_reference_children
+end_group

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -86,6 +86,12 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertTrue(args.allow_unsafe_root_release)
         self.assertEqual(args.release, "v4.29.0")
 
+    def test_reference_commands_parse_package_mode(self) -> None:
+        parser = reference_harness_mod.build_parser()
+        self.assertEqual(parser.parse_args(["generate"]).reference_package_mode, "copy")
+        self.assertEqual(parser.parse_args(["generate", "--reference-package-mode", "move"]).reference_package_mode, "move")
+        self.assertEqual(parser.parse_args(["validate", "--reference-package-mode", "move"]).reference_package_mode, "move")
+
     def test_reference_projects_parses_release_filter(self) -> None:
         parser = reference_harness_mod.build_parser()
         args = parser.parse_args(["projects", "--release", "v4.29.0"])
@@ -1163,6 +1169,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 skip_build=False,
                 serial=False,
                 allow_local_build=False,
+                reference_package_mode="copy",
             )
 
     def test_validate_run_lean_tests_does_not_auto_sync_root_lake(self) -> None:

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -138,6 +138,52 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "expected JSON object"):
                 load_project_catalog(manifest)
 
+    def test_discard_lake_packages_prunes_warmed_checkout_copy(self) -> None:
+        import scripts.blueprint_harness_references as refs_mod
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            project_dir = root / "checkout"
+            packages = project_dir / ".lake" / "packages"
+            mathlib_artifact = packages / "mathlib" / ".lake" / "build" / "Mathlib.olean"
+            mathlib_artifact.parent.mkdir(parents=True)
+            mathlib_artifact.write_text("warm", encoding="utf-8")
+
+            pruned = refs_mod.discard_lake_packages(project_dir)
+
+        self.assertEqual(pruned, packages)
+        self.assertFalse(packages.exists())
+
+    def test_move_lake_packages_moves_between_reference_checkouts(self) -> None:
+        import scripts.blueprint_harness_references as refs_mod
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cache_project_dir = root / "cache" / "nested" / "blueprint"
+            local_project_dir = root / "local" / "nested" / "blueprint"
+            source_marker = cache_project_dir / ".lake" / "packages" / "mathlib" / ".lake" / "build" / "Mathlib.olean"
+            stale_marker = local_project_dir / ".lake" / "packages" / "old" / "stale"
+            source_marker.parent.mkdir(parents=True)
+            source_marker.write_text("warm", encoding="utf-8")
+            stale_marker.parent.mkdir(parents=True)
+            stale_marker.write_text("stale", encoding="utf-8")
+
+            moved_to = refs_mod.move_lake_packages(
+                cache_project_dir,
+                local_project_dir,
+                action="moved test packages into",
+            )
+
+            self.assertEqual(moved_to, local_project_dir / ".lake" / "packages")
+            self.assertFalse((cache_project_dir / ".lake" / "packages").exists())
+            self.assertFalse(stale_marker.exists())
+            self.assertEqual(
+                (local_project_dir / ".lake" / "packages" / "mathlib" / ".lake" / "build" / "Mathlib.olean").read_text(
+                    encoding="utf-8"
+                ),
+                "warm",
+            )
+
     def test_reference_pages_workflow_stages_every_manifest_project(self) -> None:
         catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
         release = resolve_release_target(catalog, "v4.29.0", PACKAGE_ROOT)
@@ -891,9 +937,20 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             }
             commands: list[list[str]] = []
             warm_build_values: list[bool] = []
+            package_modes: list[str] = []
+
+            def fake_sync_reference_cache_checkout(_layout, _project, *, warm_build, package_mode="copy"):
+                warm_build_values.append(warm_build)
+                package_modes.append(package_mode)
+                return cache_dir
+
+            def fake_sync_reference_local_checkout(_layout, _project, _cache_dir, *, package_mode="copy"):
+                package_modes.append(package_mode)
+                return local_dir
+
             try:
-                refs_mod.sync_reference_cache_checkout = lambda _layout, _project, *, warm_build: warm_build_values.append(warm_build) or cache_dir
-                refs_mod.sync_reference_local_checkout = lambda _layout, _project, _cache_dir: local_dir
+                refs_mod.sync_reference_cache_checkout = fake_sync_reference_cache_checkout
+                refs_mod.sync_reference_local_checkout = fake_sync_reference_local_checkout
                 commands_mod.rewrite_local_blueprint_dependency = (
                     lambda _project_dir, _package_root: local_dir / "lakefile.lean"
                 )
@@ -912,9 +969,87 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                         setattr(refs_mod, name, value)
 
         self.assertEqual(warm_build_values, [False])
+        self.assertEqual(package_modes, ["copy", "copy"])
         self.assertEqual(commands[0], reference_submodule_update_command())
         self.assertIn(["lake", "update", "VersoBlueprint"], commands)
         self.assertTrue(any(command[1:] == ["lake", "build"] for command in commands))
+
+    def test_generate_git_project_move_mode_restores_packages_after_failure(self) -> None:
+        import scripts.blueprint_harness_references as refs_mod
+
+        project = HarnessProject(
+            project_id="external-blueprint",
+            source_kind="git_checkout",
+            project_root=".",
+            build_target=None,
+            generator=None,
+            repository="https://github.com/example/external-blueprint.git",
+            ref="main",
+            build_command=("lake", "build"),
+            generate_command=("lake", "exe", "blueprint-gen", "--output", "{output_dir}"),
+            site_subdir="html-multi",
+            panel_regression_script=None,
+            browser_tests_path=None,
+            description=None,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cache_dir = root / "cache"
+            local_dir = root / "local"
+            output_root = root / "out"
+            marker = cache_dir / ".lake" / "packages" / "mathlib" / ".lake" / "build" / "Mathlib.olean"
+            marker.parent.mkdir(parents=True)
+            marker.write_text("warm", encoding="utf-8")
+            layout = SimpleNamespace(
+                package_root=root / "pkg",
+                repo_root=root / "repo",
+            )
+            layout.package_root.mkdir()
+            layout.repo_root.mkdir()
+
+            originals = {
+                "rebuild_and_log_embedded_asset_owners": refs_mod.rebuild_and_log_embedded_asset_owners,
+                "sync_reference_cache_checkout": refs_mod.sync_reference_cache_checkout,
+                "sync_reference_local_checkout": refs_mod.sync_reference_local_checkout,
+                "bootstrap_reference_checkout": refs_mod.bootstrap_reference_checkout,
+            }
+            package_modes: list[str] = []
+
+            def fake_sync_reference_cache_checkout(_layout, _project, *, warm_build, package_mode="copy"):
+                package_modes.append(package_mode)
+                return cache_dir
+
+            def fake_sync_reference_local_checkout(_layout, _project, _cache_dir, *, package_mode="copy"):
+                package_modes.append(package_mode)
+                if package_mode == "move":
+                    refs_mod.move_lake_packages(
+                        cache_dir,
+                        local_dir,
+                        action="moved test packages into",
+                    )
+                return local_dir
+
+            try:
+                refs_mod.rebuild_and_log_embedded_asset_owners = lambda _package_root: None
+                refs_mod.sync_reference_cache_checkout = fake_sync_reference_cache_checkout
+                refs_mod.sync_reference_local_checkout = fake_sync_reference_local_checkout
+                refs_mod.bootstrap_reference_checkout = lambda *, project_dir: (_ for _ in ()).throw(RuntimeError("boom"))
+
+                with self.assertRaisesRegex(RuntimeError, "boom"):
+                    generate_git_project(layout, output_root, project, skip_build=False, package_mode="move")
+            finally:
+                for name, value in originals.items():
+                    setattr(refs_mod, name, value)
+
+            cache_packages = cache_dir / ".lake" / "packages"
+
+            self.assertEqual(package_modes, ["move", "move"])
+            self.assertFalse((local_dir / ".lake" / "packages").exists())
+            self.assertEqual(
+                (cache_packages / "mathlib" / ".lake" / "build" / "Mathlib.olean").read_text(encoding="utf-8"),
+                "warm",
+            )
 
     def test_bootstrap_reference_checkout_requires_harness_layout(self) -> None:
         import scripts.blueprint_harness_references as refs_mod

--- a/tests/harness/test_harness_entrypoints.py
+++ b/tests/harness/test_harness_entrypoints.py
@@ -69,6 +69,12 @@ class HarnessEntrypointSmokeTests(unittest.TestCase):
         self.assertIn("reference blueprints", result.stdout)
         self.assertIn("test blueprints", result.stdout)
 
+    def test_report_ci_disk_usage_help(self) -> None:
+        result = self.run_command(["bash", "scripts/report-ci-disk-usage.sh", "--help"])
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Print a compact disk-usage report", result.stdout)
+        self.assertIn("--reference-cache-key", result.stdout)
+
     def test_validate_reference_wrapper_help(self) -> None:
         result = self.run_command(["bash", "scripts/validate-reference-blueprints.sh", "--help"])
         self.assertEqual(result.returncode, 0, msg=result.stderr)


### PR DESCRIPTION
## Summary
Backport #117 to `v4.29.0`.

## Primary Review
- Primary review: #117
- Keep review comments on #117 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.29.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- The v4.29 branch predates the newer dedicated reference dependency-cache matrix fields, so this backport maps move mode to the existing shared reference checkout `.lake/packages` tree instead of the v4.30 dependency-cache path.