### PR TITLE
[backport v4.29.0] chore: share harness validation checks

### DIFF
--- a/scripts/blueprint_harness_validation.py
+++ b/scripts/blueprint_harness_validation.py
@@ -1,11 +1,23 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 import shutil
 import sys
 
+from scripts.blueprint_harness_utils import StepFailure, run_capturing_failure
+
 
 UV_CACHE_DIR = "/tmp/verso-blueprint-uv-cache"
+
+
+@dataclass(frozen=True)
+class SiteValidationCheck:
+    label: str
+    site_dir: Path
+    panel_regression_script: str | None
+    browser_tests_path: str | None
 
 
 def resolve_package_relative_path(package_root: Path, path_text: str) -> Path:
@@ -28,7 +40,7 @@ def browser_test_command(
     package_root: Path,
     tests_path_text: str,
     site_dir: Path,
-    pytest_args: list[str],
+    pytest_args: Sequence[str],
 ) -> list[str]:
     tests_path = resolve_package_relative_path(package_root, tests_path_text)
     if shutil.which("uv") is not None:
@@ -57,3 +69,38 @@ def browser_test_command(
         str(site_dir),
         *pytest_args,
     ]
+
+
+def run_site_validation_checks(
+    package_root: Path,
+    checks: Iterable[SiteValidationCheck],
+    pytest_args: Sequence[str],
+    *,
+    skip_panel_regression: bool = False,
+    skip_browser_tests: bool = False,
+    stop_on_first_failure: bool = False,
+) -> list[StepFailure]:
+    failures: list[StepFailure] = []
+    for check in checks:
+        if check.panel_regression_script is not None and not skip_panel_regression:
+            failure = run_capturing_failure(
+                f"{check.label} panel regression",
+                panel_regression_command(package_root, check.panel_regression_script, check.site_dir),
+                cwd=package_root,
+            )
+            if failure is not None:
+                failures.append(failure)
+                if stop_on_first_failure:
+                    return failures
+
+        if check.browser_tests_path is not None and not skip_browser_tests:
+            failure = run_capturing_failure(
+                f"{check.label} browser tests",
+                browser_test_command(package_root, check.browser_tests_path, check.site_dir, pytest_args),
+                cwd=package_root,
+            )
+            if failure is not None:
+                failures.append(failure)
+                if stop_on_first_failure:
+                    return failures
+    return failures

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -59,7 +59,7 @@ from scripts.blueprint_harness_utils import (
     run,
     run_capturing_failure,
 )
-from scripts.blueprint_harness_validation import browser_test_command, panel_regression_command
+from scripts.blueprint_harness_validation import SiteValidationCheck, run_site_validation_checks
 from scripts.blueprint_harness_worktrees import git_worktrees, rev_list_counts, worktree_is_clean
 
 
@@ -743,32 +743,22 @@ def project_validation_failures(
     pytest_args: list[str],
     stop_on_first_failure: bool,
 ) -> list[StepFailure]:
-    failures: list[StepFailure] = []
-    for project in projects:
-        site_dir = site_dir_for(project, output_root)
-        if project.panel_regression_script is not None and not skip_panel_regression:
-            failure = run_capturing_failure(
-                f"{project.project_id} panel regression",
-                panel_regression_command(layout.package_root, project.panel_regression_script or "", site_dir),
-                cwd=layout.package_root,
+    return run_site_validation_checks(
+        layout.package_root,
+        [
+            SiteValidationCheck(
+                label=project.project_id,
+                site_dir=site_dir_for(project, output_root),
+                panel_regression_script=project.panel_regression_script,
+                browser_tests_path=project.browser_tests_path,
             )
-            if failure is not None:
-                failures.append(failure)
-                if stop_on_first_failure:
-                    return failures
-
-        if project.browser_tests_path is not None and not skip_browser_tests:
-            failure = run_capturing_failure(
-                f"{project.project_id} browser tests",
-                browser_test_command(layout.package_root, project.browser_tests_path or "", site_dir, pytest_args),
-                cwd=layout.package_root,
-            )
-            if failure is not None:
-                failures.append(failure)
-                if stop_on_first_failure:
-                    return failures
-
-    return failures
+            for project in projects
+        ],
+        pytest_args,
+        skip_panel_regression=skip_panel_regression,
+        skip_browser_tests=skip_browser_tests,
+        stop_on_first_failure=stop_on_first_failure,
+    )
 
 
 def command_validate(args: argparse.Namespace) -> int:

--- a/scripts/blueprint_test_blueprints.py
+++ b/scripts/blueprint_test_blueprints.py
@@ -33,9 +33,8 @@ from scripts.blueprint_harness_utils import (
     lean_low_priority_command,
     print_failure_summary,
     run,
-    run_capturing_failure,
 )
-from scripts.blueprint_harness_validation import browser_test_command, panel_regression_command
+from scripts.blueprint_harness_validation import SiteValidationCheck, run_site_validation_checks
 
 
 TAG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
@@ -428,29 +427,24 @@ def validate_test_blueprint_outputs(
             failures.append(StepFailure("generate test blueprints", str(err)))
             return print_failure_summary(failures, prefix=TEST_BLUEPRINT_HARNESS_PREFIX)
 
-    for fixture in fixtures:
-        site_dir = test_blueprint_site_dir(output_root, fixture)
-        if fixture.panel_regression_script is not None and not skip_panel_regression:
-            failure = run_capturing_failure(
-                f"{fixture.slug} panel regression",
-                panel_regression_command(package_root, fixture.panel_regression_script or "", site_dir),
-                cwd=package_root,
-            )
-            if failure is not None:
-                failures.append(failure)
-                if stop_on_first_failure:
-                    return print_failure_summary(failures, prefix=TEST_BLUEPRINT_HARNESS_PREFIX)
-
-        if fixture.browser_tests_path is not None and not skip_browser_tests:
-            failure = run_capturing_failure(
-                f"{fixture.slug} browser tests",
-                browser_test_command(package_root, fixture.browser_tests_path or "", site_dir, pytest_args),
-                cwd=package_root,
-            )
-            if failure is not None:
-                failures.append(failure)
-                if stop_on_first_failure:
-                    return print_failure_summary(failures, prefix=TEST_BLUEPRINT_HARNESS_PREFIX)
+    failures.extend(
+        run_site_validation_checks(
+            package_root,
+            [
+                SiteValidationCheck(
+                    label=fixture.slug,
+                    site_dir=test_blueprint_site_dir(output_root, fixture),
+                    panel_regression_script=fixture.panel_regression_script,
+                    browser_tests_path=fixture.browser_tests_path,
+                )
+                for fixture in fixtures
+            ],
+            pytest_args,
+            skip_panel_regression=skip_panel_regression,
+            skip_browser_tests=skip_browser_tests,
+            stop_on_first_failure=stop_on_first_failure,
+        )
+    )
 
     return print_failure_summary(failures, prefix=TEST_BLUEPRINT_HARNESS_PREFIX)
 

--- a/tests/harness/test_blueprint_harness_validation.py
+++ b/tests/harness/test_blueprint_harness_validation.py
@@ -5,11 +5,14 @@ import sys
 import unittest
 
 from scripts.blueprint_harness_validation import (
+    SiteValidationCheck,
     UV_CACHE_DIR,
     browser_test_command,
     panel_regression_command,
     resolve_package_relative_path,
+    run_site_validation_checks,
 )
+from scripts.blueprint_harness_utils import StepFailure
 import scripts.blueprint_harness_validation as validation_mod
 
 
@@ -95,6 +98,55 @@ class HarnessValidationCommandTests(unittest.TestCase):
             )
         finally:
             validation_mod.shutil.which = original_which
+
+    def test_run_site_validation_checks_runs_panel_and_browser_checks(self) -> None:
+        check = SiteValidationCheck(
+            label="runtime-showcase",
+            site_dir=Path("/tmp/out/runtime-showcase/html-multi"),
+            panel_regression_script="tests/harness/runtime/check.py",
+            browser_tests_path="tests/browser",
+        )
+        original_run = validation_mod.run_capturing_failure
+        calls: list[tuple[str, list[str], Path]] = []
+        try:
+            validation_mod.run_capturing_failure = (
+                lambda step, command, cwd: calls.append((step, command, cwd)) or None
+            )
+
+            failures = run_site_validation_checks(PACKAGE_ROOT, [check], ["-k", "preview"])
+        finally:
+            validation_mod.run_capturing_failure = original_run
+
+        self.assertEqual(failures, [])
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0][0], "runtime-showcase panel regression")
+        self.assertIn("tests/harness/runtime/check.py", calls[0][1][1])
+        self.assertEqual(calls[1][0], "runtime-showcase browser tests")
+        self.assertIn("-k", calls[1][1])
+        self.assertIn("preview", calls[1][1])
+        self.assertEqual(calls[0][2], PACKAGE_ROOT)
+        self.assertEqual(calls[1][2], PACKAGE_ROOT)
+
+    def test_run_site_validation_checks_stops_on_first_failure(self) -> None:
+        check = SiteValidationCheck(
+            label="runtime-showcase",
+            site_dir=Path("/tmp/out/runtime-showcase/html-multi"),
+            panel_regression_script="tests/harness/runtime/check.py",
+            browser_tests_path="tests/browser",
+        )
+        original_run = validation_mod.run_capturing_failure
+        calls: list[str] = []
+        try:
+            validation_mod.run_capturing_failure = (
+                lambda step, _command, cwd: calls.append(step) or StepFailure(step, "failed")
+            )
+
+            failures = run_site_validation_checks(PACKAGE_ROOT, [check], [], stop_on_first_failure=True)
+        finally:
+            validation_mod.run_capturing_failure = original_run
+
+        self.assertEqual(calls, ["runtime-showcase panel regression"])
+        self.assertEqual(failures, [StepFailure("runtime-showcase panel regression", "failed")])
 
 
 if __name__ == "__main__":

--- a/tests/harness/test_blueprint_test_blueprints.py
+++ b/tests/harness/test_blueprint_test_blueprints.py
@@ -20,6 +20,7 @@ from scripts.blueprint_test_blueprints import (
     write_test_blueprint_index,
 )
 from scripts.blueprint_harness_utils import StepFailure
+import scripts.blueprint_harness_validation as validation_mod
 import scripts.blueprint_test_blueprints as test_blueprints_mod
 
 
@@ -370,7 +371,7 @@ class StandaloneTestBlueprintTests(unittest.TestCase):
         )
         originals = {
             "generate_test_blueprint_outputs": test_blueprints_mod.generate_test_blueprint_outputs,
-            "run_capturing_failure": test_blueprints_mod.run_capturing_failure,
+            "run_capturing_failure": validation_mod.run_capturing_failure,
         }
         calls: list[tuple[str, object]] = []
         try:
@@ -379,7 +380,7 @@ class StandaloneTestBlueprintTests(unittest.TestCase):
                     ("generate", (output_root, requested))
                 )
             )
-            test_blueprints_mod.run_capturing_failure = (
+            validation_mod.run_capturing_failure = (
                 lambda step, command, cwd: calls.append(("run", (step, command, cwd))) or None
             )
 
@@ -403,7 +404,7 @@ class StandaloneTestBlueprintTests(unittest.TestCase):
             self.assertIn("preview", calls[2][1][1])
         finally:
             test_blueprints_mod.generate_test_blueprint_outputs = originals["generate_test_blueprint_outputs"]
-            test_blueprints_mod.run_capturing_failure = originals["run_capturing_failure"]
+            validation_mod.run_capturing_failure = originals["run_capturing_failure"]
 
     def test_validate_test_blueprint_outputs_stops_on_first_failure(self) -> None:
         fixture = StandaloneTestBlueprint(
@@ -420,12 +421,12 @@ class StandaloneTestBlueprintTests(unittest.TestCase):
         )
         originals = {
             "generate_test_blueprint_outputs": test_blueprints_mod.generate_test_blueprint_outputs,
-            "run_capturing_failure": test_blueprints_mod.run_capturing_failure,
+            "run_capturing_failure": validation_mod.run_capturing_failure,
         }
         calls: list[str] = []
         try:
             test_blueprints_mod.generate_test_blueprint_outputs = lambda *_args: None
-            test_blueprints_mod.run_capturing_failure = (
+            validation_mod.run_capturing_failure = (
                 lambda step, _command, cwd: calls.append(step) or StepFailure(step, "failed")
             )
 
@@ -443,7 +444,7 @@ class StandaloneTestBlueprintTests(unittest.TestCase):
             self.assertEqual(calls, ["runtime-showcase panel regression"])
         finally:
             test_blueprints_mod.generate_test_blueprint_outputs = originals["generate_test_blueprint_outputs"]
-            test_blueprints_mod.run_capturing_failure = originals["run_capturing_failure"]
+            validation_mod.run_capturing_failure = originals["run_capturing_failure"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Backport #115 to `v4.29.0`.

## Primary Review
- Primary review: #115
- Keep review comments on #115 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.29.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.