### PR TITLE
refactor: trim harness cleanup code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,6 @@
   - `python3 -m scripts.blueprint_harness --help`
   - `python3 -m scripts.blueprint_harness sync-root-lake`
   - `python3 -m scripts.blueprint_harness paths`
-  - `python3 -m scripts.blueprint_harness worktree-sync`
   - `python3 -m scripts.blueprint_harness worktree-list`
   - `python3 -m scripts.blueprint_harness worktree-status`
   - `python3 -m scripts.blueprint_harness worktree-claim`

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -168,8 +168,6 @@ python3 -m scripts.blueprint_harness worktree-release
 ```
 
 `worktree-list` already refreshes local metadata before printing the dashboard.
-`worktree-sync` remains available as a compatibility alias for
-`worktree-list`.
 
 By default, only clean up worktrees or branches created or landed by the
 current session. Do not retire or delete unrelated local worktrees unless the

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -74,6 +74,14 @@ Reference-project commands resolve the current checkout's release line by
 default. `generate`, `validate`, and `sync` require a matching checkout release
 line; switch branches instead of forcing a different release target.
 
+Reference release metadata has two tracked sources of truth. `branch-policy.json`
+owns release ids, branch names, baseline Lean toolchain refs, baseline `verso`
+refs, default-development/backport policy, and the release-level Pages deploy
+flag. `tests/harness/projects.json` owns project ids, external repository refs,
+the `publish_reference` flag, and any per-project `rc` override. Matrix emitter
+scripts derive effective per-project `toolchain` and `verso_ref` values from
+those two files; release targets themselves do not carry `rc` metadata.
+
 ## Everyday Workflows
 
 ### Start Implementation Work
@@ -709,6 +717,12 @@ The harness is now project-driven rather than hardcoded to one project.
   repository, and it tolerates different Git refs and URL spellings for that
   source
 - local worktree bookkeeping is intentionally not tracked in the repository
+
+For example, the release id may remain `v4.30.0` while a specific published
+project target records `"rc": "4.30-rc2"`. That row then builds with
+`leanprover/lean4:v4.30.0-rc2` and pins `verso` to `v4.30.0-rc2`, while another
+project target on the same release id can use a different RC or the final
+release tag.
 
 Minimal external catalog entry shape:
 

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -517,8 +517,6 @@ The local coordination layer is now machine-readable and untracked.
 
 - `worktree-list` refreshes local metadata under `.worktrees/` and prints the
   current dashboard view, combining local metadata with live Git state
-- `worktree-sync` remains available as a compatibility alias for
-  `worktree-list`
 - `worktree-claim` records owner, lock state, priority, summary, status, and
   write scope
 - `worktree-status` shows one worktree record

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -93,6 +93,13 @@ the stable base:
 python3 -m scripts.blueprint_harness create-worktree <name> --owner codex --lock --priority P1 --summary "short description"
 ```
 
+For docs, Python harness, or other work that does not need synced Lake
+artifacts or warmed reference clones, prefer a lightweight worktree:
+
+```bash
+python3 -m scripts.blueprint_harness create-worktree <name> --lightweight
+```
+
 Before non-backport work, check the branch role and release sync state:
 
 ```bash

--- a/project_template/.github/workflows/blueprint-pages.yml
+++ b/project_template/.github/workflows/blueprint-pages.yml
@@ -99,9 +99,6 @@ jobs:
           formalization_toolchain="${{ steps.harness.outputs.formalization_path }}/lean-toolchain"
           if [ -f "$formalization_toolchain" ]; then
             cp "$formalization_toolchain" lean-toolchain
-            if [ -f ".lake/packages/VersoBlueprint/lean-toolchain" ]; then
-              cp "$formalization_toolchain" ".lake/packages/VersoBlueprint/lean-toolchain"
-            fi
           fi
       - if: ${{ inputs.harness_enabled }}
         name: Validate harness contract

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -110,7 +110,8 @@ script map, not a second command reference.
 - `blueprint_harness_projects.py`
   Project-manifest loader and schema checks for
   [`tests/harness/projects.json`](../tests/harness/projects.json), including
-  branch-policy release-target inheritance and the external reference
+  branch-policy release-target inheritance, per-project RC resolution, shared
+  reference/deploy matrix serialization, and the external reference
   dependency-cache key.
 - `blueprint_harness_references.py`
   Reference-blueprint checkout, editable-clone setup, local override,

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -48,6 +48,7 @@ Common starting points:
 
 ```bash
 python3 -m scripts.blueprint_harness create-worktree <name> --owner codex --lock --priority P1 --summary "short description"
+python3 -m scripts.blueprint_harness create-worktree <name> --lightweight  # docs/Python-only work
 python3 -m scripts.blueprint_harness release-status --require-sync
 python3 -m scripts.blueprint_harness start-release-line 4.30-rc2
 python3 -m scripts.blueprint_harness set-default-dev-branch v4.30.0

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -53,11 +53,15 @@ from scripts.blueprint_harness_toolchains import bump_toolchain_checkout
 from scripts.blueprint_harness_utils import run
 from scripts.blueprint_harness_worktrees import (
     GitWorktree,
+    git_worktree_map,
     git_worktrees,
+    is_ancestor,
     normalize_priority,
+    ref_oid,
     resolve_worktree_name,
     sync_worktree_registry,
     update_worktree_record,
+    worktree_is_clean,
     worktree_record_map,
 )
 
@@ -204,20 +208,6 @@ def source_commit_series(repo_root: Path, source_branch: str) -> list[str]:
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
-def ref_oid(repo_root: Path, ref: str) -> str | None:
-    result = subprocess.run(
-        ["git", "rev-parse", "--verify", "--quiet", resolve_git_ref(repo_root, ref)],
-        cwd=repo_root,
-        check=False,
-        text=True,
-        capture_output=True,
-    )
-    if result.returncode != 0:
-        return None
-    oid = result.stdout.strip()
-    return oid or None
-
-
 def ref_sync_status(repo_root: Path, local_ref: str, upstream_ref: str) -> RefSyncStatus:
     local_oid = ref_oid(repo_root, local_ref)
     upstream_oid = ref_oid(repo_root, upstream_ref)
@@ -263,23 +253,6 @@ def ref_sync_status(repo_root: Path, local_ref: str, upstream_ref: str) -> RefSy
 def main_sync_status(repo_root: Path) -> RefSyncStatus:
     upstream_ref = preferred_main_ref(repo_root)
     return ref_sync_status(repo_root, local_release_ref(repo_root), upstream_ref)
-
-
-def is_ancestor(repo_root: Path, ancestor: str, descendant: str) -> bool:
-    return (
-        subprocess.run(
-            [
-                "git",
-                "merge-base",
-                "--is-ancestor",
-                resolve_git_ref(repo_root, ancestor),
-                resolve_git_ref(repo_root, descendant),
-            ],
-            cwd=repo_root,
-            check=False,
-        ).returncode
-        == 0
-    )
 
 
 def resolve_create_worktree_base(layout, requested_base: str | None) -> str:
@@ -328,10 +301,6 @@ def merged_clean_worktree_candidates(repo_root: Path, current_path: Path) -> lis
     return candidates
 
 
-def git_worktree_map(repo_root: Path) -> dict[str, GitWorktree]:
-    return {worktree.name: worktree for worktree in git_worktrees(repo_root)}
-
-
 def local_branch_ref(repo_root: Path, branch: str) -> str | None:
     ref = f"refs/heads/{branch}"
     if ref_oid(repo_root, ref) is None:
@@ -354,17 +323,6 @@ def origin_branch_exists(repo_root: Path, branch: str) -> bool:
 
 def branch_worktrees(repo_root: Path, branch: str) -> list[GitWorktree]:
     return [worktree for worktree in git_worktrees(repo_root) if worktree.branch == branch]
-
-
-def worktree_is_clean(path: Path) -> bool:
-    status = subprocess.run(
-        ["git", "status", "--short"],
-        cwd=path,
-        check=True,
-        text=True,
-        capture_output=True,
-    ).stdout.strip()
-    return not status
 
 
 def text_or_blank(value: object | None) -> str:

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from scripts.blueprint_harness_branches import (
     BranchPolicyReleaseTarget,
     CHECKOUT_ROLE_CHOICES,
-    ROOT_WORKTREE_NAME,
     active_release_branch,
     branch_policy_path,
     checkout_branch_role,

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -1110,13 +1110,8 @@ def command_worktree_release(args: argparse.Namespace) -> int:
     print(f"status={record.status}")
     return 0
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="python3 -m scripts.blueprint_harness",
-        description="Worktree, landing, and local coordination CLI for this repository.",
-    )
-    subparsers = parser.add_subparsers(dest="command", required=True)
 
+def add_release_management_commands(subparsers) -> None:
     sync_root_lake = subparsers.add_parser(
         "sync-root-lake",
         help="Sync `.lake/` from the root checkout into the current linked worktree.",
@@ -1190,6 +1185,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     main_status.set_defaults(func=command_main_status)
 
+
+def add_pr_preparation_commands(subparsers) -> None:
     prepare_backports = subparsers.add_parser(
         "prepare-backports",
         help="Print PR-body lines for the required backport plan on the current default-dev release line.",
@@ -1267,6 +1264,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     prepare_backport_pr.set_defaults(func=command_prepare_backport_pr)
 
+
+def add_landing_commands(subparsers) -> None:
     require_role = subparsers.add_parser(
         "require-branch-role",
         help="Exit nonzero unless the current checkout matches the requested branch-policy role.",
@@ -1304,6 +1303,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     land_main.set_defaults(func=command_land_main)
 
+
+def add_worktree_commands(subparsers) -> None:
     create_worktree = subparsers.add_parser(
         "create-worktree",
         help=(
@@ -1400,6 +1401,8 @@ def build_parser() -> argparse.ArgumentParser:
     worktree_release.add_argument("--summary", default=None, help="Optional final summary.")
     worktree_release.set_defaults(func=command_worktree_release)
 
+
+def add_path_commands(subparsers) -> None:
     paths = subparsers.add_parser(
         "paths",
         help="Print canonical and resolved worktree-aware harness paths.",
@@ -1410,6 +1413,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="Print site paths for every manifest project instead of only the current release selection.",
     )
     paths.set_defaults(func=command_paths)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python3 -m scripts.blueprint_harness",
+        description="Worktree, landing, and local coordination CLI for this repository.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    add_release_management_commands(subparsers)
+    add_pr_preparation_commands(subparsers)
+    add_landing_commands(subparsers)
+    add_worktree_commands(subparsers)
+    add_path_commands(subparsers)
     return parser
 
 

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass
 import json
 import re
 import shutil
@@ -12,15 +11,22 @@ from pathlib import Path
 from scripts.blueprint_harness_branches import (
     BranchPolicyReleaseTarget,
     CHECKOUT_ROLE_CHOICES,
+    RefSyncStatus,
     active_release_branch,
     branch_policy_path,
     checkout_branch_role,
     default_dev_branch,
     checkout_is_backport_only,
+    current_branch_name,
+    is_ancestor,
     load_branch_policy,
     local_release_ref,
+    main_sync_status,
+    preferred_main_ref,
     preferred_release_ref,
     require_checkout_role,
+    ref_oid,
+    ref_sync_status,
     resolve_git_ref,
     root_checkout_namespace,
     write_branch_policy,
@@ -55,9 +61,7 @@ from scripts.blueprint_harness_worktrees import (
     GitWorktree,
     git_worktree_map,
     git_worktrees,
-    is_ancestor,
     normalize_priority,
-    ref_oid,
     resolve_worktree_name,
     sync_worktree_registry,
     update_worktree_record,
@@ -73,15 +77,6 @@ PUBLIC_PR_TITLE_RE = re.compile(
 PUBLIC_PR_SCOPED_TITLE_RE = re.compile(
     r"^(" + "|".join(re.escape(title_type) for title_type in PUBLIC_PR_TITLE_TYPES) + r")\([^)]*\):"
 )
-
-
-@dataclass(frozen=True)
-class RefSyncStatus:
-    local_ref: str
-    upstream_ref: str
-    local_oid: str | None
-    upstream_oid: str | None
-    relationship: str
 
 
 def sync_root_worktree_lake(layout) -> None:
@@ -150,21 +145,6 @@ def branch_exists(repo_root: Path, branch: str) -> bool:
     )
 
 
-def preferred_main_ref(repo_root: Path) -> str:
-    return preferred_release_ref(repo_root)
-
-
-def current_branch_name(repo_root: Path) -> str | None:
-    branch = subprocess.run(
-        ["git", "branch", "--show-current"],
-        cwd=repo_root,
-        check=True,
-        text=True,
-        capture_output=True,
-    ).stdout.strip()
-    return branch or None
-
-
 def current_commit_subject(repo_root: Path) -> str:
     subject = subprocess.run(
         ["git", "log", "-1", "--format=%s"],
@@ -206,53 +186,6 @@ def source_commit_series(repo_root: Path, source_branch: str) -> list[str]:
         capture_output=True,
     )
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
-
-
-def ref_sync_status(repo_root: Path, local_ref: str, upstream_ref: str) -> RefSyncStatus:
-    local_oid = ref_oid(repo_root, local_ref)
-    upstream_oid = ref_oid(repo_root, upstream_ref)
-    local_git_ref = resolve_git_ref(repo_root, local_ref)
-    upstream_git_ref = resolve_git_ref(repo_root, upstream_ref)
-
-    if local_oid is None:
-        relationship = "missing_local"
-    elif upstream_oid is None:
-        relationship = "missing_upstream"
-    elif local_oid == upstream_oid:
-        relationship = "in_sync"
-    elif (
-        subprocess.run(
-            ["git", "merge-base", "--is-ancestor", local_git_ref, upstream_git_ref],
-            cwd=repo_root,
-            check=False,
-        ).returncode
-        == 0
-    ):
-        relationship = "behind"
-    elif (
-        subprocess.run(
-            ["git", "merge-base", "--is-ancestor", upstream_git_ref, local_git_ref],
-            cwd=repo_root,
-            check=False,
-        ).returncode
-        == 0
-    ):
-        relationship = "ahead"
-    else:
-        relationship = "diverged"
-
-    return RefSyncStatus(
-        local_ref=local_ref,
-        upstream_ref=upstream_ref,
-        local_oid=local_oid,
-        upstream_oid=upstream_oid,
-        relationship=relationship,
-    )
-
-
-def main_sync_status(repo_root: Path) -> RefSyncStatus:
-    upstream_ref = preferred_main_ref(repo_root)
-    return ref_sync_status(repo_root, local_release_ref(repo_root), upstream_ref)
 
 
 def resolve_create_worktree_base(layout, requested_base: str | None) -> str:

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -1305,6 +1305,11 @@ def add_landing_commands(subparsers) -> None:
 
 
 def add_worktree_commands(subparsers) -> None:
+    add_create_worktree_command(subparsers)
+    add_worktree_lifecycle_commands(subparsers)
+
+
+def add_create_worktree_command(subparsers) -> None:
     create_worktree = subparsers.add_parser(
         "create-worktree",
         help=(
@@ -1346,6 +1351,8 @@ def add_worktree_commands(subparsers) -> None:
     create_worktree.add_argument("--scope", action="append", default=None, help="Writable scope path. Repeat for multiple scopes.")
     create_worktree.set_defaults(func=command_create_worktree)
 
+
+def add_worktree_lifecycle_commands(subparsers) -> None:
     worktree_prune_candidates = subparsers.add_parser(
         "worktree-prune-candidates",
         help="List merged clean linked worktrees that are good prune candidates.",

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -1474,8 +1474,6 @@ def build_parser() -> argparse.ArgumentParser:
 
     worktree_list = subparsers.add_parser(
         "worktree-list",
-        aliases=["worktree-sync"],
-        description="Refresh and print the local worktree dashboard. `worktree-sync` is a compatibility alias.",
         help="Refresh and print the local worktree dashboard.",
     )
     worktree_list.set_defaults(func=command_worktree_list)

--- a/scripts/blueprint_harness_branches.py
+++ b/scripts/blueprint_harness_branches.py
@@ -44,6 +44,15 @@ class BranchPolicy:
     source_path: Path
 
 
+@dataclass(frozen=True)
+class RefSyncStatus:
+    local_ref: str
+    upstream_ref: str
+    local_oid: str | None
+    upstream_oid: str | None
+    relationship: str
+
+
 def active_release_branch(repo_root: Path) -> str:
     toolchain_path = repo_root / "lean-toolchain"
     if not toolchain_path.exists():
@@ -291,6 +300,85 @@ def resolve_git_ref(repo_root: Path, ref: str) -> str:
         if ref_exists(repo_root, candidate):
             return candidate
     return ref
+
+
+def ref_oid(repo_root: Path, ref: str) -> str | None:
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", resolve_git_ref(repo_root, ref)],
+        cwd=repo_root,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return None
+    oid = result.stdout.strip()
+    return oid or None
+
+
+def is_ancestor(repo_root: Path, ancestor: str, descendant: str) -> bool:
+    return (
+        subprocess.run(
+            [
+                "git",
+                "merge-base",
+                "--is-ancestor",
+                resolve_git_ref(repo_root, ancestor),
+                resolve_git_ref(repo_root, descendant),
+            ],
+            cwd=repo_root,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def preferred_main_ref(repo_root: Path) -> str:
+    return preferred_release_ref(repo_root)
+
+
+def current_branch_name(repo_root: Path) -> str | None:
+    branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=repo_root,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+    return branch or None
+
+
+def ref_sync_status(repo_root: Path, local_ref: str, upstream_ref: str) -> RefSyncStatus:
+    local_oid = ref_oid(repo_root, local_ref)
+    upstream_oid = ref_oid(repo_root, upstream_ref)
+    local_git_ref = resolve_git_ref(repo_root, local_ref)
+    upstream_git_ref = resolve_git_ref(repo_root, upstream_ref)
+
+    if local_oid is None:
+        relationship = "missing_local"
+    elif upstream_oid is None:
+        relationship = "missing_upstream"
+    elif local_oid == upstream_oid:
+        relationship = "in_sync"
+    elif is_ancestor(repo_root, local_git_ref, upstream_git_ref):
+        relationship = "behind"
+    elif is_ancestor(repo_root, upstream_git_ref, local_git_ref):
+        relationship = "ahead"
+    else:
+        relationship = "diverged"
+
+    return RefSyncStatus(
+        local_ref=local_ref,
+        upstream_ref=upstream_ref,
+        local_oid=local_oid,
+        upstream_oid=upstream_oid,
+        relationship=relationship,
+    )
+
+
+def main_sync_status(repo_root: Path) -> RefSyncStatus:
+    upstream_ref = preferred_main_ref(repo_root)
+    return ref_sync_status(repo_root, local_release_ref(repo_root), upstream_ref)
 
 
 def remote_head_ref(repo_root: Path) -> str | None:

--- a/scripts/blueprint_harness_paths.py
+++ b/scripts/blueprint_harness_paths.py
@@ -99,11 +99,6 @@ def canonical_reference_project_site_dir(project_id: str, start: Path | None = N
     return layout.reference_output_root / project_id / "html-multi"
 
 
-def canonical_test_blueprint_package_dir(name: str, start: Path | None = None) -> Path:
-    layout = detect_harness_layout(start)
-    return layout.package_root / "tests" / "test_blueprints" / name
-
-
 def canonical_test_blueprint_output_dir(name: str, start: Path | None = None) -> Path:
     layout = detect_harness_layout(start)
     return layout.test_blueprint_output_root / name

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -466,26 +466,36 @@ def project_target_verso_ref(release_target: HarnessReleaseTarget, project: Harn
     return release_candidate_ref(project.selected_rc) if project.selected_rc is not None else release_target.verso_ref
 
 
+def reference_project_target_fields(
+    project: HarnessProject,
+    release_target: HarnessReleaseTarget,
+) -> dict[str, object]:
+    return {
+        "project_id": project.project_id,
+        "rc": project_target_rc(project),
+        "toolchain": project_target_toolchain(release_target, project),
+        "verso_ref": project_target_verso_ref(release_target, project),
+        "project_root": project.project_root,
+        "hash": project.ref,
+        "reference_cache_key": reference_dependency_cache_key(project) if project.git_checkout else "",
+    }
+
+
 def reference_build_matrix(
     projects: list[HarnessProject],
     release_target: HarnessReleaseTarget,
 ) -> dict[str, list[dict[str, object]]]:
-    return {
-        "include": [
+    include: list[dict[str, object]] = []
+    for project in projects:
+        entry = reference_project_target_fields(project, release_target)
+        entry.update(
             {
-                "project_id": project.project_id,
-                "rc": project_target_rc(project),
-                "toolchain": project_target_toolchain(release_target, project),
-                "verso_ref": project_target_verso_ref(release_target, project),
-                "project_root": project.project_root,
-                "hash": project.ref,
-                "reference_cache_key": reference_dependency_cache_key(project) if project.git_checkout else "",
                 "artifact_name": reference_artifact_name(project),
                 "artifact_path": reference_artifact_path(project),
             }
-            for project in projects
-        ]
-    }
+        )
+        include.append(entry)
+    return {"include": include}
 
 
 DEPLOY_PROJECT_ARTIFACT_SEPARATOR = "__project__"
@@ -504,3 +514,97 @@ def deploy_project_artifact_path(project: HarnessProject) -> str:
     if project.selected_release is None:
         raise ValueError(f"project `{project.project_id}` is missing selected release metadata")
     return f"_out/reference-blueprints/{project.selected_release}/{project.project_id}"
+
+
+def release_target_manifest_entry(target: HarnessReleaseTarget) -> dict[str, object]:
+    return {
+        "id": target.release_id,
+        "toolchain": target.release_toolchain,
+        "verso_ref": target.release_verso_ref,
+        "branch": target.branch,
+        "deploy_pages": target.deploy_pages,
+    }
+
+
+def project_manifest_entry(project: HarnessProject) -> dict[str, object]:
+    if project.selected_release is None:
+        raise ValueError(f"project `{project.project_id}` is missing selected release metadata")
+
+    source: dict[str, object] = {
+        "kind": project.source_kind,
+        "project_root": project.project_root,
+    }
+    if project.repository is not None:
+        source["repository"] = project.repository
+
+    target: dict[str, object] = {"release": project.selected_release}
+    if project.ref is not None:
+        target["ref"] = project.ref
+    if project.selected_rc is not None:
+        target["rc"] = project.selected_rc
+
+    entry: dict[str, object] = {
+        "id": project.project_id,
+        "source": source,
+        "targets": [target],
+        "site_subdir": project.site_subdir,
+    }
+    if project.description is not None:
+        entry["description"] = project.description
+    if project.build_target is not None:
+        entry["build_target"] = project.build_target
+    if project.generator is not None:
+        entry["generator"] = project.generator
+    if project.build_command is not None:
+        entry["build_command"] = list(project.build_command)
+    if project.generate_command is not None:
+        entry["generate_command"] = list(project.generate_command)
+    validation: dict[str, object] = {}
+    if project.panel_regression_script is not None:
+        validation["panel_regression_script"] = project.panel_regression_script
+    if project.browser_tests_path is not None:
+        validation["browser_tests_path"] = project.browser_tests_path
+    if validation:
+        entry["validation"] = validation
+    return entry
+
+
+def deploy_project_manifest(target: HarnessReleaseTarget, project: HarnessProject) -> dict[str, object]:
+    return {
+        "version": 2,
+        "release_targets": [release_target_manifest_entry(target)],
+        "projects": [project_manifest_entry(project)],
+    }
+
+
+def deploy_matrix_from_controller_catalog(
+    controller_catalog: HarnessProjectCatalog,
+    deployable_targets: tuple[HarnessReleaseTarget, ...],
+) -> dict[str, list[dict[str, object]]]:
+    include: list[dict[str, object]] = []
+    for target in deployable_targets:
+        controller_projects = resolve_projects_for_release(controller_catalog, target.release_id, None)
+        if not controller_projects:
+            raise ValueError(
+                f"release target `{target.release_id}` has `deploy_pages: true` but no published "
+                "reference project targets"
+            )
+        for project in controller_projects:
+            fields = reference_project_target_fields(project, target)
+            include.append(
+                {
+                    "release_id": target.release_id,
+                    "rc": fields["rc"],
+                    "toolchain": fields["toolchain"],
+                    "verso_ref": fields["verso_ref"],
+                    "branch": target.branch,
+                    "project_id": fields["project_id"],
+                    "project_root": fields["project_root"],
+                    "hash": fields["hash"],
+                    "reference_cache_key": fields["reference_cache_key"],
+                    "artifact_name": deploy_project_artifact_name(project),
+                    "artifact_path": deploy_project_artifact_path(project),
+                    "project_manifest": deploy_project_manifest(target, project),
+                }
+            )
+    return {"include": include}

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -498,6 +498,27 @@ def reference_build_matrix(
     return {"include": include}
 
 
+def reference_release_payload(
+    manifest_path: Path,
+    catalog: HarnessProjectCatalog,
+    release: str | None,
+    package_root: Path,
+) -> dict[str, object]:
+    release_target = resolve_release_target(catalog, release, package_root)
+    projects = resolve_projects_for_release(catalog, release_target.release_id, None)
+    return {
+        "manifest_path": str(manifest_path),
+        "release_id": release_target.release_id,
+        "rc": "",
+        "toolchain": release_target.toolchain,
+        "verso_ref": release_target.verso_ref,
+        "branch": release_target.branch,
+        "deploy_pages": release_target.deploy_pages,
+        "reference_project_count": len(projects),
+        "reference_matrix": reference_build_matrix(projects, release_target),
+    }
+
+
 DEPLOY_PROJECT_ARTIFACT_SEPARATOR = "__project__"
 
 

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -28,7 +28,7 @@ from scripts.blueprint_harness_project_commands import (
     snapshot_tracked_project_manifest,
     tracked_project_manifest_path,
 )
-from scripts.blueprint_harness_utils import lean_low_priority_command, run
+from scripts.blueprint_harness_utils import format_command, lean_low_priority_command, run
 
 
 COMMIT_HASH_PATTERN = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
@@ -704,6 +704,40 @@ def bump_reference_project(
     )
 
 
+def reference_cache_warm_build_failure_message(
+    layout,
+    project: HarnessProject,
+    command: list[str],
+    err: subprocess.CalledProcessError,
+) -> str:
+    cache_key = reference_dependency_cache_key(project)
+    source_cache = reference_source_cache_checkout_dir(layout, project)
+    dependency_cache = reference_dependency_packages_dir(layout, project)
+    return "\n".join(
+        [
+            (
+                f"[blueprint-harness] failed to warm reference cache for `{project.project_id}` "
+                f"({cache_key}); command exited with code {err.returncode}: {format_command(command)}"
+            ),
+            f"[blueprint-harness] source cache: {source_cache}",
+            f"[blueprint-harness] dependency package cache: {dependency_cache}",
+            (
+                "[blueprint-harness] stale or cross-toolchain Lake build artifacts in the shared "
+                "reference cache can cause incompatible `.olean` header errors."
+            ),
+            (
+                "[blueprint-harness] for docs/Python-only work, create the checkout with "
+                "`python3 -m scripts.blueprint_harness create-worktree <name> --lightweight`."
+            ),
+            (
+                "[blueprint-harness] to inspect or remove stale reference caches, run "
+                "`python3 -m scripts.blueprint_reference_harness prune --dry-run`, then "
+                "`python3 -m scripts.blueprint_reference_harness prune` if the listed paths are disposable."
+            ),
+        ]
+    )
+
+
 def sync_reference_cache_checkout(
     layout,
     project: HarnessProject,
@@ -732,7 +766,11 @@ def sync_reference_cache_checkout(
         with local_blueprint_dependency_override(layout.package_root, project_dir, restore_lakefile=True):
             run_reference_lake_update(layout.package_root, project_dir)
             if warm_build and project.build_command is not None:
-                run(lean_low_priority_command(layout.package_root, *project.build_command), cwd=project_dir)
+                command = lean_low_priority_command(layout.package_root, *project.build_command)
+                try:
+                    run(command, cwd=project_dir)
+                except subprocess.CalledProcessError as err:
+                    raise SystemExit(reference_cache_warm_build_failure_message(layout, project, command, err)) from err
             if store_lake_packages_in_dependency_cache(layout, project, project_dir, package_mode=package_mode) is not None:
                 # The dependency cache is now the source of truth. Drop the warmed
                 # cache checkout copy so large external projects do not keep two

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -26,7 +26,6 @@ from scripts.blueprint_harness_project_commands import (
     rewrite_pinned_blueprint_dependency,
     run_project_update_build_generate,
     snapshot_tracked_project_manifest,
-    tracked_project_manifest_path,
 )
 from scripts.blueprint_harness_utils import format_command, lean_low_priority_command, run
 

--- a/scripts/blueprint_harness_worktrees.py
+++ b/scripts/blueprint_harness_worktrees.py
@@ -6,7 +6,13 @@ import json
 from pathlib import Path
 import subprocess
 
-from scripts.blueprint_harness_branches import ROOT_WORKTREE_NAME, preferred_release_ref, resolve_git_ref
+from scripts.blueprint_harness_branches import (
+    ROOT_WORKTREE_NAME,
+    is_ancestor,
+    preferred_release_ref,
+    ref_oid,
+    resolve_git_ref,
+)
 
 
 ROOT_METADATA_FILENAME = "_root.json"
@@ -220,37 +226,6 @@ def save_registry(repo_root: Path, records: list[WorktreeRecord]) -> Path:
     }
     path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     return path
-
-
-def ref_oid(repo_root: Path, ref: str) -> str | None:
-    result = subprocess.run(
-        ["git", "rev-parse", "--verify", "--quiet", resolve_git_ref(repo_root, ref)],
-        cwd=repo_root,
-        check=False,
-        text=True,
-        capture_output=True,
-    )
-    if result.returncode != 0:
-        return None
-    oid = result.stdout.strip()
-    return oid or None
-
-
-def is_ancestor(repo_root: Path, ancestor: str, descendant: str) -> bool:
-    return (
-        subprocess.run(
-            [
-                "git",
-                "merge-base",
-                "--is-ancestor",
-                resolve_git_ref(repo_root, ancestor),
-                resolve_git_ref(repo_root, descendant),
-            ],
-            cwd=repo_root,
-            check=False,
-        ).returncode
-        == 0
-    )
 
 
 def ref_merged_into_base(repo_root: Path, ref: str, base_ref: str) -> bool:

--- a/scripts/blueprint_harness_worktrees.py
+++ b/scripts/blueprint_harness_worktrees.py
@@ -181,6 +181,10 @@ def git_worktrees(repo_root: Path) -> list[GitWorktree]:
     return parse_git_worktree_porcelain(result.stdout, repo_root)
 
 
+def git_worktree_map(repo_root: Path) -> dict[str, GitWorktree]:
+    return {worktree.name: worktree for worktree in git_worktrees(repo_root)}
+
+
 def load_record(path: Path) -> WorktreeMetadata | None:
     if not path.exists():
         return None
@@ -299,6 +303,11 @@ def worktree_status_counts(path: Path) -> tuple[bool, int, int]:
     tracked_changes = sum(1 for line in lines if not line.startswith("??"))
     untracked_changes = sum(1 for line in lines if line.startswith("??"))
     return bool(lines), tracked_changes, untracked_changes
+
+
+def worktree_is_clean(path: Path) -> bool:
+    dirty, _tracked_changes, _untracked_changes = worktree_status_counts(path)
+    return not dirty
 
 
 def worktree_last_commit(path: Path) -> tuple[str | None, str | None, str | None]:

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -347,6 +347,30 @@ def collect_reference_project_status(layout, project: HarnessProject, *, bluepri
     )
 
 
+def reference_project_status_or_error(
+    layout,
+    project: HarnessProject,
+    *,
+    blueprint_base_ref: str,
+) -> ReferenceProjectStatus:
+    try:
+        return collect_reference_project_status(layout, project, blueprint_base_ref=blueprint_base_ref)
+    except (subprocess.CalledProcessError, json.JSONDecodeError, OSError, ValueError) as err:
+        return ReferenceProjectStatus(
+            project=project,
+            catalog_ref=None,
+            project_upstream_ref=None,
+            project_relationship=None,
+            project_ahead=None,
+            project_behind=None,
+            blueprint_pin=None,
+            blueprint_relationship=None,
+            blueprint_ahead=None,
+            blueprint_behind=None,
+            error=str(err),
+        )
+
+
 def project_target_status_fields(release_target: HarnessReleaseTarget, project: HarnessProject) -> list[str]:
     return [
         f"rc={project_target_rc(project)}",
@@ -699,6 +723,68 @@ def command_generate(args: argparse.Namespace) -> int:
     return 0
 
 
+def lean_test_validation_failures(layout, *, use_local_build: bool) -> list[StepFailure]:
+    if use_local_build:
+        failure = run_capturing_failure(
+            "lean tests",
+            lean_test_runner(layout.package_root),
+            cwd=layout.package_root,
+        )
+        return [failure] if failure is not None else []
+
+    test_artifact = find_prebuilt_lean_test_artifact(layout.package_root)
+    if test_artifact is None:
+        return [
+            StepFailure(
+                "lean tests",
+                "no prebuilt Lean test library found in the current worktree `.lake/`; "
+                "run `python3 -m scripts.blueprint_harness sync-root-lake` after "
+                "building from the root checkout, or use `--allow-local-build`",
+            )
+        ]
+
+    print(f"[blueprint-reference-harness] using prebuilt Lean test library: {test_artifact}")
+    return []
+
+
+def project_validation_failures(
+    layout,
+    output_root: Path,
+    projects: list[HarnessProject],
+    *,
+    skip_panel_regression: bool,
+    skip_browser_tests: bool,
+    pytest_args: list[str],
+    stop_on_first_failure: bool,
+) -> list[StepFailure]:
+    failures: list[StepFailure] = []
+    for project in projects:
+        site_dir = site_dir_for(project, output_root)
+        if project.panel_regression_script is not None and not skip_panel_regression:
+            failure = run_capturing_failure(
+                f"{project.project_id} panel regression",
+                panel_regression_command(layout.package_root, project.panel_regression_script or "", site_dir),
+                cwd=layout.package_root,
+            )
+            if failure is not None:
+                failures.append(failure)
+                if stop_on_first_failure:
+                    return failures
+
+        if project.browser_tests_path is not None and not skip_browser_tests:
+            failure = run_capturing_failure(
+                f"{project.project_id} browser tests",
+                browser_test_command(layout.package_root, project.browser_tests_path or "", site_dir, pytest_args),
+                cwd=layout.package_root,
+            )
+            if failure is not None:
+                failures.append(failure)
+                if stop_on_first_failure:
+                    return failures
+
+    return failures
+
+
 def command_validate(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
     require_safe_root_main(layout, allow_unsafe=args.allow_unsafe_root_release, command_name="validate")
@@ -718,31 +804,9 @@ def command_validate(args: argparse.Namespace) -> int:
     print(f"[blueprint-reference-harness] release target: {release_id}")
     use_local_build = should_use_local_build(layout, args.allow_local_build)
     if args.run_lean_tests:
-        if use_local_build:
-            failure = run_capturing_failure(
-                "lean tests",
-                lean_test_runner(layout.package_root),
-                cwd=layout.package_root,
-            )
-            if failure is not None:
-                failures.append(failure)
-                if args.stop_on_first_failure:
-                    return print_failure_summary(failures, prefix=REFERENCE_HARNESS_PREFIX)
-        else:
-            test_artifact = find_prebuilt_lean_test_artifact(layout.package_root)
-            if test_artifact is None:
-                failures.append(
-                    StepFailure(
-                        "lean tests",
-                        "no prebuilt Lean test library found in the current worktree `.lake/`; "
-                        "run `python3 -m scripts.blueprint_harness sync-root-lake` after "
-                        "building from the root checkout, or use `--allow-local-build`",
-                    )
-                )
-                if args.stop_on_first_failure:
-                    return print_failure_summary(failures, prefix=REFERENCE_HARNESS_PREFIX)
-            else:
-                print(f"[blueprint-reference-harness] using prebuilt Lean test library: {test_artifact}")
+        failures.extend(lean_test_validation_failures(layout, use_local_build=use_local_build))
+        if failures and args.stop_on_first_failure:
+            return print_failure_summary(failures, prefix=REFERENCE_HARNESS_PREFIX)
 
     try:
         generate_projects(
@@ -758,29 +822,17 @@ def command_validate(args: argparse.Namespace) -> int:
         failures.append(StepFailure("generate projects", str(err)))
         return print_failure_summary(failures, prefix=REFERENCE_HARNESS_PREFIX)
 
-    for project in projects:
-        site_dir = site_dir_for(project, output_root)
-        if project.panel_regression_script is not None and not args.skip_panel_regression:
-            failure = run_capturing_failure(
-                f"{project.project_id} panel regression",
-                panel_regression_command(layout.package_root, project.panel_regression_script or "", site_dir),
-                cwd=layout.package_root,
-            )
-            if failure is not None:
-                failures.append(failure)
-                if args.stop_on_first_failure:
-                    return print_failure_summary(failures, prefix=REFERENCE_HARNESS_PREFIX)
-
-        if project.browser_tests_path is not None and not args.skip_browser_tests:
-            failure = run_capturing_failure(
-                f"{project.project_id} browser tests",
-                browser_test_command(layout.package_root, project.browser_tests_path or "", site_dir, args.pytest_arg),
-                cwd=layout.package_root,
-            )
-            if failure is not None:
-                failures.append(failure)
-                if args.stop_on_first_failure:
-                    return print_failure_summary(failures, prefix=REFERENCE_HARNESS_PREFIX)
+    failures.extend(
+        project_validation_failures(
+            layout,
+            output_root,
+            projects,
+            skip_panel_regression=args.skip_panel_regression,
+            skip_browser_tests=args.skip_browser_tests,
+            pytest_args=args.pytest_arg,
+            stop_on_first_failure=args.stop_on_first_failure,
+        )
+    )
 
     return print_failure_summary(failures, prefix=REFERENCE_HARNESS_PREFIX)
 
@@ -843,23 +895,10 @@ def command_status(args: argparse.Namespace) -> int:
     print(f"{main_status.upstream_ref}_oid={main_status.upstream_oid or ''}")
 
     for project in projects:
-        try:
-            status = collect_reference_project_status(layout, project, blueprint_base_ref=release_branch)
-        except (subprocess.CalledProcessError, json.JSONDecodeError, OSError, ValueError) as err:
-            status = ReferenceProjectStatus(
-                project=project,
-                catalog_ref=None,
-                project_upstream_ref=None,
-                project_relationship=None,
-                project_ahead=None,
-                project_behind=None,
-                blueprint_pin=None,
-                blueprint_relationship=None,
-                blueprint_ahead=None,
-                blueprint_behind=None,
-                error=str(err),
-            )
-        print_reference_project_status(status, release_target)
+        print_reference_project_status(
+            reference_project_status_or_error(layout, project, blueprint_base_ref=release_branch),
+            release_target,
+        )
     return 0
 
 
@@ -891,37 +930,16 @@ def command_release_status(args: argparse.Namespace) -> int:
         if args.project is not None and not projects:
             continue
 
-        statuses: list[ReferenceProjectStatus] = []
-        for project in projects:
-            try:
-                status = collect_reference_project_status(
-                    layout,
-                    project,
-                    blueprint_base_ref=release_target.branch,
-                )
-            except (subprocess.CalledProcessError, json.JSONDecodeError, OSError, ValueError) as err:
-                status = ReferenceProjectStatus(
-                    project=project,
-                    catalog_ref=None,
-                    project_upstream_ref=None,
-                    project_relationship=None,
-                    project_ahead=None,
-                    project_behind=None,
-                    blueprint_pin=None,
-                    blueprint_relationship=None,
-                    blueprint_ahead=None,
-                    blueprint_behind=None,
-                    error=str(err),
-                )
-            statuses.append(status)
-
         summary = ReleaseTargetStatus(
             release_id=release_target.release_id,
             toolchain=release_target.toolchain,
             verso_ref=release_target.verso_ref,
             branch=release_target.branch,
             deploy_pages=release_target.deploy_pages,
-            project_statuses=tuple(statuses),
+            project_statuses=tuple(
+                reference_project_status_or_error(layout, project, blueprint_base_ref=release_target.branch)
+                for project in projects
+            ),
         )
         if args.outdated_only and not any(status_has_catalog_issue(status) for status in summary.project_statuses):
             continue

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -1092,13 +1092,8 @@ def command_reference_prune(args: argparse.Namespace) -> int:
     print(f"[blueprint-reference-harness] reference prune: removed {len(removals)} path(s)")
     return 0
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="python3 -m scripts.blueprint_reference_harness",
-        description="Reference blueprint generation, validation, and checkout lifecycle CLI.",
-    )
-    subparsers = parser.add_subparsers(dest="command", required=True)
 
+def add_generation_commands(subparsers) -> None:
     generate = subparsers.add_parser(
         "generate",
         help="Build the selected blueprint harness projects.",
@@ -1164,6 +1159,8 @@ def build_parser() -> argparse.ArgumentParser:
     add_reference_package_mode_argument(validate)
     validate.set_defaults(func=command_validate)
 
+
+def add_reporting_commands(subparsers) -> None:
     projects = subparsers.add_parser(
         "projects",
         help="List the configured harness projects from the active manifest.",
@@ -1209,6 +1206,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     release_status.set_defaults(func=command_release_status)
 
+
+def add_checkout_sync_commands(subparsers) -> None:
     sync = subparsers.add_parser(
         "sync",
         help="Warm shared reference dependency caches and prepare local clones for the current checkout.",
@@ -1251,6 +1250,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     edit.set_defaults(func=command_reference_edit)
 
+
+def add_bump_command(subparsers) -> None:
     bump = subparsers.add_parser(
         "bump-verso-blueprint",
         help="Rewrite the pinned `VersoBlueprint` ref in editable external reference checkouts.",
@@ -1303,6 +1304,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     bump.set_defaults(func=command_reference_bump_blueprint)
 
+
+def add_prune_command(subparsers) -> None:
     prune = subparsers.add_parser(
         "prune",
         help="Remove stale harness-managed reference dependency caches and checkout clones.",
@@ -1314,6 +1317,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="List stale paths without deleting them.",
     )
     prune.set_defaults(func=command_reference_prune)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python3 -m scripts.blueprint_reference_harness",
+        description="Reference blueprint generation, validation, and checkout lifecycle CLI.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    add_generation_commands(subparsers)
+    add_reporting_commands(subparsers)
+    add_checkout_sync_commands(subparsers)
+    add_bump_command(subparsers)
+    add_prune_command(subparsers)
 
     return parser
 

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -379,15 +379,18 @@ def project_target_status_fields(release_target: HarnessReleaseTarget, project: 
     ]
 
 
+def project_source(project: HarnessProject) -> str:
+    return f"in_repo:{project.project_root}" if project.in_repo_project else f"git:{project.repository}@{project.ref}"
+
+
 def print_reference_project_status(
     status: ReferenceProjectStatus,
     release_target: HarnessReleaseTarget | None = None,
 ) -> None:
     project = status.project
-    source = f"in_repo:{project.project_root}" if project.in_repo_project else f"git:{project.repository}@{project.ref}"
     fields = [
         project.project_id,
-        f"source={source}",
+        f"source={project_source(project)}",
         f"catalog_ref={text_or_blank(status.catalog_ref)}",
         f"project_upstream_ref={text_or_blank(status.project_upstream_ref)}",
         f"catalog_status={text_or_blank(status.project_relationship)}",
@@ -446,11 +449,10 @@ def print_release_target_summary(status: ReleaseTargetStatus) -> None:
 
 def print_release_target_project_status(release_target: HarnessReleaseTarget, status: ReferenceProjectStatus) -> None:
     project = status.project
-    source = f"in_repo:{project.project_root}" if project.in_repo_project else f"git:{project.repository}@{project.ref}"
     fields = [
         f"release={release_target.release_id}",
         f"project={project.project_id}",
-        f"source={source}",
+        f"source={project_source(project)}",
         *project_target_status_fields(release_target, project),
         f"catalog_ref={text_or_blank(status.catalog_ref)}",
         f"project_upstream_ref={text_or_blank(status.project_upstream_ref)}",
@@ -499,6 +501,30 @@ def select_release_projects(
     except ValueError as err:
         raise SystemExit(f"[blueprint-reference-harness] {err}") from err
     return selected_release.release_id, projects
+
+
+def load_reference_catalog_for_args(layout, args: argparse.Namespace):
+    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
+    return manifest_path, load_project_catalog(manifest_path)
+
+
+def select_reference_projects_from_args(
+    layout,
+    args: argparse.Namespace,
+    *,
+    project_ids: list[str] | None = None,
+    default_to_published_catalog: bool = True,
+):
+    manifest_path, catalog = load_reference_catalog_for_args(layout, args)
+    selection_args = {
+        "release": args.release,
+        "project_ids": args.project if project_ids is None else project_ids,
+        "package_root": layout.package_root,
+    }
+    if not default_to_published_catalog:
+        selection_args["default_to_published_catalog"] = False
+    release_id, projects = select_release_projects(catalog, **selection_args)
+    return manifest_path, catalog, release_id, projects
 
 
 def require_checkout_release(layout, release_id: str, *, command_name: str) -> None:
@@ -576,9 +602,7 @@ def ensure_prebuilt_executable(package_root: Path, exe_name: str) -> Path:
 
 def find_prebuilt_lean_test_artifact(package_root: Path) -> Path | None:
     path = package_root / ".lake" / "build" / "lib" / "lean" / "VersoBlueprintTests.olean"
-    if path.exists():
-        return path
-    return None
+    return path if path.exists() else None
 
 
 def lean_test_runner(package_root: Path) -> list[str]:
@@ -695,14 +719,7 @@ def command_generate(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
     require_safe_root_main(layout, allow_unsafe=args.allow_unsafe_root_release, command_name="generate")
     output_root = resolve_output_root(selected_output_root(args), Path(__file__))
-    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
-    catalog = load_project_catalog(manifest_path)
-    release_id, projects = select_release_projects(
-        catalog,
-        release=args.release,
-        project_ids=args.project,
-        package_root=layout.package_root,
-    )
+    manifest_path, _catalog, release_id, projects = select_reference_projects_from_args(layout, args)
     require_checkout_release(layout, release_id, command_name="generate")
 
     generate_projects(
@@ -789,14 +806,7 @@ def command_validate(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
     require_safe_root_main(layout, allow_unsafe=args.allow_unsafe_root_release, command_name="validate")
     output_root = resolve_output_root(selected_output_root(args), Path(__file__))
-    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
-    catalog = load_project_catalog(manifest_path)
-    release_id, projects = select_release_projects(
-        catalog,
-        release=args.release,
-        project_ids=args.project,
-        package_root=layout.package_root,
-    )
+    _manifest_path, _catalog, release_id, projects = select_reference_projects_from_args(layout, args)
     require_checkout_release(layout, release_id, command_name="validate")
     failures: list[StepFailure] = []
 
@@ -839,31 +849,19 @@ def command_validate(args: argparse.Namespace) -> int:
 
 def command_projects(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
-    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
-    catalog = load_project_catalog(manifest_path)
-    release_id, projects = select_release_projects(
-        catalog,
-        release=args.release,
-        project_ids=args.project,
-        package_root=layout.package_root,
-    )
+    manifest_path, catalog, release_id, projects = select_reference_projects_from_args(layout, args)
     release_target = resolve_release_target(catalog, release_id, layout.package_root)
     print(f"project_manifest={manifest_path}")
     print(f"release_target={release_id}")
     for project in projects:
-        if project.in_repo_project:
-            source = f"in_repo:{project.project_root}"
-        else:
-            source = f"git:{project.repository}@{project.ref}"
-        validations: list[str] = []
-        if project.panel_regression_script is not None:
-            validations.append("panel")
-        if project.browser_tests_path is not None:
-            validations.append("browser")
-        validation_text = ",".join(validations) if validations else "none"
+        validation_text = ",".join(
+            name
+            for name, enabled in (("panel", project.panel_regression_script), ("browser", project.browser_tests_path))
+            if enabled is not None
+        ) or "none"
         fields = [
             project.project_id,
-            f"source={source}",
+            f"source={project_source(project)}",
             *project_target_status_fields(release_target, project),
             f"validations={validation_text}",
         ]
@@ -873,14 +871,7 @@ def command_projects(args: argparse.Namespace) -> int:
 
 def command_status(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
-    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
-    catalog = load_project_catalog(manifest_path)
-    release_id, projects = select_release_projects(
-        catalog,
-        release=args.release,
-        project_ids=args.project,
-        package_root=layout.package_root,
-    )
+    manifest_path, catalog, release_id, projects = select_reference_projects_from_args(layout, args)
     require_checkout_release(layout, release_id, command_name="status")
     release_target = resolve_release_target(catalog, release_id, layout.package_root)
     release_branch = release_target.branch
@@ -904,8 +895,7 @@ def command_status(args: argparse.Namespace) -> int:
 
 def command_release_status(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
-    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
-    catalog = load_project_catalog(manifest_path)
+    manifest_path, catalog = load_reference_catalog_for_args(layout, args)
     releases = selected_release_targets(catalog, args.release, layout.package_root)
     known_project_ids = {project.project_id for project in catalog.projects}
     if args.project is not None:
@@ -955,14 +945,7 @@ def command_release_status(args: argparse.Namespace) -> int:
 def command_reference_sync(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
     require_safe_root_main(layout, allow_unsafe=args.allow_unsafe_root_release, command_name="sync")
-    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
-    catalog = load_project_catalog(manifest_path)
-    release_id, projects = select_release_projects(
-        catalog,
-        release=args.release,
-        project_ids=args.project,
-        package_root=layout.package_root,
-    )
+    _manifest_path, _catalog, release_id, projects = select_reference_projects_from_args(layout, args)
     require_checkout_release(layout, release_id, command_name="sync")
     sync_reference_blueprints(
         layout,
@@ -979,13 +962,10 @@ def command_reference_sync(args: argparse.Namespace) -> int:
 
 def command_reference_edit(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
-    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
-    catalog = load_project_catalog(manifest_path)
-    release_id, projects = select_release_projects(
-        catalog,
-        release=args.release,
+    _manifest_path, _catalog, release_id, projects = select_reference_projects_from_args(
+        layout,
+        args,
         project_ids=[args.project],
-        package_root=layout.package_root,
     )
     project = projects[0]
     if not project.git_checkout:
@@ -1009,24 +989,15 @@ def command_reference_edit(args: argparse.Namespace) -> int:
 
 def command_reference_bump_blueprint(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
-    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
-    catalog = load_project_catalog(manifest_path)
-    release_id, selected_projects = select_release_projects(
-        catalog,
-        release=args.release,
-        project_ids=args.project,
-        package_root=layout.package_root,
+    _manifest_path, _catalog, release_id, selected_projects = select_reference_projects_from_args(
+        layout,
+        args,
         default_to_published_catalog=False,
     )
-    projects: list[HarnessProject] = []
-    for project in selected_projects:
-        if not project.git_checkout:
-            if args.project is not None:
-                raise SystemExit(
-                    f"[blueprint-reference-harness] project `{project.project_id}` is not an external git checkout project"
-                )
-            continue
-        projects.append(project)
+    projects = [project for project in selected_projects if project.git_checkout]
+    if args.project is not None and len(projects) != len(selected_projects):
+        project = next(project for project in selected_projects if not project.git_checkout)
+        raise SystemExit(f"[blueprint-reference-harness] project `{project.project_id}` is not an external git checkout project")
     if not projects:
         raise SystemExit(f"[blueprint-reference-harness] release target `{release_id}` has no external git checkout projects")
     failures: list[StepFailure] = []
@@ -1084,8 +1055,8 @@ def command_reference_bump_blueprint(args: argparse.Namespace) -> int:
 
 def command_reference_prune(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
-    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
-    projects = load_project_catalog(manifest_path).projects
+    _manifest_path, catalog = load_reference_catalog_for_args(layout, args)
+    projects = catalog.projects
     active_names = {
         root_checkout_namespace(layout.repo_root) if worktree.root_checkout else worktree.name
         for worktree in git_worktrees(layout.repo_root)

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -9,8 +9,15 @@ import shutil
 import subprocess
 import sys
 
-from scripts.blueprint_harness_branches import active_release_branch, local_release_ref, root_checkout_namespace
-from scripts.blueprint_harness import current_branch_name, main_sync_status, ref_oid, ref_sync_status, worktree_is_clean
+from scripts.blueprint_harness_branches import (
+    active_release_branch,
+    current_branch_name,
+    local_release_ref,
+    main_sync_status,
+    ref_oid,
+    ref_sync_status,
+    root_checkout_namespace,
+)
 from scripts.blueprint_harness_cli import (
     add_allow_local_build_argument,
     add_allow_unsafe_root_main_argument,
@@ -62,7 +69,7 @@ from scripts.blueprint_harness_utils import (
     run_capturing_failure,
 )
 from scripts.blueprint_harness_validation import browser_test_command, panel_regression_command
-from scripts.blueprint_harness_worktrees import git_worktrees, rev_list_counts
+from scripts.blueprint_harness_worktrees import git_worktrees, rev_list_counts, worktree_is_clean
 
 
 @dataclass(frozen=True)

--- a/scripts/blueprint_test_blueprints.py
+++ b/scripts/blueprint_test_blueprints.py
@@ -40,6 +40,138 @@ from scripts.blueprint_harness_validation import browser_test_command, panel_reg
 
 TAG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 TEST_BLUEPRINT_HARNESS_PREFIX = "[blueprint-test-blueprints]"
+TEST_BLUEPRINT_INDEX_CSS = """      :root {
+        color-scheme: light;
+        --bg: #f8fafc;
+        --panel: #ffffff;
+        --text: #0f172a;
+        --muted: #475569;
+        --border: #cbd5e1;
+        --accent: #0f766e;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font-family: ui-sans-serif, system-ui, sans-serif;
+        background: linear-gradient(180deg, #f8fafc, #eef2ff 45%, #f8fafc);
+        color: var(--text);
+      }
+      main {
+        width: min(70rem, calc(100% - 2rem));
+        margin: 0 auto;
+        padding: 2rem 0 3rem;
+      }
+      header {
+        margin-bottom: 1.5rem;
+      }
+      h1 {
+        margin: 0 0 0.5rem;
+        font-size: clamp(2rem, 4vw, 2.75rem);
+      }
+      .lede {
+        margin: 0;
+        max-width: 54rem;
+        color: var(--muted);
+        line-height: 1.5;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+        gap: 1rem;
+      }
+      .chip_row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.55rem;
+        margin: 1.1rem 0 1.6rem;
+      }
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        background: var(--panel);
+        padding: 0.35rem 0.7rem;
+        font-size: 0.92rem;
+        font-weight: 600;
+        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.05);
+      }
+      .category_section + .category_section {
+        margin-top: 1.8rem;
+      }
+      .category_header {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.5rem 1rem;
+        margin-bottom: 0.9rem;
+      }
+      .category_header h2 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+      .category_header p {
+        margin: 0;
+        color: var(--muted);
+        font-size: 0.92rem;
+      }
+      .card {
+        border: 1px solid var(--border);
+        border-radius: 1rem;
+        background: var(--panel);
+        padding: 1rem 1.05rem;
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+      }
+      .card h2 {
+        margin: 0 0 0.4rem;
+        font-size: 1.05rem;
+      }
+      .category {
+        margin: 0.25rem 0 0;
+        color: var(--accent);
+        font-size: 0.78rem;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      .kind {
+        margin: 0.2rem 0 0;
+        color: var(--muted);
+        font-size: 0.78rem;
+        font-style: italic;
+      }
+      .card p {
+        margin: 0.45rem 0 0;
+        line-height: 1.45;
+      }
+      .slug {
+        color: var(--muted);
+        font-size: 0.9rem;
+      }
+      .tag_list {
+        list-style: none;
+        padding: 0;
+        margin: 0.65rem 0 0;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.45rem;
+      }
+      .tag_list li {
+        border: 1px solid #d8dee9;
+        border-radius: 999px;
+        background: #f8fafc;
+        color: var(--muted);
+        padding: 0.2rem 0.55rem;
+        font-size: 0.78rem;
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }"""
 
 
 @dataclass(frozen=True)
@@ -191,21 +323,21 @@ def test_blueprint_index_entries(
     return [meta_by_slug[slug] for slug in selected_slugs if slug in meta_by_slug]
 
 
-def render_test_blueprint_index_html(category_order: tuple[str, ...], entries: list[dict[str, object]]) -> str:
-    cards_by_category = {category: [] for category in category_order}
-    for entry in entries:
-        category = str(entry.get("category", "Uncategorized"))
-        slug = str(entry["slug"])
-        title = str(entry["title"])
-        summary = str(entry["summary"])
-        tags = entry.get("tags", [])
-        kind = str(entry.get("kind", "curated_doc")).replace("_", " ")
-        tags_html = ""
-        if tags:
-            tag_chips = "".join(f'<li>{tag}</li>' for tag in tags)
-            tags_html = f'<ul class="tag_list">{tag_chips}</ul>'
-        cards_by_category.setdefault(category, []).append(
-            f"""
+def render_test_blueprint_tag_list(tags: object) -> str:
+    if not tags:
+        return ""
+    tag_chips = "".join(f"<li>{tag}</li>" for tag in tags)
+    return f'<ul class="tag_list">{tag_chips}</ul>'
+
+
+def render_test_blueprint_card(entry: dict[str, object]) -> str:
+    category = str(entry.get("category", "Uncategorized"))
+    slug = str(entry["slug"])
+    title = str(entry["title"])
+    summary = str(entry["summary"])
+    kind = str(entry.get("kind", "curated_doc")).replace("_", " ")
+    tags_html = render_test_blueprint_tag_list(entry.get("tags", []))
+    return f"""
         <article class="card">
           <h2><a href="./{slug}/html-multi/">{title}</a></h2>
           <p class="category">{category}</p>
@@ -216,30 +348,52 @@ def render_test_blueprint_index_html(category_order: tuple[str, ...], entries: l
           <p><a href="./{slug}/html-multi/">Open site</a></p>
         </article>
         """
-        )
 
-    nav_links = []
-    sections = []
-    for category in category_order:
-        cards = cards_by_category.get(category, [])
-        if not cards:
-            continue
-        anchor = category.lower().replace(" ", "-")
-        nav_links.append(f'<a class="chip" href="#{anchor}">{category}</a>')
-        sections.append(
-            f"""
-        <section class="category_section" id="{anchor}">
+
+def category_anchor(category: str) -> str:
+    return category.lower().replace(" ", "-")
+
+
+def group_test_blueprint_cards(
+    category_order: tuple[str, ...],
+    entries: list[dict[str, object]],
+) -> dict[str, list[str]]:
+    cards_by_category = {category: [] for category in category_order}
+    for entry in entries:
+        category = str(entry.get("category", "Uncategorized"))
+        cards_by_category.setdefault(category, []).append(render_test_blueprint_card(entry))
+    return cards_by_category
+
+
+def render_test_blueprint_nav(categories: list[str]) -> str:
+    return "".join(
+        f'<a class="chip" href="#{category_anchor(category)}">{category}</a>'
+        for category in categories
+    )
+
+
+def render_test_blueprint_category_section(category: str, cards: list[str]) -> str:
+    site_count = f"{len(cards)} site{'s' if len(cards) != 1 else ''}"
+    return f"""
+        <section class="category_section" id="{category_anchor(category)}">
           <div class="category_header">
             <h2>{category}</h2>
-            <p>{len(cards)} site{'s' if len(cards) != 1 else ''}</p>
+            <p>{site_count}</p>
           </div>
           <div class="grid">
             {''.join(cards)}
           </div>
         </section>
         """
-        )
 
+
+def render_test_blueprint_index_html(category_order: tuple[str, ...], entries: list[dict[str, object]]) -> str:
+    cards_by_category = group_test_blueprint_cards(category_order, entries)
+    visible_categories = [category for category in category_order if cards_by_category.get(category)]
+    sections_html = "".join(
+        render_test_blueprint_category_section(category, cards_by_category[category])
+        for category in visible_categories
+    )
     return f"""<!doctype html>
 <html lang="en">
   <head>
@@ -247,138 +401,7 @@ def render_test_blueprint_index_html(category_order: tuple[str, ...], entries: l
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Test Blueprint Artifacts</title>
     <style>
-      :root {{
-        color-scheme: light;
-        --bg: #f8fafc;
-        --panel: #ffffff;
-        --text: #0f172a;
-        --muted: #475569;
-        --border: #cbd5e1;
-        --accent: #0f766e;
-      }}
-      * {{ box-sizing: border-box; }}
-      body {{
-        margin: 0;
-        font-family: ui-sans-serif, system-ui, sans-serif;
-        background: linear-gradient(180deg, #f8fafc, #eef2ff 45%, #f8fafc);
-        color: var(--text);
-      }}
-      main {{
-        width: min(70rem, calc(100% - 2rem));
-        margin: 0 auto;
-        padding: 2rem 0 3rem;
-      }}
-      header {{
-        margin-bottom: 1.5rem;
-      }}
-      h1 {{
-        margin: 0 0 0.5rem;
-        font-size: clamp(2rem, 4vw, 2.75rem);
-      }}
-      .lede {{
-        margin: 0;
-        max-width: 54rem;
-        color: var(--muted);
-        line-height: 1.5;
-      }}
-      .grid {{
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
-        gap: 1rem;
-      }}
-      .chip_row {{
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.55rem;
-        margin: 1.1rem 0 1.6rem;
-      }}
-      .chip {{
-        display: inline-flex;
-        align-items: center;
-        border: 1px solid var(--border);
-        border-radius: 999px;
-        background: var(--panel);
-        padding: 0.35rem 0.7rem;
-        font-size: 0.92rem;
-        font-weight: 600;
-        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.05);
-      }}
-      .category_section + .category_section {{
-        margin-top: 1.8rem;
-      }}
-      .category_header {{
-        display: flex;
-        flex-wrap: wrap;
-        align-items: baseline;
-        justify-content: space-between;
-        gap: 0.5rem 1rem;
-        margin-bottom: 0.9rem;
-      }}
-      .category_header h2 {{
-        margin: 0;
-        font-size: 1.2rem;
-      }}
-      .category_header p {{
-        margin: 0;
-        color: var(--muted);
-        font-size: 0.92rem;
-      }}
-      .card {{
-        border: 1px solid var(--border);
-        border-radius: 1rem;
-        background: var(--panel);
-        padding: 1rem 1.05rem;
-        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
-      }}
-      .card h2 {{
-        margin: 0 0 0.4rem;
-        font-size: 1.05rem;
-      }}
-      .category {{
-        margin: 0.25rem 0 0;
-        color: var(--accent);
-        font-size: 0.78rem;
-        font-weight: 700;
-        letter-spacing: 0.04em;
-        text-transform: uppercase;
-      }}
-      .kind {{
-        margin: 0.2rem 0 0;
-        color: var(--muted);
-        font-size: 0.78rem;
-        font-style: italic;
-      }}
-      .card p {{
-        margin: 0.45rem 0 0;
-        line-height: 1.45;
-      }}
-      .slug {{
-        color: var(--muted);
-        font-size: 0.9rem;
-      }}
-      .tag_list {{
-        list-style: none;
-        padding: 0;
-        margin: 0.65rem 0 0;
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.45rem;
-      }}
-      .tag_list li {{
-        border: 1px solid #d8dee9;
-        border-radius: 999px;
-        background: #f8fafc;
-        color: var(--muted);
-        padding: 0.2rem 0.55rem;
-        font-size: 0.78rem;
-      }}
-      a {{
-        color: var(--accent);
-        text-decoration: none;
-      }}
-      a:hover {{
-        text-decoration: underline;
-      }}
+{TEST_BLUEPRINT_INDEX_CSS}
     </style>
   </head>
   <body>
@@ -389,9 +412,9 @@ def render_test_blueprint_index_html(category_order: tuple[str, ...], entries: l
         <p class="lede">Each site declares one primary category plus optional tags for cross-cutting coverage.</p>
       </header>
       <nav class="chip_row">
-        {''.join(nav_links)}
+        {render_test_blueprint_nav(visible_categories)}
       </nav>
-      {''.join(sections)}
+      {sections_html}
     </main>
   </body>
 </html>

--- a/scripts/blueprint_test_blueprints.py
+++ b/scripts/blueprint_test_blueprints.py
@@ -40,138 +40,30 @@ from scripts.blueprint_harness_validation import browser_test_command, panel_reg
 
 TAG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 TEST_BLUEPRINT_HARNESS_PREFIX = "[blueprint-test-blueprints]"
-TEST_BLUEPRINT_INDEX_CSS = """      :root {
-        color-scheme: light;
-        --bg: #f8fafc;
-        --panel: #ffffff;
-        --text: #0f172a;
-        --muted: #475569;
-        --border: #cbd5e1;
-        --accent: #0f766e;
-      }
-      * { box-sizing: border-box; }
-      body {
-        margin: 0;
-        font-family: ui-sans-serif, system-ui, sans-serif;
-        background: linear-gradient(180deg, #f8fafc, #eef2ff 45%, #f8fafc);
-        color: var(--text);
-      }
-      main {
-        width: min(70rem, calc(100% - 2rem));
-        margin: 0 auto;
-        padding: 2rem 0 3rem;
-      }
-      header {
-        margin-bottom: 1.5rem;
-      }
-      h1 {
-        margin: 0 0 0.5rem;
-        font-size: clamp(2rem, 4vw, 2.75rem);
-      }
-      .lede {
-        margin: 0;
-        max-width: 54rem;
-        color: var(--muted);
-        line-height: 1.5;
-      }
-      .grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
-        gap: 1rem;
-      }
-      .chip_row {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.55rem;
-        margin: 1.1rem 0 1.6rem;
-      }
-      .chip {
-        display: inline-flex;
-        align-items: center;
-        border: 1px solid var(--border);
-        border-radius: 999px;
-        background: var(--panel);
-        padding: 0.35rem 0.7rem;
-        font-size: 0.92rem;
-        font-weight: 600;
-        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.05);
-      }
-      .category_section + .category_section {
-        margin-top: 1.8rem;
-      }
-      .category_header {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: baseline;
-        justify-content: space-between;
-        gap: 0.5rem 1rem;
-        margin-bottom: 0.9rem;
-      }
-      .category_header h2 {
-        margin: 0;
-        font-size: 1.2rem;
-      }
-      .category_header p {
-        margin: 0;
-        color: var(--muted);
-        font-size: 0.92rem;
-      }
-      .card {
-        border: 1px solid var(--border);
-        border-radius: 1rem;
-        background: var(--panel);
-        padding: 1rem 1.05rem;
-        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
-      }
-      .card h2 {
-        margin: 0 0 0.4rem;
-        font-size: 1.05rem;
-      }
-      .category {
-        margin: 0.25rem 0 0;
-        color: var(--accent);
-        font-size: 0.78rem;
-        font-weight: 700;
-        letter-spacing: 0.04em;
-        text-transform: uppercase;
-      }
-      .kind {
-        margin: 0.2rem 0 0;
-        color: var(--muted);
-        font-size: 0.78rem;
-        font-style: italic;
-      }
-      .card p {
-        margin: 0.45rem 0 0;
-        line-height: 1.45;
-      }
-      .slug {
-        color: var(--muted);
-        font-size: 0.9rem;
-      }
-      .tag_list {
-        list-style: none;
-        padding: 0;
-        margin: 0.65rem 0 0;
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.45rem;
-      }
-      .tag_list li {
-        border: 1px solid #d8dee9;
-        border-radius: 999px;
-        background: #f8fafc;
-        color: var(--muted);
-        padding: 0.2rem 0.55rem;
-        font-size: 0.78rem;
-      }
-      a {
-        color: var(--accent);
-        text-decoration: none;
-      }
-      a:hover {
-        text-decoration: underline;
-      }"""
+TEST_BLUEPRINT_INDEX_CSS = """:root { color-scheme: light; --bg: #f8fafc; --panel: #ffffff; --text: #0f172a; --muted: #475569; --border: #cbd5e1; --accent: #0f766e; }
+* { box-sizing: border-box; }
+body { margin: 0; font-family: ui-sans-serif, system-ui, sans-serif; background: linear-gradient(180deg, #f8fafc, #eef2ff 45%, #f8fafc); color: var(--text); }
+main { width: min(70rem, calc(100% - 2rem)); margin: 0 auto; padding: 2rem 0 3rem; }
+header { margin-bottom: 1.5rem; }
+h1 { margin: 0 0 0.5rem; font-size: clamp(2rem, 4vw, 2.75rem); }
+.lede { margin: 0; max-width: 54rem; color: var(--muted); line-height: 1.5; }
+.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr)); gap: 1rem; }
+.chip_row { display: flex; flex-wrap: wrap; gap: 0.55rem; margin: 1.1rem 0 1.6rem; }
+.chip { display: inline-flex; align-items: center; border: 1px solid var(--border); border-radius: 999px; background: var(--panel); padding: 0.35rem 0.7rem; font-size: 0.92rem; font-weight: 600; box-shadow: 0 6px 18px rgba(15, 23, 42, 0.05); }
+.category_section + .category_section { margin-top: 1.8rem; }
+.category_header { display: flex; flex-wrap: wrap; align-items: baseline; justify-content: space-between; gap: 0.5rem 1rem; margin-bottom: 0.9rem; }
+.category_header h2 { margin: 0; font-size: 1.2rem; }
+.category_header p { margin: 0; color: var(--muted); font-size: 0.92rem; }
+.card { border: 1px solid var(--border); border-radius: 1rem; background: var(--panel); padding: 1rem 1.05rem; box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06); }
+.card h2 { margin: 0 0 0.4rem; font-size: 1.05rem; }
+.category { margin: 0.25rem 0 0; color: var(--accent); font-size: 0.78rem; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; }
+.kind { margin: 0.2rem 0 0; color: var(--muted); font-size: 0.78rem; font-style: italic; }
+.card p { margin: 0.45rem 0 0; line-height: 1.45; }
+.slug { color: var(--muted); font-size: 0.9rem; }
+.tag_list { list-style: none; padding: 0; margin: 0.65rem 0 0; display: flex; flex-wrap: wrap; gap: 0.45rem; }
+.tag_list li { border: 1px solid #d8dee9; border-radius: 999px; background: #f8fafc; color: var(--muted); padding: 0.2rem 0.55rem; font-size: 0.78rem; }
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }"""
 
 
 @dataclass(frozen=True)

--- a/scripts/emit_reference_deploy_matrix.py
+++ b/scripts/emit_reference_deploy_matrix.py
@@ -11,18 +11,9 @@ if __package__ in {None, ""}:
 
 from scripts.blueprint_harness_paths import detect_harness_layout
 from scripts.blueprint_harness_projects import (
-    HarnessProject,
-    HarnessProjectCatalog,
-    HarnessReleaseTarget,
-    deploy_project_artifact_name,
-    deploy_project_artifact_path,
+    deploy_matrix_from_controller_catalog,
     load_project_catalog,
-    project_target_rc,
-    project_target_toolchain,
-    project_target_verso_ref,
-    reference_dependency_cache_key,
     resolve_manifest_path,
-    resolve_projects_for_release,
 )
 
 
@@ -41,99 +32,6 @@ def parse_args() -> argparse.Namespace:
         help="Print GitHub Actions step outputs instead of plain JSON.",
     )
     return parser.parse_args()
-
-
-def release_target_manifest_entry(target: HarnessReleaseTarget) -> dict[str, object]:
-    return {
-        "id": target.release_id,
-        "toolchain": target.release_toolchain,
-        "verso_ref": target.release_verso_ref,
-        "branch": target.branch,
-        "deploy_pages": target.deploy_pages,
-    }
-
-
-def project_manifest_entry(project: HarnessProject) -> dict[str, object]:
-    if project.selected_release is None:
-        raise ValueError(f"project `{project.project_id}` is missing selected release metadata")
-
-    source: dict[str, object] = {
-        "kind": project.source_kind,
-        "project_root": project.project_root,
-    }
-    if project.repository is not None:
-        source["repository"] = project.repository
-
-    target: dict[str, object] = {"release": project.selected_release}
-    if project.ref is not None:
-        target["ref"] = project.ref
-    if project.selected_rc is not None:
-        target["rc"] = project.selected_rc
-
-    entry: dict[str, object] = {
-        "id": project.project_id,
-        "source": source,
-        "targets": [target],
-        "site_subdir": project.site_subdir,
-    }
-    if project.description is not None:
-        entry["description"] = project.description
-    if project.build_target is not None:
-        entry["build_target"] = project.build_target
-    if project.generator is not None:
-        entry["generator"] = project.generator
-    if project.build_command is not None:
-        entry["build_command"] = list(project.build_command)
-    if project.generate_command is not None:
-        entry["generate_command"] = list(project.generate_command)
-    validation: dict[str, object] = {}
-    if project.panel_regression_script is not None:
-        validation["panel_regression_script"] = project.panel_regression_script
-    if project.browser_tests_path is not None:
-        validation["browser_tests_path"] = project.browser_tests_path
-    if validation:
-        entry["validation"] = validation
-    return entry
-
-
-def deploy_project_manifest(target: HarnessReleaseTarget, project: HarnessProject) -> dict[str, object]:
-    return {
-        "version": 2,
-        "release_targets": [release_target_manifest_entry(target)],
-        "projects": [project_manifest_entry(project)],
-    }
-
-
-def deploy_matrix_from_controller_catalog(
-    controller_catalog: HarnessProjectCatalog,
-    deployable_targets: tuple[HarnessReleaseTarget, ...],
-) -> dict[str, list[dict[str, object]]]:
-    include: list[dict[str, object]] = []
-    for target in deployable_targets:
-        controller_projects = resolve_projects_for_release(controller_catalog, target.release_id, None)
-        if not controller_projects:
-            raise ValueError(
-                f"release target `{target.release_id}` has `deploy_pages: true` but no published "
-                "reference project targets"
-            )
-        for project in controller_projects:
-            include.append(
-                {
-                    "release_id": target.release_id,
-                    "rc": project_target_rc(project),
-                    "toolchain": project_target_toolchain(target, project),
-                    "verso_ref": project_target_verso_ref(target, project),
-                    "branch": target.branch,
-                    "project_id": project.project_id,
-                    "project_root": project.project_root,
-                    "hash": project.ref,
-                    "reference_cache_key": reference_dependency_cache_key(project) if project.git_checkout else "",
-                    "artifact_name": deploy_project_artifact_name(project),
-                    "artifact_path": deploy_project_artifact_path(project),
-                    "project_manifest": deploy_project_manifest(target, project),
-                }
-            )
-    return {"include": include}
 
 
 def payload(args: argparse.Namespace) -> dict[str, object]:

--- a/scripts/emit_reference_release_matrix.py
+++ b/scripts/emit_reference_release_matrix.py
@@ -12,10 +12,8 @@ if __package__ in {None, ""}:
 from scripts.blueprint_harness_paths import detect_harness_layout
 from scripts.blueprint_harness_projects import (
     load_project_catalog,
-    reference_build_matrix,
+    reference_release_payload,
     resolve_manifest_path,
-    resolve_projects_for_release,
-    resolve_release_target,
 )
 
 
@@ -45,19 +43,7 @@ def payload(args: argparse.Namespace) -> dict[str, object]:
     layout = detect_harness_layout(Path(__file__))
     manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
     catalog = load_project_catalog(manifest_path)
-    release_target = resolve_release_target(catalog, args.release, layout.package_root)
-    projects = resolve_projects_for_release(catalog, release_target.release_id, None)
-    return {
-        "manifest_path": str(manifest_path),
-        "release_id": release_target.release_id,
-        "rc": "",
-        "toolchain": release_target.toolchain,
-        "verso_ref": release_target.verso_ref,
-        "branch": release_target.branch,
-        "deploy_pages": release_target.deploy_pages,
-        "reference_project_count": len(projects),
-        "reference_matrix": reference_build_matrix(projects, release_target),
-    }
+    return reference_release_payload(manifest_path, catalog, args.release, layout.package_root)
 
 
 def emit_github_output(data: dict[str, object]) -> None:

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -1,4 +1,3 @@
-import json
 import pytest
 import random
 import shutil
@@ -14,17 +13,10 @@ if str(PACKAGE_ROOT) not in sys.path:
 
 from scripts.blueprint_harness_paths import (
     canonical_test_blueprint_output_dir,
-    default_test_blueprint_site_dir,
 )
 
 
 DEFAULT_TEST_BLUEPRINT = "preview_runtime_showcase"
-
-def default_site_dir() -> Path:
-    return default_test_blueprint_site_dir(DEFAULT_TEST_BLUEPRINT, Path(__file__))
-
-
-DEFAULT_SITE_DIR = default_site_dir()
 
 
 def browser_executable(browser_type: str) -> str | None:
@@ -37,18 +29,6 @@ def browser_executable(browser_type: str) -> str | None:
         if path:
             return path
     return None
-
-
-def load_redirects(site_dir: str | Path):
-    json_path = Path(site_dir)
-    if not json_path.is_absolute():
-        json_path = (Path(__file__).parent / json_path).resolve()
-    json_path = json_path / "xref.json"
-    with open(json_path) as f:
-        data = json.load(f)
-
-    sections = data["Verso.Genre.Manual.section"]["contents"]
-    return [(s, sections[s][0]["address"] + "#" + sections[s][0]["id"]) for s in sections]
 
 
 def build_test_blueprint_site(name: str) -> Path:

--- a/tests/browser/test_blueprint_slides_runtime.py
+++ b/tests/browser/test_blueprint_slides_runtime.py
@@ -14,7 +14,7 @@ from support import (
     record_runtime_errors,
     wait_for_server,
 )
-from scripts.blueprint_harness_references import (
+from scripts.blueprint_harness_project_commands import (
     maybe_rewrite_in_repo_blueprint_dependency,
     restore_tracked_project_manifest,
     snapshot_tracked_project_manifest,

--- a/tests/harness/test_blueprint_harness_branches.py
+++ b/tests/harness/test_blueprint_harness_branches.py
@@ -7,7 +7,6 @@ import tempfile
 import unittest
 
 import scripts.blueprint_harness_branches as branches_mod
-import scripts.blueprint_harness_releases as releases_mod
 
 
 class BlueprintHarnessBranchPolicyTests(unittest.TestCase):
@@ -35,44 +34,6 @@ class BlueprintHarnessBranchPolicyTests(unittest.TestCase):
             self.assertEqual(policy.default_dev_branch, "v4.29.0")
             self.assertEqual(policy.required_backport_branches, ())
             self.assertEqual(policy.source_path, root / "branch-policy.json")
-
-    def test_release_candidate_names_normalize_to_tags_and_branch_ids(self) -> None:
-        self.assertEqual(releases_mod.normalize_release_candidate_name("4.30-rc2"), "4.30-rc2")
-        self.assertEqual(releases_mod.normalize_release_candidate_name("v4.30.0-rc2"), "4.30-rc2")
-        self.assertEqual(releases_mod.release_candidate_name_or_none("v4.30.0-rc2"), "4.30-rc2")
-        self.assertIsNone(releases_mod.release_candidate_name_or_none("v4.30.0"))
-        self.assertEqual(releases_mod.release_candidate_ref("4.30-rc2"), "v4.30.0-rc2")
-        self.assertEqual(releases_mod.normalize_lean_release_ref("4.30-rc2"), "v4.30.0-rc2")
-        self.assertEqual(releases_mod.release_branch_from_lean_ref("leanprover/lean4:v4.30.0-rc2"), "v4.30.0")
-
-    def test_lean_release_order_key_orders_release_candidates_before_final_release(self) -> None:
-        self.assertLess(
-            releases_mod.lean_release_order_key("v4.30.0-rc1"),
-            releases_mod.lean_release_order_key("v4.30.0-rc2"),
-        )
-        self.assertLess(
-            releases_mod.lean_release_order_key("v4.30.0-rc2"),
-            releases_mod.lean_release_order_key("v4.30.0"),
-        )
-        self.assertEqual(
-            releases_mod.lean_release_order_key("v4.30-rc2"),
-            releases_mod.lean_release_order_key("v4.30.0-rc2"),
-        )
-        self.assertIsNone(releases_mod.lean_release_order_key("nightly-testing"))
-
-    def test_rewrite_lean_toolchain_preserves_existing_final_newline_style(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            with_newline = root / "with-newline" / "lean-toolchain"
-            without_newline = root / "without-newline" / "lean-toolchain"
-            self.write(with_newline, "leanprover/lean4:v4.29.0\n")
-            self.write(without_newline, "leanprover/lean4:v4.29.0")
-
-            releases_mod.rewrite_lean_toolchain(with_newline, "v4.30.0")
-            releases_mod.rewrite_lean_toolchain(without_newline, "v4.30.0")
-
-            self.assertEqual(with_newline.read_text(encoding="utf-8"), "leanprover/lean4:v4.30.0\n")
-            self.assertEqual(without_newline.read_text(encoding="utf-8"), "leanprover/lean4:v4.30.0")
 
     def test_active_release_branch_uses_release_id_for_release_candidate_toolchain(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -46,16 +46,6 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         args = argparse.Namespace(skip_sync=True, skip_reference_sync=False, lightweight=False)
         self.assertEqual(create_worktree_sync_policy(args), (True, False))
 
-    def test_reference_sync_rejects_legacy_example_alias(self) -> None:
-        parser = reference_harness_mod.build_parser()
-        with self.assertRaises(SystemExit):
-            parser.parse_args(["sync", "--example", "noperthedron"])
-
-    def test_reference_status_rejects_legacy_example_alias(self) -> None:
-        parser = reference_harness_mod.build_parser()
-        with self.assertRaises(SystemExit):
-            parser.parse_args(["status", "--example", "noperthedron"])
-
     def test_reference_generate_parses_allow_unsafe_root_release(self) -> None:
         parser = reference_harness_mod.build_parser()
         args = parser.parse_args(["generate", "--allow-unsafe-root-release", "--release", "v4.29.0"])
@@ -778,16 +768,6 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 ["git", "push", "origin", "--delete", "feat/demo"],
             ],
         )
-
-    def test_reference_generate_rejects_legacy_example_alias(self) -> None:
-        parser = reference_harness_mod.build_parser()
-        with self.assertRaises(SystemExit):
-            parser.parse_args(["generate", "--example", "noperthedron"])
-
-    def test_reference_validate_rejects_legacy_example_alias(self) -> None:
-        parser = reference_harness_mod.build_parser()
-        with self.assertRaises(SystemExit):
-            parser.parse_args(["validate", "--example", "noperthedron"])
 
     def test_reference_generate_rejects_unsafe_root_main_without_override(self) -> None:
         args = argparse.Namespace(

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -181,6 +181,11 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         args = parser.parse_args(["create-worktree", "demo", "--lock"])
         self.assertTrue(args.lock)
 
+    def test_worktree_sync_alias_is_retired(self) -> None:
+        parser = build_parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["worktree-sync"])
+
     def test_worktree_claim_parses_lock_flags(self) -> None:
         parser = build_parser()
         lock_args = parser.parse_args(["worktree-claim", "demo", "--lock"])

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -1002,6 +1002,76 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             self.assertEqual(seen["package_root"], layout.package_root)
             self.assertEqual(lakefile.read_text(encoding="utf-8"), OFFICIAL_BLUEPRINT_REQUIRE + "\n")
 
+    def test_reference_cache_warm_build_failure_reports_recovery_hints(self) -> None:
+        import scripts.blueprint_harness_references as refs_mod
+
+        project = HarnessProject(
+            project_id="external-blueprint",
+            source_kind="git_checkout",
+            project_root="nested/blueprint",
+            build_target=None,
+            generator=None,
+            repository="https://github.com/example/external-blueprint.git",
+            ref="main",
+            build_command=("lake", "build"),
+            generate_command=("lake", "exe", "blueprint-gen"),
+            site_subdir="html-multi",
+            panel_regression_script=None,
+            browser_tests_path=None,
+            description=None,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cache_key = reference_dependency_cache_key(project)
+            cache_dir = root / "cache" / cache_key
+            project_dir = cache_dir / "nested" / "blueprint"
+            project_dir.mkdir(parents=True)
+            (cache_dir / ".git").mkdir()
+            lakefile = project_dir / "lakefile.lean"
+            lakefile.write_text(OFFICIAL_BLUEPRINT_REQUIRE + "\n", encoding="utf-8")
+            layout = SimpleNamespace(
+                package_root=root / "worktree",
+                repo_root=root / "root",
+                reference_source_cache_root=root / "cache",
+                reference_dependency_cache_root=root / "deps",
+            )
+            layout.package_root.mkdir()
+            layout.repo_root.mkdir()
+
+            originals = {
+                "update_git_checkout": refs_mod.update_git_checkout,
+                "bootstrap_reference_checkout": refs_mod.bootstrap_reference_checkout,
+                "project_lake_update_command": refs_mod.project_lake_update_command,
+                "run": refs_mod.run,
+            }
+
+            def fake_run(command, *, cwd):
+                if command == ["lake", "update"]:
+                    return
+                raise subprocess.CalledProcessError(7, command)
+
+            try:
+                refs_mod.update_git_checkout = lambda _project, _cache_dir: None
+                refs_mod.bootstrap_reference_checkout = lambda *, project_dir: None
+                refs_mod.project_lake_update_command = lambda _package_root, _project_dir: ["lake", "update"]
+                refs_mod.run = fake_run
+
+                with self.assertRaises(SystemExit) as raised:
+                    refs_mod.sync_reference_cache_checkout(layout, project, warm_build=True)
+            finally:
+                for name, value in originals.items():
+                    setattr(refs_mod, name, value)
+
+            message = str(raised.exception)
+            self.assertIn("failed to warm reference cache for `external-blueprint`", message)
+            self.assertIn(cache_key, message)
+            self.assertIn(str(cache_dir), message)
+            self.assertIn(str(root / "deps" / cache_key / "packages"), message)
+            self.assertIn("incompatible `.olean` header", message)
+            self.assertIn("create-worktree <name> --lightweight", message)
+            self.assertIn("blueprint_reference_harness prune --dry-run", message)
+            self.assertEqual(lakefile.read_text(encoding="utf-8"), OFFICIAL_BLUEPRINT_REQUIRE + "\n")
+
     def test_child_manifests_inherit_verso_and_subverso_from_root_without_mathlib(self) -> None:
         root_manifest_path = PACKAGE_ROOT / "lake-manifest.json"
         child_manifest_paths = [

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -16,6 +16,7 @@ from scripts.blueprint_harness_projects import (
     load_project_catalog_data,
     reference_build_matrix,
     reference_dependency_cache_key,
+    reference_release_payload,
     resolve_projects_for_release,
     resolve_release_target,
 )
@@ -425,6 +426,28 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 self.assertTrue(entry["reference_cache_key"])
             else:
                 self.assertEqual(entry["reference_cache_key"], "")
+
+    def test_reference_release_payload_uses_project_target_rcs(self) -> None:
+        manifest = default_project_manifest(PACKAGE_ROOT)
+        catalog = load_project_catalog(manifest)
+
+        payload = reference_release_payload(manifest, catalog, "v4.30.0", PACKAGE_ROOT)
+
+        self.assertEqual(payload["manifest_path"], str(manifest))
+        self.assertEqual(payload["release_id"], "v4.30.0")
+        self.assertEqual(payload["rc"], "")
+        self.assertEqual(payload["toolchain"], "v4.30.0")
+        self.assertEqual(payload["verso_ref"], "v4.30.0")
+        self.assertEqual(payload["reference_project_count"], 3)
+        rows = {
+            entry["project_id"]: entry
+            for entry in payload["reference_matrix"]["include"]
+        }
+        self.assertEqual(set(rows), {"noperthedron", "verso-flt", "verso-carleson"})
+        for row in rows.values():
+            self.assertEqual(row["rc"], "4.30-rc2")
+            self.assertEqual(row["toolchain"], "v4.30.0-rc2")
+            self.assertEqual(row["verso_ref"], "v4.30.0-rc2")
 
     def test_deploy_matrix_uses_controller_publish_targets_for_generated_manifests(self) -> None:
         controller_catalog = load_project_catalog_text(

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -11,6 +11,7 @@ from scripts.blueprint_harness_projects import (
     HarnessProject,
     IN_REPO_PROJECT_SOURCE_KIND,
     default_project_manifest,
+    deploy_matrix_from_controller_catalog,
     load_project_catalog,
     load_project_catalog_data,
     reference_build_matrix,
@@ -18,7 +19,6 @@ from scripts.blueprint_harness_projects import (
     resolve_projects_for_release,
     resolve_release_target,
 )
-from scripts.emit_reference_deploy_matrix import deploy_matrix_from_controller_catalog
 from scripts.blueprint_harness_project_commands import (
     OFFICIAL_BLUEPRINT_REQUIRE,
     tracked_project_manifest_path,

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -1790,7 +1790,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         )
 
     def test_reference_prune_plan_finds_stale_cache_and_checkout_paths(self) -> None:
-        from scripts.blueprint_harness import reference_prune_plan
+        from scripts.blueprint_harness_references import reference_prune_plan
 
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/harness/test_blueprint_harness_releases.py
+++ b/tests/harness/test_blueprint_harness_releases.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+
+import scripts.blueprint_harness_releases as releases_mod
+
+
+class BlueprintHarnessReleaseHelperTests(unittest.TestCase):
+    def write(self, path: Path, text: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+    def test_release_candidate_names_normalize_to_tags_and_branch_ids(self) -> None:
+        self.assertEqual(releases_mod.normalize_release_candidate_name("4.30-rc2"), "4.30-rc2")
+        self.assertEqual(releases_mod.normalize_release_candidate_name("v4.30.0-rc2"), "4.30-rc2")
+        self.assertEqual(releases_mod.release_candidate_name_or_none("v4.30.0-rc2"), "4.30-rc2")
+        self.assertIsNone(releases_mod.release_candidate_name_or_none("v4.30.0"))
+        self.assertEqual(releases_mod.release_candidate_ref("4.30-rc2"), "v4.30.0-rc2")
+        self.assertEqual(releases_mod.normalize_lean_release_ref("4.30-rc2"), "v4.30.0-rc2")
+        self.assertEqual(releases_mod.release_branch_from_lean_ref("leanprover/lean4:v4.30.0-rc2"), "v4.30.0")
+
+    def test_lean_release_order_key_orders_release_candidates_before_final_release(self) -> None:
+        self.assertLess(
+            releases_mod.lean_release_order_key("v4.30.0-rc1"),
+            releases_mod.lean_release_order_key("v4.30.0-rc2"),
+        )
+        self.assertLess(
+            releases_mod.lean_release_order_key("v4.30.0-rc2"),
+            releases_mod.lean_release_order_key("v4.30.0"),
+        )
+        self.assertEqual(
+            releases_mod.lean_release_order_key("v4.30-rc2"),
+            releases_mod.lean_release_order_key("v4.30.0-rc2"),
+        )
+        self.assertIsNone(releases_mod.lean_release_order_key("nightly-testing"))
+
+    def test_rewrite_lean_toolchain_preserves_existing_final_newline_style(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with_newline = root / "with-newline" / "lean-toolchain"
+            without_newline = root / "without-newline" / "lean-toolchain"
+            self.write(with_newline, "leanprover/lean4:v4.29.0\n")
+            self.write(without_newline, "leanprover/lean4:v4.29.0")
+
+            releases_mod.rewrite_lean_toolchain(with_newline, "v4.30.0")
+            releases_mod.rewrite_lean_toolchain(without_newline, "v4.30.0")
+
+            self.assertEqual(with_newline.read_text(encoding="utf-8"), "leanprover/lean4:v4.30.0\n")
+            self.assertEqual(without_newline.read_text(encoding="utf-8"), "leanprover/lean4:v4.30.0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR trims and deduplicates maintainer harness code after the reference-catalog cleanup, with the main goal of reducing obsolete aliases, repeated setup, oversized helper functions, and stale template drift.

- Remove the retired worktree-sync alias and stale browser-test helpers.
- Centralize shared reference matrix, release payload, Git/ref, and command setup helpers.
- Split large harness parser, validation, and test-blueprint index rendering functions, then compact generated index styles.
- Sync the project template Pages workflow with the canonical workflow after the package-toolchain cleanup.

Backport v4.29.0: #124