### PR TITLE
[backport v4.29.0] fix: normalize preview behavior and asset owner outputs

### DIFF
--- a/scripts/blueprint_harness_project_commands.py
+++ b/scripts/blueprint_harness_project_commands.py
@@ -7,7 +7,12 @@ from pathlib import Path
 import re
 import subprocess
 
-from scripts.blueprint_harness_utils import lean_low_priority_command, rebuild_embedded_asset_owners, run
+from scripts.blueprint_harness_utils import (
+    ensure_embedded_asset_owner_outputs,
+    lean_low_priority_command,
+    rebuild_embedded_asset_owners,
+    run,
+)
 
 
 OFFICIAL_BLUEPRINT_REPOSITORY = "leanprover/verso-blueprint"
@@ -198,6 +203,13 @@ def rebuild_and_log_embedded_asset_owners(package_root: Path) -> list[str]:
     return rebuilt
 
 
+def ensure_and_log_embedded_asset_owner_outputs(package_root: Path) -> list[str]:
+    materialized = ensure_embedded_asset_owner_outputs(package_root)
+    for target in materialized:
+        print(f"[blueprint-harness] materialized embedded-asset owner output: {target}")
+    return materialized
+
+
 def format_project_command(command: tuple[str, ...], placeholders: Mapping[str, object]) -> list[str]:
     values = {key: str(value) for key, value in placeholders.items()}
     return [part.format(**values) for part in command]
@@ -219,6 +231,7 @@ def run_project_update_build_generate(
             lean_low_priority_command(package_root, *format_command(build_command)),
             cwd=project_dir,
         )
+    ensure_and_log_embedded_asset_owner_outputs(package_root)
     run(
         lean_low_priority_command(package_root, *format_command(generate_command)),
         cwd=project_dir,

--- a/scripts/blueprint_harness_utils.py
+++ b/scripts/blueprint_harness_utils.py
@@ -32,6 +32,11 @@ def run(command: list[str], *, cwd: Path) -> None:
     subprocess.run(command, cwd=cwd, check=True)
 
 
+def run_output(command: list[str], *, cwd: Path) -> str:
+    print(f"[blueprint-harness] $ {format_command(command)}")
+    return subprocess.run(command, cwd=cwd, check=True, text=True, stdout=subprocess.PIPE).stdout
+
+
 def run_capturing_failure(step: str, command: list[str], *, cwd: Path) -> StepFailure | None:
     try:
         run(command, cwd=cwd)
@@ -55,6 +60,163 @@ def lean_low_priority_command(package_root: Path, *args: str) -> list[str]:
     return [str(package_root / "scripts" / "lean-low-priority"), *args]
 
 
+def _module_build_stem(package_root: Path, build_root: str, target: str) -> Path:
+    return package_root / ".lake" / "build" / build_root / Path(*target.split("."))
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_dir():
+        shutil.rmtree(path)
+    elif path.exists():
+        path.unlink()
+
+
+def _remove_module_artifacts(package_root: Path, target: str) -> None:
+    rel_target_stem = Path(*target.split("."))
+    for build_root in (package_root / ".lake" / "build" / "lib" / "lean", package_root / ".lake" / "build" / "ir"):
+        base = build_root / rel_target_stem
+        for artifact in base.parent.glob(base.name + "*"):
+            _remove_path(artifact)
+
+
+def _remove_module_output_sidecars(package_root: Path, target: str) -> None:
+    lean_base = _module_build_stem(package_root, "lib/lean", target)
+    ir_base = _module_build_stem(package_root, "ir", target)
+    for path in (
+        lean_base.with_suffix(".olean"),
+        lean_base.with_suffix(".olean.hash"),
+        lean_base.with_suffix(".ilean"),
+        lean_base.with_suffix(".ilean.hash"),
+        lean_base.with_suffix(".trace"),
+        ir_base.with_suffix(".c"),
+        ir_base.with_suffix(".c.hash"),
+        ir_base.with_suffix(".setup.json"),
+    ):
+        _remove_path(path)
+
+
+def _source_root_arg(package_root: Path, owner: Path) -> str:
+    src_root = package_root / "src"
+    try:
+        owner.relative_to(src_root)
+        return "src"
+    except ValueError:
+        return "."
+
+
+def _relative_to_package_root(package_root: Path, path: Path) -> str:
+    return str(path.relative_to(package_root))
+
+
+def _target_from_source(package_root: Path, source: Path) -> str:
+    source_root = package_root / _source_root_arg(package_root, source)
+    return ".".join(source.relative_to(source_root).with_suffix("").parts)
+
+
+def _local_olean_source(package_root: Path, olean: Path) -> Path | None:
+    lean_build_root = package_root / ".lake" / "build" / "lib" / "lean"
+    try:
+        module_rel = olean.relative_to(lean_build_root).with_suffix(".lean")
+    except ValueError:
+        return None
+    source = package_root / "src" / module_rel
+    return source if source.exists() else None
+
+
+def _missing_local_olean_deps(package_root: Path, source: Path) -> list[tuple[Path, str]]:
+    command = lean_low_priority_command(
+        package_root,
+        "lake",
+        "env",
+        "lean",
+        "-Dexperimental.module=true",
+        "-R",
+        _source_root_arg(package_root, source),
+        "--deps",
+        _relative_to_package_root(package_root, source),
+    )
+    deps = []
+    seen_targets: set[str] = set()
+    for line in run_output(command, cwd=package_root).splitlines():
+        dep_olean = Path(line.strip())
+        if not dep_olean.name.endswith(".olean") or dep_olean.exists():
+            continue
+        dep_source = _local_olean_source(package_root, dep_olean)
+        if dep_source is None:
+            continue
+        dep_target = _target_from_source(package_root, dep_source)
+        if dep_target in seen_targets:
+            continue
+        deps.append((dep_source, dep_target))
+        seen_targets.add(dep_target)
+    return deps
+
+
+# Lake can satisfy these root-package module targets from the cache by writing a
+# synthetic trace without materializing the canonical `.olean`. Generators import
+# through the canonical search path, so direct Lean compilation fills that gap.
+def _materialize_module_source(
+    package_root: Path,
+    source: Path,
+    target: str,
+    materializing: set[str],
+) -> bool:
+    lean_base = _module_build_stem(package_root, "lib/lean", target)
+    ir_base = _module_build_stem(package_root, "ir", target)
+    olean = lean_base.with_suffix(".olean")
+    if olean.exists():
+        return False
+    if target in materializing:
+        raise RuntimeError(f"cyclic embedded asset owner dependency while materializing {target}")
+
+    materializing.add(target)
+    for dep_source, dep_target in _missing_local_olean_deps(package_root, source):
+        _materialize_module_source(package_root, dep_source, dep_target, materializing)
+
+    _remove_module_output_sidecars(package_root, target)
+    olean.parent.mkdir(parents=True, exist_ok=True)
+    ir_base.parent.mkdir(parents=True, exist_ok=True)
+    command = lean_low_priority_command(
+        package_root,
+        "lake",
+        "env",
+        "lean",
+        "-Dexperimental.module=true",
+        "-R",
+        _source_root_arg(package_root, source),
+        "-o",
+        _relative_to_package_root(package_root, olean),
+        "-i",
+        _relative_to_package_root(package_root, lean_base.with_suffix(".ilean")),
+        "-c",
+        _relative_to_package_root(package_root, ir_base.with_suffix(".c")),
+        _relative_to_package_root(package_root, source),
+    )
+    run(command, cwd=package_root)
+    if not olean.exists():
+        raise FileNotFoundError(f"expected rebuilt owner module output was not materialized: {olean}")
+    materializing.remove(target)
+    return True
+
+
+def _materialize_module_owner(package_root: Path, owner_rel: str, target: str) -> bool:
+    return _materialize_module_source(package_root, package_root / owner_rel, target, set())
+
+
+def ensure_embedded_asset_owner_outputs(package_root: Path) -> list[str]:
+    materialized_targets: list[str] = []
+    seen_targets: set[str] = set()
+    for asset_rel, owner_rel, target in EMBEDDED_ASSET_OWNER_PATHS:
+        asset = package_root / asset_rel
+        owner = package_root / owner_rel
+        if not asset.exists() or not owner.exists() or target in seen_targets:
+            continue
+        if _materialize_module_owner(package_root, owner_rel, target):
+            materialized_targets.append(target)
+        seen_targets.add(target)
+    return materialized_targets
+
+
 def refresh_embedded_asset_owner_mtimes(package_root: Path) -> list[Path]:
     touched: list[Path] = []
     for asset_rel, owner_rel, _target in EMBEDDED_ASSET_OWNER_PATHS:
@@ -71,6 +233,7 @@ def refresh_embedded_asset_owner_mtimes(package_root: Path) -> list[Path]:
 
 def rebuild_embedded_asset_owners(package_root: Path) -> list[str]:
     touched_targets: list[str] = []
+    owners_by_target: dict[str, str] = {}
     seen_targets: set[str] = set()
     for asset_rel, owner_rel, target in EMBEDDED_ASSET_OWNER_PATHS:
         asset = package_root / asset_rel
@@ -78,17 +241,13 @@ def rebuild_embedded_asset_owners(package_root: Path) -> list[str]:
         if not asset.exists() or not owner.exists():
             continue
         os.utime(owner, None)
-        rel_target_stem = Path(*target.split("."))
-        for build_root in (package_root / ".lake" / "build" / "lib" / "lean", package_root / ".lake" / "build" / "ir"):
-            base = build_root / rel_target_stem
-            for artifact in base.parent.glob(base.name + "*"):
-                if artifact.is_dir():
-                    shutil.rmtree(artifact)
-                else:
-                    artifact.unlink()
+        _remove_module_artifacts(package_root, target)
         if target not in seen_targets:
             touched_targets.append(target)
+            owners_by_target[target] = owner_rel
             seen_targets.add(target)
     if touched_targets:
         run(lean_low_priority_command(package_root, "lake", "build", *touched_targets), cwd=package_root)
+        for target in touched_targets:
+            _materialize_module_owner(package_root, owners_by_target[target], target)
     return touched_targets

--- a/src/VersoBlueprint/Commands/Common.lean
+++ b/src/VersoBlueprint/Commands/Common.lean
@@ -549,15 +549,50 @@ def previewHoverUtilsJs : String := r##"(function () {
     return false;
   }
 
-  function readPanelBehavior(panel, defaults) {
-    const defaultMode =
-      defaults && (defaults.mode === "hover" || defaults.mode === "pinned")
-        ? defaults.mode
-        : "hover";
+  function normalizePreviewMode(rawMode, fallback) {
+    const defaultMode = fallback === "hover" || fallback === "pinned" ? fallback : "hover";
+    const mode = String(rawMode || "").trim().toLowerCase();
+    if (mode === "hover" || mode === "transient") return "hover";
+    if (
+      mode === "pinned" ||
+      mode === "pin" ||
+      mode === "click" ||
+      mode === "click-to-pin" ||
+      mode === "click-and-stay" ||
+      mode === "click-to-stay"
+    ) {
+      return "pinned";
+    }
+    return defaultMode;
+  }
+
+  function normalizePreviewPlacement(rawPlacement, fallback) {
     const defaultPlacement =
-      defaults && (defaults.placement === "anchored" || defaults.placement === "docked")
-        ? defaults.placement
-        : "anchored";
+      fallback === "anchored" || fallback === "docked" ? fallback : "anchored";
+    const placement = String(rawPlacement || "").trim().toLowerCase();
+    if (
+      placement === "anchored" ||
+      placement === "anchor" ||
+      placement === "near" ||
+      placement === "near-node" ||
+      placement === "node"
+    ) {
+      return "anchored";
+    }
+    if (
+      placement === "docked" ||
+      placement === "dock" ||
+      placement === "fixed" ||
+      placement === "panel"
+    ) {
+      return "docked";
+    }
+    return defaultPlacement;
+  }
+
+  function readPanelBehavior(panel, defaults) {
+    const defaultMode = normalizePreviewMode(defaults && defaults.mode, "hover");
+    const defaultPlacement = normalizePreviewPlacement(defaults && defaults.placement, "anchored");
     if (!(panel instanceof Element)) {
       return {
         mode: defaultMode,
@@ -570,9 +605,8 @@ def previewHoverUtilsJs : String := r##"(function () {
     }
     const rawMode = (panel.getAttribute("data-bp-preview-mode") || "").trim();
     const rawPlacement = (panel.getAttribute("data-bp-preview-placement") || "").trim();
-    const mode = rawMode === "hover" || rawMode === "pinned" ? rawMode : defaultMode;
-    const placement =
-      rawPlacement === "anchored" || rawPlacement === "docked" ? rawPlacement : defaultPlacement;
+    const mode = normalizePreviewMode(rawMode, defaultMode);
+    const placement = normalizePreviewPlacement(rawPlacement, defaultPlacement);
     return {
       mode: mode,
       placement: placement,
@@ -933,6 +967,8 @@ def previewHoverUtilsJs : String := r##"(function () {
     bindCloseOnce: bindCloseOnce,
     positionAnchoredPanel: positionAnchoredPanel,
     shouldKeepOpen: shouldKeepOpen,
+    normalizePreviewMode: normalizePreviewMode,
+    normalizePreviewPlacement: normalizePreviewPlacement,
     readPanelBehavior: readPanelBehavior,
     resetPanelPosition: resetPanelPosition,
     configureCloseButton: configureCloseButton,

--- a/src/VersoBlueprint/Commands/graph.js
+++ b/src/VersoBlueprint/Commands/graph.js
@@ -38,35 +38,16 @@
     return true;
   }
 
-  function normalizePreviewMode(rawMode) {
-    const mode = String(rawMode || "").trim().toLowerCase();
-    if (mode === "hover" || mode === "transient") return "hover";
-    return "pinned";
-  }
-
-  function normalizePreviewPlacement(rawPlacement) {
-    const placement = String(rawPlacement || "").trim().toLowerCase();
-    if (
-      placement === "anchored" ||
-      placement === "anchor" ||
-      placement === "near" ||
-      placement === "near-node" ||
-      placement === "node"
-    ) {
-      return "anchored";
-    }
-    return "docked";
-  }
-
   function previewBehaviorForMode(previewUtils, mode, placement) {
-    const normalized = normalizePreviewMode(mode);
-    const normalizedPlacement = normalizePreviewPlacement(placement);
     if (previewUtils && typeof previewUtils.readPanelBehavior === "function") {
       return previewUtils.readPanelBehavior(null, {
-        mode: normalized,
-        placement: normalizedPlacement
+        mode: mode,
+        placement: placement
       });
     }
+    const normalized = mode === "hover" || mode === "pinned" ? mode : "pinned";
+    const normalizedPlacement =
+      placement === "anchored" || placement === "docked" ? placement : "docked";
     return {
       mode: normalized,
       placement: normalizedPlacement,
@@ -889,15 +870,15 @@
         };
         const setPreviewBehavior = function (nextMode, nextPlacement, options) {
           const opts = options && typeof options === "object" ? options : {};
-          const mode = normalizePreviewMode(nextMode);
-          const placement = normalizePreviewPlacement(nextPlacement);
+          const behavior = previewBehaviorForMode(previewUtils, nextMode, nextPlacement);
+          const mode = behavior.mode;
+          const placement = behavior.placement;
           if (previewPanelNode) {
             previewPanelNode.setAttribute("data-bp-preview-mode", mode);
             previewPanelNode.setAttribute("data-bp-preview-placement", placement);
           }
           if (previewModeSelector) previewModeSelector.value = mode;
           if (previewPlacementSelector) previewPlacementSelector.value = placement;
-          const behavior = previewBehaviorForMode(previewUtils, mode, placement);
           if (previewController) {
             previewController.behavior = behavior;
             configurePanelCloseButton(previewUtils, previewClose, function () {

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
@@ -102,8 +102,8 @@ Base statement for graph preview mode option coverage.
       | some graphJs =>
         hasSubstr graphJs "return utils.readPreviewTemplate(entry);" &&
         hasSubstr graphJs "function layoutGraphCanvas(graphRoot, graphState)" &&
-        hasSubstr graphJs "function normalizePreviewMode(rawMode)" &&
-        hasSubstr graphJs "function normalizePreviewPlacement(rawPlacement)" &&
+        !hasSubstr graphJs "function normalizePreviewMode(rawMode)" &&
+        !hasSubstr graphJs "function normalizePreviewPlacement(rawPlacement)" &&
         hasSubstr graphJs "function ensureGraphBlockState(graphBlock)" &&
         hasSubstr graphJs "function createPanelController(panel, behavior, titleSelector, bodySelector, options)" &&
         hasSubstr graphJs "function bindHoverablePanelLifetime(previewUtils, controller, getActiveAnchor, boundAttr)" &&
@@ -112,6 +112,7 @@ Base statement for graph preview mode option coverage.
         hasSubstr graphJs "const previewPlacementSelector = graphBlock.querySelector(\".bp_graph_preview_placement_select\");" &&
         hasSubstr graphJs "const previewKey = nodeId ? (previewKeys.get(nodeId) || \"\") : \"\";" &&
         hasSubstr graphJs "previewUtils.loadBlueprintHtmlCacheEntry(previewKey)" &&
+        hasSubstr graphJs "previewUtils.readPanelBehavior(null, {" &&
         hasSubstr graphJs "previewUtils.readPanelBehavior(previewPanelNode, { mode: \"pinned\", placement: \"docked\" })" &&
         hasSubstr graphJs "previewUtils.hydratePreviewSubtree(body)" &&
         hasSubstr graphJs "previewUtils.readPanelBehavior(groupHoverPanel, { mode: \"pinned\", placement: \"docked\" })" &&

--- a/tests/browser/test_graph_layout_runtime.py
+++ b/tests/browser/test_graph_layout_runtime.py
@@ -308,6 +308,39 @@ class TestGraphLayoutRuntime:
             }"""
         )
 
+    def test_preview_utils_normalize_graph_preview_aliases(self, server: str, page: Page):
+        page.set_viewport_size({"width": 1400, "height": 900})
+        page.goto(f"{server}/Dependency-Graph/")
+        wait_for_graph(page)
+
+        assert page.evaluate(
+            """() => {
+                const utils = window.bpPreviewUtils;
+                if (
+                    !utils ||
+                    typeof utils.normalizePreviewMode !== "function" ||
+                    typeof utils.normalizePreviewPlacement !== "function" ||
+                    typeof utils.readPanelBehavior !== "function"
+                ) {
+                    return false;
+                }
+                const behavior = utils.readPanelBehavior(null, {
+                    mode: "click-and-stay",
+                    placement: "near-node",
+                });
+                return (
+                    utils.normalizePreviewMode("transient", "pinned") === "hover" &&
+                    utils.normalizePreviewMode("click-to-pin", "hover") === "pinned" &&
+                    utils.normalizePreviewPlacement("fixed", "anchored") === "docked" &&
+                    utils.normalizePreviewPlacement("near-node", "docked") === "anchored" &&
+                    behavior.mode === "pinned" &&
+                    behavior.placement === "anchored" &&
+                    behavior.isPinned &&
+                    behavior.isAnchored
+                );
+            }"""
+        )
+
     def test_graph_preview_can_switch_to_hover_autohide(self, server: str, page: Page):
         page.set_viewport_size({"width": 1400, "height": 900})
         page.goto(f"{server}/Dependency-Graph/")

--- a/tests/harness/test_blueprint_harness_project_commands.py
+++ b/tests/harness/test_blueprint_harness_project_commands.py
@@ -194,9 +194,13 @@ class BlueprintHarnessProjectCommandTests(unittest.TestCase):
             package_root.mkdir()
             project_dir.mkdir()
             original_run = commands_mod.run
+            original_ensure = commands_mod.ensure_and_log_embedded_asset_owner_outputs
             commands: list[list[str]] = []
             try:
                 commands_mod.run = lambda command, *, cwd: commands.append(command)
+                commands_mod.ensure_and_log_embedded_asset_owner_outputs = (
+                    lambda package_root: commands.append(["ensure", str(package_root)]) or []
+                )
 
                 run_project_update_build_generate(
                     package_root,
@@ -209,12 +213,14 @@ class BlueprintHarnessProjectCommandTests(unittest.TestCase):
                 )
             finally:
                 commands_mod.run = original_run
+                commands_mod.ensure_and_log_embedded_asset_owner_outputs = original_ensure
 
         self.assertEqual(
             commands,
             [
                 ["lake", "update"],
                 [str(package_root / "scripts" / "lean-low-priority"), "lake", "build", "--formatted"],
+                ["ensure", str(package_root)],
                 [str(package_root / "scripts" / "lean-low-priority"), "lake", "exe", "blueprint-gen", "--formatted"],
             ],
         )
@@ -229,9 +235,13 @@ class BlueprintHarnessProjectCommandTests(unittest.TestCase):
             package_root.mkdir()
             project_dir.mkdir()
             original_run = commands_mod.run
+            original_ensure = commands_mod.ensure_and_log_embedded_asset_owner_outputs
             commands: list[list[str]] = []
             try:
                 commands_mod.run = lambda command, *, cwd: commands.append(command)
+                commands_mod.ensure_and_log_embedded_asset_owner_outputs = (
+                    lambda package_root: commands.append(["ensure", str(package_root)]) or []
+                )
 
                 run_project_update_build_generate(
                     package_root,
@@ -244,11 +254,13 @@ class BlueprintHarnessProjectCommandTests(unittest.TestCase):
                 )
             finally:
                 commands_mod.run = original_run
+                commands_mod.ensure_and_log_embedded_asset_owner_outputs = original_ensure
 
         self.assertEqual(
             commands,
             [
                 ["lake", "update"],
+                ["ensure", str(package_root)],
                 [str(package_root / "scripts" / "lean-low-priority"), "lake", "exe", "blueprint-gen"],
             ],
         )

--- a/tests/harness/test_blueprint_harness_utils.py
+++ b/tests/harness/test_blueprint_harness_utils.py
@@ -5,7 +5,15 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from scripts.blueprint_harness_utils import rebuild_embedded_asset_owners, refresh_embedded_asset_owner_mtimes
+from scripts.blueprint_harness_utils import (
+    ensure_embedded_asset_owner_outputs,
+    rebuild_embedded_asset_owners,
+    refresh_embedded_asset_owner_mtimes,
+)
+
+
+def _command_arg(command: list[str], option: str) -> str:
+    return command[command.index(option) + 1]
 
 
 class TestBlueprintHarnessUtils(unittest.TestCase):
@@ -65,7 +73,14 @@ class TestBlueprintHarnessUtils(unittest.TestCase):
             os.utime(owner, (now - 10, now - 10))
             os.utime(asset, (now, now))
 
-            with patch("scripts.blueprint_harness_utils.run") as run_mock:
+            def fake_run(command: list[str], *, cwd: Path) -> None:
+                self.assertEqual(cwd, root)
+                cached_olean.write_text("fresh", encoding="utf-8")
+
+            with (
+                patch("scripts.blueprint_harness_utils.run", side_effect=fake_run) as run_mock,
+                patch("scripts.blueprint_harness_utils.run_output", return_value=""),
+            ):
                 rebuilt = rebuild_embedded_asset_owners(root)
 
             self.assertEqual(rebuilt, ["VersoBlueprint.Commands.Graph"])
@@ -74,7 +89,7 @@ class TestBlueprintHarnessUtils(unittest.TestCase):
             self.assertEqual(command[1:3], ["lake", "build"])
             self.assertIn("VersoBlueprint.Commands.Graph", command)
             self.assertEqual(run_mock.call_args.kwargs["cwd"], root)
-            self.assertFalse(cached_olean.exists())
+            self.assertEqual(cached_olean.read_text(encoding="utf-8"), "fresh")
             self.assertFalse(cached_ir.exists())
 
     def test_rebuild_embedded_asset_owners_runs_even_when_owner_is_newer(self) -> None:
@@ -90,8 +105,184 @@ class TestBlueprintHarnessUtils(unittest.TestCase):
             os.utime(asset, (now - 10, now - 10))
             os.utime(owner, (now, now))
 
-            with patch("scripts.blueprint_harness_utils.run") as run_mock:
+            cached_olean = root / ".lake" / "build" / "lib" / "lean" / "VersoBlueprint" / "Commands" / "Graph.olean"
+            cached_olean.parent.mkdir(parents=True, exist_ok=True)
+
+            def fake_run(command: list[str], *, cwd: Path) -> None:
+                self.assertEqual(cwd, root)
+                cached_olean.write_text("fresh", encoding="utf-8")
+
+            with (
+                patch("scripts.blueprint_harness_utils.run", side_effect=fake_run) as run_mock,
+                patch("scripts.blueprint_harness_utils.run_output", return_value=""),
+            ):
                 rebuilt = rebuild_embedded_asset_owners(root)
 
             self.assertEqual(rebuilt, ["VersoBlueprint.Commands.Graph"])
             run_mock.assert_called_once()
+            self.assertEqual(cached_olean.read_text(encoding="utf-8"), "fresh")
+
+    def test_rebuild_embedded_asset_owners_materializes_missing_owner_olean(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            asset = root / "src" / "VersoBlueprint" / "Commands" / "graph.css"
+            owner = root / "src" / "VersoBlueprint" / "Commands" / "Graph.lean"
+            cached_olean = root / ".lake" / "build" / "lib" / "lean" / "VersoBlueprint" / "Commands" / "Graph.olean"
+            cached_ilean = root / ".lake" / "build" / "lib" / "lean" / "VersoBlueprint" / "Commands" / "Graph.ilean"
+            cached_ilean_hash = cached_ilean.with_suffix(".ilean.hash")
+            cached_trace = cached_ilean.with_suffix(".trace")
+            cached_c = root / ".lake" / "build" / "ir" / "VersoBlueprint" / "Commands" / "Graph.c"
+            owner.parent.mkdir(parents=True, exist_ok=True)
+            cached_ilean.parent.mkdir(parents=True, exist_ok=True)
+            cached_c.parent.mkdir(parents=True, exist_ok=True)
+            asset.write_text("/* css */", encoding="utf-8")
+            owner.write_text("-- lean", encoding="utf-8")
+            cached_ilean.write_text("fetched ilean", encoding="utf-8")
+            cached_ilean_hash.write_text("old hash", encoding="utf-8")
+            cached_trace.write_text("synthetic trace", encoding="utf-8")
+
+            def fake_run(command: list[str], *, cwd: Path) -> None:
+                self.assertEqual(cwd, root)
+                if command[1:4] == ["lake", "env", "lean"]:
+                    cached_olean.write_text("fresh", encoding="utf-8")
+                    cached_ilean.write_text("fresh ilean", encoding="utf-8")
+                    cached_c.write_text("fresh c", encoding="utf-8")
+
+            with (
+                patch("scripts.blueprint_harness_utils.run", side_effect=fake_run) as run_mock,
+                patch("scripts.blueprint_harness_utils.run_output", return_value=""),
+            ):
+                rebuilt = rebuild_embedded_asset_owners(root)
+
+            self.assertEqual(rebuilt, ["VersoBlueprint.Commands.Graph"])
+            self.assertEqual(run_mock.call_count, 2)
+            lake_command = run_mock.call_args_list[0].args[0]
+            lean_command = run_mock.call_args_list[1].args[0]
+            self.assertEqual(lake_command[1:3], ["lake", "build"])
+            self.assertEqual(lean_command[1:4], ["lake", "env", "lean"])
+            self.assertIn("-Dexperimental.module=true", lean_command)
+            self.assertEqual(_command_arg(lean_command, "-R"), "src")
+            self.assertEqual(
+                _command_arg(lean_command, "-o"),
+                ".lake/build/lib/lean/VersoBlueprint/Commands/Graph.olean",
+            )
+            self.assertEqual(
+                _command_arg(lean_command, "-i"),
+                ".lake/build/lib/lean/VersoBlueprint/Commands/Graph.ilean",
+            )
+            self.assertEqual(
+                _command_arg(lean_command, "-c"),
+                ".lake/build/ir/VersoBlueprint/Commands/Graph.c",
+            )
+            self.assertEqual(lean_command[-1], "src/VersoBlueprint/Commands/Graph.lean")
+            self.assertEqual(cached_olean.read_text(encoding="utf-8"), "fresh")
+            self.assertEqual(cached_ilean.read_text(encoding="utf-8"), "fresh ilean")
+            self.assertFalse(cached_ilean_hash.exists())
+            self.assertFalse(cached_trace.exists())
+
+    def test_rebuild_embedded_asset_owners_materializes_missing_owner_deps(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            asset = root / "src" / "VersoBlueprint" / "Commands" / "summary.css"
+            owner = root / "src" / "VersoBlueprint" / "Commands" / "Summary.lean"
+            dep_source = root / "src" / "VersoBlueprint" / "Commands" / "Summary" / "Data.lean"
+            owner_olean = root / ".lake" / "build" / "lib" / "lean" / "VersoBlueprint" / "Commands" / "Summary.olean"
+            dep_olean = root / ".lake" / "build" / "lib" / "lean" / "VersoBlueprint" / "Commands" / "Summary" / "Data.olean"
+            owner.parent.mkdir(parents=True, exist_ok=True)
+            dep_source.parent.mkdir(parents=True, exist_ok=True)
+            dep_olean.parent.mkdir(parents=True, exist_ok=True)
+            asset.write_text("/* css */", encoding="utf-8")
+            owner.write_text("-- lean", encoding="utf-8")
+            dep_source.write_text("-- lean", encoding="utf-8")
+
+            def fake_run(command: list[str], *, cwd: Path) -> None:
+                self.assertEqual(cwd, root)
+                if command[-1] == "src/VersoBlueprint/Commands/Summary/Data.lean":
+                    dep_olean.write_text("fresh dep", encoding="utf-8")
+                elif command[-1] == "src/VersoBlueprint/Commands/Summary.lean":
+                    owner_olean.write_text("fresh owner", encoding="utf-8")
+
+            def fake_run_output(command: list[str], *, cwd: Path) -> str:
+                self.assertEqual(cwd, root)
+                if command[-1] == "src/VersoBlueprint/Commands/Summary.lean":
+                    return str(dep_olean) + "\n" + str(dep_olean) + "\n"
+                return ""
+
+            with (
+                patch("scripts.blueprint_harness_utils.run", side_effect=fake_run) as run_mock,
+                patch("scripts.blueprint_harness_utils.run_output", side_effect=fake_run_output) as deps_mock,
+            ):
+                rebuilt = rebuild_embedded_asset_owners(root)
+
+            self.assertEqual(rebuilt, ["VersoBlueprint.Commands.Summary"])
+            self.assertEqual(run_mock.call_count, 3)
+            self.assertEqual(deps_mock.call_count, 2)
+            dep_command = run_mock.call_args_list[1].args[0]
+            owner_command = run_mock.call_args_list[2].args[0]
+            self.assertEqual(dep_command[1:4], ["lake", "env", "lean"])
+            self.assertEqual(owner_command[1:4], ["lake", "env", "lean"])
+            self.assertEqual(dep_command[-1], "src/VersoBlueprint/Commands/Summary/Data.lean")
+            self.assertEqual(owner_command[-1], "src/VersoBlueprint/Commands/Summary.lean")
+            self.assertEqual(dep_olean.read_text(encoding="utf-8"), "fresh dep")
+            self.assertEqual(owner_olean.read_text(encoding="utf-8"), "fresh owner")
+
+    def test_ensure_embedded_asset_owner_outputs_materializes_without_lake_build(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            asset = root / "static-web" / "math.js"
+            owner = root / "src" / "VersoBlueprint" / "Macros.lean"
+            owner_olean = root / ".lake" / "build" / "lib" / "lean" / "VersoBlueprint" / "Macros.olean"
+            owner.parent.mkdir(parents=True, exist_ok=True)
+            asset.parent.mkdir(parents=True, exist_ok=True)
+            owner_olean.parent.mkdir(parents=True, exist_ok=True)
+            asset.write_text("// js", encoding="utf-8")
+            owner.write_text("-- lean", encoding="utf-8")
+
+            def fake_run(command: list[str], *, cwd: Path) -> None:
+                self.assertEqual(cwd, root)
+                self.assertEqual(command[1:4], ["lake", "env", "lean"])
+                owner_olean.write_text("fresh", encoding="utf-8")
+
+            with (
+                patch("scripts.blueprint_harness_utils.run", side_effect=fake_run) as run_mock,
+                patch("scripts.blueprint_harness_utils.run_output", return_value="") as deps_mock,
+            ):
+                materialized = ensure_embedded_asset_owner_outputs(root)
+
+            self.assertEqual(materialized, ["VersoBlueprint.Macros"])
+            run_mock.assert_called_once()
+            deps_mock.assert_called_once()
+            command = run_mock.call_args.args[0]
+            self.assertEqual(command[-1], "src/VersoBlueprint/Macros.lean")
+            self.assertEqual(owner_olean.read_text(encoding="utf-8"), "fresh")
+
+    def test_rebuild_embedded_asset_owners_rebuilds_slide_asset_owner_once(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            css = root / "src" / "VersoBlueprint" / "Slides" / "blueprint-slides.css"
+            js = root / "src" / "VersoBlueprint" / "Slides" / "blueprint-slides.js"
+            owner = root / "src" / "VersoBlueprint" / "Slides" / "Assets.lean"
+            cached_olean = root / ".lake" / "build" / "lib" / "lean" / "VersoBlueprint" / "Slides" / "Assets.olean"
+            cached_ir = root / ".lake" / "build" / "ir" / "VersoBlueprint" / "Slides" / "Assets.c"
+            owner.parent.mkdir(parents=True, exist_ok=True)
+            cached_olean.parent.mkdir(parents=True, exist_ok=True)
+            cached_ir.parent.mkdir(parents=True, exist_ok=True)
+            css.write_text("/* css */", encoding="utf-8")
+            js.write_text("// js", encoding="utf-8")
+            owner.write_text("-- lean", encoding="utf-8")
+            cached_olean.write_text("stale", encoding="utf-8")
+            cached_ir.write_text("stale", encoding="utf-8")
+
+            def fake_run(command: list[str], *, cwd: Path) -> None:
+                self.assertEqual(cwd, root)
+                cached_olean.write_text("fresh", encoding="utf-8")
+
+            with patch("scripts.blueprint_harness_utils.run", side_effect=fake_run) as run_mock:
+                rebuilt = rebuild_embedded_asset_owners(root)
+
+            self.assertEqual(rebuilt, ["VersoBlueprint.Slides.Assets"])
+            run_mock.assert_called_once()
+            command = run_mock.call_args.kwargs["command"] if "command" in run_mock.call_args.kwargs else run_mock.call_args.args[0]
+            self.assertEqual(command.count("VersoBlueprint.Slides.Assets"), 1)
+            self.assertEqual(cached_olean.read_text(encoding="utf-8"), "fresh")
+            self.assertFalse(cached_ir.exists())

--- a/tests/harness/test_blueprint_harness_utils.py
+++ b/tests/harness/test_blueprint_harness_utils.py
@@ -255,34 +255,3 @@ class TestBlueprintHarnessUtils(unittest.TestCase):
             command = run_mock.call_args.args[0]
             self.assertEqual(command[-1], "src/VersoBlueprint/Macros.lean")
             self.assertEqual(owner_olean.read_text(encoding="utf-8"), "fresh")
-
-    def test_rebuild_embedded_asset_owners_rebuilds_slide_asset_owner_once(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            css = root / "src" / "VersoBlueprint" / "Slides" / "blueprint-slides.css"
-            js = root / "src" / "VersoBlueprint" / "Slides" / "blueprint-slides.js"
-            owner = root / "src" / "VersoBlueprint" / "Slides" / "Assets.lean"
-            cached_olean = root / ".lake" / "build" / "lib" / "lean" / "VersoBlueprint" / "Slides" / "Assets.olean"
-            cached_ir = root / ".lake" / "build" / "ir" / "VersoBlueprint" / "Slides" / "Assets.c"
-            owner.parent.mkdir(parents=True, exist_ok=True)
-            cached_olean.parent.mkdir(parents=True, exist_ok=True)
-            cached_ir.parent.mkdir(parents=True, exist_ok=True)
-            css.write_text("/* css */", encoding="utf-8")
-            js.write_text("// js", encoding="utf-8")
-            owner.write_text("-- lean", encoding="utf-8")
-            cached_olean.write_text("stale", encoding="utf-8")
-            cached_ir.write_text("stale", encoding="utf-8")
-
-            def fake_run(command: list[str], *, cwd: Path) -> None:
-                self.assertEqual(cwd, root)
-                cached_olean.write_text("fresh", encoding="utf-8")
-
-            with patch("scripts.blueprint_harness_utils.run", side_effect=fake_run) as run_mock:
-                rebuilt = rebuild_embedded_asset_owners(root)
-
-            self.assertEqual(rebuilt, ["VersoBlueprint.Slides.Assets"])
-            run_mock.assert_called_once()
-            command = run_mock.call_args.kwargs["command"] if "command" in run_mock.call_args.kwargs else run_mock.call_args.args[0]
-            self.assertEqual(command.count("VersoBlueprint.Slides.Assets"), 1)
-            self.assertEqual(cached_olean.read_text(encoding="utf-8"), "fresh")
-            self.assertFalse(cached_ir.exists())


### PR DESCRIPTION
## Summary
Backport #110 to `v4.29.0`.

## Primary Review
- Primary review: #110
- Keep review comments on #110 unless this backport diverges materially.

## Scope
- Backport the preview behavior normalization, embedded asset-owner output materialization, and graph preview wiring guard onto `v4.29.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x` for the default-development commits that apply on this release line.

## Backport Delta
- Drops the slide asset-owner unit coverage from the backport because `v4.29.0` does not include those slide asset owner mappings in its release-line owner table.
- No intentional release-specific production changes.
