### PR TITLE
[backport v4.29.0] refactor: trim harness cleanup code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,6 @@
   - `python3 -m scripts.blueprint_harness --help`
   - `python3 -m scripts.blueprint_harness sync-root-lake`
   - `python3 -m scripts.blueprint_harness paths`
-  - `python3 -m scripts.blueprint_harness worktree-sync`
   - `python3 -m scripts.blueprint_harness worktree-list`
   - `python3 -m scripts.blueprint_harness worktree-status`
   - `python3 -m scripts.blueprint_harness worktree-claim`

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -131,8 +131,6 @@ python3 -m scripts.blueprint_harness worktree-release
 ```
 
 `worktree-list` already refreshes local metadata before printing the dashboard.
-`worktree-sync` remains available as a compatibility alias for
-`worktree-list`.
 
 By default, only clean up worktrees or branches created or landed by the
 current session. Do not retire or delete unrelated local worktrees unless the

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -84,6 +84,13 @@ the stable base:
 python3 -m scripts.blueprint_harness create-worktree <name> --owner codex --lock --priority P1 --summary "short description"
 ```
 
+For docs, Python harness, or other work that does not need synced Lake
+artifacts or warmed reference clones, prefer a lightweight worktree:
+
+```bash
+python3 -m scripts.blueprint_harness create-worktree <name> --lightweight
+```
+
 Before non-backport work, check the branch role and release sync state:
 
 ```bash

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -452,8 +452,6 @@ The local coordination layer is now machine-readable and untracked.
 
 - `worktree-list` refreshes local metadata under `.worktrees/` and prints the
   current dashboard view, combining local metadata with live Git state
-- `worktree-sync` remains available as a compatibility alias for
-  `worktree-list`
 - `worktree-claim` records owner, lock state, priority, summary, status, and
   write scope
 - `worktree-status` shows one worktree record

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -48,6 +48,7 @@ Common starting points:
 
 ```bash
 python3 -m scripts.blueprint_harness create-worktree <name> --owner codex --lock --priority P1 --summary "short description"
+python3 -m scripts.blueprint_harness create-worktree <name> --lightweight  # docs/Python-only work
 python3 -m scripts.blueprint_harness release-status --require-sync
 python3 -m scripts.blueprint_harness paths
 python3 -m scripts.blueprint_reference_harness projects

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -99,7 +99,8 @@ script map, not a second command reference.
   the harness catalog loaders.
 - `blueprint_harness_projects.py`
   Project-manifest loader and schema checks for
-  [`tests/harness/projects.json`](../tests/harness/projects.json).
+  [`tests/harness/projects.json`](../tests/harness/projects.json), including
+  shared reference/deploy matrix serialization.
 - `blueprint_harness_references.py`
   Reference-blueprint checkout, editable-clone setup, local override, cache
   warm-up, and prune helpers shared by the reference CLI.

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -944,13 +944,8 @@ def command_worktree_release(args: argparse.Namespace) -> int:
     print(f"status={record.status}")
     return 0
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="python3 -m scripts.blueprint_harness",
-        description="Worktree, landing, and local coordination CLI for this repository.",
-    )
-    subparsers = parser.add_subparsers(dest="command", required=True)
 
+def add_release_management_commands(subparsers) -> None:
     sync_root_lake = subparsers.add_parser(
         "sync-root-lake",
         help="Sync `.lake/` from the root checkout into the current linked worktree.",
@@ -989,6 +984,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     main_status.set_defaults(func=command_main_status)
 
+
+def add_pr_preparation_commands(subparsers) -> None:
     prepare_backports = subparsers.add_parser(
         "prepare-backports",
         help="Print PR-body lines for the required backport plan on the current default-dev release line.",
@@ -1066,6 +1063,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     prepare_backport_pr.set_defaults(func=command_prepare_backport_pr)
 
+
+def add_landing_commands(subparsers) -> None:
     require_role = subparsers.add_parser(
         "require-branch-role",
         help="Exit nonzero unless the current checkout matches the requested branch-policy role.",
@@ -1103,6 +1102,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     land_main.set_defaults(func=command_land_main)
 
+
+def add_worktree_commands(subparsers) -> None:
     create_worktree = subparsers.add_parser(
         "create-worktree",
         help=(
@@ -1199,6 +1200,8 @@ def build_parser() -> argparse.ArgumentParser:
     worktree_release.add_argument("--summary", default=None, help="Optional final summary.")
     worktree_release.set_defaults(func=command_worktree_release)
 
+
+def add_path_commands(subparsers) -> None:
     paths = subparsers.add_parser(
         "paths",
         help="Print canonical and resolved worktree-aware harness paths.",
@@ -1209,6 +1212,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="Print site paths for every manifest project instead of only the current release selection.",
     )
     paths.set_defaults(func=command_paths)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python3 -m scripts.blueprint_harness",
+        description="Worktree, landing, and local coordination CLI for this repository.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    add_release_management_commands(subparsers)
+    add_pr_preparation_commands(subparsers)
+    add_landing_commands(subparsers)
+    add_worktree_commands(subparsers)
+    add_path_commands(subparsers)
     return parser
 
 

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -1264,8 +1264,6 @@ def build_parser() -> argparse.ArgumentParser:
 
     worktree_list = subparsers.add_parser(
         "worktree-list",
-        aliases=["worktree-sync"],
-        description="Refresh and print the local worktree dashboard. `worktree-sync` is a compatibility alias.",
         help="Refresh and print the local worktree dashboard.",
     )
     worktree_list.set_defaults(func=command_worktree_list)

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass
+import json
 import re
 import shutil
 import subprocess
@@ -10,16 +10,23 @@ from pathlib import Path
 
 from scripts.blueprint_harness_branches import (
     CHECKOUT_ROLE_CHOICES,
+    RefSyncStatus,
     active_release_branch,
     branch_policy_path,
     checkout_branch_role,
     default_dev_branch,
     checkout_is_backport_only,
+    current_branch_name,
+    is_ancestor,
     load_branch_policy,
     local_release_ref,
+    main_sync_status,
     normalize_lean_release_ref,
+    preferred_main_ref,
     preferred_release_ref,
     require_checkout_role,
+    ref_oid,
+    ref_sync_status,
     root_checkout_namespace,
 )
 from scripts.blueprint_harness_cli import add_optional_worktree_name_argument
@@ -46,9 +53,7 @@ from scripts.blueprint_harness_worktrees import (
     GitWorktree,
     git_worktree_map,
     git_worktrees,
-    is_ancestor,
     normalize_priority,
-    ref_oid,
     resolve_worktree_name,
     sync_worktree_registry,
     update_worktree_record,
@@ -64,15 +69,6 @@ PUBLIC_PR_TITLE_RE = re.compile(
 PUBLIC_PR_SCOPED_TITLE_RE = re.compile(
     r"^(" + "|".join(re.escape(title_type) for title_type in PUBLIC_PR_TITLE_TYPES) + r")\([^)]*\):"
 )
-
-
-@dataclass(frozen=True)
-class RefSyncStatus:
-    local_ref: str
-    upstream_ref: str
-    local_oid: str | None
-    upstream_oid: str | None
-    relationship: str
 
 
 def load_project_catalog(manifest_path: Path) -> list[HarnessProject]:
@@ -147,21 +143,6 @@ def branch_exists(repo_root: Path, branch: str) -> bool:
     )
 
 
-def preferred_main_ref(repo_root: Path) -> str:
-    return preferred_release_ref(repo_root)
-
-
-def current_branch_name(repo_root: Path) -> str | None:
-    branch = subprocess.run(
-        ["git", "branch", "--show-current"],
-        cwd=repo_root,
-        check=True,
-        text=True,
-        capture_output=True,
-    ).stdout.strip()
-    return branch or None
-
-
 def current_commit_subject(repo_root: Path) -> str:
     subject = subprocess.run(
         ["git", "log", "-1", "--format=%s"],
@@ -203,51 +184,6 @@ def source_commit_series(repo_root: Path, source_branch: str) -> list[str]:
         capture_output=True,
     )
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
-
-
-def ref_sync_status(repo_root: Path, local_ref: str, upstream_ref: str) -> RefSyncStatus:
-    local_oid = ref_oid(repo_root, local_ref)
-    upstream_oid = ref_oid(repo_root, upstream_ref)
-
-    if local_oid is None:
-        relationship = "missing_local"
-    elif upstream_oid is None:
-        relationship = "missing_upstream"
-    elif local_oid == upstream_oid:
-        relationship = "in_sync"
-    elif (
-        subprocess.run(
-            ["git", "merge-base", "--is-ancestor", local_ref, upstream_ref],
-            cwd=repo_root,
-            check=False,
-        ).returncode
-        == 0
-    ):
-        relationship = "behind"
-    elif (
-        subprocess.run(
-            ["git", "merge-base", "--is-ancestor", upstream_ref, local_ref],
-            cwd=repo_root,
-            check=False,
-        ).returncode
-        == 0
-    ):
-        relationship = "ahead"
-    else:
-        relationship = "diverged"
-
-    return RefSyncStatus(
-        local_ref=local_ref,
-        upstream_ref=upstream_ref,
-        local_oid=local_oid,
-        upstream_oid=upstream_oid,
-        relationship=relationship,
-    )
-
-
-def main_sync_status(repo_root: Path) -> RefSyncStatus:
-    upstream_ref = preferred_main_ref(repo_root)
-    return ref_sync_status(repo_root, local_release_ref(repo_root), upstream_ref)
 
 
 def resolve_create_worktree_base(layout, requested_base: str | None) -> str:

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -44,11 +44,15 @@ from scripts.blueprint_harness_toolchains import bump_toolchain_checkout
 from scripts.blueprint_harness_utils import run
 from scripts.blueprint_harness_worktrees import (
     GitWorktree,
+    git_worktree_map,
     git_worktrees,
+    is_ancestor,
     normalize_priority,
+    ref_oid,
     resolve_worktree_name,
     sync_worktree_registry,
     update_worktree_record,
+    worktree_is_clean,
     worktree_record_map,
 )
 
@@ -201,20 +205,6 @@ def source_commit_series(repo_root: Path, source_branch: str) -> list[str]:
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
-def ref_oid(repo_root: Path, ref: str) -> str | None:
-    result = subprocess.run(
-        ["git", "rev-parse", "--verify", "--quiet", ref],
-        cwd=repo_root,
-        check=False,
-        text=True,
-        capture_output=True,
-    )
-    if result.returncode != 0:
-        return None
-    oid = result.stdout.strip()
-    return oid or None
-
-
 def ref_sync_status(repo_root: Path, local_ref: str, upstream_ref: str) -> RefSyncStatus:
     local_oid = ref_oid(repo_root, local_ref)
     upstream_oid = ref_oid(repo_root, upstream_ref)
@@ -258,17 +248,6 @@ def ref_sync_status(repo_root: Path, local_ref: str, upstream_ref: str) -> RefSy
 def main_sync_status(repo_root: Path) -> RefSyncStatus:
     upstream_ref = preferred_main_ref(repo_root)
     return ref_sync_status(repo_root, local_release_ref(repo_root), upstream_ref)
-
-
-def is_ancestor(repo_root: Path, ancestor: str, descendant: str) -> bool:
-    return (
-        subprocess.run(
-            ["git", "merge-base", "--is-ancestor", ancestor, descendant],
-            cwd=repo_root,
-            check=False,
-        ).returncode
-        == 0
-    )
 
 
 def resolve_create_worktree_base(layout, requested_base: str | None) -> str:
@@ -321,10 +300,6 @@ def merged_clean_worktree_candidates(repo_root: Path, current_path: Path) -> lis
     return candidates
 
 
-def git_worktree_map(repo_root: Path) -> dict[str, GitWorktree]:
-    return {worktree.name: worktree for worktree in git_worktrees(repo_root)}
-
-
 def local_branch_ref(repo_root: Path, branch: str) -> str | None:
     ref = f"refs/heads/{branch}"
     if ref_oid(repo_root, ref) is None:
@@ -347,17 +322,6 @@ def origin_branch_exists(repo_root: Path, branch: str) -> bool:
 
 def branch_worktrees(repo_root: Path, branch: str) -> list[GitWorktree]:
     return [worktree for worktree in git_worktrees(repo_root) if worktree.branch == branch]
-
-
-def worktree_is_clean(path: Path) -> bool:
-    status = subprocess.run(
-        ["git", "status", "--short"],
-        cwd=path,
-        check=True,
-        text=True,
-        capture_output=True,
-    ).stdout.strip()
-    return not status
 
 
 def text_or_blank(value: object | None) -> str:

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 from scripts.blueprint_harness_branches import (
     CHECKOUT_ROLE_CHOICES,
-    ROOT_WORKTREE_NAME,
     active_release_branch,
     branch_policy_path,
     checkout_branch_role,

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -1104,6 +1104,11 @@ def add_landing_commands(subparsers) -> None:
 
 
 def add_worktree_commands(subparsers) -> None:
+    add_create_worktree_command(subparsers)
+    add_worktree_lifecycle_commands(subparsers)
+
+
+def add_create_worktree_command(subparsers) -> None:
     create_worktree = subparsers.add_parser(
         "create-worktree",
         help=(
@@ -1145,6 +1150,8 @@ def add_worktree_commands(subparsers) -> None:
     create_worktree.add_argument("--scope", action="append", default=None, help="Writable scope path. Repeat for multiple scopes.")
     create_worktree.set_defaults(func=command_create_worktree)
 
+
+def add_worktree_lifecycle_commands(subparsers) -> None:
     worktree_prune_candidates = subparsers.add_parser(
         "worktree-prune-candidates",
         help="List merged clean linked worktrees that are good prune candidates.",

--- a/scripts/blueprint_harness_branches.py
+++ b/scripts/blueprint_harness_branches.py
@@ -27,6 +27,15 @@ class BranchPolicy:
     source_path: Path
 
 
+@dataclass(frozen=True)
+class RefSyncStatus:
+    local_ref: str
+    upstream_ref: str
+    local_oid: str | None
+    upstream_oid: str | None
+    relationship: str
+
+
 def clean_lean_ref(raw_ref: str) -> str:
     ref = raw_ref.strip()
     if ref.startswith(LEAN_TOOLCHAIN_PREFIX):
@@ -213,6 +222,107 @@ def ref_exists(repo_root: Path, ref: str) -> bool:
         ).returncode
         == 0
     )
+
+
+def resolve_git_ref(repo_root: Path, ref: str) -> str:
+    if ref.startswith("refs/"):
+        return ref
+
+    candidates: list[str] = []
+    if ref.startswith("origin/"):
+        candidates.append(f"refs/remotes/{ref}")
+    else:
+        candidates.append(f"refs/heads/{ref}")
+        candidates.append(f"refs/remotes/{ref}")
+    candidates.append(ref)
+
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        if ref_exists(repo_root, candidate):
+            return candidate
+    return ref
+
+
+def ref_oid(repo_root: Path, ref: str) -> str | None:
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", resolve_git_ref(repo_root, ref)],
+        cwd=repo_root,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return None
+    oid = result.stdout.strip()
+    return oid or None
+
+
+def is_ancestor(repo_root: Path, ancestor: str, descendant: str) -> bool:
+    return (
+        subprocess.run(
+            [
+                "git",
+                "merge-base",
+                "--is-ancestor",
+                resolve_git_ref(repo_root, ancestor),
+                resolve_git_ref(repo_root, descendant),
+            ],
+            cwd=repo_root,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def preferred_main_ref(repo_root: Path) -> str:
+    return preferred_release_ref(repo_root)
+
+
+def current_branch_name(repo_root: Path) -> str | None:
+    branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=repo_root,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+    return branch or None
+
+
+def ref_sync_status(repo_root: Path, local_ref: str, upstream_ref: str) -> RefSyncStatus:
+    local_oid = ref_oid(repo_root, local_ref)
+    upstream_oid = ref_oid(repo_root, upstream_ref)
+    local_git_ref = resolve_git_ref(repo_root, local_ref)
+    upstream_git_ref = resolve_git_ref(repo_root, upstream_ref)
+
+    if local_oid is None:
+        relationship = "missing_local"
+    elif upstream_oid is None:
+        relationship = "missing_upstream"
+    elif local_oid == upstream_oid:
+        relationship = "in_sync"
+    elif is_ancestor(repo_root, local_git_ref, upstream_git_ref):
+        relationship = "behind"
+    elif is_ancestor(repo_root, upstream_git_ref, local_git_ref):
+        relationship = "ahead"
+    else:
+        relationship = "diverged"
+
+    return RefSyncStatus(
+        local_ref=local_ref,
+        upstream_ref=upstream_ref,
+        local_oid=local_oid,
+        upstream_oid=upstream_oid,
+        relationship=relationship,
+    )
+
+
+def main_sync_status(repo_root: Path) -> RefSyncStatus:
+    upstream_ref = preferred_main_ref(repo_root)
+    return ref_sync_status(repo_root, local_release_ref(repo_root), upstream_ref)
 
 
 def remote_head_ref(repo_root: Path) -> str | None:

--- a/scripts/blueprint_harness_paths.py
+++ b/scripts/blueprint_harness_paths.py
@@ -95,11 +95,6 @@ def canonical_reference_project_site_dir(project_id: str, start: Path | None = N
     return layout.reference_output_root / project_id / "html-multi"
 
 
-def canonical_test_blueprint_package_dir(name: str, start: Path | None = None) -> Path:
-    layout = detect_harness_layout(start)
-    return layout.package_root / "tests" / "test_blueprints" / name
-
-
 def canonical_test_blueprint_output_dir(name: str, start: Path | None = None) -> Path:
     layout = detect_harness_layout(start)
     return layout.test_blueprint_output_root / name

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -448,6 +448,27 @@ def reference_build_matrix(projects: list[HarnessProject]) -> dict[str, list[dic
     }
 
 
+def reference_release_payload(
+    manifest_path: Path,
+    catalog: HarnessProjectCatalog,
+    release: str | None,
+    package_root: Path,
+) -> dict[str, object]:
+    release_target = resolve_release_target(catalog, release, package_root)
+    projects = resolve_projects_for_release(catalog, release_target.release_id, None)
+    return {
+        "manifest_path": str(manifest_path),
+        "release_id": release_target.release_id,
+        "rc": "",
+        "toolchain": release_target.toolchain,
+        "verso_ref": release_target.verso_ref,
+        "branch": release_target.branch,
+        "deploy_pages": release_target.deploy_pages,
+        "reference_project_count": len(projects),
+        "reference_matrix": reference_build_matrix(projects),
+    }
+
+
 DEPLOY_PROJECT_ARTIFACT_SEPARATOR = "__project__"
 
 

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, replace
 import json
 from pathlib import Path
+import subprocess
 
 from scripts.blueprint_harness_branches import active_release_branch, normalize_lean_release_ref
 from scripts.blueprint_harness_manifest import (
@@ -488,6 +490,99 @@ def deploy_project_matrix(
                     "toolchain": target.toolchain,
                     "verso_ref": target.verso_ref,
                     "branch": target.branch,
+                    "project_id": project.project_id,
+                    "hash": project.ref,
+                    "artifact_name": deploy_project_artifact_name(project),
+                    "artifact_path": deploy_project_artifact_path(project),
+                }
+            )
+    return {"include": include}
+
+
+def manifest_relative_to_package(manifest_path: Path, package_root: Path) -> Path | None:
+    try:
+        return manifest_path.relative_to(package_root)
+    except ValueError:
+        return None
+
+
+def release_branch_ref_candidates(branch: str) -> tuple[str, ...]:
+    return (f"origin/{branch}", f"refs/remotes/origin/{branch}", branch)
+
+
+def load_branch_project_catalog(
+    *,
+    branch: str,
+    manifest_path: Path,
+    package_root: Path,
+) -> HarnessProjectCatalog:
+    manifest_relpath = manifest_relative_to_package(manifest_path, package_root)
+    if manifest_relpath is None:
+        return load_project_catalog(manifest_path)
+
+    errors: list[str] = []
+    for ref in release_branch_ref_candidates(branch):
+        result = subprocess.run(
+            ["git", "show", f"{ref}:{manifest_relpath.as_posix()}"],
+            cwd=package_root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return load_project_catalog_text(result.stdout, f"{ref}:{manifest_relpath.as_posix()}")
+        errors.append(result.stderr.strip() or result.stdout.strip())
+
+    raise ValueError(
+        f"could not load reference project catalog for release branch `{branch}` from `{manifest_relpath}`; "
+        + "; ".join(error for error in errors if error)
+    )
+
+
+def deploy_matrix_from_release_catalogs(
+    controller_catalog: HarnessProjectCatalog,
+    deployable_targets: tuple[HarnessReleaseTarget, ...],
+    catalog_for_target: Callable[[HarnessReleaseTarget], HarnessProjectCatalog],
+) -> dict[str, list[dict[str, object]]]:
+    include: list[dict[str, object]] = []
+    for target in deployable_targets:
+        selected_blueprints = [
+            blueprint
+            for blueprint in controller_catalog.reference_blueprints
+            if blueprint.toolchain == target.toolchain
+        ]
+        selected_project_ids = reference_blueprint_ids_for_toolchain(controller_catalog, target.toolchain)
+        expected_hash_by_project = {blueprint.blueprint: blueprint.hash for blueprint in selected_blueprints}
+        if controller_catalog.reference_blueprints and not selected_blueprints:
+            raise ValueError(
+                f"release target `{target.release_id}` has `deploy_pages: true` but no reference "
+                f"blueprints for toolchain `{target.toolchain}`"
+            )
+        release_catalog = catalog_for_target(target)
+        release_target = release_catalog.release_target(target.release_id)
+        if release_target is None:
+            raise ValueError(
+                f"catalog for branch `{target.branch}` does not define release target `{target.release_id}`"
+            )
+        projects = resolve_projects_for_release(
+            release_catalog,
+            release_target.release_id,
+            selected_project_ids or None,
+        )
+        for project in projects:
+            expected_hash = expected_hash_by_project.get(project.project_id)
+            if expected_hash is not None and project.ref != expected_hash:
+                raise ValueError(
+                    f"reference blueprint `{project.project_id}` for toolchain `{target.toolchain}` resolves "
+                    f"to `{project.ref}` on branch `{target.branch}`, but the deploy catalog declares `{expected_hash}`"
+                )
+            include.append(
+                {
+                    "release_id": release_target.release_id,
+                    "rc": getattr(release_target, "rc", None),
+                    "toolchain": release_target.toolchain,
+                    "verso_ref": release_target.verso_ref,
+                    "branch": release_target.branch,
                     "project_id": project.project_id,
                     "hash": project.ref,
                     "artifact_name": deploy_project_artifact_name(project),

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -26,7 +26,6 @@ from scripts.blueprint_harness_project_commands import (
     rewrite_pinned_blueprint_dependency,
     run_project_update_build_generate,
     snapshot_tracked_project_manifest,
-    tracked_project_manifest_path,
 )
 from scripts.blueprint_harness_utils import format_command, lean_low_priority_command, run
 

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -28,7 +28,7 @@ from scripts.blueprint_harness_project_commands import (
     snapshot_tracked_project_manifest,
     tracked_project_manifest_path,
 )
-from scripts.blueprint_harness_utils import lean_low_priority_command, run
+from scripts.blueprint_harness_utils import format_command, lean_low_priority_command, run
 
 
 COMMIT_HASH_PATTERN = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
@@ -608,6 +608,36 @@ def bump_reference_project(
     )
 
 
+def reference_cache_warm_build_failure_message(
+    layout,
+    project: HarnessProject,
+    command: list[str],
+    err: subprocess.CalledProcessError,
+) -> str:
+    cache_dir = reference_cache_checkout_dir(layout, project)
+    return "\n".join(
+        [
+            (
+                f"[blueprint-harness] failed to warm reference cache for `{project.project_id}` "
+                f"at {cache_dir}; command exited with code {err.returncode}: {format_command(command)}"
+            ),
+            (
+                "[blueprint-harness] stale or cross-toolchain Lake build artifacts in the shared "
+                "reference cache can cause incompatible `.olean` header errors."
+            ),
+            (
+                "[blueprint-harness] for docs/Python-only work, create the checkout with "
+                "`python3 -m scripts.blueprint_harness create-worktree <name> --lightweight`."
+            ),
+            (
+                "[blueprint-harness] to inspect or remove stale reference caches, run "
+                "`python3 -m scripts.blueprint_reference_harness prune --dry-run`, then "
+                "`python3 -m scripts.blueprint_reference_harness prune` if the listed paths are disposable."
+            ),
+        ]
+    )
+
+
 def sync_reference_cache_checkout(
     layout,
     project: HarnessProject,
@@ -628,7 +658,11 @@ def sync_reference_cache_checkout(
     with local_blueprint_dependency_override(layout.package_root, project_dir, restore_lakefile=True):
         run_reference_lake_update(layout.package_root, project_dir)
         if warm_build and project.build_command is not None:
-            run(lean_low_priority_command(layout.package_root, *project.build_command), cwd=project_dir)
+            command = lean_low_priority_command(layout.package_root, *project.build_command)
+            try:
+                run(command, cwd=project_dir)
+            except subprocess.CalledProcessError as err:
+                raise SystemExit(reference_cache_warm_build_failure_message(layout, project, command, err)) from err
     return cache_dir
 
 

--- a/scripts/blueprint_harness_worktrees.py
+++ b/scripts/blueprint_harness_worktrees.py
@@ -6,7 +6,13 @@ import json
 from pathlib import Path
 import subprocess
 
-from scripts.blueprint_harness_branches import ROOT_WORKTREE_NAME, preferred_release_ref
+from scripts.blueprint_harness_branches import (
+    ROOT_WORKTREE_NAME,
+    is_ancestor,
+    preferred_release_ref,
+    ref_oid,
+    resolve_git_ref,
+)
 
 
 ROOT_METADATA_FILENAME = "_root.json"
@@ -220,31 +226,6 @@ def save_registry(repo_root: Path, records: list[WorktreeRecord]) -> Path:
     }
     path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     return path
-
-
-def ref_oid(repo_root: Path, ref: str) -> str | None:
-    result = subprocess.run(
-        ["git", "rev-parse", "--verify", "--quiet", ref],
-        cwd=repo_root,
-        check=False,
-        text=True,
-        capture_output=True,
-    )
-    if result.returncode != 0:
-        return None
-    oid = result.stdout.strip()
-    return oid or None
-
-
-def is_ancestor(repo_root: Path, ancestor: str, descendant: str) -> bool:
-    return (
-        subprocess.run(
-            ["git", "merge-base", "--is-ancestor", ancestor, descendant],
-            cwd=repo_root,
-            check=False,
-        ).returncode
-        == 0
-    )
 
 
 def ref_merged_into_base(repo_root: Path, ref: str, base_ref: str) -> bool:

--- a/scripts/blueprint_harness_worktrees.py
+++ b/scripts/blueprint_harness_worktrees.py
@@ -181,6 +181,10 @@ def git_worktrees(repo_root: Path) -> list[GitWorktree]:
     return parse_git_worktree_porcelain(result.stdout, repo_root)
 
 
+def git_worktree_map(repo_root: Path) -> dict[str, GitWorktree]:
+    return {worktree.name: worktree for worktree in git_worktrees(repo_root)}
+
+
 def load_record(path: Path) -> WorktreeMetadata | None:
     if not path.exists():
         return None
@@ -287,6 +291,11 @@ def worktree_status_counts(path: Path) -> tuple[bool, int, int]:
     tracked_changes = sum(1 for line in lines if not line.startswith("??"))
     untracked_changes = sum(1 for line in lines if line.startswith("??"))
     return bool(lines), tracked_changes, untracked_changes
+
+
+def worktree_is_clean(path: Path) -> bool:
+    dirty, _tracked_changes, _untracked_changes = worktree_status_counts(path)
+    return not dirty
 
 
 def worktree_last_commit(path: Path) -> tuple[str | None, str | None, str | None]:

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -338,6 +338,30 @@ def collect_reference_project_status(layout, project: HarnessProject, *, bluepri
     )
 
 
+def reference_project_status_or_error(
+    layout,
+    project: HarnessProject,
+    *,
+    blueprint_base_ref: str,
+) -> ReferenceProjectStatus:
+    try:
+        return collect_reference_project_status(layout, project, blueprint_base_ref=blueprint_base_ref)
+    except (subprocess.CalledProcessError, json.JSONDecodeError, OSError, ValueError) as err:
+        return ReferenceProjectStatus(
+            project=project,
+            catalog_ref=None,
+            project_upstream_ref=None,
+            project_relationship=None,
+            project_ahead=None,
+            project_behind=None,
+            blueprint_pin=None,
+            blueprint_relationship=None,
+            blueprint_ahead=None,
+            blueprint_behind=None,
+            error=str(err),
+        )
+
+
 def print_reference_project_status(status: ReferenceProjectStatus) -> None:
     project = status.project
     source = f"in_repo:{project.project_root}" if project.in_repo_project else f"git:{project.repository}@{project.ref}"
@@ -665,6 +689,68 @@ def command_generate(args: argparse.Namespace) -> int:
     return 0
 
 
+def lean_test_validation_failures(layout, *, use_local_build: bool) -> list[StepFailure]:
+    if use_local_build:
+        failure = run_capturing_failure(
+            "lean tests",
+            lean_test_runner(layout.package_root),
+            cwd=layout.package_root,
+        )
+        return [failure] if failure is not None else []
+
+    test_artifact = find_prebuilt_lean_test_artifact(layout.package_root)
+    if test_artifact is None:
+        return [
+            StepFailure(
+                "lean tests",
+                "no prebuilt Lean test library found in the current worktree `.lake/`; "
+                "run `python3 -m scripts.blueprint_harness sync-root-lake` after "
+                "building from the root checkout, or use `--allow-local-build`",
+            )
+        ]
+
+    print(f"[blueprint-reference-harness] using prebuilt Lean test library: {test_artifact}")
+    return []
+
+
+def project_validation_failures(
+    layout,
+    output_root: Path,
+    projects: list[HarnessProject],
+    *,
+    skip_panel_regression: bool,
+    skip_browser_tests: bool,
+    pytest_args: list[str],
+    stop_on_first_failure: bool,
+) -> list[StepFailure]:
+    failures: list[StepFailure] = []
+    for project in projects:
+        site_dir = site_dir_for(project, output_root)
+        if project.panel_regression_script is not None and not skip_panel_regression:
+            failure = run_capturing_failure(
+                f"{project.project_id} panel regression",
+                panel_regression_command(layout.package_root, project.panel_regression_script or "", site_dir),
+                cwd=layout.package_root,
+            )
+            if failure is not None:
+                failures.append(failure)
+                if stop_on_first_failure:
+                    return failures
+
+        if project.browser_tests_path is not None and not skip_browser_tests:
+            failure = run_capturing_failure(
+                f"{project.project_id} browser tests",
+                browser_test_command(layout.package_root, project.browser_tests_path or "", site_dir, pytest_args),
+                cwd=layout.package_root,
+            )
+            if failure is not None:
+                failures.append(failure)
+                if stop_on_first_failure:
+                    return failures
+
+    return failures
+
+
 def command_validate(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
     require_safe_root_main(layout, allow_unsafe=args.allow_unsafe_root_release, command_name="validate")
@@ -684,31 +770,9 @@ def command_validate(args: argparse.Namespace) -> int:
     print(f"[blueprint-reference-harness] release target: {release_id}")
     use_local_build = should_use_local_build(layout, args.allow_local_build)
     if args.run_lean_tests:
-        if use_local_build:
-            failure = run_capturing_failure(
-                "lean tests",
-                lean_test_runner(layout.package_root),
-                cwd=layout.package_root,
-            )
-            if failure is not None:
-                failures.append(failure)
-                if args.stop_on_first_failure:
-                    return print_failure_summary(failures, prefix=REFERENCE_HARNESS_PREFIX)
-        else:
-            test_artifact = find_prebuilt_lean_test_artifact(layout.package_root)
-            if test_artifact is None:
-                failures.append(
-                    StepFailure(
-                        "lean tests",
-                        "no prebuilt Lean test library found in the current worktree `.lake/`; "
-                        "run `python3 -m scripts.blueprint_harness sync-root-lake` after "
-                        "building from the root checkout, or use `--allow-local-build`",
-                    )
-                )
-                if args.stop_on_first_failure:
-                    return print_failure_summary(failures, prefix=REFERENCE_HARNESS_PREFIX)
-            else:
-                print(f"[blueprint-reference-harness] using prebuilt Lean test library: {test_artifact}")
+        failures.extend(lean_test_validation_failures(layout, use_local_build=use_local_build))
+        if failures and args.stop_on_first_failure:
+            return print_failure_summary(failures, prefix=REFERENCE_HARNESS_PREFIX)
 
     try:
         generate_projects(
@@ -724,29 +788,17 @@ def command_validate(args: argparse.Namespace) -> int:
         failures.append(StepFailure("generate projects", str(err)))
         return print_failure_summary(failures, prefix=REFERENCE_HARNESS_PREFIX)
 
-    for project in projects:
-        site_dir = site_dir_for(project, output_root)
-        if project.panel_regression_script is not None and not args.skip_panel_regression:
-            failure = run_capturing_failure(
-                f"{project.project_id} panel regression",
-                panel_regression_command(layout.package_root, project.panel_regression_script or "", site_dir),
-                cwd=layout.package_root,
-            )
-            if failure is not None:
-                failures.append(failure)
-                if args.stop_on_first_failure:
-                    return print_failure_summary(failures, prefix=REFERENCE_HARNESS_PREFIX)
-
-        if project.browser_tests_path is not None and not args.skip_browser_tests:
-            failure = run_capturing_failure(
-                f"{project.project_id} browser tests",
-                browser_test_command(layout.package_root, project.browser_tests_path or "", site_dir, args.pytest_arg),
-                cwd=layout.package_root,
-            )
-            if failure is not None:
-                failures.append(failure)
-                if args.stop_on_first_failure:
-                    return print_failure_summary(failures, prefix=REFERENCE_HARNESS_PREFIX)
+    failures.extend(
+        project_validation_failures(
+            layout,
+            output_root,
+            projects,
+            skip_panel_regression=args.skip_panel_regression,
+            skip_browser_tests=args.skip_browser_tests,
+            pytest_args=args.pytest_arg,
+            stop_on_first_failure=args.stop_on_first_failure,
+        )
+    )
 
     return print_failure_summary(failures, prefix=REFERENCE_HARNESS_PREFIX)
 
@@ -800,23 +852,9 @@ def command_status(args: argparse.Namespace) -> int:
     print(f"{main_status.upstream_ref}_oid={main_status.upstream_oid or ''}")
 
     for project in projects:
-        try:
-            status = collect_reference_project_status(layout, project)
-        except (subprocess.CalledProcessError, json.JSONDecodeError, OSError, ValueError) as err:
-            status = ReferenceProjectStatus(
-                project=project,
-                catalog_ref=None,
-                project_upstream_ref=None,
-                project_relationship=None,
-                project_ahead=None,
-                project_behind=None,
-                blueprint_pin=None,
-                blueprint_relationship=None,
-                blueprint_ahead=None,
-                blueprint_behind=None,
-                error=str(err),
-            )
-        print_reference_project_status(status)
+        print_reference_project_status(
+            reference_project_status_or_error(layout, project, blueprint_base_ref=release_branch)
+        )
     return 0
 
 
@@ -841,37 +879,16 @@ def command_release_status(args: argparse.Namespace) -> int:
             allowed = set(args.project)
             projects = [project for project in projects if project.project_id in allowed]
 
-        statuses: list[ReferenceProjectStatus] = []
-        for project in projects:
-            try:
-                status = collect_reference_project_status(
-                    layout,
-                    project,
-                    blueprint_base_ref=release_target.branch,
-                )
-            except (subprocess.CalledProcessError, json.JSONDecodeError, OSError, ValueError) as err:
-                status = ReferenceProjectStatus(
-                    project=project,
-                    catalog_ref=None,
-                    project_upstream_ref=None,
-                    project_relationship=None,
-                    project_ahead=None,
-                    project_behind=None,
-                    blueprint_pin=None,
-                    blueprint_relationship=None,
-                    blueprint_ahead=None,
-                    blueprint_behind=None,
-                    error=str(err),
-                )
-            statuses.append(status)
-
         summary = ReleaseTargetStatus(
             release_id=release_target.release_id,
             toolchain=release_target.toolchain,
             verso_ref=release_target.verso_ref,
             branch=release_target.branch,
             deploy_pages=release_target.deploy_pages,
-            project_statuses=tuple(statuses),
+            project_statuses=tuple(
+                reference_project_status_or_error(layout, project, blueprint_base_ref=release_target.branch)
+                for project in projects
+            ),
         )
         if args.outdated_only and not any(status_has_catalog_issue(status) for status in summary.project_statuses):
             continue

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -1030,13 +1030,8 @@ def command_reference_prune(args: argparse.Namespace) -> int:
     print(f"[blueprint-reference-harness] reference prune: removed {len(removals)} path(s)")
     return 0
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="python3 -m scripts.blueprint_reference_harness",
-        description="Reference blueprint generation, validation, and checkout lifecycle CLI.",
-    )
-    subparsers = parser.add_subparsers(dest="command", required=True)
 
+def add_generation_commands(subparsers) -> None:
     generate = subparsers.add_parser(
         "generate",
         help="Build the selected blueprint harness projects.",
@@ -1102,6 +1097,8 @@ def build_parser() -> argparse.ArgumentParser:
     add_reference_package_mode_argument(validate)
     validate.set_defaults(func=command_validate)
 
+
+def add_reporting_commands(subparsers) -> None:
     projects = subparsers.add_parser(
         "projects",
         help="List the configured harness projects from the active manifest.",
@@ -1147,6 +1144,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     release_status.set_defaults(func=command_release_status)
 
+
+def add_checkout_sync_commands(subparsers) -> None:
     sync = subparsers.add_parser(
         "sync",
         help="Warm shared reference blueprint caches and prepare local clones for the current checkout.",
@@ -1188,6 +1187,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     edit.set_defaults(func=command_reference_edit)
 
+
+def add_bump_command(subparsers) -> None:
     bump = subparsers.add_parser(
         "bump-verso-blueprint",
         help="Rewrite the pinned `VersoBlueprint` ref in editable external reference checkouts.",
@@ -1239,6 +1240,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     bump.set_defaults(func=command_reference_bump_blueprint)
 
+
+def add_prune_command(subparsers) -> None:
     prune = subparsers.add_parser(
         "prune",
         help="Remove stale harness-managed reference blueprint caches and checkout clones.",
@@ -1250,6 +1253,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="List stale paths without deleting them.",
     )
     prune.set_defaults(func=command_reference_prune)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python3 -m scripts.blueprint_reference_harness",
+        description="Reference blueprint generation, validation, and checkout lifecycle CLI.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    add_generation_commands(subparsers)
+    add_reporting_commands(subparsers)
+    add_checkout_sync_commands(subparsers)
+    add_bump_command(subparsers)
+    add_prune_command(subparsers)
 
     return parser
 

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -9,8 +9,15 @@ import shutil
 import subprocess
 import sys
 
-from scripts.blueprint_harness_branches import active_release_branch, local_release_ref, root_checkout_namespace
-from scripts.blueprint_harness import current_branch_name, main_sync_status, ref_oid, ref_sync_status, worktree_is_clean
+from scripts.blueprint_harness_branches import (
+    active_release_branch,
+    current_branch_name,
+    local_release_ref,
+    main_sync_status,
+    ref_oid,
+    ref_sync_status,
+    root_checkout_namespace,
+)
 from scripts.blueprint_harness_cli import (
     add_allow_local_build_argument,
     add_allow_unsafe_root_main_argument,
@@ -53,7 +60,7 @@ from scripts.blueprint_harness_utils import (
     run_capturing_failure,
 )
 from scripts.blueprint_harness_validation import browser_test_command, panel_regression_command
-from scripts.blueprint_harness_worktrees import git_worktrees, rev_list_counts
+from scripts.blueprint_harness_worktrees import git_worktrees, rev_list_counts, worktree_is_clean
 
 
 @dataclass(frozen=True)

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -342,9 +342,11 @@ def reference_project_status_or_error(
     layout,
     project: HarnessProject,
     *,
-    blueprint_base_ref: str,
+    blueprint_base_ref: str | None = None,
 ) -> ReferenceProjectStatus:
     try:
+        if blueprint_base_ref is None:
+            return collect_reference_project_status(layout, project)
         return collect_reference_project_status(layout, project, blueprint_base_ref=blueprint_base_ref)
     except (subprocess.CalledProcessError, json.JSONDecodeError, OSError, ValueError) as err:
         return ReferenceProjectStatus(
@@ -362,12 +364,15 @@ def reference_project_status_or_error(
         )
 
 
+def project_source(project: HarnessProject) -> str:
+    return f"in_repo:{project.project_root}" if project.in_repo_project else f"git:{project.repository}@{project.ref}"
+
+
 def print_reference_project_status(status: ReferenceProjectStatus) -> None:
     project = status.project
-    source = f"in_repo:{project.project_root}" if project.in_repo_project else f"git:{project.repository}@{project.ref}"
     fields = [
         project.project_id,
-        f"source={source}",
+        f"source={project_source(project)}",
         f"catalog_ref={text_or_blank(status.catalog_ref)}",
         f"project_upstream_ref={text_or_blank(status.project_upstream_ref)}",
         f"catalog_status={text_or_blank(status.project_relationship)}",
@@ -424,11 +429,10 @@ def print_release_target_summary(status: ReleaseTargetStatus) -> None:
 
 def print_release_target_project_status(release_id: str, status: ReferenceProjectStatus) -> None:
     project = status.project
-    source = f"in_repo:{project.project_root}" if project.in_repo_project else f"git:{project.repository}@{project.ref}"
     fields = [
         f"release={release_id}",
         f"project={project.project_id}",
-        f"source={source}",
+        f"source={project_source(project)}",
         f"catalog_ref={text_or_blank(status.catalog_ref)}",
         f"project_upstream_ref={text_or_blank(status.project_upstream_ref)}",
         f"catalog_status={text_or_blank(status.project_relationship)}",
@@ -465,6 +469,31 @@ def select_release_projects(
     except ValueError as err:
         raise SystemExit(f"[blueprint-reference-harness] {err}") from err
     return selected_release.release_id, projects
+
+
+def load_reference_catalog_for_args(layout, args: argparse.Namespace):
+    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
+    return manifest_path, load_project_catalog(manifest_path)
+
+
+def select_reference_projects_from_args(
+    layout,
+    args: argparse.Namespace,
+    *,
+    project_ids: list[str] | None = None,
+    default_to_published_catalog: bool = True,
+):
+    manifest_path, catalog = load_reference_catalog_for_args(layout, args)
+    selected_project_ids = getattr(args, "project", None) if project_ids is None else project_ids
+    if selected_project_ids is None and not default_to_published_catalog:
+        selected_project_ids = [project.project_id for project in catalog.projects]
+    selection_args = {
+        "release": getattr(args, "release", None),
+        "project_ids": selected_project_ids,
+        "package_root": layout.package_root,
+    }
+    release_id, projects = select_release_projects(catalog, **selection_args)
+    return manifest_path, catalog, release_id, projects
 
 
 def require_checkout_release(layout, release_id: str, *, command_name: str) -> None:
@@ -542,9 +571,7 @@ def ensure_prebuilt_executable(package_root: Path, exe_name: str) -> Path:
 
 def find_prebuilt_lean_test_artifact(package_root: Path) -> Path | None:
     path = package_root / ".lake" / "build" / "lib" / "lean" / "VersoBlueprintTests.olean"
-    if path.exists():
-        return path
-    return None
+    return path if path.exists() else None
 
 
 def lean_test_runner(package_root: Path) -> list[str]:
@@ -661,14 +688,7 @@ def command_generate(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
     require_safe_root_main(layout, allow_unsafe=args.allow_unsafe_root_release, command_name="generate")
     output_root = resolve_output_root(selected_output_root(args), Path(__file__))
-    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
-    catalog = load_project_catalog(manifest_path)
-    release_id, projects = select_release_projects(
-        catalog,
-        release=args.release,
-        project_ids=args.project,
-        package_root=layout.package_root,
-    )
+    manifest_path, _catalog, release_id, projects = select_reference_projects_from_args(layout, args)
     require_checkout_release(layout, release_id, command_name="generate")
 
     generate_projects(
@@ -755,14 +775,7 @@ def command_validate(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
     require_safe_root_main(layout, allow_unsafe=args.allow_unsafe_root_release, command_name="validate")
     output_root = resolve_output_root(selected_output_root(args), Path(__file__))
-    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
-    catalog = load_project_catalog(manifest_path)
-    release_id, projects = select_release_projects(
-        catalog,
-        release=args.release,
-        project_ids=args.project,
-        package_root=layout.package_root,
-    )
+    _manifest_path, _catalog, release_id, projects = select_reference_projects_from_args(layout, args)
     require_checkout_release(layout, release_id, command_name="validate")
     failures: list[StepFailure] = []
 
@@ -805,41 +818,27 @@ def command_validate(args: argparse.Namespace) -> int:
 
 def command_projects(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
-    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
-    catalog = load_project_catalog(manifest_path)
-    release_id, projects = select_release_projects(
-        catalog,
-        release=args.release,
-        project_ids=args.project,
-        package_root=layout.package_root,
-    )
+    manifest_path, _catalog, release_id, projects = select_reference_projects_from_args(layout, args)
     print(f"project_manifest={manifest_path}")
     print(f"release_target={release_id}")
     for project in projects:
-        if project.in_repo_project:
-            source = f"in_repo:{project.project_root}"
-        else:
-            source = f"git:{project.repository}@{project.ref}"
-        validations: list[str] = []
-        if project.panel_regression_script is not None:
-            validations.append("panel")
-        if project.browser_tests_path is not None:
-            validations.append("browser")
-        validation_text = ",".join(validations) if validations else "none"
-        print(f"{project.project_id}\tsource={source}\tvalidations={validation_text}")
+        validation_text = ",".join(
+            name
+            for name, enabled in (("panel", project.panel_regression_script), ("browser", project.browser_tests_path))
+            if enabled is not None
+        ) or "none"
+        fields = [
+            project.project_id,
+            f"source={project_source(project)}",
+            f"validations={validation_text}",
+        ]
+        print("\t".join(fields))
     return 0
 
 
 def command_status(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
-    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
-    catalog = load_project_catalog(manifest_path)
-    release_id, projects = select_release_projects(
-        catalog,
-        release=args.release,
-        project_ids=args.project,
-        package_root=layout.package_root,
-    )
+    manifest_path, catalog, release_id, projects = select_reference_projects_from_args(layout, args)
     require_checkout_release(layout, release_id, command_name="status")
     release_branch = active_release_branch(layout.repo_root)
     main_status = main_sync_status(layout.repo_root)
@@ -853,15 +852,14 @@ def command_status(args: argparse.Namespace) -> int:
 
     for project in projects:
         print_reference_project_status(
-            reference_project_status_or_error(layout, project, blueprint_base_ref=release_branch)
+            reference_project_status_or_error(layout, project)
         )
     return 0
 
 
 def command_release_status(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
-    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
-    catalog = load_project_catalog(manifest_path)
+    manifest_path, catalog = load_reference_catalog_for_args(layout, args)
     releases = selected_release_targets(catalog, args.release, layout.package_root)
     known_project_ids = {project.project_id for project in catalog.projects}
     if args.project is not None:
@@ -904,14 +902,7 @@ def command_release_status(args: argparse.Namespace) -> int:
 def command_reference_sync(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
     require_safe_root_main(layout, allow_unsafe=args.allow_unsafe_root_release, command_name="sync")
-    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
-    catalog = load_project_catalog(manifest_path)
-    release_id, projects = select_release_projects(
-        catalog,
-        release=args.release,
-        project_ids=args.project,
-        package_root=layout.package_root,
-    )
+    _manifest_path, _catalog, release_id, projects = select_reference_projects_from_args(layout, args)
     require_checkout_release(layout, release_id, command_name="sync")
     sync_reference_blueprints(
         layout,
@@ -927,13 +918,23 @@ def command_reference_sync(args: argparse.Namespace) -> int:
 
 def command_reference_edit(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
-    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
-    catalog = load_project_catalog(manifest_path)
-    project_map = {project.project_id: project for project in catalog.projects}
-    if args.project not in project_map:
-        known = ", ".join(sorted(project_map))
-        raise SystemExit(f"[blueprint-reference-harness] unknown project `{args.project}`; known projects: {known}")
-    project = project_map[args.project]
+    if hasattr(args, "release"):
+        _manifest_path, _catalog, _release_id, projects = select_reference_projects_from_args(
+            layout,
+            args,
+            project_ids=[args.project],
+        )
+        project = projects[0]
+    else:
+        manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
+        catalog = load_project_catalog(manifest_path)
+        project_map = {project.project_id: project for project in catalog.projects}
+        if args.project not in project_map:
+            known = ", ".join(sorted(project_map))
+            raise SystemExit(f"[blueprint-reference-harness] unknown project `{args.project}`; known projects: {known}")
+        project = project_map[args.project]
+    if not project.git_checkout:
+        raise SystemExit(f"[blueprint-reference-harness] project `{project.project_id}` is not an external git checkout project")
     edit_dir, branch, base_ref = prepare_reference_edit_checkout(
         layout,
         project,
@@ -952,21 +953,36 @@ def command_reference_edit(args: argparse.Namespace) -> int:
 
 def command_reference_bump_blueprint(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
-    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
-    catalog = load_project_catalog(manifest_path)
-    project_map = {project.project_id: project for project in catalog.projects if project.git_checkout}
-    if args.project:
-        seen: set[str] = set()
-        projects: list[HarnessProject] = []
-        for value in args.project:
-            if value not in project_map:
-                known = ", ".join(sorted(project_map))
-                raise SystemExit(f"[blueprint-reference-harness] unknown project `{value}`; known projects: {known}")
-            if value not in seen:
-                projects.append(project_map[value])
-                seen.add(value)
+    if hasattr(args, "release"):
+        _manifest_path, _catalog, release_id, selected_projects = select_reference_projects_from_args(
+            layout,
+            args,
+            default_to_published_catalog=False,
+        )
+        projects = [project for project in selected_projects if project.git_checkout]
+        if args.project is not None and len(projects) != len(selected_projects):
+            project = next(project for project in selected_projects if not project.git_checkout)
+            raise SystemExit(
+                f"[blueprint-reference-harness] project `{project.project_id}` is not an external git checkout project"
+            )
+        if not projects:
+            raise SystemExit(f"[blueprint-reference-harness] release target `{release_id}` has no external git checkout projects")
     else:
-        projects = list(project_map.values())
+        manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
+        catalog = load_project_catalog(manifest_path)
+        project_map = {project.project_id: project for project in catalog.projects if project.git_checkout}
+        if args.project:
+            seen: set[str] = set()
+            projects = []
+            for value in args.project:
+                if value not in project_map:
+                    known = ", ".join(sorted(project_map))
+                    raise SystemExit(f"[blueprint-reference-harness] unknown project `{value}`; known projects: {known}")
+                if value not in seen:
+                    projects.append(project_map[value])
+                    seen.add(value)
+        else:
+            projects = list(project_map.values())
     failures: list[StepFailure] = []
     output_root = layout.artifact_root / "reference-blueprints-edit"
 
@@ -1022,8 +1038,8 @@ def command_reference_bump_blueprint(args: argparse.Namespace) -> int:
 
 def command_reference_prune(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
-    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
-    projects = load_project_catalog(manifest_path).projects
+    _manifest_path, catalog = load_reference_catalog_for_args(layout, args)
+    projects = catalog.projects
     active_names = {
         root_checkout_namespace(layout.repo_root) if worktree.root_checkout else worktree.name
         for worktree in git_worktrees(layout.repo_root)

--- a/scripts/blueprint_test_blueprints.py
+++ b/scripts/blueprint_test_blueprints.py
@@ -40,6 +40,138 @@ from scripts.blueprint_harness_validation import browser_test_command, panel_reg
 
 TAG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 TEST_BLUEPRINT_HARNESS_PREFIX = "[blueprint-test-blueprints]"
+TEST_BLUEPRINT_INDEX_CSS = """      :root {
+        color-scheme: light;
+        --bg: #f8fafc;
+        --panel: #ffffff;
+        --text: #0f172a;
+        --muted: #475569;
+        --border: #cbd5e1;
+        --accent: #0f766e;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font-family: ui-sans-serif, system-ui, sans-serif;
+        background: linear-gradient(180deg, #f8fafc, #eef2ff 45%, #f8fafc);
+        color: var(--text);
+      }
+      main {
+        width: min(70rem, calc(100% - 2rem));
+        margin: 0 auto;
+        padding: 2rem 0 3rem;
+      }
+      header {
+        margin-bottom: 1.5rem;
+      }
+      h1 {
+        margin: 0 0 0.5rem;
+        font-size: clamp(2rem, 4vw, 2.75rem);
+      }
+      .lede {
+        margin: 0;
+        max-width: 54rem;
+        color: var(--muted);
+        line-height: 1.5;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+        gap: 1rem;
+      }
+      .chip_row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.55rem;
+        margin: 1.1rem 0 1.6rem;
+      }
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        background: var(--panel);
+        padding: 0.35rem 0.7rem;
+        font-size: 0.92rem;
+        font-weight: 600;
+        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.05);
+      }
+      .category_section + .category_section {
+        margin-top: 1.8rem;
+      }
+      .category_header {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.5rem 1rem;
+        margin-bottom: 0.9rem;
+      }
+      .category_header h2 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+      .category_header p {
+        margin: 0;
+        color: var(--muted);
+        font-size: 0.92rem;
+      }
+      .card {
+        border: 1px solid var(--border);
+        border-radius: 1rem;
+        background: var(--panel);
+        padding: 1rem 1.05rem;
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+      }
+      .card h2 {
+        margin: 0 0 0.4rem;
+        font-size: 1.05rem;
+      }
+      .category {
+        margin: 0.25rem 0 0;
+        color: var(--accent);
+        font-size: 0.78rem;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      .kind {
+        margin: 0.2rem 0 0;
+        color: var(--muted);
+        font-size: 0.78rem;
+        font-style: italic;
+      }
+      .card p {
+        margin: 0.45rem 0 0;
+        line-height: 1.45;
+      }
+      .slug {
+        color: var(--muted);
+        font-size: 0.9rem;
+      }
+      .tag_list {
+        list-style: none;
+        padding: 0;
+        margin: 0.65rem 0 0;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.45rem;
+      }
+      .tag_list li {
+        border: 1px solid #d8dee9;
+        border-radius: 999px;
+        background: #f8fafc;
+        color: var(--muted);
+        padding: 0.2rem 0.55rem;
+        font-size: 0.78rem;
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }"""
 
 
 @dataclass(frozen=True)
@@ -191,21 +323,21 @@ def test_blueprint_index_entries(
     return [meta_by_slug[slug] for slug in selected_slugs if slug in meta_by_slug]
 
 
-def render_test_blueprint_index_html(category_order: tuple[str, ...], entries: list[dict[str, object]]) -> str:
-    cards_by_category = {category: [] for category in category_order}
-    for entry in entries:
-        category = str(entry.get("category", "Uncategorized"))
-        slug = str(entry["slug"])
-        title = str(entry["title"])
-        summary = str(entry["summary"])
-        tags = entry.get("tags", [])
-        kind = str(entry.get("kind", "curated_doc")).replace("_", " ")
-        tags_html = ""
-        if tags:
-            tag_chips = "".join(f'<li>{tag}</li>' for tag in tags)
-            tags_html = f'<ul class="tag_list">{tag_chips}</ul>'
-        cards_by_category.setdefault(category, []).append(
-            f"""
+def render_test_blueprint_tag_list(tags: object) -> str:
+    if not tags:
+        return ""
+    tag_chips = "".join(f"<li>{tag}</li>" for tag in tags)
+    return f'<ul class="tag_list">{tag_chips}</ul>'
+
+
+def render_test_blueprint_card(entry: dict[str, object]) -> str:
+    category = str(entry.get("category", "Uncategorized"))
+    slug = str(entry["slug"])
+    title = str(entry["title"])
+    summary = str(entry["summary"])
+    kind = str(entry.get("kind", "curated_doc")).replace("_", " ")
+    tags_html = render_test_blueprint_tag_list(entry.get("tags", []))
+    return f"""
         <article class="card">
           <h2><a href="./{slug}/html-multi/">{title}</a></h2>
           <p class="category">{category}</p>
@@ -216,30 +348,52 @@ def render_test_blueprint_index_html(category_order: tuple[str, ...], entries: l
           <p><a href="./{slug}/html-multi/">Open site</a></p>
         </article>
         """
-        )
 
-    nav_links = []
-    sections = []
-    for category in category_order:
-        cards = cards_by_category.get(category, [])
-        if not cards:
-            continue
-        anchor = category.lower().replace(" ", "-")
-        nav_links.append(f'<a class="chip" href="#{anchor}">{category}</a>')
-        sections.append(
-            f"""
-        <section class="category_section" id="{anchor}">
+
+def category_anchor(category: str) -> str:
+    return category.lower().replace(" ", "-")
+
+
+def group_test_blueprint_cards(
+    category_order: tuple[str, ...],
+    entries: list[dict[str, object]],
+) -> dict[str, list[str]]:
+    cards_by_category = {category: [] for category in category_order}
+    for entry in entries:
+        category = str(entry.get("category", "Uncategorized"))
+        cards_by_category.setdefault(category, []).append(render_test_blueprint_card(entry))
+    return cards_by_category
+
+
+def render_test_blueprint_nav(categories: list[str]) -> str:
+    return "".join(
+        f'<a class="chip" href="#{category_anchor(category)}">{category}</a>'
+        for category in categories
+    )
+
+
+def render_test_blueprint_category_section(category: str, cards: list[str]) -> str:
+    site_count = f"{len(cards)} site{'s' if len(cards) != 1 else ''}"
+    return f"""
+        <section class="category_section" id="{category_anchor(category)}">
           <div class="category_header">
             <h2>{category}</h2>
-            <p>{len(cards)} site{'s' if len(cards) != 1 else ''}</p>
+            <p>{site_count}</p>
           </div>
           <div class="grid">
             {''.join(cards)}
           </div>
         </section>
         """
-        )
 
+
+def render_test_blueprint_index_html(category_order: tuple[str, ...], entries: list[dict[str, object]]) -> str:
+    cards_by_category = group_test_blueprint_cards(category_order, entries)
+    visible_categories = [category for category in category_order if cards_by_category.get(category)]
+    sections_html = "".join(
+        render_test_blueprint_category_section(category, cards_by_category[category])
+        for category in visible_categories
+    )
     return f"""<!doctype html>
 <html lang="en">
   <head>
@@ -247,138 +401,7 @@ def render_test_blueprint_index_html(category_order: tuple[str, ...], entries: l
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Test Blueprint Artifacts</title>
     <style>
-      :root {{
-        color-scheme: light;
-        --bg: #f8fafc;
-        --panel: #ffffff;
-        --text: #0f172a;
-        --muted: #475569;
-        --border: #cbd5e1;
-        --accent: #0f766e;
-      }}
-      * {{ box-sizing: border-box; }}
-      body {{
-        margin: 0;
-        font-family: ui-sans-serif, system-ui, sans-serif;
-        background: linear-gradient(180deg, #f8fafc, #eef2ff 45%, #f8fafc);
-        color: var(--text);
-      }}
-      main {{
-        width: min(70rem, calc(100% - 2rem));
-        margin: 0 auto;
-        padding: 2rem 0 3rem;
-      }}
-      header {{
-        margin-bottom: 1.5rem;
-      }}
-      h1 {{
-        margin: 0 0 0.5rem;
-        font-size: clamp(2rem, 4vw, 2.75rem);
-      }}
-      .lede {{
-        margin: 0;
-        max-width: 54rem;
-        color: var(--muted);
-        line-height: 1.5;
-      }}
-      .grid {{
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
-        gap: 1rem;
-      }}
-      .chip_row {{
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.55rem;
-        margin: 1.1rem 0 1.6rem;
-      }}
-      .chip {{
-        display: inline-flex;
-        align-items: center;
-        border: 1px solid var(--border);
-        border-radius: 999px;
-        background: var(--panel);
-        padding: 0.35rem 0.7rem;
-        font-size: 0.92rem;
-        font-weight: 600;
-        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.05);
-      }}
-      .category_section + .category_section {{
-        margin-top: 1.8rem;
-      }}
-      .category_header {{
-        display: flex;
-        flex-wrap: wrap;
-        align-items: baseline;
-        justify-content: space-between;
-        gap: 0.5rem 1rem;
-        margin-bottom: 0.9rem;
-      }}
-      .category_header h2 {{
-        margin: 0;
-        font-size: 1.2rem;
-      }}
-      .category_header p {{
-        margin: 0;
-        color: var(--muted);
-        font-size: 0.92rem;
-      }}
-      .card {{
-        border: 1px solid var(--border);
-        border-radius: 1rem;
-        background: var(--panel);
-        padding: 1rem 1.05rem;
-        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
-      }}
-      .card h2 {{
-        margin: 0 0 0.4rem;
-        font-size: 1.05rem;
-      }}
-      .category {{
-        margin: 0.25rem 0 0;
-        color: var(--accent);
-        font-size: 0.78rem;
-        font-weight: 700;
-        letter-spacing: 0.04em;
-        text-transform: uppercase;
-      }}
-      .kind {{
-        margin: 0.2rem 0 0;
-        color: var(--muted);
-        font-size: 0.78rem;
-        font-style: italic;
-      }}
-      .card p {{
-        margin: 0.45rem 0 0;
-        line-height: 1.45;
-      }}
-      .slug {{
-        color: var(--muted);
-        font-size: 0.9rem;
-      }}
-      .tag_list {{
-        list-style: none;
-        padding: 0;
-        margin: 0.65rem 0 0;
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.45rem;
-      }}
-      .tag_list li {{
-        border: 1px solid #d8dee9;
-        border-radius: 999px;
-        background: #f8fafc;
-        color: var(--muted);
-        padding: 0.2rem 0.55rem;
-        font-size: 0.78rem;
-      }}
-      a {{
-        color: var(--accent);
-        text-decoration: none;
-      }}
-      a:hover {{
-        text-decoration: underline;
-      }}
+{TEST_BLUEPRINT_INDEX_CSS}
     </style>
   </head>
   <body>
@@ -389,9 +412,9 @@ def render_test_blueprint_index_html(category_order: tuple[str, ...], entries: l
         <p class="lede">Each site declares one primary category plus optional tags for cross-cutting coverage.</p>
       </header>
       <nav class="chip_row">
-        {''.join(nav_links)}
+        {render_test_blueprint_nav(visible_categories)}
       </nav>
-      {''.join(sections)}
+      {sections_html}
     </main>
   </body>
 </html>

--- a/scripts/blueprint_test_blueprints.py
+++ b/scripts/blueprint_test_blueprints.py
@@ -40,138 +40,30 @@ from scripts.blueprint_harness_validation import browser_test_command, panel_reg
 
 TAG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 TEST_BLUEPRINT_HARNESS_PREFIX = "[blueprint-test-blueprints]"
-TEST_BLUEPRINT_INDEX_CSS = """      :root {
-        color-scheme: light;
-        --bg: #f8fafc;
-        --panel: #ffffff;
-        --text: #0f172a;
-        --muted: #475569;
-        --border: #cbd5e1;
-        --accent: #0f766e;
-      }
-      * { box-sizing: border-box; }
-      body {
-        margin: 0;
-        font-family: ui-sans-serif, system-ui, sans-serif;
-        background: linear-gradient(180deg, #f8fafc, #eef2ff 45%, #f8fafc);
-        color: var(--text);
-      }
-      main {
-        width: min(70rem, calc(100% - 2rem));
-        margin: 0 auto;
-        padding: 2rem 0 3rem;
-      }
-      header {
-        margin-bottom: 1.5rem;
-      }
-      h1 {
-        margin: 0 0 0.5rem;
-        font-size: clamp(2rem, 4vw, 2.75rem);
-      }
-      .lede {
-        margin: 0;
-        max-width: 54rem;
-        color: var(--muted);
-        line-height: 1.5;
-      }
-      .grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
-        gap: 1rem;
-      }
-      .chip_row {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.55rem;
-        margin: 1.1rem 0 1.6rem;
-      }
-      .chip {
-        display: inline-flex;
-        align-items: center;
-        border: 1px solid var(--border);
-        border-radius: 999px;
-        background: var(--panel);
-        padding: 0.35rem 0.7rem;
-        font-size: 0.92rem;
-        font-weight: 600;
-        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.05);
-      }
-      .category_section + .category_section {
-        margin-top: 1.8rem;
-      }
-      .category_header {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: baseline;
-        justify-content: space-between;
-        gap: 0.5rem 1rem;
-        margin-bottom: 0.9rem;
-      }
-      .category_header h2 {
-        margin: 0;
-        font-size: 1.2rem;
-      }
-      .category_header p {
-        margin: 0;
-        color: var(--muted);
-        font-size: 0.92rem;
-      }
-      .card {
-        border: 1px solid var(--border);
-        border-radius: 1rem;
-        background: var(--panel);
-        padding: 1rem 1.05rem;
-        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
-      }
-      .card h2 {
-        margin: 0 0 0.4rem;
-        font-size: 1.05rem;
-      }
-      .category {
-        margin: 0.25rem 0 0;
-        color: var(--accent);
-        font-size: 0.78rem;
-        font-weight: 700;
-        letter-spacing: 0.04em;
-        text-transform: uppercase;
-      }
-      .kind {
-        margin: 0.2rem 0 0;
-        color: var(--muted);
-        font-size: 0.78rem;
-        font-style: italic;
-      }
-      .card p {
-        margin: 0.45rem 0 0;
-        line-height: 1.45;
-      }
-      .slug {
-        color: var(--muted);
-        font-size: 0.9rem;
-      }
-      .tag_list {
-        list-style: none;
-        padding: 0;
-        margin: 0.65rem 0 0;
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.45rem;
-      }
-      .tag_list li {
-        border: 1px solid #d8dee9;
-        border-radius: 999px;
-        background: #f8fafc;
-        color: var(--muted);
-        padding: 0.2rem 0.55rem;
-        font-size: 0.78rem;
-      }
-      a {
-        color: var(--accent);
-        text-decoration: none;
-      }
-      a:hover {
-        text-decoration: underline;
-      }"""
+TEST_BLUEPRINT_INDEX_CSS = """:root { color-scheme: light; --bg: #f8fafc; --panel: #ffffff; --text: #0f172a; --muted: #475569; --border: #cbd5e1; --accent: #0f766e; }
+* { box-sizing: border-box; }
+body { margin: 0; font-family: ui-sans-serif, system-ui, sans-serif; background: linear-gradient(180deg, #f8fafc, #eef2ff 45%, #f8fafc); color: var(--text); }
+main { width: min(70rem, calc(100% - 2rem)); margin: 0 auto; padding: 2rem 0 3rem; }
+header { margin-bottom: 1.5rem; }
+h1 { margin: 0 0 0.5rem; font-size: clamp(2rem, 4vw, 2.75rem); }
+.lede { margin: 0; max-width: 54rem; color: var(--muted); line-height: 1.5; }
+.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr)); gap: 1rem; }
+.chip_row { display: flex; flex-wrap: wrap; gap: 0.55rem; margin: 1.1rem 0 1.6rem; }
+.chip { display: inline-flex; align-items: center; border: 1px solid var(--border); border-radius: 999px; background: var(--panel); padding: 0.35rem 0.7rem; font-size: 0.92rem; font-weight: 600; box-shadow: 0 6px 18px rgba(15, 23, 42, 0.05); }
+.category_section + .category_section { margin-top: 1.8rem; }
+.category_header { display: flex; flex-wrap: wrap; align-items: baseline; justify-content: space-between; gap: 0.5rem 1rem; margin-bottom: 0.9rem; }
+.category_header h2 { margin: 0; font-size: 1.2rem; }
+.category_header p { margin: 0; color: var(--muted); font-size: 0.92rem; }
+.card { border: 1px solid var(--border); border-radius: 1rem; background: var(--panel); padding: 1rem 1.05rem; box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06); }
+.card h2 { margin: 0 0 0.4rem; font-size: 1.05rem; }
+.category { margin: 0.25rem 0 0; color: var(--accent); font-size: 0.78rem; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; }
+.kind { margin: 0.2rem 0 0; color: var(--muted); font-size: 0.78rem; font-style: italic; }
+.card p { margin: 0.45rem 0 0; line-height: 1.45; }
+.slug { color: var(--muted); font-size: 0.9rem; }
+.tag_list { list-style: none; padding: 0; margin: 0.65rem 0 0; display: flex; flex-wrap: wrap; gap: 0.45rem; }
+.tag_list li { border: 1px solid #d8dee9; border-radius: 999px; background: #f8fafc; color: var(--muted); padding: 0.2rem 0.55rem; font-size: 0.78rem; }
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }"""
 
 
 @dataclass(frozen=True)

--- a/scripts/emit_reference_deploy_matrix.py
+++ b/scripts/emit_reference_deploy_matrix.py
@@ -2,10 +2,8 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Callable
 import json
 from pathlib import Path
-import subprocess
 import sys
 
 if __package__ in {None, ""}:
@@ -13,15 +11,10 @@ if __package__ in {None, ""}:
 
 from scripts.blueprint_harness_paths import detect_harness_layout
 from scripts.blueprint_harness_projects import (
-    HarnessProjectCatalog,
-    HarnessReleaseTarget,
-    default_project_manifest,
-    deploy_project_artifact_name,
-    deploy_project_artifact_path,
+    deploy_matrix_from_release_catalogs,
+    load_branch_project_catalog,
     load_project_catalog,
-    load_project_catalog_text,
-    reference_blueprint_ids_for_toolchain,
-    resolve_projects_for_release,
+    resolve_manifest_path,
 )
 
 
@@ -42,111 +35,9 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def resolve_manifest_path(layout, path_text: str | None) -> Path:
-    if path_text is None:
-        return default_project_manifest(layout.package_root)
-    path = Path(path_text)
-    if path.is_absolute():
-        return path.resolve()
-    return (Path.cwd() / path).resolve()
-
-
-def manifest_relative_to_package(manifest_path: Path, package_root: Path) -> Path | None:
-    try:
-        return manifest_path.relative_to(package_root)
-    except ValueError:
-        return None
-
-
-def release_branch_ref_candidates(branch: str) -> tuple[str, ...]:
-    return (f"origin/{branch}", f"refs/remotes/origin/{branch}", branch)
-
-
-def load_branch_project_catalog(
-    *,
-    branch: str,
-    manifest_path: Path,
-    package_root: Path,
-) -> HarnessProjectCatalog:
-    manifest_relpath = manifest_relative_to_package(manifest_path, package_root)
-    if manifest_relpath is None:
-        return load_project_catalog(manifest_path)
-
-    errors: list[str] = []
-    for ref in release_branch_ref_candidates(branch):
-        result = subprocess.run(
-            ["git", "show", f"{ref}:{manifest_relpath.as_posix()}"],
-            cwd=package_root,
-            text=True,
-            capture_output=True,
-            check=False,
-        )
-        if result.returncode == 0:
-            return load_project_catalog_text(result.stdout, f"{ref}:{manifest_relpath.as_posix()}")
-        errors.append(result.stderr.strip() or result.stdout.strip())
-
-    raise ValueError(
-        f"could not load reference project catalog for release branch `{branch}` from `{manifest_relpath}`; "
-        + "; ".join(error for error in errors if error)
-    )
-
-
-def deploy_matrix_from_release_catalogs(
-    controller_catalog: HarnessProjectCatalog,
-    deployable_targets: tuple[HarnessReleaseTarget, ...],
-    catalog_for_target: Callable[[HarnessReleaseTarget], HarnessProjectCatalog],
-) -> dict[str, list[dict[str, object]]]:
-    include: list[dict[str, object]] = []
-    for target in deployable_targets:
-        selected_blueprints = [
-            blueprint
-            for blueprint in controller_catalog.reference_blueprints
-            if blueprint.toolchain == target.toolchain
-        ]
-        selected_project_ids = reference_blueprint_ids_for_toolchain(controller_catalog, target.toolchain)
-        expected_hash_by_project = {blueprint.blueprint: blueprint.hash for blueprint in selected_blueprints}
-        if controller_catalog.reference_blueprints and not selected_blueprints:
-            raise ValueError(
-                f"release target `{target.release_id}` has `deploy_pages: true` but no reference "
-                f"blueprints for toolchain `{target.toolchain}`"
-            )
-        release_catalog = catalog_for_target(target)
-        release_target = release_catalog.release_target(target.release_id)
-        if release_target is None:
-            raise ValueError(
-                f"catalog for branch `{target.branch}` does not define release target `{target.release_id}`"
-            )
-        projects = resolve_projects_for_release(
-            release_catalog,
-            release_target.release_id,
-            selected_project_ids or None,
-        )
-        for project in projects:
-            expected_hash = expected_hash_by_project.get(project.project_id)
-            if expected_hash is not None and project.ref != expected_hash:
-                raise ValueError(
-                    f"reference blueprint `{project.project_id}` for toolchain `{target.toolchain}` resolves "
-                    f"to `{project.ref}` on branch `{target.branch}`, but the deploy catalog declares `{expected_hash}`"
-                )
-            include.append(
-                {
-                    "release_id": release_target.release_id,
-                    "rc": getattr(release_target, "rc", None),
-                    "toolchain": release_target.toolchain,
-                    "verso_ref": release_target.verso_ref,
-                    "branch": release_target.branch,
-                    "project_id": project.project_id,
-                    "hash": project.ref,
-                    "artifact_name": deploy_project_artifact_name(project),
-                    "artifact_path": deploy_project_artifact_path(project),
-                }
-            )
-    return {"include": include}
-
-
 def payload(args: argparse.Namespace) -> dict[str, object]:
     layout = detect_harness_layout(Path(__file__))
-    manifest_path = resolve_manifest_path(layout, args.manifest)
+    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
     catalog = load_project_catalog(manifest_path)
     deployable_targets = tuple(
         target

--- a/scripts/emit_reference_release_matrix.py
+++ b/scripts/emit_reference_release_matrix.py
@@ -11,11 +11,9 @@ if __package__ in {None, ""}:
 
 from scripts.blueprint_harness_paths import detect_harness_layout
 from scripts.blueprint_harness_projects import (
-    default_project_manifest,
     load_project_catalog,
-    reference_build_matrix,
-    resolve_projects_for_release,
-    resolve_release_target,
+    reference_release_payload,
+    resolve_manifest_path,
 )
 
 
@@ -41,31 +39,11 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def resolve_manifest_path(layout, path_text: str | None) -> Path:
-    if path_text is None:
-        return default_project_manifest(layout.package_root)
-    path = Path(path_text)
-    if path.is_absolute():
-        return path.resolve()
-    return (Path.cwd() / path).resolve()
-
-
 def payload(args: argparse.Namespace) -> dict[str, object]:
     layout = detect_harness_layout(Path(__file__))
-    manifest_path = resolve_manifest_path(layout, args.manifest)
+    manifest_path = resolve_manifest_path(args.manifest, layout.package_root)
     catalog = load_project_catalog(manifest_path)
-    release_target = resolve_release_target(catalog, args.release, layout.package_root)
-    projects = resolve_projects_for_release(catalog, release_target.release_id, None)
-    return {
-        "manifest_path": str(manifest_path),
-        "release_id": release_target.release_id,
-        "toolchain": release_target.toolchain,
-        "verso_ref": release_target.verso_ref,
-        "branch": release_target.branch,
-        "deploy_pages": release_target.deploy_pages,
-        "reference_project_count": len(projects),
-        "reference_matrix": reference_build_matrix(projects),
-    }
+    return reference_release_payload(manifest_path, catalog, args.release, layout.package_root)
 
 
 def emit_github_output(data: dict[str, object]) -> None:

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -1,4 +1,3 @@
-import json
 import pytest
 import random
 import shutil
@@ -14,17 +13,10 @@ if str(PACKAGE_ROOT) not in sys.path:
 
 from scripts.blueprint_harness_paths import (
     canonical_test_blueprint_output_dir,
-    default_test_blueprint_site_dir,
 )
 
 
 DEFAULT_TEST_BLUEPRINT = "preview_runtime_showcase"
-
-def default_site_dir() -> Path:
-    return default_test_blueprint_site_dir(DEFAULT_TEST_BLUEPRINT, Path(__file__))
-
-
-DEFAULT_SITE_DIR = default_site_dir()
 
 
 def browser_executable(browser_type: str) -> str | None:
@@ -37,18 +29,6 @@ def browser_executable(browser_type: str) -> str | None:
         if path:
             return path
     return None
-
-
-def load_redirects(site_dir: str | Path):
-    json_path = Path(site_dir)
-    if not json_path.is_absolute():
-        json_path = (Path(__file__).parent / json_path).resolve()
-    json_path = json_path / "xref.json"
-    with open(json_path) as f:
-        data = json.load(f)
-
-    sections = data["Verso.Genre.Manual.section"]["contents"]
-    return [(s, sections[s][0]["address"] + "#" + sections[s][0]["id"]) for s in sections]
 
 
 def build_test_blueprint_site(name: str) -> Path:

--- a/tests/browser/test_blueprint_slides_runtime.py
+++ b/tests/browser/test_blueprint_slides_runtime.py
@@ -14,18 +14,17 @@ from support import (
     record_runtime_errors,
     wait_for_server,
 )
+from scripts.blueprint_harness_project_commands import (
+    maybe_rewrite_in_repo_blueprint_dependency,
+    restore_tracked_project_manifest,
+    snapshot_tracked_project_manifest,
+)
 from scripts.blueprint_harness_utils import lean_low_priority_command, rebuild_embedded_asset_owners
 
 pytestmark = pytest.mark.skip(reason="Verso Slides support is not built on the v4.29 backport line")
 
 
 def generate_project_template_preview_data(output_dir: Path) -> tuple[Path, Path]:
-    from scripts.blueprint_harness_references import (
-        maybe_rewrite_in_repo_blueprint_dependency,
-        restore_tracked_project_manifest,
-        snapshot_tracked_project_manifest,
-    )
-
     project_dir = PACKAGE_ROOT / "project_template"
     manifest_snapshot = snapshot_tracked_project_manifest(project_dir)
     rewritten_lakefile, original_lakefile_text = maybe_rewrite_in_repo_blueprint_dependency(

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -167,6 +167,11 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         args = parser.parse_args(["create-worktree", "demo", "--lock"])
         self.assertTrue(args.lock)
 
+    def test_worktree_sync_alias_is_retired(self) -> None:
+        parser = build_parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["worktree-sync"])
+
     def test_worktree_claim_parses_lock_flags(self) -> None:
         parser = build_parser()
         lock_args = parser.parse_args(["worktree-claim", "demo", "--lock"])

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -44,16 +44,6 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         args = argparse.Namespace(skip_sync=True, skip_reference_sync=False, lightweight=False)
         self.assertEqual(create_worktree_sync_policy(args), (True, False))
 
-    def test_reference_sync_rejects_legacy_example_alias(self) -> None:
-        parser = reference_harness_mod.build_parser()
-        with self.assertRaises(SystemExit):
-            parser.parse_args(["sync", "--example", "noperthedron"])
-
-    def test_reference_status_rejects_legacy_example_alias(self) -> None:
-        parser = reference_harness_mod.build_parser()
-        with self.assertRaises(SystemExit):
-            parser.parse_args(["status", "--example", "noperthedron"])
-
     def test_reference_generate_parses_allow_unsafe_root_release(self) -> None:
         parser = reference_harness_mod.build_parser()
         args = parser.parse_args(["generate", "--allow-unsafe-root-release", "--release", "v4.29.0"])
@@ -668,16 +658,6 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 ["git", "push", "origin", "--delete", "feat/demo"],
             ],
         )
-
-    def test_reference_generate_rejects_legacy_example_alias(self) -> None:
-        parser = reference_harness_mod.build_parser()
-        with self.assertRaises(SystemExit):
-            parser.parse_args(["generate", "--example", "noperthedron"])
-
-    def test_reference_validate_rejects_legacy_example_alias(self) -> None:
-        parser = reference_harness_mod.build_parser()
-        with self.assertRaises(SystemExit):
-            parser.parse_args(["validate", "--example", "noperthedron"])
 
     def test_reference_generate_rejects_unsafe_root_main_without_override(self) -> None:
         args = argparse.Namespace(

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -689,6 +689,72 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             self.assertEqual(seen["package_root"], layout.package_root)
             self.assertEqual(lakefile.read_text(encoding="utf-8"), OFFICIAL_BLUEPRINT_REQUIRE + "\n")
 
+    def test_reference_cache_warm_build_failure_reports_recovery_hints(self) -> None:
+        import scripts.blueprint_harness_references as refs_mod
+
+        project = HarnessProject(
+            project_id="external-blueprint",
+            source_kind="git_checkout",
+            project_root="nested/blueprint",
+            build_target=None,
+            generator=None,
+            repository="https://github.com/example/external-blueprint.git",
+            ref="main",
+            build_command=("lake", "build"),
+            generate_command=("lake", "exe", "blueprint-gen"),
+            site_subdir="html-multi",
+            panel_regression_script=None,
+            browser_tests_path=None,
+            description=None,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cache_dir = root / "cache" / "external-blueprint"
+            project_dir = cache_dir / "nested" / "blueprint"
+            project_dir.mkdir(parents=True)
+            (cache_dir / ".git").mkdir()
+            lakefile = project_dir / "lakefile.lean"
+            lakefile.write_text(OFFICIAL_BLUEPRINT_REQUIRE + "\n", encoding="utf-8")
+            layout = SimpleNamespace(
+                package_root=root / "worktree",
+                repo_root=root / "root",
+                reference_project_cache_root=root / "cache",
+            )
+            layout.package_root.mkdir()
+            layout.repo_root.mkdir()
+
+            originals = {
+                "update_git_checkout": refs_mod.update_git_checkout,
+                "bootstrap_reference_checkout": refs_mod.bootstrap_reference_checkout,
+                "project_lake_update_command": refs_mod.project_lake_update_command,
+                "run": refs_mod.run,
+            }
+
+            def fake_run(command, *, cwd):
+                if command == ["lake", "update"]:
+                    return
+                raise subprocess.CalledProcessError(7, command)
+
+            try:
+                refs_mod.update_git_checkout = lambda _project, _cache_dir: None
+                refs_mod.bootstrap_reference_checkout = lambda *, project_dir: None
+                refs_mod.project_lake_update_command = lambda _package_root, _project_dir: ["lake", "update"]
+                refs_mod.run = fake_run
+
+                with self.assertRaises(SystemExit) as raised:
+                    refs_mod.sync_reference_cache_checkout(layout, project, warm_build=True)
+            finally:
+                for name, value in originals.items():
+                    setattr(refs_mod, name, value)
+
+            message = str(raised.exception)
+            self.assertIn("failed to warm reference cache for `external-blueprint`", message)
+            self.assertIn(str(cache_dir), message)
+            self.assertIn("incompatible `.olean` header", message)
+            self.assertIn("create-worktree <name> --lightweight", message)
+            self.assertIn("blueprint_reference_harness prune --dry-run", message)
+            self.assertEqual(lakefile.read_text(encoding="utf-8"), OFFICIAL_BLUEPRINT_REQUIRE + "\n")
+
     def test_child_manifests_inherit_verso_and_subverso_from_root_without_mathlib(self) -> None:
         root_manifest_path = PACKAGE_ROOT / "lake-manifest.json"
         child_manifest_paths = [

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -17,6 +17,7 @@ from scripts.blueprint_harness_projects import (
     load_project_catalog_text,
     load_projects_manifest,
     reference_build_matrix,
+    reference_release_payload,
     resolve_projects_for_release,
     resolve_release_target,
 )
@@ -227,6 +228,26 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             matrix,
             {"include": expected_entries},
         )
+
+    def test_reference_release_payload_uses_release_catalog_metadata(self) -> None:
+        manifest = default_project_manifest(PACKAGE_ROOT)
+        catalog = load_project_catalog(manifest)
+
+        payload = reference_release_payload(manifest, catalog, "v4.29.0", PACKAGE_ROOT)
+
+        self.assertEqual(payload["manifest_path"], str(manifest))
+        self.assertEqual(payload["release_id"], "v4.29.0")
+        self.assertEqual(payload["rc"], "")
+        self.assertEqual(payload["toolchain"], "v4.29.0")
+        self.assertEqual(payload["verso_ref"], "v4.29.0")
+        self.assertEqual(payload["branch"], "v4.29.0")
+        self.assertTrue(payload["deploy_pages"])
+        self.assertEqual(payload["reference_project_count"], 1)
+        rows = {
+            entry["project_id"]: entry
+            for entry in payload["reference_matrix"]["include"]
+        }
+        self.assertEqual(set(rows), {"spherepackingblueprint"})
 
     def test_deploy_matrix_uses_controller_reference_blueprints_with_release_branch_catalogs(self) -> None:
         controller_catalog = load_project_catalog_text(

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -12,6 +12,7 @@ from scripts.blueprint_harness_projects import (
     HarnessProject,
     IN_REPO_PROJECT_SOURCE_KIND,
     default_project_manifest,
+    deploy_matrix_from_release_catalogs,
     load_project_catalog,
     load_project_catalog_text,
     load_projects_manifest,
@@ -19,7 +20,6 @@ from scripts.blueprint_harness_projects import (
     resolve_projects_for_release,
     resolve_release_target,
 )
-from scripts.emit_reference_deploy_matrix import deploy_matrix_from_release_catalogs
 from scripts.blueprint_harness_project_commands import (
     OFFICIAL_BLUEPRINT_REQUIRE,
     tracked_project_manifest_path,

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -1452,7 +1452,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         )
 
     def test_reference_prune_plan_finds_stale_cache_and_checkout_paths(self) -> None:
-        from scripts.blueprint_harness import reference_prune_plan
+        from scripts.blueprint_harness_references import reference_prune_plan
 
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
Backport #120 to `v4.29.0`.

## Primary Review
- Primary review: #120
- Keep review comments on #120 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.29.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x` where the patch is applicable to v4.29.

## Backport Delta
- Keep the older v4.29 harness catalog model with top-level `reference_blueprints` instead of v4.30 per-target `publish_reference`/`rc` metadata.
- Keep v4.29 command shapes for reference edit/bump, which do not take a `--release` option.
- Skip v4.30-only test-split/workflow-sync changes that are empty or not applicable on v4.29.