### PR TITLE
feat: add vbp agent helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,19 @@ Read these in order:
 9. [doc/UPSTREAM_BACKLOG.md](./doc/UPSTREAM_BACKLOG.md): items intended to move
    back into `verso`, Lake, or Lean
 
+### Agent Helper Skill
+
+The repository includes an agent-facing skill under
+[`skills/verso-blueprint/`](./skills/verso-blueprint/) for Codex/Claude-style
+local coding agents. The skill teaches agents to use `lake exe vbp ...` for
+project discovery, build/serve previews, generated-data queries, and
+post-edit checks.
+
+This helper does not replace the normal Blueprint generation interface for
+projects. `lake exe blueprint-gen ...` and the generator entry point remain the
+documented user-facing rendering path. Treat `vbp` query JSON as an unstable
+agent interface, not a public compatibility contract.
+
 ### Maintainer CLI Split
 
 The repository now uses two small maintainer CLIs instead of one large mixed

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -47,6 +47,20 @@ python3 -m scripts.blueprint_reference_harness --help
 python3 -m scripts.blueprint_test_blueprints --help
 ```
 
+### Agent-Facing `vbp` Helper
+
+`lake exe vbp ...` and `skills/verso-blueprint/` are maintained as an
+agent-facing helper surface for local coding agents. They do not replace the
+user-facing Blueprint generation path: end-user docs should continue to present
+`lake exe blueprint-gen ...` and the project generator entry point as the
+normal rendering workflow.
+
+Treat `vbp` JSON as fully unstable. It may change within this repository as
+agent workflows evolve, and should not be documented as a public compatibility
+contract. Prefer in-band discovery through `lake exe vbp --help`,
+`lake exe vbp discover`, and `lake exe vbp query selectors` instead of copying
+selector lists or JSON shapes into long-lived docs.
+
 The two generated artifact families serve different purposes:
 
 - reference blueprints are the release-facing validation catalog selected from

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -19,6 +19,12 @@ lean_lib VersoBlueprint where
   srcDir := "src"
   roots := #[`VersoBlueprint]
 
+@[default_target]
+lean_exe «vbp» where
+  root := `VersoBlueprint.VbpMain
+  srcDir := "src"
+  supportInterpreter := true
+
 @[default_target, test_driver]
 lean_lib VersoBlueprintTests where
   srcDir := "tests"
@@ -56,7 +62,8 @@ lean_lib VersoBlueprintTests where
     `VersoBlueprintTests.RuntimeCache,
     `VersoBlueprintTests.TestBlueprintRegistryMeta,
     `VersoBlueprintTests.TestBlueprintRegistryChecks,
-    `VersoBlueprintTests.TestBlueprintRegistryCoverage
+    `VersoBlueprintTests.TestBlueprintRegistryCoverage,
+    `VersoBlueprintTests.Vbp
   ]
 
 lean_lib VersoBlueprintTestDocs where

--- a/skills/verso-blueprint/SKILL.md
+++ b/skills/verso-blueprint/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: verso-blueprint
+description: Work with Verso Blueprint Lean projects. Use when Codex needs to build or serve Blueprint HTML, query Blueprint labels/dependencies/owners/tags/work queues, debug generated graph/summary/preview data, inspect or edit Blueprint source modules, add conservative Blueprint nodes or metadata, or reason about `lake exe vbp` workflows in repositories using `VersoBlueprint`.
+---
+
+# Verso Blueprint
+
+## Quick Start
+
+Prefer the project-local helper:
+
+```bash
+lake exe vbp discover
+lake exe vbp build
+lake exe vbp query labels
+lake exe vbp check
+```
+
+Read `references/vbp.md` when you need exact command behavior, JSON shapes, serve behavior, or fallback commands.
+
+Read `references/authoring-patterns.md` before editing Blueprint source, adding nodes, changing dependencies, or diagnosing authoring syntax.
+
+## Workflow
+
+1. Run `lake exe vbp discover` first to identify the package, generator, top-level Blueprint module, output paths, and chapter candidates.
+2. Build with `lake exe vbp build` before querying unless generated output already exists and the user only asks to inspect it.
+3. Query with `lake exe vbp query ...`; do not ask users to inspect manifest/cache files directly for normal tasks.
+4. Use `lake exe vbp query all <label>` when you need the full agent bundle for one Blueprint node.
+5. Edit source conservatively when requested. Preserve stable labels, use existing chapter/module patterns, and keep dependency intent clear.
+6. Rebuild or run `lake exe vbp check` after edits. Report changed labels, changed dependency edges, and remaining diagnostics.
+
+## Guardrails
+
+- Treat `_out/site` as the default generated site. Use `--output` only for build destinations and `--site` only for reading an alternate generated site.
+- Do not expose `blueprint-manifest.json` or `blueprint-html-cache.json` as the normal interface; `vbp query` and `vbp check` are the normal interface.
+- Treat all `vbp query` JSON shapes as unstable. They are for current agent consumption, not a compatibility promise.
+- Use `uses` only for mathematical dependency edges. Use `bpref` for prose links that should not affect the graph.
+- Keep statement and proof dependencies separate. Statement blocks use statement-side `uses`; `:::proof` blocks use proof-side `uses`.
+- Prefer small, explicit source patches over broad rewrites. Do not rename labels unless the user asks for a migration and validation plan.
+- If `vbp` is unavailable, fall back to the generator commands in `references/vbp.md` and explain that the project predates the helper.

--- a/skills/verso-blueprint/agents/openai.yaml
+++ b/skills/verso-blueprint/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Verso Blueprint"
+  short_description: "Work with Verso Blueprint projects"
+  default_prompt: "Use $verso-blueprint to build, query, or edit this Blueprint project."

--- a/skills/verso-blueprint/references/authoring-patterns.md
+++ b/skills/verso-blueprint/references/authoring-patterns.md
@@ -1,0 +1,125 @@
+# Blueprint Authoring Patterns
+
+## Project Shape
+
+A standard project has:
+
+- chapter modules with `#doc (Manual) ...` content
+- a top-level Blueprint module that includes chapters and overview pages
+- a generator entry point, usually `<Project>Main.lean`
+- a `blueprint-gen` executable in `lakefile.lean`
+
+Keep this structure unless the user asks for a project reorganization.
+
+## Blocks And Labels
+
+Blueprint nodes use stable labels:
+
+```lean
+:::definition "addition_spec"
+...
+:::
+
+:::theorem "addition_assoc" (uses := "addition_spec")
+...
+:::
+
+:::proof "addition_assoc"
+...
+:::
+```
+
+Use existing local styles for labels. Do not rename existing labels casually; labels drive links, graph nodes, summary entries, code associations, and generated metadata.
+
+Common statement directives:
+
+- `:::definition`
+- `:::proposition`
+- `:::lemma_`
+- `:::theorem`
+- `:::corollary`
+- `:::proof`
+
+## Dependencies
+
+Use `{uses "target"}[]` or block-level `(uses := "target")` when the current node mathematically depends on `target`.
+
+Use `{bpref "target"}[]` for prose references that should link but should not create graph edges.
+
+Dependency metadata:
+
+```lean
+:::theorem "main_result" (uses := "technical_lemma") (uses_intent := "technical")
+...
+:::
+```
+
+Allowed intent values are `"regular"`, `"auxiliary"`, and `"technical"`. Author-written dependencies are normally manual; use automatic origin only when tooling generated the edge.
+
+Statement and proof dependencies are separate. Add proof-only dependencies on the `:::proof` block, not on the statement block.
+
+## Metadata
+
+Follow existing metadata conventions:
+
+```lean
+:::author "project_author" (name := "Project Author")
+:::
+
+:::group "addition_core"
+Core statements about addition.
+:::
+
+:::theorem "addition_right_identity"
+  (parent := "addition_core")
+  (owner := "project_author")
+  (tags := "starter, arithmetic")
+  (effort := "small")
+  (priority := "high")
+...
+:::
+```
+
+Do not invent new metadata vocabularies in source files. Reuse owners, tags, priorities, and effort values already present unless the user asks for new policy.
+
+## Lean, Rust, And TeX Attachments
+
+Attach inline Lean code with a labeled code block:
+
+````lean
+```lean "addition_right_identity"
+theorem nat_add_zero_right (n : Nat) : n + 0 = n := by
+  simp
+```
+````
+
+Link to existing compiled declarations with `(lean := "Nat.add_assoc")`.
+
+Attach Rust or raw TeX with labeled code blocks only when the project already uses those surfaces or the user asks for them:
+
+````lean
+```rust "ffi_helper"
+pub fn ffi_helper(x: i32) -> i32 {
+    x + 1
+}
+```
+````
+
+````lean
+```tex "addition_right_identity"
+\begin{theorem}
+...
+\end{theorem}
+```
+````
+
+## Editing Checklist
+
+Before editing, inspect the neighboring chapter and top-level Blueprint module. After editing, run:
+
+```bash
+lake exe vbp build
+lake exe vbp check
+```
+
+When reporting changes, name the labels changed, dependency edges added or removed, and any remaining build/check diagnostics.

--- a/skills/verso-blueprint/references/vbp.md
+++ b/skills/verso-blueprint/references/vbp.md
@@ -1,0 +1,102 @@
+# `vbp` Reference
+
+Use `lake exe vbp ...` from the Blueprint project root.
+
+## Commands
+
+Run `lake exe vbp --help` for complete local CLI usage. The main command forms are:
+
+```bash
+lake exe vbp discover
+lake exe vbp build [--output <dir>] [--serve] [--port <n>]
+lake exe vbp query [--site <dir>] <selector>
+lake exe vbp check
+```
+
+Query selectors:
+
+```text
+selectors
+labels
+node <label>
+all <label>
+uses <label>
+used-by <label>
+group <label>
+owners
+tags
+work-queue
+search <text>
+code <decl>
+stats
+```
+
+Defaults:
+
+- `build` writes `_out/site`.
+- `query` and `check` read `_out/site`.
+- Pass `--output <dir>` only to choose where `build` writes generated output.
+- Pass `--site <dir>` to `query` or `check` only when reading a non-default site.
+
+## Build And Serve
+
+`discover` reports the Lake-backed package, generator executable, generator root, generator source file, and default output paths. Fields ending in `Guess`, such as `topLevelBlueprintModuleGuess` and `chapterCandidateGuesses`, are convention-based hints for agents and may be null or incomplete. The JSON includes `"apiStability":"unstable"` and a `discoveryErrors` array. When Lake workspace discovery fails, package and generator fields are null and `discoveryErrors` explains why.
+
+`build` asks Lake for the configured `blueprint-gen` executable root, runs `lake build <package>`, prepares/elaborates the generator file with Lake so imported OLeans are materialized, then runs the generator through Lean's interpreter:
+
+```bash
+lake lean <GeneratorMain>.lean
+lake env lean --run <GeneratorMain>.lean --output <output>
+```
+
+`build --serve` builds once, then serves `<output>/html-multi` with a local static server and keeps running. Without `--port`, it tries port `8000` and falls back to an available port. With `--serve --port <n>`, it fails if the requested port is unavailable. `--port` is accepted only with `--serve`. The command prints the actual preview URL.
+
+## Query Output
+
+All query commands print compact JSON for agent consumption. The JSON shape is fully unstable today; do not treat it as a compatibility contract. Top-level query objects include `"apiStability":"unstable"`. Query reads the semantic manifest only; use `check` when you need to validate the rendered HTML cache as well.
+
+- `selectors`: query selector forms supported by this `vbp` binary. This selector does not require generated Blueprint data.
+- `labels`: statement-level Blueprint block summaries.
+- `node <label>`: one block entry with title, kind, href, parent/group, owner/tags/priority/effort, statement/proof uses, reverse uses, and Lean preview keys.
+- `all <label>`: one-stop agent bundle for a node, including the node, statement/proof uses, reverse uses, and group data.
+- `uses <label>`: statement/proof dependencies and resolved related entries for one label.
+- `used-by <label>`: reverse dependencies for one label.
+- `group <label>`: group metadata and sibling entries for one label, when present.
+- `owners` and `tags`: distinct values from statement-level block entries.
+- `work-queue`: statement-level entries with owner, tags, priority, or effort metadata.
+- `search <text>`: statement-level entries whose label, title, owner, tag, or parent title contains the text, case-insensitively.
+- `code <decl>`: statement-level entries with Lean preview keys containing the declaration text.
+- `stats`: counts of statement-level entries by kind, owner, and tag.
+
+If generated data is missing, run `lake exe vbp build` first. If a label is unknown, `query` returns JSON with `"error":"unknown-label"`.
+
+## Check
+
+`lake exe vbp check` is a post-build generated-data health check. It does not replace `build`: build catches Lean/Lake compilation, elaboration, generator, and rendering failures. `check` parses generated data and verifies that semantic entries, Lean preview keys, relation previews, and group previews have corresponding rendered HTML cache entries. It prints:
+
+```json
+{"apiStability":"unstable","ok":true,"manifestEntries":0,"htmlCacheEntries":0,"errors":[]}
+```
+
+The command exits nonzero when generated data is missing, malformed, or internally inconsistent.
+
+## Fallback Without `vbp`
+
+For older projects, inspect the generator entry point, then use:
+
+```bash
+lake build <library-or-formalization-target>
+lake lean <GeneratorMain>.lean
+lake env lean --run <GeneratorMain>.lean --output _out/site
+lake env lean --run <GeneratorMain>.lean --dump-manifest
+lake env lean --run <GeneratorMain>.lean --dump-html-cache
+lake env lean --run <GeneratorMain>.lean --help
+```
+
+The manifest/cache files are implementation details for normal agent work; use them directly only when `vbp query` is unavailable or when debugging `vbp` itself.
+
+## Adoption Boundary
+
+This skill assumes the target project depends on a version of `VersoBlueprint` that provides `lake exe vbp`. Install or copy the whole `skills/verso-blueprint/` directory into the agent runtime's skill directory.
+
+The `vbp query` JSON output is fully unstable for now. It is useful as an agent interface inside one release line, but it is not yet a public compatibility contract.

--- a/src/VersoBlueprint/Vbp.lean
+++ b/src/VersoBlueprint/Vbp.lean
@@ -1,0 +1,407 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import Lean
+import VersoBlueprint.PreviewManifest
+
+namespace VersoBlueprint.Vbp
+
+open Lean
+open System
+
+abbrev ManifestFile := Informal.PreviewManifest.File
+abbrev HtmlCacheFile := Informal.PreviewManifest.HtmlCache.File
+abbrev Entry := Informal.PreviewManifest.Entry
+abbrev RelatedEntry := Informal.PreviewManifest.RelatedEntry
+abbrev GroupRelation := Informal.PreviewManifest.GroupRelation
+abbrev RelationAxis := Informal.PreviewManifest.RelationAxis
+
+def defaultSite : FilePath := "_out" / "site"
+
+def defaultOutput : FilePath := defaultSite
+
+def apiStability : String := "unstable"
+
+def querySelectorLines : List String := [
+  "selectors",
+  "labels",
+  "node <label>",
+  "all <label>",
+  "uses <label>",
+  "used-by <label>",
+  "group <label>",
+  "owners",
+  "tags",
+  "work-queue",
+  "search <text>",
+  "code <decl>",
+  "stats"
+]
+
+def responseJson (fields : List (String × Json)) : Json :=
+  Json.mkObj (("apiStability", Json.str apiStability) :: fields)
+
+def querySelectorsJson : Json :=
+  responseJson [
+    ("selectors", Json.arr (querySelectorLines.toArray.map Json.str))
+  ]
+
+def htmlDirForSite (site : FilePath) : IO FilePath := do
+  if ← (site / "-verso-data" / Informal.PreviewManifest.manifestFilename).pathExists then
+    pure site
+  else
+    pure (site / "html-multi")
+
+def dataDirForSite (site : FilePath) : IO FilePath := do
+  pure ((← htmlDirForSite site) / "-verso-data")
+
+def manifestPathForSite (site : FilePath) : IO FilePath := do
+  pure ((← dataDirForSite site) / Informal.PreviewManifest.manifestFilename)
+
+def htmlCachePathForSite (site : FilePath) : IO FilePath := do
+  pure ((← dataDirForSite site) / Informal.PreviewManifest.htmlCacheFilename)
+
+def labelString : Name → String
+  | .str .anonymous s => s
+  | name => name.toString
+
+private def nameJson (name : Name) : Json :=
+  Json.str (labelString name)
+
+private def optionStringJson : Option String → Json
+  | none => Json.null
+  | some value => Json.str value
+
+private def optionNameJson : Option Name → Json
+  | none => Json.null
+  | some value => nameJson value
+
+private def stringArrayJson (values : Array String) : Json :=
+  Json.arr (values.map Json.str)
+
+private def kindString : Option Informal.Data.NodeKind → String
+  | none => "unknown"
+  | some kind => (toString kind).toLower
+
+private def useRefJson (useRef : Informal.Data.UseRef) : Json :=
+  Json.mkObj [
+    ("label", nameJson useRef.label),
+    ("origin", Json.str (toString useRef.origin)),
+    ("intent", Json.str (toString useRef.intent))
+  ]
+
+private def relationAxisJson (axis : RelationAxis) : Json :=
+  Json.str axis.display
+
+private def relatedEntryJson (entry : RelatedEntry) : Json :=
+  Json.mkObj [
+    ("label", nameJson entry.label),
+    ("title", Json.str entry.title),
+    ("href", optionStringJson entry.href),
+    ("previewKey", Json.str entry.previewKey),
+    ("axes", Json.arr (entry.axes.map relationAxisJson))
+  ]
+
+private def groupRelationJson (group : GroupRelation) : Json :=
+  Json.mkObj [
+    ("label", nameJson group.label),
+    ("title", Json.str group.title),
+    ("declared", Json.bool group.declared),
+    ("entries", Json.arr (group.entries.map relatedEntryJson))
+  ]
+
+private def entrySummaryFields (entry : Entry) : List (String × Json) := [
+    ("key", Json.str entry.key),
+    ("label", nameJson entry.label),
+    ("title", Json.str entry.title),
+    ("kind", toJson entry.kind),
+    ("facet", toJson entry.facet),
+    ("href", optionStringJson entry.href),
+    ("parent", optionNameJson entry.parent),
+    ("parentTitle", optionStringJson entry.parentTitle),
+    ("ownerDisplayName", optionStringJson entry.ownerDisplayName),
+    ("tags", stringArrayJson entry.tags),
+    ("priority", optionStringJson entry.priority),
+    ("effort", optionStringJson entry.effort),
+    ("leanCodePreviewKeys", stringArrayJson entry.leanCodePreviewKeys)
+  ]
+
+private def entrySummaryJson (entry : Entry) : Json :=
+  Json.mkObj (entrySummaryFields entry)
+
+private def entryGroupJson (entry : Entry) : Json :=
+  match entry.group with
+  | none => Json.null
+  | some group => groupRelationJson group
+
+private def entryDetailFields (entry : Entry) : List (String × Json) := [
+    ("key", Json.str entry.key),
+    ("targetKind", toJson entry.targetKind),
+    ("label", nameJson entry.label),
+    ("facet", toJson entry.facet),
+    ("kind", toJson entry.kind),
+    ("title", Json.str entry.title),
+    ("displayCaption", optionStringJson entry.displayCaption),
+    ("displayLabel", optionStringJson entry.displayLabel),
+    ("href", optionStringJson entry.href),
+    ("parent", optionNameJson entry.parent),
+    ("parentTitle", optionStringJson entry.parentTitle),
+    ("statementUses", Json.arr (entry.statementUses.map useRefJson)),
+    ("proofUses", Json.arr (entry.proofUses.map useRefJson)),
+    ("leanCodePreviewKeys", stringArrayJson entry.leanCodePreviewKeys),
+    ("codeData", toJson entry.codeData),
+    ("uses", Json.arr (entry.uses.map relatedEntryJson)),
+    ("usedBy", Json.arr (entry.usedBy.map relatedEntryJson)),
+    ("group", entryGroupJson entry),
+    ("ownerDisplayName", optionStringJson entry.ownerDisplayName),
+    ("tags", stringArrayJson entry.tags),
+    ("priority", optionStringJson entry.priority),
+    ("effort", optionStringJson entry.effort)
+  ]
+
+def entryJson (entry : Entry) : Json :=
+  Json.mkObj (entryDetailFields entry)
+
+private def entryResponseJson (entry : Entry) : Json :=
+  responseJson (entryDetailFields entry)
+
+private def entryAllJson (label : String) (entry : Entry) : Json :=
+  responseJson [
+    ("label", Json.str label),
+    ("node", entryJson entry),
+    ("statementUses", Json.arr (entry.statementUses.map useRefJson)),
+    ("proofUses", Json.arr (entry.proofUses.map useRefJson)),
+    ("uses", Json.arr (entry.uses.map relatedEntryJson)),
+    ("usedBy", Json.arr (entry.usedBy.map relatedEntryJson)),
+    ("group", entryGroupJson entry)
+  ]
+
+def isBlockEntry (entry : Entry) : Bool :=
+  match entry.targetKind with
+  | .block => true
+  | _ => false
+
+def isStatementEntry (entry : Entry) : Bool :=
+  match entry.facet with
+  | .statement => true
+  | _ => false
+
+def blockStatementEntries (manifest : ManifestFile) : Array Entry :=
+  manifest.previews.filter (fun entry => isBlockEntry entry && isStatementEntry entry)
+
+def findBlockEntriesByLabel (manifest : ManifestFile) (label : String) : Array Entry :=
+  manifest.previews.filter fun entry =>
+    isBlockEntry entry && labelString entry.label == label
+
+def findPrimaryBlockEntry? (manifest : ManifestFile) (label : String) : Option Entry :=
+  let entries := findBlockEntriesByLabel manifest label
+  entries.find? isStatementEntry <|> entries[0]?
+
+def ownerValues (manifest : ManifestFile) : Array String :=
+  let owners := blockStatementEntries manifest |>.foldl (init := #[]) fun owners entry =>
+      match entry.ownerDisplayName with
+      | none => owners
+      | some owner =>
+          if owners.contains owner then owners else owners.push owner
+  owners.qsort (· < ·)
+
+def tagValues (manifest : ManifestFile) : Array String :=
+  let tags := blockStatementEntries manifest |>.foldl (init := #[]) fun tags entry =>
+      entry.tags.foldl
+        (fun tags tag => if tags.contains tag then tags else tags.push tag)
+        tags
+  tags.qsort (· < ·)
+
+def workQueueEntries (manifest : ManifestFile) : Array Entry :=
+  blockStatementEntries manifest |>.filter fun entry =>
+    entry.ownerDisplayName.isSome || entry.priority.isSome ||
+      entry.effort.isSome || !entry.tags.isEmpty
+
+private def incrementCount (counts : Array (String × Nat)) (key : String) : Array (String × Nat) :=
+  let rec go (seen : Bool) (acc : Array (String × Nat)) : List (String × Nat) → Array (String × Nat)
+    | [] =>
+        if seen then acc else acc.push (key, 1)
+    | (name, count) :: rest =>
+        if name == key then
+          go true (acc.push (name, count + 1)) rest
+        else
+          go seen (acc.push (name, count)) rest
+  go false #[] counts.toList
+
+private def countsJson (counts : Array (String × Nat)) : Json :=
+  let counts := counts.qsort (fun a b => a.1 < b.1)
+  Json.mkObj (counts.toList.map fun (key, count) => (key, Json.num count))
+
+private def statsJson (manifest : ManifestFile) : Json :=
+  let entries := blockStatementEntries manifest
+  let byKind := entries.foldl (fun counts entry => incrementCount counts (kindString entry.kind)) #[]
+  let byOwner := entries.foldl
+    (fun counts entry => entry.ownerDisplayName.map (incrementCount counts ·) |>.getD counts)
+    #[]
+  let byTag := entries.foldl
+    (fun counts entry => entry.tags.foldl incrementCount counts)
+    #[]
+  responseJson [
+    ("statements", Json.num entries.size),
+    ("byKind", countsJson byKind),
+    ("byOwner", countsJson byOwner),
+    ("byTag", countsJson byTag)
+  ]
+
+private def containsSearchText (text value : String) : Bool :=
+  value.toLower.contains text
+
+private def entryMatchesText (text : String) (entry : Entry) : Bool :=
+  let text := text.toLower
+  containsSearchText text (labelString entry.label) ||
+    containsSearchText text entry.title ||
+    entry.parentTitle.any (containsSearchText text) ||
+    entry.tags.any (containsSearchText text) ||
+    entry.ownerDisplayName.any (containsSearchText text)
+
+private def entryMatchesCode (decl : String) (entry : Entry) : Bool :=
+  entry.leanCodePreviewKeys.any (fun key => key.contains decl)
+
+private def missingLabelJson (label : String) : Json :=
+  responseJson [
+    ("error", Json.str "unknown-label"),
+    ("label", Json.str label)
+  ]
+
+private def withPrimaryEntry
+    (manifest : ManifestFile) (label : String) (mkJson : Entry → Json) : Except String Json :=
+  match findPrimaryBlockEntry? manifest label with
+  | some entry => .ok (mkJson entry)
+  | none => .ok (missingLabelJson label)
+
+def queryJson (manifest : ManifestFile) (args : List String) : Except String Json :=
+  match args with
+  | ["selectors"] =>
+      .ok querySelectorsJson
+  | ["labels"] =>
+      .ok <| responseJson [
+        ("labels", Json.arr (blockStatementEntries manifest |>.map entrySummaryJson))
+      ]
+  | ["node", label] =>
+      withPrimaryEntry manifest label entryResponseJson
+  | ["all", label] =>
+      withPrimaryEntry manifest label (entryAllJson label)
+  | ["uses", label] =>
+      withPrimaryEntry manifest label fun entry =>
+        responseJson [
+          ("label", Json.str label),
+          ("statementUses", Json.arr (entry.statementUses.map useRefJson)),
+          ("proofUses", Json.arr (entry.proofUses.map useRefJson)),
+          ("uses", Json.arr (entry.uses.map relatedEntryJson))
+        ]
+  | ["used-by", label] =>
+      withPrimaryEntry manifest label fun entry =>
+        responseJson [
+          ("label", Json.str label),
+          ("usedBy", Json.arr (entry.usedBy.map relatedEntryJson))
+        ]
+  | ["group", label] =>
+      withPrimaryEntry manifest label fun entry =>
+        responseJson [
+          ("label", Json.str label),
+          ("group", entryGroupJson entry)
+        ]
+  | ["owners"] =>
+      .ok <| responseJson [("owners", stringArrayJson (ownerValues manifest))]
+  | ["tags"] =>
+      .ok <| responseJson [("tags", stringArrayJson (tagValues manifest))]
+  | ["work-queue"] =>
+      .ok <| responseJson [
+        ("entries", Json.arr (workQueueEntries manifest |>.map entrySummaryJson))
+      ]
+  | ["search", text] =>
+      .ok <| responseJson [
+        ("query", Json.str text),
+        ("labels", Json.arr (blockStatementEntries manifest |>.filter (entryMatchesText text) |>.map entrySummaryJson))
+      ]
+  | ["code", decl] =>
+      .ok <| responseJson [
+        ("query", Json.str decl),
+        ("labels", Json.arr (blockStatementEntries manifest |>.filter (entryMatchesCode decl) |>.map entrySummaryJson))
+      ]
+  | ["stats"] =>
+      .ok (statsJson manifest)
+  | [] => .error "missing query selector"
+  | selector :: _ => .error s!"unknown query selector '{selector}'"
+
+structure GeneratedData where
+  manifest : ManifestFile
+  htmlCache : HtmlCacheFile
+
+def readManifestForSite (site : FilePath) : IO ManifestFile := do
+  let manifestPath ← manifestPathForSite site
+  unless ← manifestPath.pathExists do
+    throw <| IO.userError s!"missing Blueprint manifest at {manifestPath}; run `lake exe vbp build` first"
+  Informal.PreviewManifest.readFile manifestPath
+
+def readHtmlCacheForSite (site : FilePath) : IO HtmlCacheFile := do
+  let htmlCachePath ← htmlCachePathForSite site
+  unless ← htmlCachePath.pathExists do
+    throw <| IO.userError s!"missing Blueprint HTML cache at {htmlCachePath}; run `lake exe vbp build` first"
+  Informal.PreviewManifest.HtmlCache.readFile htmlCachePath
+
+def readGeneratedData (site : FilePath) : IO GeneratedData := do
+  let manifest ← readManifestForSite site
+  let htmlCache ← readHtmlCacheForSite site
+  pure { manifest, htmlCache }
+
+def cacheKeySet (cache : HtmlCacheFile) : Std.HashSet String :=
+  cache.entries.foldl (fun keys entry => keys.insert entry.key) {}
+
+def manifestKeySet (manifest : ManifestFile) : Std.HashSet String :=
+  manifest.previews.foldl (fun keys entry => keys.insert entry.key) {}
+
+private def pushMissingCacheKey
+    (keys : Std.HashSet String) (errors : Array String) (context key : String) : Array String :=
+  if keys.contains key then
+    errors
+  else
+    errors.push s!"missing HTML cache entry for {context}: {key}"
+
+private def checkRelatedEntries
+    (cacheKeys : Std.HashSet String) (context : String) (entries : Array RelatedEntry)
+    (errors : Array String) : Array String :=
+  entries.foldl
+    (fun errors entry => pushMissingCacheKey cacheKeys errors s!"{context} relation {labelString entry.label}" entry.previewKey)
+    errors
+
+def checkGeneratedData (manifest : ManifestFile) (htmlCache : HtmlCacheFile) : Array String :=
+  let manifestKeys := manifestKeySet manifest
+  let cacheKeys := cacheKeySet htmlCache
+  manifest.previews.foldl
+    (fun errors entry =>
+      let errors := pushMissingCacheKey cacheKeys errors s!"entry {entry.key}" entry.key
+      let errors := entry.leanCodePreviewKeys.foldl
+        (fun errors key =>
+          let errors :=
+            if manifestKeys.contains key then errors else errors.push s!"missing manifest entry for Lean preview key {key}"
+          pushMissingCacheKey cacheKeys errors s!"Lean preview key on {entry.key}" key)
+        errors
+      let errors := checkRelatedEntries cacheKeys s!"uses of {entry.key}" entry.uses errors
+      let errors := checkRelatedEntries cacheKeys s!"used-by of {entry.key}" entry.usedBy errors
+      match entry.group with
+      | none => errors
+      | some group => checkRelatedEntries cacheKeys s!"group {labelString group.label} on {entry.key}" group.entries errors)
+    #[]
+
+def checkJsonFromErrors
+    (manifest : ManifestFile) (htmlCache : HtmlCacheFile) (errors : Array String) : Json :=
+  responseJson [
+    ("ok", Json.bool errors.isEmpty),
+    ("manifestEntries", Json.num manifest.previews.size),
+    ("htmlCacheEntries", Json.num htmlCache.entries.size),
+    ("errors", Json.arr (errors.map Json.str))
+  ]
+
+def checkJson (manifest : ManifestFile) (htmlCache : HtmlCacheFile) : Json :=
+  checkJsonFromErrors manifest htmlCache (checkGeneratedData manifest htmlCache)
+
+end VersoBlueprint.Vbp

--- a/src/VersoBlueprint/VbpMain.lean
+++ b/src/VersoBlueprint/VbpMain.lean
@@ -1,0 +1,374 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoBlueprint.Vbp
+import Lake.CLI.Main
+
+open Lean
+open System
+
+namespace VersoBlueprint.Vbp.Main
+
+private def mainCommandLines : List String := [
+  "lake exe vbp discover",
+  "lake exe vbp build [--output <dir>] [--serve] [--port <n>]",
+  "lake exe vbp query [--site <dir>] <selector>",
+  "lake exe vbp check [--site <dir>]"
+]
+
+private def defaultHelpLines : List String := [
+  "build writes _out/site",
+  "query and check read _out/site",
+  "--serve serves the generated html-multi directory after a successful build",
+  "--serve --port <n> serves on a fixed port"
+]
+
+private def indentHelpLine (line : String) : String :=
+  "  " ++ line
+
+def helpText : String := String.intercalate "\n" <|
+  [
+  "vbp - Verso Blueprint project helper",
+  "",
+  "Usage:"
+  ] ++ mainCommandLines.map indentHelpLine ++ [
+    "",
+    "Query selectors:"
+  ] ++ VersoBlueprint.Vbp.querySelectorLines.map indentHelpLine ++ [
+    "",
+    "Defaults:"
+  ] ++ defaultHelpLines.map indentHelpLine
+
+private def printJson (json : Json) : IO Unit :=
+  IO.println json.compress
+
+private def firstToken? (text : String) : Option String :=
+  text.trimAscii.toString.splitOn " " |>.filter (!·.isEmpty) |>.head?
+
+private def blueprintGenName : Name :=
+  .str .anonymous "blueprint-gen"
+
+structure ProjectInfo where
+  packageName : String
+  generatorRoot : Name
+  generatorFile : FilePath
+
+private def loadWorkspace : IO (Except String Lake.Workspace) := do
+  let cwd ← IO.currentDir
+  let (elanInstall?, leanInstall?, lakeInstall?) ← Lake.findInstall?
+  let some leanInstall := leanInstall?
+    | pure (.error "could not detect a Lean installation")
+  let some lakeInstall := lakeInstall?
+    | pure (.error "could not detect the configuration of the Lake installation")
+  match ← (Lake.Env.compute lakeInstall leanInstall elanInstall?).toBaseIO with
+  | .error err => pure (.error err)
+  | .ok lakeEnv =>
+      let config : Lake.LoadConfig := {
+        lakeEnv,
+        wsDir := cwd,
+        updateToolchain := false
+      }
+      match ← (Lake.loadWorkspace config).toBaseIO with
+      | some workspace => pure (.ok workspace)
+      | none => pure (.error "could not load Lake workspace")
+
+private def projectInfo : IO (Except String ProjectInfo) := do
+  match ← loadWorkspace with
+  | .error err => pure (.error err)
+  | .ok workspace =>
+      let some generator := workspace.findLeanExe? blueprintGenName
+        | pure (.error "could not find a `blueprint-gen` executable in the Lake workspace")
+      pure (.ok {
+        packageName := workspace.root.prettyName,
+        generatorRoot := generator.config.root,
+        generatorFile := generator.root.leanFile
+      })
+
+private def lineImportModule? (line : String) : Option String :=
+  let line := line.trimAscii.toString
+  if line.startsWith "import " then
+    firstToken? ((line.drop "import ".length).toString)
+  else
+    none
+
+private def docModule? (text : String) : Option String :=
+  text.splitOn "\n" |>.findSome? fun line =>
+    match line.splitOn "%doc " with
+    | _ :: after :: _ =>
+      firstToken? (after.replace ")" " ")
+    | _ => none
+
+private def topLevelBlueprintModule? (cwd generator : FilePath) : IO (Option String) := do
+  if !(← (cwd / generator).pathExists) then
+    pure none
+  else
+    let text ← IO.FS.readFile (cwd / generator)
+    pure <|
+      docModule? text <|>
+        (text.splitOn "\n" |>.filterMap lineImportModule? |>.find? (·.endsWith ".Blueprint"))
+
+private def pathString (path : FilePath) : String :=
+  path.toString
+
+private def chapterCandidates (cwd : FilePath) (packageName? : Option String) : IO (Array String) := do
+  match packageName? with
+  | none => pure #[]
+  | some packageName =>
+      let dir := cwd / packageName / "Chapters"
+      if !(← dir.pathExists) then
+        pure #[]
+      else
+        try
+          let mut chapters := #[]
+          for entry in ← dir.readDir do
+            let pathText := entry.path.toString
+            if pathText.endsWith ".lean" then
+              chapters := chapters.push (pathString (FilePath.mk packageName / "Chapters" / entry.path.fileName.getD ""))
+          pure <| chapters.qsort (· < ·)
+        catch _ =>
+          pure #[]
+
+def discover : IO UInt32 := do
+  let cwd ← IO.currentDir
+  let info? ← projectInfo
+  let (packageName?, generatorExecutable?, generator?, generatorRoot?, discoveryErrors) :=
+    match info? with
+    | .ok info =>
+        (some info.packageName, some "blueprint-gen", some info.generatorFile, some info.generatorRoot.toString, #[])
+    | .error err => (none, none, none, none, #[err])
+  let topLevel? ←
+    match generator? with
+    | none => pure none
+    | some generator => topLevelBlueprintModule? cwd generator
+  let chapters ← chapterCandidates cwd packageName?
+  let manifestPath ← VersoBlueprint.Vbp.manifestPathForSite VersoBlueprint.Vbp.defaultSite
+  let cachePath ← VersoBlueprint.Vbp.htmlCachePathForSite VersoBlueprint.Vbp.defaultSite
+  printJson <| VersoBlueprint.Vbp.responseJson [
+    ("projectRoot", Json.str cwd.toString),
+    ("packageName", packageName?.map Json.str |>.getD Json.null),
+    ("generatorExecutable", generatorExecutable?.map Json.str |>.getD Json.null),
+    ("generatorRoot", generatorRoot?.map Json.str |>.getD Json.null),
+    ("generator", generator?.map (Json.str ∘ pathString) |>.getD Json.null),
+    ("topLevelBlueprintModuleGuess", topLevel?.map Json.str |>.getD Json.null),
+    ("defaultOutput", Json.str VersoBlueprint.Vbp.defaultOutput.toString),
+    ("manifest", Json.str manifestPath.toString),
+    ("htmlCache", Json.str cachePath.toString),
+    ("chapterCandidateGuesses", Json.arr (chapters.map Json.str)),
+    ("discoveryErrors", Json.arr (discoveryErrors.map Json.str))
+  ]
+  pure 0
+
+structure BuildOptions where
+  output : FilePath := VersoBlueprint.Vbp.defaultOutput
+  serve : Bool := false
+  port? : Option Nat := none
+
+structure BuildPlan where
+  packageName : String
+  generatorPrepareArgs : Array String
+  generatorArgs : Array String
+
+private def maxTcpPort : Nat := 65535
+
+private def parseTcpPort (raw : String) : Except String Nat :=
+  match raw.toNat? with
+  | some port =>
+      if port <= maxTcpPort then
+        .ok port
+      else
+        .error s!"invalid --port value '{raw}'; expected a TCP port between 0 and {maxTcpPort}"
+  | none => .error s!"invalid --port value '{raw}'"
+
+private partial def parseBuildOptionsCore : List String → BuildOptions → Except String BuildOptions
+  | [], opts => .ok opts
+  | "--output" :: dir :: args, opts => parseBuildOptionsCore args { opts with output := FilePath.mk dir }
+  | "--output" :: [], _ => .error "missing value after --output"
+  | "--serve" :: args, opts => parseBuildOptionsCore args { opts with serve := true }
+  | "--port" :: raw :: args, opts =>
+      match parseTcpPort raw with
+      | .ok port => parseBuildOptionsCore args { opts with port? := some port }
+      | .error err => .error err
+  | "--port" :: [], _ => .error "missing value after --port"
+  | arg :: _, _ => .error s!"unknown build option '{arg}'"
+
+private def validateBuildOptions (opts : BuildOptions) : Except String BuildOptions :=
+  if opts.port?.isSome && !opts.serve then
+    .error "--port requires --serve"
+  else
+    .ok opts
+
+def parseBuildOptions (args : List String) (opts : BuildOptions) : Except String BuildOptions :=
+  match parseBuildOptionsCore args opts with
+  | .ok opts => validateBuildOptions opts
+  | .error err => .error err
+
+structure SiteOptions where
+  site : FilePath := VersoBlueprint.Vbp.defaultSite
+  rest : List String := []
+
+partial def parseSiteOptions : List String → SiteOptions → Except String SiteOptions
+  | [], opts => .ok { opts with rest := opts.rest.reverse }
+  | "--site" :: dir :: args, opts => parseSiteOptions args { opts with site := FilePath.mk dir }
+  | "--site" :: [], _ => .error "missing value after --site"
+  | arg :: args, opts => parseSiteOptions args { opts with rest := arg :: opts.rest }
+
+private def formatCommand (cmd : String) (args : Array String) : String :=
+  String.intercalate " " (cmd :: args.toList)
+
+private def runAttached (cmd : String) (args : Array String) : IO UInt32 := do
+  let child ← IO.Process.spawn { cmd, args }
+  child.wait
+
+private def runBuildStage (stage cmd : String) (args : Array String) : IO UInt32 := do
+  let code ← runAttached cmd args
+  unless code == 0 do
+    IO.eprintln s!"vbp build: {stage} failed with exit code {code}: {formatCommand cmd args}"
+  pure code
+
+private structure BuildStage where
+  stage : String
+  cmd : String
+  args : Array String
+
+private partial def runBuildStages : List BuildStage → IO UInt32
+  | [] => pure 0
+  | stage :: rest => do
+      let code ← runBuildStage stage.stage stage.cmd stage.args
+      if code == 0 then
+        runBuildStages rest
+      else
+        pure code
+
+private def buildPlan (output : FilePath) : IO (Except String BuildPlan) := do
+  match ← projectInfo with
+  | .error err => pure (.error err)
+  | .ok info =>
+      pure (.ok {
+        packageName := info.packageName,
+        generatorPrepareArgs := #["lean", info.generatorFile.toString],
+        generatorArgs := #["env", "lean", "--run", info.generatorFile.toString, "--output", output.toString]
+      })
+
+private def serveScript : String := String.intercalate "\n" [
+  "import functools, http.server, socketserver, sys",
+  "mode = sys.argv[1]",
+  "requested = int(sys.argv[2])",
+  "directory = sys.argv[3]",
+  "host = '127.0.0.1'",
+  "ports = [requested] if mode == 'fixed' else [requested, 0]",
+  "last_error = None",
+  "for port in ports:",
+  "    handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=directory)",
+  "    try:",
+  "        with socketserver.TCPServer((host, port), handler) as httpd:",
+  "            actual = httpd.server_address[1]",
+  "            print(f'Preview URL: http://{host}:{actual}/', flush=True)",
+  "            httpd.serve_forever()",
+  "    except OSError as exc:",
+  "        last_error = exc",
+  "        continue",
+  "print(f'could not start preview server: {last_error}', file=sys.stderr)",
+  "sys.exit(1)"
+]
+
+private def serve (output : FilePath) (port? : Option Nat) : IO UInt32 := do
+  let htmlDir := output / "html-multi"
+  if !(← htmlDir.pathExists) then
+    IO.eprintln s!"missing generated HTML directory {htmlDir}; build did not produce html-multi output"
+    pure 1
+  else
+    let mode := if port?.isSome then "fixed" else "auto"
+    let port := port?.getD 8000
+    runAttached "python3" #["-c", serveScript, mode, toString port, htmlDir.toString]
+
+def build (args : List String) : IO UInt32 := do
+  match parseBuildOptions args {} with
+  | .error err =>
+      IO.eprintln err
+      pure 2
+  | .ok opts =>
+      match ← buildPlan opts.output with
+      | .error err =>
+          IO.eprintln err
+          pure 1
+      | .ok plan =>
+          let code ← runBuildStages [
+            { stage := "package build", cmd := "lake", args := #["build", plan.packageName] },
+            { stage := "generator preparation", cmd := "lake", args := plan.generatorPrepareArgs },
+            { stage := "generator run", cmd := "lake", args := plan.generatorArgs }
+          ]
+          if code != 0 then
+            pure code
+          else if opts.serve then
+            serve opts.output opts.port?
+          else
+            pure 0
+
+def query (args : List String) : IO UInt32 := do
+  match parseSiteOptions args {} with
+  | .error err =>
+      IO.eprintln err
+      pure 2
+  | .ok opts =>
+      match opts.rest with
+      | ["selectors"] =>
+          printJson VersoBlueprint.Vbp.querySelectorsJson
+          pure 0
+      | _ =>
+          try
+            let manifest ← VersoBlueprint.Vbp.readManifestForSite opts.site
+            match VersoBlueprint.Vbp.queryJson manifest opts.rest with
+            | .ok json =>
+                printJson json
+                pure 0
+            | .error err =>
+                IO.eprintln err
+                pure 2
+          catch err =>
+            IO.eprintln err.toString
+            pure 1
+
+def check (args : List String) : IO UInt32 := do
+  match parseSiteOptions args {} with
+  | .error err =>
+      IO.eprintln err
+      pure 2
+  | .ok opts =>
+      try
+        let data ← VersoBlueprint.Vbp.readGeneratedData opts.site
+        let errors := VersoBlueprint.Vbp.checkGeneratedData data.manifest data.htmlCache
+        printJson (VersoBlueprint.Vbp.checkJsonFromErrors data.manifest data.htmlCache errors)
+        if errors.isEmpty then pure 0 else pure 1
+      catch err =>
+        IO.eprintln err.toString
+        pure 1
+
+def main (args : List String) : IO UInt32 := do
+  match args with
+  | [] =>
+      IO.println helpText
+      pure 0
+  | ["--help"] | ["-h"] | ["help"] =>
+      IO.println helpText
+      pure 0
+  | "discover" :: rest =>
+      match rest with
+      | [] => discover
+      | _ =>
+          IO.eprintln "discover does not accept arguments"
+          pure 2
+  | "build" :: rest => build rest
+  | "query" :: rest => query rest
+  | "check" :: rest => check rest
+  | cmd :: _ =>
+      IO.eprintln s!"unknown command '{cmd}'"
+      IO.eprintln helpText
+      pure 2
+
+end VersoBlueprint.Vbp.Main
+
+def main (args : List String) : IO UInt32 :=
+  VersoBlueprint.Vbp.Main.main args

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -1,0 +1,471 @@
+import VersoBlueprint.Vbp
+import VersoBlueprint.VbpMain
+
+namespace Verso.VersoBlueprintTests.Vbp
+
+open Lean
+
+abbrev ManifestFile := Informal.PreviewManifest.File
+abbrev HtmlCacheFile := Informal.PreviewManifest.HtmlCache.File
+abbrev RelatedEntry := Informal.PreviewManifest.RelatedEntry
+
+private def label (value : String) : Name :=
+  Name.mkSimple value
+
+private def related (value title key : String) : RelatedEntry :=
+  {
+    label := label value
+    title := title
+    previewKey := key
+    axes := #[.statement]
+  }
+
+private def sampleManifest : ManifestFile := {
+  previews := #[
+    {
+      key := "informal:addition_spec:statement"
+      targetKind := .block
+      label := label "addition_spec"
+      facet := .statement
+      kind := some .definition
+      title := "Definition 1"
+      usedBy := #[related "addition_assoc" "Theorem 2" "informal:addition_assoc:statement"]
+      tags := #["starter"]
+    },
+    {
+      key := "informal:addition_assoc:statement"
+      targetKind := .block
+      label := label "addition_assoc"
+      facet := .statement
+      kind := some .theorem
+      title := "Theorem 2"
+      statementUses := #[{ label := label "addition_spec" }]
+      uses := #[related "addition_spec" "Definition 1" "informal:addition_spec:statement"]
+      leanCodePreviewKeys := #["lean:Nat.add_assoc"]
+      ownerDisplayName := some "Project Author"
+      tags := #["starter", "arithmetic"]
+      priority := some "high"
+      effort := some "small"
+    },
+    {
+      key := "lean:Nat.add_assoc"
+      targetKind := .leanDecl
+      label := label "Nat.add_assoc"
+      facet := .statement
+      title := "Nat.add_assoc"
+    }
+  ]
+}
+
+private def sampleCache : HtmlCacheFile := {
+  entries := #[
+    { key := "informal:addition_spec:statement", html := "<div>addition spec</div>" },
+    { key := "informal:addition_assoc:statement", html := "<div>addition assoc</div>" },
+    { key := "lean:Nat.add_assoc", html := "<pre>Nat.add_assoc</pre>" }
+  ]
+}
+
+private def sampleMetadataManifest : ManifestFile := {
+  previews := #[
+    {
+      key := "informal:zeta_statement:statement"
+      targetKind := .block
+      label := label "zeta_statement"
+      facet := .statement
+      title := "Zeta"
+      ownerDisplayName := some "Zed"
+      tags := #["zeta", "alpha"]
+    },
+    {
+      key := "informal:alpha_statement:statement"
+      targetKind := .block
+      label := label "alpha_statement"
+      facet := .statement
+      title := "Alpha"
+      ownerDisplayName := some "Alpha"
+      tags := #["beta"]
+    }
+  ]
+}
+
+private def jsonField? (json : Json) (field : String) : Option Json :=
+  match json.getObjVal? field with
+  | .ok value => some value
+  | .error _ => none
+
+private def jsonStringField? (json : Json) (field : String) : Option String :=
+  match json.getObjValAs? String field with
+  | .ok value => some value
+  | .error _ => none
+
+private def jsonBoolField? (json : Json) (field : String) : Option Bool :=
+  match json.getObjValAs? Bool field with
+  | .ok value => some value
+  | .error _ => none
+
+private def jsonNatField? (json : Json) (field : String) : Option Nat :=
+  match json.getObjValAs? Nat field with
+  | .ok value => some value
+  | .error _ => none
+
+private def jsonArrayField? (json : Json) (field : String) : Option (Array Json) :=
+  match jsonField? json field with
+  | some (.arr values) => some values
+  | _ => none
+
+private def jsonHasApiStability (json : Json) : Bool :=
+  jsonStringField? json "apiStability" == some VersoBlueprint.Vbp.apiStability
+
+private def jsonArrayContainsString (values : Array Json) (expected : String) : Bool :=
+  values.any (fun
+    | .str value => value == expected
+    | _ => false)
+
+private def jsonArrayHasStringField (values : Array Json) (field expected : String) : Bool :=
+  values.any (fun json => jsonStringField? json field == some expected)
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    let text := VersoBlueprint.Vbp.Main.helpText
+    text.contains "lake exe vbp query [--site <dir>] <selector>" &&
+      text.contains "Query selectors:" &&
+      text.contains "selectors" &&
+      text.contains "all <label>" &&
+      text.contains "search <text>" &&
+      text.contains "--serve --port <n>" &&
+      text.contains "build writes _out/site" &&
+      !text.contains "lake exe vbp query [--site <dir>] node <label>"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    VersoBlueprint.Vbp.ownerValues sampleMetadataManifest == #["Alpha", "Zed"] &&
+      VersoBlueprint.Vbp.tagValues sampleMetadataManifest == #["alpha", "beta", "zeta"]
+
+private partial def freshVbpFixtureRoot : IO System.FilePath := do
+  let suffix ← IO.rand 0 1000000000000
+  let root :=
+    System.FilePath.mk ".lake" / "build" / "tmp" /
+      "verso-blueprint-vbp-test" / toString suffix
+  if ← root.pathExists then
+    freshVbpFixtureRoot
+  else
+    pure root
+
+private def writeManifestOnlySite (site : System.FilePath) : IO Unit := do
+  let dataDir := site / "html-multi" / "-verso-data"
+  IO.FS.createDirAll dataDir
+  IO.FS.writeFile
+    (dataDir / Informal.PreviewManifest.manifestFilename)
+    (toJson sampleManifest).compress
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.queryJson sampleManifest ["selectors"] with
+    | .ok json =>
+        match jsonArrayField? json "selectors" with
+        | some selectors =>
+            jsonHasApiStability json &&
+              jsonArrayContainsString selectors "selectors" &&
+              jsonArrayContainsString selectors "all <label>" &&
+              jsonArrayContainsString selectors "search <text>"
+        | none => false
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.queryJson sampleManifest ["labels"] with
+    | .ok json =>
+        match jsonArrayField? json "labels" with
+        | some labels =>
+            jsonHasApiStability json &&
+              jsonArrayHasStringField labels "label" "addition_spec" &&
+              jsonArrayHasStringField labels "label" "addition_assoc" &&
+              !jsonArrayHasStringField labels "label" "Nat.add_assoc"
+        | none => false
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.queryJson sampleManifest ["node", "addition_assoc"] with
+    | .ok json =>
+        match jsonArrayField? json "statementUses" with
+        | some statementUses =>
+            jsonHasApiStability json &&
+              jsonStringField? json "label" == some "addition_assoc" &&
+              jsonStringField? json "ownerDisplayName" == some "Project Author" &&
+              jsonArrayHasStringField statementUses "label" "addition_spec" &&
+              jsonArrayContainsString (jsonArrayField? json "leanCodePreviewKeys" |>.getD #[]) "lean:Nat.add_assoc"
+        | none => false
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.queryJson sampleManifest ["used-by", "addition_spec"] with
+    | .ok json =>
+        match jsonArrayField? json "usedBy" with
+        | some usedBy =>
+            jsonHasApiStability json &&
+              jsonStringField? json "label" == some "addition_spec" &&
+              jsonArrayHasStringField usedBy "label" "addition_assoc" &&
+              jsonArrayHasStringField usedBy "previewKey" "informal:addition_assoc:statement"
+        | none => false
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.queryJson sampleManifest ["all", "addition_assoc"] with
+    | .ok json =>
+        match jsonField? json "node", jsonArrayField? json "statementUses" with
+        | some node, some statementUses =>
+            jsonHasApiStability json &&
+              jsonStringField? json "label" == some "addition_assoc" &&
+              jsonStringField? node "label" == some "addition_assoc" &&
+              jsonArrayHasStringField statementUses "label" "addition_spec" &&
+              (jsonArrayField? json "usedBy").isSome
+        | _, _ => false
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.queryJson sampleManifest ["search", "assoc"] with
+    | .ok json =>
+        match jsonArrayField? json "labels" with
+        | some labels =>
+            jsonStringField? json "query" == some "assoc" &&
+              jsonArrayHasStringField labels "label" "addition_assoc" &&
+              !jsonArrayHasStringField labels "label" "addition_spec"
+        | none => false
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.queryJson sampleManifest ["search", "THEOREM"] with
+    | .ok json =>
+        match jsonArrayField? json "labels" with
+        | some labels =>
+            jsonStringField? json "query" == some "THEOREM" &&
+              jsonArrayHasStringField labels "label" "addition_assoc" &&
+              !jsonArrayHasStringField labels "label" "addition_spec"
+        | none => false
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.queryJson sampleManifest ["code", "Nat.add_assoc"] with
+    | .ok json =>
+        match jsonArrayField? json "labels" with
+        | some labels =>
+            jsonStringField? json "query" == some "Nat.add_assoc" &&
+              jsonArrayHasStringField labels "label" "addition_assoc"
+        | none => false
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.queryJson sampleManifest ["stats"] with
+    | .ok json =>
+        match jsonField? json "byKind", jsonField? json "byTag" with
+        | some byKind, some byTag =>
+            jsonHasApiStability json &&
+              jsonNatField? json "statements" == some 2 &&
+              jsonNatField? byKind "definition" == some 1 &&
+              jsonNatField? byKind "theorem" == some 1 &&
+              jsonNatField? byTag "starter" == some 2
+        | _, _ => false
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.queryJson sampleManifest [] with
+    | .ok _ => false
+    | .error err => err == "missing query selector"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.queryJson sampleManifest ["bogus"] with
+    | .ok _ => false
+    | .error err => err == "unknown query selector 'bogus'"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.queryJson sampleManifest ["node", "missing_label"] with
+    | .ok json =>
+        jsonHasApiStability json &&
+          jsonStringField? json "error" == some "unknown-label" &&
+          jsonStringField? json "label" == some "missing_label"
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    VersoBlueprint.Vbp.checkGeneratedData sampleManifest sampleCache |>.isEmpty
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    let json := VersoBlueprint.Vbp.checkJson sampleManifest sampleCache
+    jsonHasApiStability json &&
+      jsonBoolField? json "ok" == some true &&
+      jsonNatField? json "manifestEntries" == some 3 &&
+      jsonNatField? json "htmlCacheEntries" == some 3
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    let json := VersoBlueprint.Vbp.checkJsonFromErrors sampleManifest sampleCache #["forced diagnostic"]
+    let errors := jsonArrayField? json "errors" |>.getD #[]
+    jsonBoolField? json "ok" == some false &&
+      jsonArrayContainsString errors "forced diagnostic"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    let brokenCache : HtmlCacheFile := {
+      entries := sampleCache.entries.filter (fun entry => entry.key != "lean:Nat.add_assoc")
+    }
+    VersoBlueprint.Vbp.checkGeneratedData sampleManifest brokenCache |>.any (·.contains "lean:Nat.add_assoc")
+
+/-- info: true -/
+#guard_msgs in
+#eval do
+  let site ← freshVbpFixtureRoot
+  writeManifestOnlySite site
+  let manifest ← VersoBlueprint.Vbp.readManifestForSite site
+  let queryOk :=
+    match VersoBlueprint.Vbp.queryJson manifest ["labels"] with
+    | .ok json =>
+        let labels := jsonArrayField? json "labels" |>.getD #[]
+        jsonArrayHasStringField labels "label" "addition_assoc"
+    | .error _ => false
+  let cacheMissing ←
+    try
+      let _ ← VersoBlueprint.Vbp.readHtmlCacheForSite site
+      pure false
+    catch err =>
+      let message := IO.Error.toString err
+      pure <| message.contains "run `lake exe vbp build` first" &&
+        !message.contains "vbp check"
+  pure (queryOk && cacheMissing)
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.Main.parseBuildOptions ["--output", "_out/custom", "--serve", "--port", "8080"] {} with
+    | .ok opts =>
+        opts.output.toString == "_out/custom" &&
+          opts.serve &&
+          opts.port? == some 8080
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.Main.parseBuildOptions ["--port", "not-a-port"] {} with
+    | .ok _ => false
+    | .error err => err.contains "invalid --port value"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.Main.parseBuildOptions ["--port", "8080"] {} with
+    | .ok _ => false
+    | .error err => err == "--port requires --serve"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.Main.parseBuildOptions ["--port", "8080", "--serve"] {} with
+    | .ok opts =>
+        opts.serve &&
+          opts.port? == some 8080
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.Main.parseBuildOptions ["--port", "70000"] {} with
+    | .ok _ => false
+    | .error err =>
+        err.contains "invalid --port value" &&
+          err.contains "65535"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.Main.parseBuildOptions ["--output"] {} with
+    | .ok _ => false
+    | .error err => err == "missing value after --output"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.Main.parseBuildOptions ["--bogus"] {} with
+    | .ok _ => false
+    | .error err => err == "unknown build option '--bogus'"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.Main.parseSiteOptions ["--site", "_out/custom", "node", "addition_assoc"] {} with
+    | .ok opts =>
+        opts.site.toString == "_out/custom" &&
+          opts.rest == ["node", "addition_assoc"]
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.Main.parseSiteOptions ["--site"] {} with
+    | .ok _ => false
+    | .error err => err.contains "missing value after --site"
+
+/-- info: discover does not accept arguments
+---
+info: true -/
+#guard_msgs in
+#eval do
+  let code ← VersoBlueprint.Vbp.Main.main ["discover", "extra"]
+  pure (code == 2)
+
+end Verso.VersoBlueprintTests.Vbp

--- a/tests/harness/test_verso_blueprint_skill.py
+++ b/tests/harness/test_verso_blueprint_skill.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+SKILL_ROOT = PACKAGE_ROOT / "skills" / "verso-blueprint"
+
+
+class VersoBlueprintSkillTests(unittest.TestCase):
+    def test_skill_frontmatter_and_references_are_present(self) -> None:
+        skill = SKILL_ROOT / "SKILL.md"
+        text = skill.read_text(encoding="utf-8")
+        self.assertTrue(text.startswith("---\n"))
+        self.assertIn("name: verso-blueprint", text)
+        self.assertIn("description: Work with Verso Blueprint Lean projects.", text)
+        self.assertIn("references/vbp.md", text)
+        self.assertIn("references/authoring-patterns.md", text)
+        self.assertIn("JSON shapes as unstable", text)
+        self.assertNotIn("TODO", text)
+
+    def test_vbp_reference_documents_public_surface(self) -> None:
+        text = (SKILL_ROOT / "references" / "vbp.md").read_text(encoding="utf-8")
+        self.assertIn("lake exe vbp build [--output <dir>] [--serve] [--port <n>]", text)
+        self.assertIn("lake exe vbp query [--site <dir>] <selector>", text)
+        self.assertIn("lake lean <GeneratorMain>.lean", text)
+        self.assertIn("lake env lean --run <GeneratorMain>.lean --output <output>", text)
+        self.assertIn("selectors`: query selector forms", text)
+        self.assertIn("does not require generated Blueprint data", text)
+        self.assertIn("all <label>", text)
+        self.assertIn("search <text>", text)
+        self.assertIn("case-insensitively", text)
+        self.assertIn("code <decl>", text)
+        self.assertIn("stats", text)
+        self.assertIn("used-by <label>", text)
+        self.assertIn("Pass `--output <dir>` only", text)
+        self.assertIn("Pass `--site <dir>`", text)
+        self.assertIn("`--port` is accepted only with `--serve`", text)
+        self.assertIn('"apiStability":"unstable"', text)
+        self.assertIn("discoveryErrors", text)
+        self.assertIn("Query reads the semantic manifest only", text)
+        self.assertIn("topLevelBlueprintModuleGuess", text)
+        self.assertIn("chapterCandidateGuesses", text)
+        self.assertIn("fully unstable", text)
+        self.assertIn("Fallback Without `vbp`", text)
+
+    def test_vbp_reference_documents_build_check_boundary(self) -> None:
+        text = (SKILL_ROOT / "references" / "vbp.md").read_text(encoding="utf-8")
+        self.assertIn("post-build generated-data health check", text)
+        self.assertIn("does not replace `build`", text)
+        self.assertIn("Lean/Lake compilation", text)
+
+    def test_vbp_reference_documents_adoption_boundary(self) -> None:
+        text = (SKILL_ROOT / "references" / "vbp.md").read_text(encoding="utf-8")
+        self.assertIn("lake exe vbp discover", text)
+        self.assertIn("lake env lean --run", text)
+        self.assertIn("fully unstable", text)
+
+    def test_readme_marks_vbp_json_unstable(self) -> None:
+        text = (PACKAGE_ROOT / "README.md").read_text(encoding="utf-8")
+        self.assertIn("Treat `vbp` query JSON as an unstable", text)
+        self.assertIn("not a public compatibility contract", text)
+
+    def test_maintainer_guide_records_vbp_boundary(self) -> None:
+        text = (PACKAGE_ROOT / "doc" / "MAINTAINER_GUIDE.md").read_text(encoding="utf-8")
+        self.assertIn("Agent-Facing `vbp` Helper", text)
+        self.assertIn("fully unstable", text)
+        self.assertIn("lake exe vbp query selectors", text)
+
+    def test_authoring_reference_records_dependency_guardrails(self) -> None:
+        text = (SKILL_ROOT / "references" / "authoring-patterns.md").read_text(encoding="utf-8")
+        self.assertIn('Use `{uses "target"}[]`', text)
+        self.assertIn('Use `{bpref "target"}[]`', text)
+        self.assertIn("Statement and proof dependencies are separate.", text)
+        self.assertIn("Do not rename existing labels casually", text)
+
+    def test_openai_metadata_matches_skill(self) -> None:
+        text = (SKILL_ROOT / "agents" / "openai.yaml").read_text(encoding="utf-8")
+        self.assertIn('display_name: "Verso Blueprint"', text)
+        self.assertIn('short_description: "Work with Verso Blueprint projects"', text)
+        self.assertIn('default_prompt: "Use $verso-blueprint', text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds an unstable agent-facing `vbp` helper executable and a Verso Blueprint skill so local coding agents can discover Blueprint projects, build and serve previews, query generated Blueprint data, and run post-edit checks.

Backport v4.29.0: exempt: manual backport #123 opened; patch-id differs only because README and maintainer-guide context differs on the release line