### PR TITLE
feat: add Blueprint graft commands

### DIFF
--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -195,14 +195,14 @@ rather than page-local template bodies:
    `Informal/Block/Assets.lean` code-summary preview wiring binds the generic
    runtime to concrete surfaces.
 5. `VersoBlueprint.Graft` provides the `{blueprint_node}` and
-   `blueprint_side_by_side` grafting commands. Manual grafts project the current
-   traversal state into the same semantic entry shape emitted by
-   `PreviewManifest.lean`, then use the shared manifest-backed block renderer.
-   Slide grafts consume the semantic manifest and rendered HTML cache during
-   deck generation to render `{blueprint_node}` shells into the deck HTML.
-   Browser JavaScript then hydrates links, math, and related-entry preview
-   panels; it does not reconstruct Blueprint block markup or relationship
-   topology from ad hoc manifest scans.
+   `blueprint_side_by_side` grafting commands. Manual grafts resolve their exact
+   traversal preview through `PreviewSource.lean`, project that preview into the
+   same semantic entry shape emitted by `PreviewManifest.lean`, then use the
+   shared manifest-backed block renderer. Slide grafts consume the semantic
+   manifest and rendered HTML cache during deck generation to render
+   `{blueprint_node}` shells into the deck HTML. Browser JavaScript then hydrates
+   links, math, and related-entry preview panels; it does not reconstruct
+   Blueprint block markup or relationship topology from ad hoc manifest scans.
 
 Inline Blueprint references, citation references, and the `used by`/group
 relationship panels are now preview-data callers: the rendered page carries the
@@ -406,7 +406,7 @@ reasons:
 | --- | --- | --- | --- |
 | `InlineCode` | `Block.informalCode.traverse` | Informal block/code renderers | Store at most one inline Lean code payload per informal label. The rendered statement then resolves inline code separately from the semantic node metadata, and inline code takes precedence over external declaration hints when both are available. |
 | `ExternalMarkup` | `Block.externalMarkup.traverse` | Preview-manifest construction and optional external-markup display | Store markup attachments outside `Nodes` so late source blocks can be merged by label during traversal. Preview-backed labels expose the deterministic language/slot array on their block manifest entry; witness-only labels become semantic `externalMarkup` manifest entries without HTML-cache bodies. |
-| `TraversalPreviews` | Informal block traversal, once per statement/proof block | `PreviewSource.traversalEntry?` and preview-data construction | Store rendered-preview source blocks once per `(label, facet)`, where facet is statement or proof. Entries may point at associated Lean-code HTML-cache keys, but they do not duplicate declaration-preview payloads. This keeps hover/cache consumers from embedding preview bodies into every link or node entry. |
+| `TraversalPreviews` | Informal block traversal, once per statement/proof block | `PreviewSource.traversalEntry?`, `PreviewSource.traversalEntryByKey?`, and preview-data construction | Store rendered-preview source blocks once per `(label, facet)`, where facet is statement or proof. Entries may point at associated Lean-code HTML-cache keys, but they do not duplicate declaration-preview payloads. This keeps hover/cache consumers from embedding preview bodies into every link or node entry. |
 | `LeanCodePreviews` | Inline Lean code traversal and external declaration snapshot registration | Lean-code preview-data construction and Lean declaration links via the shared lookup key | Store declaration previews by canonical Lean declaration target, not by the Blueprint block or link occurrence that mentions it. Inline and external declaration previews therefore share the same declaration-preview namespace. |
 | `ExternalDeclAnchors` | Informal block traversal for rendered external declarations | Informal block rendering plus summary/graph/code-summary links that jump to rendered external rows | Store only occurrence-specific row anchors keyed by `(informal label, canonical declaration)`. The same Lean declaration may be rendered under multiple Blueprint labels, and each rendered row needs its own destination. |
 | `CitationPreviews` | Citation inline traversal | Preview-manifest construction and citation inline hovers via the shared lookup key | Store bibliography hover data once per rendered citation target and locator. Inline citations then carry a manifest key instead of owning page-local preview templates. |

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -194,11 +194,15 @@ rather than page-local template bodies:
 4. Feature-owned JS such as `Commands/Summary.lean` summary preview wiring or
    `Informal/Block/Assets.lean` code-summary preview wiring binds the generic
    runtime to concrete surfaces.
-5. `VersoBlueprint.Slides` consumes the semantic manifest and rendered HTML
-   cache during slide generation to render `{blueprint_node}` shells into the
-   deck HTML. Browser JavaScript then hydrates links, math, and related-entry
-   preview panels; it does not reconstruct Blueprint block markup or
-   relationship topology from ad hoc manifest scans.
+5. `VersoBlueprint.Graft` provides the `{blueprint_node}` and
+   `blueprint_side_by_side` grafting commands. Manual grafts project the current
+   traversal state into the same semantic entry shape emitted by
+   `PreviewManifest.lean`, then use the shared manifest-backed block renderer.
+   Slide grafts consume the semantic manifest and rendered HTML cache during
+   deck generation to render `{blueprint_node}` shells into the deck HTML.
+   Browser JavaScript then hydrates links, math, and related-entry preview
+   panels; it does not reconstruct Blueprint block markup or relationship
+   topology from ad hoc manifest scans.
 
 Inline Blueprint references, citation references, and the `used by`/group
 relationship panels are now preview-data callers: the rendered page carries the

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -198,11 +198,13 @@ rather than page-local template bodies:
    `blueprint_side_by_side` grafting commands. Manual grafts resolve their exact
    traversal preview through `PreviewSource.lean`, project that preview into the
    same semantic entry shape emitted by `PreviewManifest.lean`, then use the
-   shared manifest-backed block renderer. Slide grafts consume the semantic
-   manifest and rendered HTML cache during deck generation to render
-   `{blueprint_node}` shells into the deck HTML. Browser JavaScript then hydrates
-   links, math, and related-entry preview panels; it does not reconstruct
-   Blueprint block markup or relationship topology from ad hoc manifest scans.
+   shared manifest-backed block renderer. `VersoBlueprint.Graft.Render` owns the
+   reusable manifest/cache rendering path for generated consumers; Slides supply
+   slide-specific link attributes, classes, and diagnostics while delegating the
+   semantic lookup and block assembly to that shared path. Browser JavaScript
+   then hydrates links, math, and related-entry preview panels; it does not
+   reconstruct Blueprint block markup or relationship topology from ad hoc
+   manifest scans.
 
 Inline Blueprint references, citation references, and the `used by`/group
 relationship panels are now preview-data callers: the rendered page carries the

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -854,7 +854,9 @@ interfaces can reuse:
 - `BlueprintNodeConfig.toNode` normalizes that selection into
   `Informal.Graft.BlueprintNode`, including the exact preview `key`.
 - `BlueprintNode.toAttrs` and `BlueprintNode.fromAttrs?` encode and decode the
-  stable DOM shell used by Slides and other generated interfaces.
+  stable DOM shell used by Slides and other generated interfaces. The shell
+  carries the neutral `bp_graft_manifest_node` class as a stable selector for
+  non-slide consumers.
 - `Informal.Graft.setClassAttr`, `Informal.Graft.appendClassAttr`, and
   `BlueprintNode.renderedAttrsWithClass` let custom renderers replace or extend
   CSS classes without creating duplicate `class` attributes.

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -778,6 +778,11 @@ cache emitted by a Blueprint site. The slide deck generator reads those files
 and writes the Blueprint node shell into the generated slide HTML; it does not
 re-traverse the Blueprint source document itself.
 
+Use Manual grafts for same-document reuse while writing an overview,
+introduction, or roadmap page. Use Slides grafts when the deck is generated
+next to an already-rendered Blueprint site and should feature exact entries from
+that site.
+
 Manual source:
 
 ```lean

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -828,10 +828,11 @@ are:
 - `(siteBase := "...")`, for Slides decks whose manifest links should open
   against a Blueprint site hosted next to, or below, the deck
 
-Use `blueprint_side_by_side` to place grafts next to each other:
+Use `blueprint_side_by_side` to place grafts next to each other. Add `+boxed`
+when each side should be visually framed:
 
 ```lean
-:::blueprint_side_by_side
+:::blueprint_side_by_side +boxed
 {blueprint_node "thm:key" -header +compact}
 
 {blueprint_node "thm:key" (facet := "proof") -header +compact}
@@ -841,6 +842,40 @@ Use `blueprint_side_by_side` to place grafts next to each other:
 The side-by-side directive is presentation-only. Each child remains an ordinary
 `{blueprint_node ...}` command with its own label and options; the directive does
 not create dependencies, groups, or new manifest entries.
+
+### API for Custom Graft Consumers
+
+The graft commands are built on the same small data boundary that other
+interfaces can reuse:
+
+- `Informal.Graft.BlueprintNodeConfig` is the command-level selection shape. It
+  records the label plus options such as `facet`, `displayLabel`, `compact`,
+  `showHeader`, and `siteBase`.
+- `BlueprintNodeConfig.toNode` normalizes that selection into
+  `Informal.Graft.BlueprintNode`, including the exact preview `key`.
+- `BlueprintNode.toAttrs` and `BlueprintNode.fromAttrs?` encode and decode the
+  stable DOM shell used by Slides and other generated interfaces.
+- `Informal.Graft.SideBySideConfig` parses wrapper options such as `+boxed`.
+  Its `attrs` and `slideAttrs` helpers produce the standard wrapper classes,
+  but consumers can also ignore them and arrange nodes in their own UI.
+
+For server-side or generator-side renderers, prefer the manifest/cache path over
+ad hoc browser scans. Read or build the semantic
+`Informal.PreviewManifest.File` and rendered
+`Informal.PreviewManifest.HtmlCache.File`, then look up the same normalized node
+key with `PreviewManifest.File.findEntry?` and
+`PreviewManifest.HtmlCache.File.findHtml?`. Code panels can reuse
+`HtmlCache.File.codeHtmlBodies`.
+
+The final shared assembly point is
+`Informal.PreviewManifest.BlockRender.renderWithRenderedContent`. Pass it the
+semantic manifest entry plus `BlockRender.RenderedContent`, using
+`BlockRender.RenderedContent.ofHtmlStrings` when the body came from
+`blueprint-html-cache.json`. The render options map directly to graft behavior:
+`displayLabelOverride?`, `compact`, and `showHeader`. This lets an audit
+interface, dashboard, or slide generator use the same semantic entry and cached
+HTML while placing the rendered nodes in its own side-by-side, tabbed, or
+comparison wrapper.
 
 Use the Blueprint slide wrapper in the deck generator:
 
@@ -866,6 +901,21 @@ output under `-verso-data/` so related-entry and Lean-code hover previews can
 load their bodies. The slide generator also seeds the deck's Verso hover table
 from the cache, so cached Lean fragments keep the usual `data-verso-hover`
 markup instead of embedding duplicate hover payloads into each code token.
+
+### Troubleshooting Grafts
+
+- `Blueprint node not found` means the label/facet pair did not match a
+  rendered Blueprint preview. Check the label spelling and use
+  `(facet := "proof")` when grafting a proof block instead of the statement.
+- `Preview manifest unavailable` in Slides means the deck generator did not pass
+  `previewManifest?` to `slidesMainWithBlueprintPreviews`.
+- `Blueprint HTML cache entry not found` means the manifest entry was found, but
+  the matching rendered body was not in `blueprint-html-cache.json`. Keep the
+  manifest and cache from the same Blueprint render.
+- `siteBase` only affects Slides link rewriting. Manual grafts resolve from the
+  current document traversal state and do not need it.
+- `-header`, `+compact`, and `+boxed` are presentation options only. They do not
+  create new nodes, dependencies, groups, or manifest entries.
 
 ## The Generator Entry Point
 

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -855,11 +855,16 @@ interfaces can reuse:
   `Informal.Graft.BlueprintNode`, including the exact preview `key`.
 - `BlueprintNode.toAttrs` and `BlueprintNode.fromAttrs?` encode and decode the
   stable DOM shell used by Slides and other generated interfaces.
-- `BlueprintNode.renderedAttrsWithClass` appends a custom class to that shell
-  without creating duplicate `class` attributes.
+- `Informal.Graft.setClassAttr`, `Informal.Graft.appendClassAttr`, and
+  `BlueprintNode.renderedAttrsWithClass` let custom renderers replace or extend
+  CSS classes without creating duplicate `class` attributes.
 - `Informal.Graft.SideBySideConfig` parses wrapper options such as `+boxed`.
   Its `attrs` and `slideAttrs` helpers produce the standard wrapper classes,
   but consumers can also ignore them and arrange nodes in their own UI.
+- `Informal.Slides.BlueprintSlideNode` and
+  `Informal.Slides.BlueprintNodeConfig` remain compatibility aliases for older
+  slide-oriented code. New generated consumers should import and use the
+  `Informal.Graft` names directly.
 
 For server-side or generator-side renderers, prefer the manifest/cache path over
 ad hoc browser scans. Read or build the semantic

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -765,13 +765,37 @@ lake env lean --run <GeneratorMain>.lean --help
 - `--help` includes these manifest-related flags alongside the usual rendering
   options
 
-## Blueprint Nodes in Verso Slides
+## Blueprint Grafts in Manual and Slides
 
-`VersoBlueprint.Slides` adds a `{blueprint_node ...}` block command for Verso
-Slides decks. It renders an entry from the semantic manifest plus rendered HTML
+`VersoBlueprint` adds a `{blueprint_node ...}` block command that grafts an
+existing Blueprint node into another place in the document. The same command is
+also available in Verso Slides decks through `VersoBlueprint.Slides`.
+
+In Manual documents, grafts use the current traversal state and render through
+the same manifest-backed Blueprint block shell used by generated preview data.
+In Slides decks, grafts render from the semantic manifest plus rendered HTML
 cache emitted by a Blueprint site. The slide deck generator reads those files
 and writes the Blueprint node shell into the generated slide HTML; it does not
 re-traverse the Blueprint source document itself.
+
+Manual source:
+
+```lean
+import VersoBlueprint
+
+open Verso
+open Verso.Genre.Manual
+open Informal
+
+#docs (Genre.Manual) doc "Overview" :=
+:::::::
+:::theorem "thm:key"
+The statement to feature.
+:::
+
+{blueprint_node "thm:key" -header +compact}
+:::::::
+```
 
 Slide source:
 
@@ -788,13 +812,30 @@ open VersoSlides
 :::::::
 ```
 
-The `siteBase` option is useful when links in the manifest should open
-against a Blueprint site hosted next to, or below, the slide deck. Omit it when
-the manifest links are already correct relative to the deck.
+The first positional argument is the Blueprint label to graft. Available options
+are:
 
-Use `displayLabel` only when a slide needs a talk-specific heading label. It
-overrides the displayed label/number in the Blueprint shell, not the semantic
-manifest title.
+- `(facet := "statement")` or `(facet := "proof")`; statement is the default
+- `(displayLabel := "...")`, which overrides the displayed label/number in the
+  grafted shell without changing the semantic manifest entry
+- `+compact`, which omits attached Lean-code panels
+- `+header` or `-header`; headers are shown by default
+- `(siteBase := "...")`, for Slides decks whose manifest links should open
+  against a Blueprint site hosted next to, or below, the deck
+
+Use `blueprint_side_by_side` to place grafts next to each other:
+
+```lean
+:::blueprint_side_by_side
+{blueprint_node "thm:key" -header +compact}
+
+{blueprint_node "thm:key" (facet := "proof") -header +compact}
+:::
+```
+
+The side-by-side directive is presentation-only. Each child remains an ordinary
+`{blueprint_node ...}` command with its own label and options; the directive does
+not create dependencies, groups, or new manifest entries.
 
 Use the Blueprint slide wrapper in the deck generator:
 

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -854,19 +854,19 @@ interfaces can reuse:
 - `BlueprintNodeConfig.toNode` normalizes that selection into
   `Informal.Graft.BlueprintNode`, including the exact preview `key`.
 - `BlueprintNode.toAttrs` and `BlueprintNode.fromAttrs?` encode and decode the
-  stable DOM shell used by Slides and other generated interfaces. The shell
-  carries the neutral `bp_graft_manifest_node` class as a stable selector for
-  non-slide consumers.
+  neutral DOM shell used by generated interfaces. The shell carries the
+  `bp_graft_manifest_node` class as a stable selector for custom consumers.
+  Slides use `BlueprintNode.slideAttrs` and `BlueprintNode.slideRenderedAttrs`
+  to add slide-specific classes without making them part of the generic graft
+  contract.
 - `Informal.Graft.setClassAttr`, `Informal.Graft.appendClassAttr`, and
   `BlueprintNode.renderedAttrsWithClass` let custom renderers replace or extend
   CSS classes without creating duplicate `class` attributes.
 - `Informal.Graft.SideBySideConfig` parses wrapper options such as `+boxed`.
   Its `attrs` and `slideAttrs` helpers produce the standard wrapper classes,
   but consumers can also ignore them and arrange nodes in their own UI.
-- `Informal.Slides.BlueprintSlideNode` and
-  `Informal.Slides.BlueprintNodeConfig` remain compatibility aliases for older
-  slide-oriented code. New generated consumers should import and use the
-  `Informal.Graft` names directly.
+- Slide generators and other generated consumers should import and use the
+  `Informal.Graft` node/config names directly.
 
 For server-side or generator-side renderers, prefer the manifest/cache path over
 ad hoc browser scans. Read or build the semantic
@@ -957,6 +957,8 @@ markup instead of embedding duplicate hover payloads into each code token.
 - `Blueprint node not found` means the label/facet pair did not match a
   rendered Blueprint preview. Check the label spelling and use
   `(facet := "proof")` when grafting a proof block instead of the statement.
+  The diagnostic includes the requested label, facet, and normalized manifest
+  key.
 - `Preview manifest unavailable` in Slides means the deck generator did not pass
   `previewManifest?` to `slidesMainWithBlueprintPreviews`.
 - `Blueprint HTML cache entry not found` means the manifest entry was found, but

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -911,9 +911,15 @@ missing rendered HTML-cache body for a manifest entry. The cache-miss branch
 also calls the context's `logError` callback so generators can fail or report
 broken manifest/cache pairs consistently.
 
-For lower-level consumers, the final shared assembly point remains
-`Informal.PreviewManifest.BlockRender.renderWithRenderedContent`. Pass it the
-semantic manifest entry plus `BlockRender.RenderedContent`, using
+Consumers that already have a semantic manifest entry and rendered body content
+can call `Informal.Graft.renderNodeWithContent` directly. This keeps the graft
+node attributes, wrapper classes, and `displayLabel`/`compact`/`showHeader`
+behavior aligned with `{blueprint_node}` while letting the caller decide where
+the content came from.
+
+For still lower-level consumers, the final shared block-shell assembly point
+remains `Informal.PreviewManifest.BlockRender.renderWithRenderedContent`. Pass
+it the semantic manifest entry plus `BlockRender.RenderedContent`, using
 `BlockRender.RenderedContent.ofHtmlStrings` when the body came from
 `blueprint-html-cache.json`. The render options map directly to graft behavior:
 `displayLabelOverride?`, `compact`, and `showHeader`. This lets an audit

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -855,6 +855,8 @@ interfaces can reuse:
   `Informal.Graft.BlueprintNode`, including the exact preview `key`.
 - `BlueprintNode.toAttrs` and `BlueprintNode.fromAttrs?` encode and decode the
   stable DOM shell used by Slides and other generated interfaces.
+- `BlueprintNode.renderedAttrsWithClass` appends a custom class to that shell
+  without creating duplicate `class` attributes.
 - `Informal.Graft.SideBySideConfig` parses wrapper options such as `+boxed`.
   Its `attrs` and `slideAttrs` helpers produce the standard wrapper classes,
   but consumers can also ignore them and arrange nodes in their own UI.
@@ -889,15 +891,18 @@ def renderAuditNode
         codeBodyClass := "audit_blueprint_code"
       }
       nodeAttrs := fun node =>
-        node.renderedAttrs.map (fun attr =>
-          if attr.1 == "class" then
-            ("class", attr.2 ++ " audit_graft_node")
-          else
-            attr)
+        node.renderedAttrsWithClass "audit_graft_node"
     }
     ctx
     node
 ```
+
+`renderNodeFromManifestCache` has three diagnostic branches that custom
+interfaces can keep or override with `ManifestRenderConfig.renderMissingNode`:
+missing manifest, missing manifest entry for the normalized node key, and
+missing rendered HTML-cache body for a manifest entry. The cache-miss branch
+also calls the context's `logError` callback so generators can fail or report
+broken manifest/cache pairs consistently.
 
 For lower-level consumers, the final shared assembly point remains
 `Informal.PreviewManifest.BlockRender.renderWithRenderedContent`. Pass it the

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -867,7 +867,39 @@ key with `PreviewManifest.File.findEntry?` and
 `PreviewManifest.HtmlCache.File.findHtml?`. Code panels can reuse
 `HtmlCache.File.codeHtmlBodies`.
 
-The final shared assembly point is
+`VersoBlueprint.Graft.Render` packages that lookup-and-render path for custom
+interfaces. A consumer such as an audit view can provide its own wrapper
+classes and diagnostics while reusing the same manifest/cache content:
+
+```lean
+import VersoBlueprint.Graft
+
+def renderAuditNode
+    (manifest : Informal.PreviewManifest.File)
+    (htmlCache : Informal.PreviewManifest.HtmlCache.File)
+    (label : String) : IO Verso.Output.Html := do
+  let node :=
+    ({ label := label, compact := true, showHeader := false } :
+      Informal.Graft.BlueprintNodeConfig).toNode
+  let ctx := Informal.Graft.RenderContext.ofPreviewData? (some manifest) (some htmlCache)
+  Informal.Graft.renderNodeFromManifestCache
+    {
+      blockRenderConfig := {
+        wrapperClass := "audit_blueprint_node"
+        codeBodyClass := "audit_blueprint_code"
+      }
+      nodeAttrs := fun node =>
+        node.renderedAttrs.map (fun attr =>
+          if attr.1 == "class" then
+            ("class", attr.2 ++ " audit_graft_node")
+          else
+            attr)
+    }
+    ctx
+    node
+```
+
+For lower-level consumers, the final shared assembly point remains
 `Informal.PreviewManifest.BlockRender.renderWithRenderedContent`. Pass it the
 semantic manifest entry plus `BlockRender.RenderedContent`, using
 `BlockRender.RenderedContent.ofHtmlStrings` when the body came from

--- a/doc/UPSTREAM_BACKLOG.md
+++ b/doc/UPSTREAM_BACKLOG.md
@@ -68,11 +68,12 @@ pull requests unless that upstream write action is explicitly requested.
 
 - [ ] Add a Verso Slides `Block.ofHtml` constructor.
   - current Blueprint workaround:
-    `VersoBlueprint.Slides.slidesMainWithBlueprintRenderer` supplies a local
-    `GenreHtml Slides IO` instance so `{blueprint_node}` blocks render from the
-    Blueprint manifest/cache data before the HTML document is serialized; because
-    `VersoSlides.slidesMain` owns both rendering and file emission, Blueprint
-    also mirrors the small config-asset plan and write loop
+    `VersoBlueprint.Slides.slidesMainWithBlueprintPreviews` supplies a local
+    `GenreHtml Slides IO` instance so slide graft blocks elaborated through
+    `{blueprint_node}` render from the Blueprint manifest/cache data before the
+    HTML document is serialized; because `VersoSlides.slidesMain` owns both
+    rendering and file emission, Blueprint also mirrors the small config-asset
+    plan and write loop
   - desired upstream behavior:
     downstream packages should be able to elaborate a slide block to an
     already-rendered HTML body, while reusing the upstream `slidesMain` asset

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -39,6 +39,7 @@ lean_lib VersoBlueprintTests where
     `VersoBlueprintTests.BlueprintImportedDuplicates.Reexport,
     `VersoBlueprintTests.BlueprintImportedDuplicates.Transitive,
     `VersoBlueprintTests.BlueprintExternalHeadingStatus,
+    `VersoBlueprintTests.BlueprintGraft,
     `VersoBlueprintTests.BlueprintGraph,
     `VersoBlueprintTests.BlueprintHeaderExtras,
     `VersoBlueprintTests.BlueprintInformal,

--- a/src/VersoBlueprint.lean
+++ b/src/VersoBlueprint.lean
@@ -51,6 +51,7 @@ import VersoBlueprint.LabelNameParsing
 import VersoBlueprint.LeanNameParsing
 import VersoBlueprint.PreviewCache
 import VersoBlueprint.PreviewManifest
+import VersoBlueprint.Graft
 import VersoBlueprint.Resolve
 import VersoBlueprint.TraversalIndex
 import VersoBlueprint.StyleSwitcher

--- a/src/VersoBlueprint/Graft.lean
+++ b/src/VersoBlueprint/Graft.lean
@@ -10,6 +10,7 @@ import Verso.Doc.Elab
 import VersoBlueprint.Informal.Block.Assets
 import VersoBlueprint.Informal.LeanCodePreview
 import VersoBlueprint.Graft.Assets
+import VersoBlueprint.Graft.Node
 import VersoBlueprint.PreviewManifest.BlockRender
 import VersoBlueprint.Slides.Node
 import VersoBlueprint.TraversalIndex
@@ -48,13 +49,13 @@ private def replaceClassAttr (attrs : Array (String × String)) (className : Str
     else
       out.push ("class", className)
 
-private def manualNodeClass (node : Informal.Slides.BlueprintSlideNode) : String :=
+private def manualNodeClass (node : Informal.Graft.BlueprintNode) : String :=
   if node.compact then
     "bp_graft_node bp_graft_node_compact"
   else
     "bp_graft_node"
 
-private def manualNodeAttrs (node : Informal.Slides.BlueprintSlideNode) :
+private def manualNodeAttrs (node : Informal.Graft.BlueprintNode) :
     Array (String × String) :=
   replaceClassAttr node.renderedAttrs (manualNodeClass node)
 
@@ -126,9 +127,9 @@ private def renderLeanCodeBodies
 private def renderManualGraftNode
     [Monad m]
     (goB : Doc.Block Verso.Genre.Manual → Doc.Html.HtmlT Verso.Genre.Manual m Html)
-    (cfg : Informal.Slides.BlueprintNodeConfig) :
+    (cfg : Informal.Graft.BlueprintNodeConfig) :
     Doc.Html.HtmlT Verso.Genre.Manual m Html := do
-  let node := cfg.toSlideNode
+  let node := cfg.toNode
   let state ← Doc.Html.HtmlT.state
   match Informal.PreviewManifest.findTraversalBlockEntry? state node.key with
   | none =>
@@ -161,7 +162,7 @@ private def renderManualGraftNode
             }
 
 open Verso Doc Elab Genre Manual in
-block_extension Block.blueprintGraftNode (cfg : Informal.Slides.BlueprintNodeConfig) where
+block_extension Block.blueprintGraftNode (cfg : Informal.Graft.BlueprintNodeConfig) where
   data := toJson cfg
   traverse _ _ _ := pure none
   toTeX := none
@@ -171,14 +172,15 @@ block_extension Block.blueprintGraftNode (cfg : Informal.Slides.BlueprintNodeCon
     open Verso.Doc.Html in
     open Verso.Output.Html in
     some <| fun _goI goB _id data _blocks => do
-      match fromJson? (α := Informal.Slides.BlueprintNodeConfig) data with
+      match fromJson? (α := Informal.Graft.BlueprintNodeConfig) data with
       | .error err =>
           HtmlT.logError s!"Malformed Blueprint graft node data ({err}): {data}"
           pure .empty
       | .ok cfg => renderManualGraftNode goB cfg
 
 open Verso Doc Elab Genre Manual in
-block_extension Block.blueprintGraftSideBySide where
+block_extension Block.blueprintGraftSideBySide (cfg : Informal.Graft.SideBySideConfig) where
+  data := toJson cfg
   traverse _ _ _ := pure none
   toTeX := none
   extraCss := Informal.Block.Assets.blockCssAssets ++ Informal.Graft.cssAssets
@@ -186,9 +188,15 @@ block_extension Block.blueprintGraftSideBySide where
   toHtml :=
     open Verso.Doc.Html in
     open Verso.Output.Html in
-    some <| fun _goI goB _id _data blocks => do
+    some <| fun _goI goB _id data blocks => do
+      let cfg ←
+        match fromJson? (α := Informal.Graft.SideBySideConfig) data with
+        | .error err =>
+            HtmlT.logError s!"Malformed Blueprint graft side-by-side data ({err}): {data}"
+            pure {}
+        | .ok cfg => pure cfg
       let content ← blocks.mapM goB
-      pure <| Html.tag "div" #[("class", "bp_graft_side_by_side")] (Html.seq content)
+      pure <| Html.tag "div" cfg.attrs (Html.seq content)
 
 private meta def currentGenreIs (genreTerm : Term) : DocElabM Bool := do
   let current := (← readThe DocElabContext).genre
@@ -201,10 +209,7 @@ private meta def inManualGenre : DocElabM Bool := do
 private meta def inSlidesGenre : DocElabM Bool := do
   currentGenreIs (← `(VersoSlides.Slides))
 
-def sideBySideAttrs : Array (String × String) :=
-  #[("class", "bp_graft_side_by_side bp_slide_graft_side_by_side")]
-
-public meta def blueprintNodeBlock (cfg : Informal.Slides.BlueprintNodeConfig) :
+public meta def blueprintNodeBlock (cfg : Informal.Graft.BlueprintNodeConfig) :
     DocElabM Term := do
   if ← inManualGenre then
     ``(Verso.Doc.Block.other
@@ -215,16 +220,17 @@ public meta def blueprintNodeBlock (cfg : Informal.Slides.BlueprintNodeConfig) :
   else
     throwError "Blueprint graft nodes are only available in Manual and Slides documents"
 
-public meta def blueprintSideBySide : DirectiveExpanderOf Unit
-  | (), stxs => do
+public meta def blueprintSideBySide : DirectiveExpanderOf Informal.Graft.SideBySideConfig
+  | cfg, stxs => do
       let contents ← stxs.mapM elabBlock
       if ← inManualGenre then
         ``(Verso.Doc.Block.other
-            Informal.Graft.Block.blueprintGraftSideBySide
+            (Informal.Graft.Block.blueprintGraftSideBySide $(quote cfg))
             #[$contents,*])
       else if ← inSlidesGenre then
+        let attrs := cfg.slideAttrs
         ``(Verso.Doc.Block.other
-            (VersoSlides.BlockExt.wrap $(quote sideBySideAttrs))
+            (VersoSlides.BlockExt.wrap $(quote attrs))
             #[$contents,*])
       else
         throwError "Blueprint side-by-side grafts are only available in Manual and Slides documents"
@@ -238,7 +244,7 @@ Render a Blueprint preview node by label in either a Manual document or a Slides
 deck.
 -/
 @[block_command]
-public meta def blueprint_node : BlockCommandOf Informal.Slides.BlueprintNodeConfig
+public meta def blueprint_node : BlockCommandOf Informal.Graft.BlueprintNodeConfig
   | cfg => Informal.Graft.blueprintNodeBlock cfg
 
 /--
@@ -246,5 +252,5 @@ Lay out Blueprint graft nodes side by side. Child blocks are ordinary
 `{blueprint_node ...}` commands and keep their own options.
 -/
 @[directive]
-public meta def blueprint_side_by_side : DirectiveExpanderOf Unit :=
+public meta def blueprint_side_by_side : DirectiveExpanderOf Informal.Graft.SideBySideConfig :=
   Informal.Graft.blueprintSideBySide

--- a/src/VersoBlueprint/Graft.lean
+++ b/src/VersoBlueprint/Graft.lean
@@ -11,6 +11,7 @@ import VersoBlueprint.Informal.Block.Assets
 import VersoBlueprint.Informal.LeanCodePreview
 import VersoBlueprint.Graft.Assets
 import VersoBlueprint.Graft.Node
+import VersoBlueprint.Graft.Render
 import VersoBlueprint.PreviewManifest.BlockRender
 import VersoBlueprint.Slides.Node
 import VersoBlueprint.TraversalIndex

--- a/src/VersoBlueprint/Graft.lean
+++ b/src/VersoBlueprint/Graft.lean
@@ -1,0 +1,299 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoManual
+import VersoSlides
+import Verso.Doc.Elab
+import VersoBlueprint.Informal.Block.Assets
+import VersoBlueprint.Informal.LeanCodePreview
+import VersoBlueprint.PreviewManifest.BlockRender
+import VersoBlueprint.Slides.Node
+import VersoBlueprint.TraversalIndex
+
+set_option doc.verso true
+
+namespace Informal.Graft
+
+open Lean
+open Verso Doc Elab
+open Verso.Genre Manual
+open Verso.Output
+open Verso.Output.Html
+
+def css : String := r##"
+.bp_graft_node {
+  display: block;
+  margin: 0.75rem 0;
+}
+
+.bp_graft_node_compact .bp_code_panel_wrapper {
+  display: none;
+}
+
+.bp_graft_node_notice {
+  margin: 0.75rem 0;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--bp-color-status-error-border-soft);
+  border-radius: var(--bp-radius-md);
+  background: var(--bp-color-surface-warn);
+  color: var(--bp-color-status-error-strong);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.bp_graft_side_by_side {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(22rem, 100%), 1fr));
+  gap: 0.9rem;
+  align-items: start;
+  margin: 0.9rem 0;
+}
+
+.bp_graft_side_by_side > * {
+  min-width: 0;
+}
+
+.bp_graft_side_by_side .bp_wrapper,
+.bp_graft_side_by_side .bp_graft_node {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.bp_graft_side_by_side .bp_heading {
+  align-items: flex-start;
+}
+
+.bp_graft_side_by_side .bp_extras {
+  margin-left: 0;
+}
+"##
+
+def cssAssets : List String := [css]
+
+private def renderNotice (kind title detail : String) : Html :=
+  {{
+    <div class={{"bp_graft_node_notice bp_graft_node_notice_" ++ kind}}>
+      <strong>{{Html.ofString title}}</strong><br/>
+      {{Html.ofString detail}}
+    </div>
+  }}
+
+private def replaceClassAttr (attrs : Array (String × String)) (className : String) :
+    Array (String × String) :=
+  Id.run do
+    let mut out := #[]
+    let mut found := false
+    for attr in attrs do
+      if attr.1 == "class" then
+        out := out.push ("class", className)
+        found := true
+      else
+        out := out.push attr
+    if found then
+      out
+    else
+      out.push ("class", className)
+
+private def manualNodeClass (node : Informal.Slides.BlueprintSlideNode) : String :=
+  if node.compact then
+    "bp_graft_node bp_graft_node_compact"
+  else
+    "bp_graft_node"
+
+private def manualNodeAttrs (node : Informal.Slides.BlueprintSlideNode) :
+    Array (String × String) :=
+  replaceClassAttr node.renderedAttrs (manualNodeClass node)
+
+private def manualBlockRenderConfig : Informal.PreviewManifest.BlockRender.RenderConfig :=
+  {
+    wrapperClass := "bp_graft_node_blueprint"
+    codeBodyClass := "bp_graft_code_body"
+    relationPanels := {
+      wrapClass := fun kind => "bp_relation_wrap bp_graft_" ++ kind.key ++ "_wrap"
+      idPrefix := fun kind entry =>
+        match kind with
+        | .group => s!"bp-graft-group-{entry.label}"
+        | .uses => "bp-graft-uses"
+        | .usedBy => "bp-graft-used-by"
+    }
+  }
+
+private def pushDistinctHtml (bodies : Array Html) (body : Html) : Array Html :=
+  let html := body.asString
+  if bodies.any (fun existing => existing.asString == html) then
+    bodies
+  else
+    bodies.push body
+
+private def renderManualBlocks
+    [Monad m]
+    (goB : Doc.Block Verso.Genre.Manual → Doc.Html.HtmlT Verso.Genre.Manual m Html)
+    (blocks : Array (Doc.Block Verso.Genre.Manual)) :
+    Doc.Html.HtmlT Verso.Genre.Manual m Html := do
+  Html.seq <$> blocks.mapM goB
+
+private def renderLeanCodePreviewBody?
+    [Monad m]
+    (goB : Doc.Block Verso.Genre.Manual → Doc.Html.HtmlT Verso.Genre.Manual m Html)
+    (state : TraverseState)
+    (key : String) :
+    Doc.Html.HtmlT Verso.Genre.Manual m (Option Html) := do
+  match Informal.TraversalIndex.LeanCodePreviews.object? state key with
+  | none =>
+      Doc.Html.HtmlT.logError s!"Blueprint graft: missing Lean-code preview {key}"
+      pure none
+  | some obj =>
+      match fromJson? (α := Informal.LeanCodePreview.Entry) obj.data with
+      | .error err =>
+          Doc.Html.HtmlT.logError s!"Blueprint graft: malformed Lean-code preview {key}: {err}"
+          pure none
+      | .ok entry =>
+          match entry.source with
+          | .inlineBlocks blocks => some <$> renderManualBlocks goB blocks
+          | .externalDecl decl => pure <| some <| Informal.ExternalCode.renderPreviewHtml #[decl]
+
+private def renderLeanCodeBodies
+    [Monad m]
+    (goB : Doc.Block Verso.Genre.Manual → Doc.Html.HtmlT Verso.Genre.Manual m Html)
+    (state : TraverseState)
+    (entry : Informal.PreviewManifest.Entry) :
+    Doc.Html.HtmlT Verso.Genre.Manual m (Array Html) := do
+  let mut bodies := #[]
+  for key in entry.leanCodePreviewKeys do
+    match ← renderLeanCodePreviewBody? goB state key with
+    | none => pure ()
+    | some body =>
+        if body.asString.trimAscii.isEmpty then
+          pure ()
+        else
+          bodies := pushDistinctHtml bodies body
+  pure bodies
+
+private def renderManualGraftNode
+    [Monad m]
+    (goB : Doc.Block Verso.Genre.Manual → Doc.Html.HtmlT Verso.Genre.Manual m Html)
+    (cfg : Informal.Slides.BlueprintNodeConfig) :
+    Doc.Html.HtmlT Verso.Genre.Manual m Html := do
+  let node := cfg.toSlideNode
+  let state ← Doc.Html.HtmlT.state
+  match Informal.PreviewManifest.findTraversalBlockEntry? state node.key with
+  | none =>
+      pure <| Html.tag "div" (manualNodeAttrs node) <|
+        renderNotice "error" "Blueprint node not found" node.key
+  | some (preview, entry) =>
+      if preview.blocks.isEmpty then
+        pure <| Html.tag "div" (manualNodeAttrs node) <|
+          renderNotice "error" "Blueprint node has no cached content" node.key
+      else
+        let body ← renderManualBlocks goB preview.blocks
+        let codeBodies ←
+          if node.compact then
+            pure #[]
+          else
+            renderLeanCodeBodies goB state entry
+        let content : Informal.PreviewManifest.BlockRender.RenderedContent := {
+          body
+          codeBodies
+        }
+        pure <| Html.tag "div" (manualNodeAttrs node) <|
+          Informal.PreviewManifest.BlockRender.renderWithRenderedContent
+            manualBlockRenderConfig
+            entry
+            content
+            {
+              displayLabelOverride? := node.displayLabel?
+              compact := node.compact
+              showHeader := node.showHeader
+            }
+
+open Verso Doc Elab Genre Manual in
+block_extension Block.blueprintGraftNode (cfg : Informal.Slides.BlueprintNodeConfig) where
+  data := toJson cfg
+  traverse _ _ _ := pure none
+  toTeX := none
+  extraCss := Informal.Block.Assets.blockCssAssets ++ Informal.Graft.cssAssets
+  extraJs := Informal.Block.Assets.blockJsAssets
+  toHtml :=
+    open Verso.Doc.Html in
+    open Verso.Output.Html in
+    some <| fun _goI goB _id data _blocks => do
+      match fromJson? (α := Informal.Slides.BlueprintNodeConfig) data with
+      | .error err =>
+          HtmlT.logError s!"Malformed Blueprint graft node data ({err}): {data}"
+          pure .empty
+      | .ok cfg => renderManualGraftNode goB cfg
+
+open Verso Doc Elab Genre Manual in
+block_extension Block.blueprintGraftSideBySide where
+  traverse _ _ _ := pure none
+  toTeX := none
+  extraCss := Informal.Block.Assets.blockCssAssets ++ Informal.Graft.cssAssets
+  extraJs := Informal.Block.Assets.blockJsAssets
+  toHtml :=
+    open Verso.Doc.Html in
+    open Verso.Output.Html in
+    some <| fun _goI goB _id _data blocks => do
+      let content ← blocks.mapM goB
+      pure <| Html.tag "div" #[("class", "bp_graft_side_by_side")] (Html.seq content)
+
+private meta def currentGenreIs (genreTerm : Term) : DocElabM Bool := do
+  let current := (← readThe DocElabContext).genre
+  let expected ← Lean.Elab.Term.elabTerm genreTerm (some (.const ``Verso.Doc.Genre []))
+  Lean.Meta.isDefEq current expected
+
+private meta def inManualGenre : DocElabM Bool := do
+  currentGenreIs (← `(Verso.Genre.Manual))
+
+private meta def inSlidesGenre : DocElabM Bool := do
+  currentGenreIs (← `(VersoSlides.Slides))
+
+def sideBySideAttrs : Array (String × String) :=
+  #[("class", "bp_graft_side_by_side bp_slide_graft_side_by_side")]
+
+public meta def blueprintNodeBlock (cfg : Informal.Slides.BlueprintNodeConfig) :
+    DocElabM Term := do
+  if ← inManualGenre then
+    ``(Verso.Doc.Block.other
+        (Informal.Graft.Block.blueprintGraftNode $(quote cfg))
+        #[])
+  else if ← inSlidesGenre then
+    Informal.Slides.blueprintNodeBlock cfg
+  else
+    throwError "Blueprint graft nodes are only available in Manual and Slides documents"
+
+public meta def blueprintSideBySide : DirectiveExpanderOf Unit
+  | (), stxs => do
+      let contents ← stxs.mapM elabBlock
+      if ← inManualGenre then
+        ``(Verso.Doc.Block.other
+            Informal.Graft.Block.blueprintGraftSideBySide
+            #[$contents,*])
+      else if ← inSlidesGenre then
+        ``(Verso.Doc.Block.other
+            (VersoSlides.BlockExt.wrap $(quote sideBySideAttrs))
+            #[$contents,*])
+      else
+        throwError "Blueprint side-by-side grafts are only available in Manual and Slides documents"
+
+end Informal.Graft
+
+open Verso Doc Elab
+
+/--
+Render a Blueprint preview node by label in either a Manual document or a Slides
+deck.
+-/
+@[block_command]
+public meta def blueprint_node : BlockCommandOf Informal.Slides.BlueprintNodeConfig
+  | cfg => Informal.Graft.blueprintNodeBlock cfg
+
+/--
+Lay out Blueprint graft nodes side by side. Child blocks are ordinary
+`{blueprint_node ...}` commands and keep their own options.
+-/
+@[directive]
+public meta def blueprint_side_by_side : DirectiveExpanderOf Unit :=
+  Informal.Graft.blueprintSideBySide

--- a/src/VersoBlueprint/Graft.lean
+++ b/src/VersoBlueprint/Graft.lean
@@ -34,22 +34,6 @@ private def renderNotice (kind title detail : String) : Html :=
     </div>
   }}
 
-private def replaceClassAttr (attrs : Array (String × String)) (className : String) :
-    Array (String × String) :=
-  Id.run do
-    let mut out := #[]
-    let mut found := false
-    for attr in attrs do
-      if attr.1 == "class" then
-        out := out.push ("class", className)
-        found := true
-      else
-        out := out.push attr
-    if found then
-      out
-    else
-      out.push ("class", className)
-
 private def manualNodeClass (node : Informal.Graft.BlueprintNode) : String :=
   if node.compact then
     "bp_graft_node bp_graft_node_compact"
@@ -58,7 +42,7 @@ private def manualNodeClass (node : Informal.Graft.BlueprintNode) : String :=
 
 private def manualNodeAttrs (node : Informal.Graft.BlueprintNode) :
     Array (String × String) :=
-  replaceClassAttr node.renderedAttrs (manualNodeClass node)
+  setClassAttr node.renderedAttrs (manualNodeClass node)
 
 private def manualBlockRenderConfig : Informal.PreviewManifest.BlockRender.RenderConfig :=
   {

--- a/src/VersoBlueprint/Graft.lean
+++ b/src/VersoBlueprint/Graft.lean
@@ -58,6 +58,12 @@ private def manualBlockRenderConfig : Informal.PreviewManifest.BlockRender.Rende
     }
   }
 
+private def manualManifestRenderConfig : Informal.Graft.ManifestRenderConfig :=
+  {
+    blockRenderConfig := manualBlockRenderConfig
+    nodeAttrs := manualNodeAttrs
+  }
+
 private def pushDistinctHtml (bodies : Array Html) (body : Html) : Array Html :=
   let html := body.asString
   if bodies.any (fun existing => existing.asString == html) then
@@ -135,16 +141,11 @@ private def renderManualGraftNode
           body
           codeBodies
         }
-        pure <| Html.tag "div" (manualNodeAttrs node) <|
-          Informal.PreviewManifest.BlockRender.renderWithRenderedContent
-            manualBlockRenderConfig
-            entry
-            content
-            {
-              displayLabelOverride? := node.displayLabel?
-              compact := node.compact
-              showHeader := node.showHeader
-            }
+        pure <| Informal.Graft.renderNodeWithContent
+          manualManifestRenderConfig
+          node
+          entry
+          content
 
 open Verso Doc Elab Genre Manual in
 block_extension Block.blueprintGraftNode (cfg : Informal.Graft.BlueprintNodeConfig) where

--- a/src/VersoBlueprint/Graft.lean
+++ b/src/VersoBlueprint/Graft.lean
@@ -36,9 +36,9 @@ private def renderNotice (kind title detail : String) : Html :=
 
 private def manualNodeClass (node : Informal.Graft.BlueprintNode) : String :=
   if node.compact then
-    "bp_graft_node bp_graft_node_compact"
+    "bp_graft_node bp_graft_manifest_node bp_graft_node_compact"
   else
-    "bp_graft_node"
+    "bp_graft_node bp_graft_manifest_node"
 
 private def manualNodeAttrs (node : Informal.Graft.BlueprintNode) :
     Array (String × String) :=

--- a/src/VersoBlueprint/Graft.lean
+++ b/src/VersoBlueprint/Graft.lean
@@ -125,7 +125,7 @@ private def renderManualGraftNode
   match Informal.PreviewManifest.findTraversalBlockEntry? state node.key with
   | none =>
       pure <| Html.tag "div" (manualNodeAttrs node) <|
-        renderNotice "error" "Blueprint node not found" node.key
+        renderNotice "error" "Blueprint node not found" node.selectionDescription
   | some (preview, entry) =>
       if preview.blocks.isEmpty then
         pure <| Html.tag "div" (manualNodeAttrs node) <|

--- a/src/VersoBlueprint/Graft.lean
+++ b/src/VersoBlueprint/Graft.lean
@@ -9,6 +9,7 @@ import VersoSlides
 import Verso.Doc.Elab
 import VersoBlueprint.Informal.Block.Assets
 import VersoBlueprint.Informal.LeanCodePreview
+import VersoBlueprint.Graft.Assets
 import VersoBlueprint.PreviewManifest.BlockRender
 import VersoBlueprint.Slides.Node
 import VersoBlueprint.TraversalIndex
@@ -22,56 +23,6 @@ open Verso Doc Elab
 open Verso.Genre Manual
 open Verso.Output
 open Verso.Output.Html
-
-def css : String := r##"
-.bp_graft_node {
-  display: block;
-  margin: 0.75rem 0;
-}
-
-.bp_graft_node_compact .bp_code_panel_wrapper {
-  display: none;
-}
-
-.bp_graft_node_notice {
-  margin: 0.75rem 0;
-  padding: 0.6rem 0.75rem;
-  border: 1px solid var(--bp-color-status-error-border-soft);
-  border-radius: var(--bp-radius-md);
-  background: var(--bp-color-surface-warn);
-  color: var(--bp-color-status-error-strong);
-  font-size: 0.9rem;
-  line-height: 1.4;
-}
-
-.bp_graft_side_by_side {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(22rem, 100%), 1fr));
-  gap: 0.9rem;
-  align-items: start;
-  margin: 0.9rem 0;
-}
-
-.bp_graft_side_by_side > * {
-  min-width: 0;
-}
-
-.bp_graft_side_by_side .bp_wrapper,
-.bp_graft_side_by_side .bp_graft_node {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.bp_graft_side_by_side .bp_heading {
-  align-items: flex-start;
-}
-
-.bp_graft_side_by_side .bp_extras {
-  margin-left: 0;
-}
-"##
-
-def cssAssets : List String := [css]
 
 private def renderNotice (kind title detail : String) : Html :=
   {{

--- a/src/VersoBlueprint/Graft/Assets.lean
+++ b/src/VersoBlueprint/Graft/Assets.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+namespace Informal.Graft
+
+def css : String := r##"
+.bp_graft_node {
+  display: block;
+  margin: 0.75rem 0;
+}
+
+.bp_graft_node_compact .bp_code_panel_wrapper {
+  display: none;
+}
+
+.bp_graft_node_notice {
+  margin: 0.75rem 0;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--bp-color-status-error-border-soft);
+  border-radius: var(--bp-radius-md);
+  background: var(--bp-color-surface-warn);
+  color: var(--bp-color-status-error-strong);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.bp_graft_side_by_side {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(22rem, 100%), 1fr));
+  gap: 0.9rem;
+  align-items: start;
+  margin: 0.9rem 0;
+}
+
+.bp_graft_side_by_side > * {
+  min-width: 0;
+}
+
+.bp_graft_side_by_side .bp_wrapper,
+.bp_graft_side_by_side .bp_graft_node {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.bp_graft_side_by_side .bp_heading {
+  align-items: flex-start;
+}
+
+.bp_graft_side_by_side .bp_extras {
+  margin-left: 0;
+}
+"##
+
+def cssAssets : List String := [css]
+
+end Informal.Graft

--- a/src/VersoBlueprint/Graft/Assets.lean
+++ b/src/VersoBlueprint/Graft/Assets.lean
@@ -39,6 +39,14 @@ def css : String := r##"
   min-width: 0;
 }
 
+.bp_graft_side_by_side_boxed > * {
+  padding: 0.75rem;
+  border: 1px solid var(--bp-color-border-soft, #d8dee8);
+  border-radius: var(--bp-radius-md, 0.45rem);
+  background: var(--bp-color-surface, #ffffff);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+}
+
 .bp_graft_side_by_side .bp_wrapper,
 .bp_graft_side_by_side .bp_graft_node {
   margin-top: 0;

--- a/src/VersoBlueprint/Graft/Node.lean
+++ b/src/VersoBlueprint/Graft/Node.lean
@@ -73,9 +73,9 @@ public def appendClassAttr (attrs : Array (String × String)) (className : Strin
 
 private def BlueprintNode.domClassName (node : BlueprintNode) : String :=
   if node.compact then
-    "bp_slide_node bp_graft_manifest_node bp_slide_node_compact"
+    "bp_graft_manifest_node bp_graft_manifest_node_compact"
   else
-    "bp_slide_node bp_graft_manifest_node"
+    "bp_graft_manifest_node"
 
 def BlueprintNode.toAttrs (node : BlueprintNode) : Array (String × String) :=
   nodeMarkerAttrs ++
@@ -104,6 +104,16 @@ def BlueprintNode.fromAttrs? (attrs : Array (String × String)) : Option Bluepri
 def BlueprintNode.renderedAttrs (node : BlueprintNode) : Array (String × String) :=
   node.toAttrs ++ #[("data-bp-rendered", "static")]
 
+def BlueprintNode.slideAttrs (node : BlueprintNode) : Array (String × String) :=
+  appendClassAttr node.toAttrs <|
+    if node.compact then
+      "bp_slide_node bp_slide_node_compact"
+    else
+      "bp_slide_node"
+
+def BlueprintNode.slideRenderedAttrs (node : BlueprintNode) : Array (String × String) :=
+  node.slideAttrs ++ #[("data-bp-rendered", "static")]
+
 /-- Rendered DOM attributes with one additional CSS class. -/
 def BlueprintNode.renderedAttrsWithClass (node : BlueprintNode) (className : String) :
     Array (String × String) :=
@@ -111,6 +121,9 @@ def BlueprintNode.renderedAttrsWithClass (node : BlueprintNode) (className : Str
 
 def BlueprintNode.fallbackText (node : BlueprintNode) : String :=
   s!"Loading Blueprint node {node.label}..."
+
+def BlueprintNode.selectionDescription (node : BlueprintNode) : String :=
+  s!"label `{node.label}`, facet `{node.facet}`, key `{node.key}`"
 
 public structure BlueprintNodeConfig where
   label : String

--- a/src/VersoBlueprint/Graft/Node.lean
+++ b/src/VersoBlueprint/Graft/Node.lean
@@ -33,7 +33,7 @@ deriving Repr, BEq
 private def attrValue? (attrs : Array (String × String)) (name : String) : Option String :=
   (attrs.find? fun attr => attr.1 == name).map (·.2)
 
-private def BlueprintNode.slideClassName (node : BlueprintNode) : String :=
+private def BlueprintNode.domClassName (node : BlueprintNode) : String :=
   if node.compact then
     "bp_slide_node bp_slide_node_compact"
   else
@@ -41,7 +41,7 @@ private def BlueprintNode.slideClassName (node : BlueprintNode) : String :=
 
 def BlueprintNode.toAttrs (node : BlueprintNode) : Array (String × String) :=
   nodeMarkerAttrs ++
-    #[ ("class", node.slideClassName)
+    #[ ("class", node.domClassName)
      , ("data-bp-label", node.label)
      , ("data-bp-facet", node.facet)
      , ("data-bp-preview-key", node.key)

--- a/src/VersoBlueprint/Graft/Node.lean
+++ b/src/VersoBlueprint/Graft/Node.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import Verso.Doc.ArgParse
+import Verso.Doc.Elab
+import VersoBlueprint.LabelNameParsing
+import VersoBlueprint.PreviewCache
+
+namespace Informal.Graft
+
+open Lean
+open Verso Doc Elab ArgParse
+
+private def nodeMarkerAttr : String := "data-bp-blueprint-node"
+private def nodeMarkerValue : String := "true"
+
+private def nodeMarkerAttrs : Array (String × String) :=
+  #[(nodeMarkerAttr, nodeMarkerValue)]
+
+public structure BlueprintNode where
+  label : String
+  facet : String := "statement"
+  key : String
+  displayLabel? : Option String := none
+  compact : Bool := false
+  showHeader : Bool := true
+  siteBase? : Option String := none
+deriving Repr, BEq
+
+private def attrValue? (attrs : Array (String × String)) (name : String) : Option String :=
+  (attrs.find? fun attr => attr.1 == name).map (·.2)
+
+private def BlueprintNode.slideClassName (node : BlueprintNode) : String :=
+  if node.compact then
+    "bp_slide_node bp_slide_node_compact"
+  else
+    "bp_slide_node"
+
+def BlueprintNode.toAttrs (node : BlueprintNode) : Array (String × String) :=
+  nodeMarkerAttrs ++
+    #[ ("class", node.slideClassName)
+     , ("data-bp-label", node.label)
+     , ("data-bp-facet", node.facet)
+     , ("data-bp-preview-key", node.key)
+     , ("data-bp-compact", if node.compact then "true" else "false")
+     , ("data-bp-show-header", if node.showHeader then "true" else "false")
+     ] ++
+    (node.displayLabel?.map (fun label => #[("data-bp-display-label", label)] ) |>.getD #[]) ++
+    (node.siteBase?.map (fun siteBase => #[("data-bp-site-base", siteBase)] ) |>.getD #[])
+
+def BlueprintNode.fromAttrs? (attrs : Array (String × String)) : Option BlueprintNode := do
+  let marker ← attrValue? attrs nodeMarkerAttr
+  guard (marker == nodeMarkerValue)
+  let label ← attrValue? attrs "data-bp-label"
+  let facet := attrValue? attrs "data-bp-facet" |>.getD "statement"
+  let key := attrValue? attrs "data-bp-preview-key" |>.getD s!"{label}--{facet}"
+  let displayLabel? := attrValue? attrs "data-bp-display-label"
+  let compact := attrValue? attrs "data-bp-compact" == some "true"
+  let showHeader := attrValue? attrs "data-bp-show-header" != some "false"
+  let siteBase? := attrValue? attrs "data-bp-site-base"
+  some { label, facet, key, displayLabel?, compact, showHeader, siteBase? }
+
+def BlueprintNode.renderedAttrs (node : BlueprintNode) : Array (String × String) :=
+  node.toAttrs ++ #[("data-bp-rendered", "static")]
+
+def BlueprintNode.fallbackText (node : BlueprintNode) : String :=
+  s!"Loading Blueprint node {node.label}..."
+
+public structure BlueprintNodeConfig where
+  label : String
+  facet : Option String := none
+  displayLabel : Option String := none
+  compact : Bool := false
+  showHeader : Bool := true
+  siteBase : Option String := none
+deriving Repr, BEq, ToJson, FromJson, Quote
+
+public meta instance : FromArgs BlueprintNodeConfig DocElabM where
+  fromArgs :=
+    BlueprintNodeConfig.mk <$>
+      .positional `label .string <*>
+      .named `facet .string true <*>
+      .named `displayLabel .string true <*>
+      .flag `compact false <*>
+      .flag `header true <*>
+      .named `siteBase .string true
+
+private def previewKey (label facet : String) : String :=
+  let label := Informal.LabelNameParsing.parse label
+  match facet with
+  | "statement" => Informal.PreviewCache.key label .statement
+  | "proof" => Informal.PreviewCache.key label .proof
+  | other => s!"{label}--{other}"
+
+def BlueprintNodeConfig.toNode (cfg : BlueprintNodeConfig) : BlueprintNode :=
+  let facet := cfg.facet.getD "statement"
+  {
+    label := cfg.label
+    facet
+    key := previewKey cfg.label facet
+    displayLabel? := cfg.displayLabel
+    compact := cfg.compact
+    showHeader := cfg.showHeader
+    siteBase? := cfg.siteBase
+  }
+
+public structure SideBySideConfig where
+  boxed : Bool := false
+deriving Repr, BEq, Inhabited, ToJson, FromJson, Quote
+
+public meta instance : FromArgs SideBySideConfig DocElabM where
+  fromArgs :=
+    SideBySideConfig.mk <$>
+      .flag `boxed false
+
+namespace SideBySideConfig
+
+public def className (cfg : SideBySideConfig) : String :=
+  if cfg.boxed then
+    "bp_graft_side_by_side bp_graft_side_by_side_boxed"
+  else
+    "bp_graft_side_by_side"
+
+public def slideClassName (cfg : SideBySideConfig) : String :=
+  cfg.className ++ " bp_slide_graft_side_by_side"
+
+public def attrs (cfg : SideBySideConfig) : Array (String × String) :=
+  #[("class", cfg.className)]
+
+public def slideAttrs (cfg : SideBySideConfig) : Array (String × String) :=
+  #[("class", cfg.slideClassName)]
+
+end SideBySideConfig
+
+end Informal.Graft

--- a/src/VersoBlueprint/Graft/Node.lean
+++ b/src/VersoBlueprint/Graft/Node.lean
@@ -73,9 +73,9 @@ public def appendClassAttr (attrs : Array (String × String)) (className : Strin
 
 private def BlueprintNode.domClassName (node : BlueprintNode) : String :=
   if node.compact then
-    "bp_slide_node bp_slide_node_compact"
+    "bp_slide_node bp_graft_manifest_node bp_slide_node_compact"
   else
-    "bp_slide_node"
+    "bp_slide_node bp_graft_manifest_node"
 
 def BlueprintNode.toAttrs (node : BlueprintNode) : Array (String × String) :=
   nodeMarkerAttrs ++

--- a/src/VersoBlueprint/Graft/Node.lean
+++ b/src/VersoBlueprint/Graft/Node.lean
@@ -33,6 +33,32 @@ deriving Repr, BEq
 private def attrValue? (attrs : Array (String × String)) (name : String) : Option String :=
   (attrs.find? fun attr => attr.1 == name).map (·.2)
 
+/-- Append a CSS class to an HTML attribute array, creating the `class` attribute if needed. -/
+public def appendClassAttr (attrs : Array (String × String)) (className : String) :
+    Array (String × String) :=
+  Id.run do
+    let className := className.trimAscii.toString
+    if className.isEmpty then
+      return attrs
+    let mut out := #[]
+    let mut found := false
+    for attr in attrs do
+      if attr.1 == "class" then
+        let current := attr.2.trimAscii.toString
+        let value :=
+          if current.isEmpty then
+            className
+          else
+            current ++ " " ++ className
+        out := out.push ("class", value)
+        found := true
+      else
+        out := out.push attr
+    if found then
+      out
+    else
+      out.push ("class", className)
+
 private def BlueprintNode.domClassName (node : BlueprintNode) : String :=
   if node.compact then
     "bp_slide_node bp_slide_node_compact"
@@ -65,6 +91,11 @@ def BlueprintNode.fromAttrs? (attrs : Array (String × String)) : Option Bluepri
 
 def BlueprintNode.renderedAttrs (node : BlueprintNode) : Array (String × String) :=
   node.toAttrs ++ #[("data-bp-rendered", "static")]
+
+/-- Rendered DOM attributes with one additional CSS class. -/
+def BlueprintNode.renderedAttrsWithClass (node : BlueprintNode) (className : String) :
+    Array (String × String) :=
+  appendClassAttr node.renderedAttrs className
 
 def BlueprintNode.fallbackText (node : BlueprintNode) : String :=
   s!"Loading Blueprint node {node.label}..."

--- a/src/VersoBlueprint/Graft/Node.lean
+++ b/src/VersoBlueprint/Graft/Node.lean
@@ -33,8 +33,11 @@ deriving Repr, BEq
 private def attrValue? (attrs : Array (String × String)) (name : String) : Option String :=
   (attrs.find? fun attr => attr.1 == name).map (·.2)
 
-/-- Append a CSS class to an HTML attribute array, creating the `class` attribute if needed. -/
-public def appendClassAttr (attrs : Array (String × String)) (className : String) :
+/--
+Set the CSS class in an HTML attribute array, replacing an existing `class`
+attribute or creating one when needed.
+-/
+public def setClassAttr (attrs : Array (String × String)) (className : String) :
     Array (String × String) :=
   Id.run do
     let className := className.trimAscii.toString
@@ -44,13 +47,7 @@ public def appendClassAttr (attrs : Array (String × String)) (className : Strin
     let mut found := false
     for attr in attrs do
       if attr.1 == "class" then
-        let current := attr.2.trimAscii.toString
-        let value :=
-          if current.isEmpty then
-            className
-          else
-            current ++ " " ++ className
-        out := out.push ("class", value)
+        out := out.push ("class", className)
         found := true
       else
         out := out.push attr
@@ -58,6 +55,21 @@ public def appendClassAttr (attrs : Array (String × String)) (className : Strin
       out
     else
       out.push ("class", className)
+
+/-- Append a CSS class to an HTML attribute array, creating the `class` attribute if needed. -/
+public def appendClassAttr (attrs : Array (String × String)) (className : String) :
+    Array (String × String) :=
+  let className := className.trimAscii.toString
+  if className.isEmpty then
+    attrs
+  else
+    let current := (attrValue? attrs "class").map (·.trimAscii.toString) |>.getD ""
+    let value :=
+      if current.isEmpty then
+        className
+      else
+        current ++ " " ++ className
+    setClassAttr attrs value
 
 private def BlueprintNode.domClassName (node : BlueprintNode) : String :=
   if node.compact then

--- a/src/VersoBlueprint/Graft/Render.lean
+++ b/src/VersoBlueprint/Graft/Render.lean
@@ -74,6 +74,29 @@ public structure ManifestRenderConfig where
   manifestUnavailableDetail : String :=
     "Provide a Blueprint preview manifest and rendered HTML cache before rendering graft nodes."
 
+/--
+Render a graft node when the semantic manifest entry and already-rendered body
+content are both available.
+
+This is the shared assembly point for same-document Manual grafts and
+manifest/cache-backed generated consumers.
+-/
+public def renderNodeWithContent
+    (cfg : ManifestRenderConfig)
+    (node : BlueprintNode)
+    (entry : Informal.PreviewManifest.Entry)
+    (content : Informal.PreviewManifest.BlockRender.RenderedContent) : Html :=
+  .tag "div" (cfg.nodeAttrs node) <|
+    Informal.PreviewManifest.BlockRender.renderWithRenderedContent
+      cfg.blockRenderConfig
+      entry
+      content
+      {
+        displayLabelOverride? := node.displayLabel?
+        compact := node.compact
+        showHeader := node.showHeader
+      }
+
 public def renderNodeFromManifestCache
     (cfg : ManifestRenderConfig)
     (ctx : RenderContext)
@@ -91,16 +114,7 @@ public def renderNodeFromManifestCache
           | none =>
               pure <| cfg.renderMissingNode node "Blueprint HTML cache entry not found" entry.key
           | some content =>
-              pure <| .tag "div" (cfg.nodeAttrs node) <|
-                Informal.PreviewManifest.BlockRender.renderWithRenderedContent
-                  cfg.blockRenderConfig
-                  entry
-                  content
-                  {
-                    displayLabelOverride? := node.displayLabel?
-                    compact := node.compact
-                    showHeader := node.showHeader
-                  }
+              pure <| renderNodeWithContent cfg node entry content
 
 public def readBlueprintManifest (path : System.FilePath) :
     IO Informal.PreviewManifest.File :=

--- a/src/VersoBlueprint/Graft/Render.lean
+++ b/src/VersoBlueprint/Graft/Render.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import Verso.Output.Html
+import VersoBlueprint.Graft.Node
+import VersoBlueprint.PreviewManifest
+import VersoBlueprint.PreviewManifest.BlockRender
+
+namespace Informal.Graft
+
+open Verso.Output
+open Verso.Output.Html
+
+public structure RenderContext where
+  manifest? : Option Informal.PreviewManifest.File := none
+  index : Informal.PreviewManifest.Index := {}
+  htmlCacheIndex : Informal.PreviewManifest.HtmlCache.Index := {}
+  logError : String → IO Unit := fun _ => pure ()
+
+namespace RenderContext
+
+public def ofPreviewData?
+    (manifest? : Option Informal.PreviewManifest.File)
+    (htmlCache? : Option Informal.PreviewManifest.HtmlCache.File := none)
+    (logError : String → IO Unit := fun _ => pure ()) : RenderContext :=
+  let htmlCache := htmlCache?.getD {}
+  {
+    manifest?
+    index := manifest?.map (·.index) |>.getD {}
+    htmlCacheIndex := htmlCache.index
+    logError
+  }
+
+public def findEntry? (ctx : RenderContext) (key : String) :
+    Option Informal.PreviewManifest.Entry :=
+  ctx.index.findEntry? key
+
+public def renderedContent?
+    (ctx : RenderContext)
+    (node : BlueprintNode)
+    (entry : Informal.PreviewManifest.Entry) :
+    IO (Option Informal.PreviewManifest.BlockRender.RenderedContent) := do
+  match ctx.htmlCacheIndex.findHtml? entry.key with
+  | none =>
+      ctx.logError s!"Blueprint HTML cache: missing rendered body for {entry.key}"
+      pure none
+  | some bodyHtml =>
+      let codeBodies :=
+        if node.compact then
+          #[]
+        else
+          (ctx.htmlCacheIndex.codeHtmlBodies entry).map
+            Informal.PreviewManifest.BlockRender.htmlFragment
+      pure <| some {
+        body := Informal.PreviewManifest.BlockRender.htmlFragment bodyHtml
+        codeBodies
+      }
+
+end RenderContext
+
+private def defaultRenderMissingNode (node : BlueprintNode) (title detail : String) : Html :=
+  .tag "div" node.renderedAttrs <| {{
+    <strong>{{Html.ofString title}}</strong><br/>
+    {{Html.ofString detail}}
+  }}
+
+public structure ManifestRenderConfig where
+  blockRenderConfig : Informal.PreviewManifest.BlockRender.RenderConfig := {}
+  nodeAttrs : BlueprintNode → Array (String × String) := (·.renderedAttrs)
+  renderMissingNode : BlueprintNode → String → String → Html := defaultRenderMissingNode
+  manifestUnavailableDetail : String :=
+    "Provide a Blueprint preview manifest and rendered HTML cache before rendering graft nodes."
+
+public def renderNodeFromManifestCache
+    (cfg : ManifestRenderConfig)
+    (ctx : RenderContext)
+    (node : BlueprintNode) : IO Html := do
+  match ctx.manifest? with
+  | none =>
+      pure <| cfg.renderMissingNode node "Preview manifest unavailable"
+        cfg.manifestUnavailableDetail
+  | some _manifest =>
+      match ctx.findEntry? node.key with
+      | none =>
+          pure <| cfg.renderMissingNode node "Blueprint node not found" node.key
+      | some entry =>
+          match ← ctx.renderedContent? node entry with
+          | none =>
+              pure <| cfg.renderMissingNode node "Blueprint HTML cache entry not found" entry.key
+          | some content =>
+              pure <| .tag "div" (cfg.nodeAttrs node) <|
+                Informal.PreviewManifest.BlockRender.renderWithRenderedContent
+                  cfg.blockRenderConfig
+                  entry
+                  content
+                  {
+                    displayLabelOverride? := node.displayLabel?
+                    compact := node.compact
+                    showHeader := node.showHeader
+                  }
+
+public def readBlueprintManifest (path : System.FilePath) :
+    IO Informal.PreviewManifest.File :=
+  Informal.PreviewManifest.readFile path
+
+public def readBlueprintHtmlCache (path : System.FilePath) :
+    IO Informal.PreviewManifest.HtmlCache.File :=
+  Informal.PreviewManifest.HtmlCache.readFile path
+
+end Informal.Graft

--- a/src/VersoBlueprint/Graft/Render.lean
+++ b/src/VersoBlueprint/Graft/Render.lean
@@ -108,7 +108,7 @@ public def renderNodeFromManifestCache
   | some _manifest =>
       match ctx.findEntry? node.key with
       | none =>
-          pure <| cfg.renderMissingNode node "Blueprint node not found" node.key
+          pure <| cfg.renderMissingNode node "Blueprint node not found" node.selectionDescription
       | some entry =>
           match ← ctx.renderedContent? node entry with
           | none =>

--- a/src/VersoBlueprint/Informal/Block/Render.lean
+++ b/src/VersoBlueprint/Informal/Block/Render.lean
@@ -385,6 +385,7 @@ structure InformalBlockRenderModel where
   content : Array Verso.Output.Html := #[]
   companionPanels : Array Verso.Output.Html := #[]
   wrapperClass? : Option String := none
+  showHeader : Bool := true
 
 /--
 Genre-neutral inputs for the reusable Blueprint informal-block shell.
@@ -403,6 +404,7 @@ structure InformalBlockShell where
   headerExtras : HeaderExtras := {}
   metadataPanel : Verso.Output.Html := .empty
   folded : Bool := false
+  showHeader : Bool := true
 
 private def renderShellTitleRow (shell : InformalBlockShell) : Verso.Output.Html :=
   let titleRow := renderBlockTitleRow shell.style shell.labelText shell.numberText shell.captionText
@@ -419,7 +421,14 @@ def renderInformalBlockShell (shell : InformalBlockShell)
   let contentClass := s!"bp_content bp_kind_{style.kindCss}_content {style.contentCss}"
   let titleRow := renderShellTitleRow shell
   let extras := renderHeaderExtras shell.headerExtras
-  if shell.folded then
+  if !shell.showHeader then
+    {{
+      <div class={{wrapperClass}} title={{shell.labelText}} {{shell.attrs}}>
+        {{shell.metadataPanel}}
+        <div class={{contentClass}}> {{content}} </div>
+      </div>
+    }}
+  else if shell.folded then
     {{
       <details class={{wrapperClass}} title={{shell.labelText}} {{shell.attrs}}>
         <summary class={{headingClass}}>
@@ -450,7 +459,7 @@ already-rendered content plus the resolved metadata in
 {name}`InformalBlockRenderContext`.
 -/
 def renderInformalBlockHtml (data : BlockData) (ctx : InformalBlockRenderContext)
-    (content : Array Verso.Output.Html) : Verso.Output.Html :=
+    (content : Array Verso.Output.Html) (showHeader : Bool := true) : Verso.Output.Html :=
   open Verso.Output.Html in
   let style := blockKindRenderStyle data
   let labelText := s!"{data.label}"
@@ -469,6 +478,7 @@ def renderInformalBlockHtml (data : BlockData) (ctx : InformalBlockRenderContext
       headerExtras := ctx.headerExtras
       metadataPanel
       folded := ctx.folded
+      showHeader
     }
     (.seq content)
 
@@ -479,6 +489,7 @@ def htmlClassAttrs (className : String) : Array (String × String) :=
 /-- Render a complete informal block model, including companion panels. -/
 def renderInformalBlockModel (model : InformalBlockRenderModel) : Verso.Output.Html :=
   let blockHtml := renderInformalBlockHtml model.data model.context model.content
+    (showHeader := model.showHeader)
   let html := Verso.Output.Html.seq (#[blockHtml] ++ model.companionPanels)
   match model.wrapperClass? with
   | some className => Verso.Output.Html.tag "div" (htmlClassAttrs className) html

--- a/src/VersoBlueprint/Lib/PreviewSource.lean
+++ b/src/VersoBlueprint/Lib/PreviewSource.lean
@@ -74,12 +74,20 @@ private def firstNonEmptyEntry?
       if entry.blocks.isEmpty then none else some entry
     | none => none
 
+def traversalEntryByKey?
+    (s : Verso.Genre.Manual.TraverseState) (key : String) : Option PreviewCache.Entry :=
+  Informal.TraversalIndex.TraversalPreviews.entry? s key
+
+def traversalFacetEntry?
+    (s : Verso.Genre.Manual.TraverseState)
+    (label : Name)
+    (facet : PreviewCache.Facet) : Option PreviewCache.Entry :=
+  let key := Informal.TraversalIndex.TraversalPreviews.key label facet
+  traversalEntryByKey? s key
+
 def traversalEntry?
     (s : Verso.Genre.Manual.TraverseState) (label : Name) : Option PreviewCache.Entry := do
-  let traversalFacetEntry? (facet : PreviewCache.Facet) : Option PreviewCache.Entry := do
-    let key := Informal.TraversalIndex.TraversalPreviews.key label facet
-    Informal.TraversalIndex.TraversalPreviews.entry? s key
-  firstNonEmptyEntry? traversalFacetEntry?
+  firstNonEmptyEntry? (traversalFacetEntry? s label)
 
 def traversalLookupKey?
     (s : Verso.Genre.Manual.TraverseState) (label : Name) : Option String := do

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -15,6 +15,7 @@ import VersoBlueprint.Informal.Block
 import VersoBlueprint.Informal.Block.Store
 import VersoBlueprint.Informal.Group
 import VersoBlueprint.Informal.LeanCodePreview
+import VersoBlueprint.Lib.PreviewSource
 import VersoBlueprint.PreviewCache
 import VersoBlueprint.PreviewRender
 import VersoBlueprint.Git
@@ -1205,7 +1206,7 @@ def blockEntryOfTraversalPreview
 
 def findTraversalBlockEntry? (state : TraverseState) (key : String) :
     Option (PreviewCache.Entry × Entry) := do
-  let preview ← Informal.TraversalIndex.TraversalPreviews.entry? state key
+  let preview ← Informal.PreviewSource.traversalEntryByKey? state key
   some (preview, blockEntryOfTraversalPreview state preview)
 
 private def buildTraversalEntries

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -1169,6 +1169,45 @@ private def buildGroupRelation?
     entries
   }
 
+def blockEntryOfTraversalPreview
+    (state : TraverseState)
+    (preview : PreviewCache.Entry) : Entry :=
+  let blockData? := blockInfo? state preview.label
+  let key := PreviewCache.key preview.label preview.facet
+  let headingParts? := blockHeadingParts? state preview.label preview.facet blockData?
+  let codeData := blockCodeData? state preview.label preview blockData?
+  let storedBlocks := Informal.collectStoredBlocks state
+  {
+    key
+    targetKind := .block
+    label := preview.label
+    facet := preview.facet
+    kind := blockKind? blockData?
+    title := blockTitle state preview.label preview.facet blockData?
+    displayCaption := headingParts?.map (·.caption)
+    displayLabel := headingParts?.map (·.label)
+    href := blockHref state preview.label preview.facet
+    parent := blockData?.bind (·.parent)
+    parentTitle := blockParentTitle? state blockData?
+    statementUses := blockData?.map (·.statementUses) |>.getD #[]
+    proofUses := blockData?.map (·.proofUses) |>.getD #[]
+    leanCodePreviewKeys := blockLeanCodePreviewKeys state preview.label preview
+    codeData
+    externalMarkup := externalMarkupArray state preview.label
+    uses := blockData?.map (buildUsesRelations state ·) |>.getD #[]
+    usedBy := blockData?.map (buildUsedByRelations state storedBlocks ·) |>.getD #[]
+    group := blockData?.bind (buildGroupRelation? state storedBlocks)
+    ownerDisplayName := blockData?.bind (·.ownerDisplayName)
+    tags := blockData?.map (·.tags) |>.getD #[]
+    priority := blockData?.bind (·.priority)
+    effort := blockData?.bind (·.effort)
+  }
+
+def findTraversalBlockEntry? (state : TraverseState) (key : String) :
+    Option (PreviewCache.Entry × Entry) := do
+  let preview ← Informal.TraversalIndex.TraversalPreviews.entry? state key
+  some (preview, blockEntryOfTraversalPreview state preview)
+
 private def buildTraversalEntries
     (impls : ExtensionImpls)
     (logError : String → IO Unit)
@@ -1177,7 +1216,6 @@ private def buildTraversalEntries
     IO (Array Entry × Array HtmlCache.Entry × Verso.Code.Hover.State Output.Html) := do
   let some domain := Informal.TraversalIndex.TraversalPreviews.domain? state
     | return (#[], #[], hoverState)
-  let storedBlocks := Informal.collectStoredBlocks state
   let mut entries := #[]
   let mut htmlEntries := #[]
   let mut hoverState := hoverState
@@ -1194,35 +1232,8 @@ private def buildTraversalEntries
       let html := rendered.html.asString
       if html.trimAscii.isEmpty then
         continue
-      let blockData? := blockInfo? state entry.label
       let key := PreviewCache.key entry.label entry.facet
-      let headingParts? := blockHeadingParts? state entry.label entry.facet blockData?
-      let codeData := blockCodeData? state entry.label entry blockData?
-      let manifestEntry : Entry := {
-        key
-        targetKind := .block
-        label := entry.label
-        facet := entry.facet
-        kind := blockKind? blockData?
-        title := blockTitle state entry.label entry.facet blockData?
-        displayCaption := headingParts?.map (·.caption)
-        displayLabel := headingParts?.map (·.label)
-        href := blockHref state entry.label entry.facet
-        parent := blockData?.bind (·.parent)
-        parentTitle := blockParentTitle? state blockData?
-        statementUses := blockData?.map (·.statementUses) |>.getD #[]
-        proofUses := blockData?.map (·.proofUses) |>.getD #[]
-        leanCodePreviewKeys := blockLeanCodePreviewKeys state entry.label entry
-        codeData
-        externalMarkup := externalMarkupArray state entry.label
-        uses := blockData?.map (buildUsesRelations state ·) |>.getD #[]
-        usedBy := blockData?.map (buildUsedByRelations state storedBlocks ·) |>.getD #[]
-        group := blockData?.bind (buildGroupRelation? state storedBlocks)
-        ownerDisplayName := blockData?.bind (·.ownerDisplayName)
-        tags := blockData?.map (·.tags) |>.getD #[]
-        priority := blockData?.bind (·.priority)
-        effort := blockData?.bind (·.effort)
-      }
+      let manifestEntry := blockEntryOfTraversalPreview state entry
       entries := entries.push manifestEntry
       htmlEntries := htmlEntries.push { key, html }
   pure (entries, htmlEntries, hoverState)

--- a/src/VersoBlueprint/PreviewManifest/BlockRender.lean
+++ b/src/VersoBlueprint/PreviewManifest/BlockRender.lean
@@ -69,6 +69,7 @@ structure RenderConfig where
 structure RenderOptions where
   displayLabelOverride? : Option String := none
   compact : Bool := false
+  showHeader : Bool := true
 
 /--
 Rendered content for a Blueprint block shell.
@@ -239,6 +240,7 @@ def renderWithRenderedContent
       content := #[content.body]
       companionPanels := #[codePanel]
       wrapperClass? := some cfg.wrapperClass
+      showHeader := opts.showHeader
     }
 
 end Informal.PreviewManifest.BlockRender

--- a/src/VersoBlueprint/Slides.lean
+++ b/src/VersoBlueprint/Slides.lean
@@ -114,16 +114,3 @@ public def slidesMainWithBlueprintPreviews
   pure rc
 
 end Informal.Slides
-
-open Verso Doc Elab
-
-/--
-Render a Blueprint manifest/cache entry by label inside a Verso Slides deck.
-
-Use {name}`Informal.Slides.slidesMainWithBlueprintPreviews` in the deck
-generator, or add {name}`Informal.Slides.withBlueprintSlidesAssets` to the
-config and call {name}`Informal.Slides.writeBlueprintSlidesJs` manually.
--/
-@[block_command]
-public meta def blueprint_node : BlockCommandOf Informal.Slides.BlueprintNodeConfig
-  | cfg => Informal.Slides.blueprintNodeBlock cfg

--- a/src/VersoBlueprint/Slides/Assets.lean
+++ b/src/VersoBlueprint/Slides/Assets.lean
@@ -8,6 +8,7 @@ import Std.Data.HashMap
 import VersoSlides
 import VersoManual
 import VersoBlueprint.Commands.Common
+import VersoBlueprint.Graft
 import VersoBlueprint.Informal.Block.Assets
 import VersoBlueprint.PreviewManifest
 
@@ -21,7 +22,7 @@ private def slideNodeCss : String := include_str "blueprint-slides.css"
 def blueprintSlidesCss : String :=
   String.intercalate "\n\n" <|
     Informal.Commands.withPreviewPanelInlinePreviewCssAssets
-      [Informal.Block.Assets.css, Verso.Genre.Manual.docstringStyle, slideNodeCss]
+      [Informal.Block.Assets.css, Informal.Graft.css, Verso.Genre.Manual.docstringStyle, slideNodeCss]
 
 def blueprintSlidesCssFile : VersoSlides.CssFile where
   filename := blueprintSlidesCssFilename

--- a/src/VersoBlueprint/Slides/Assets.lean
+++ b/src/VersoBlueprint/Slides/Assets.lean
@@ -8,7 +8,7 @@ import Std.Data.HashMap
 import VersoSlides
 import VersoManual
 import VersoBlueprint.Commands.Common
-import VersoBlueprint.Graft
+import VersoBlueprint.Graft.Assets
 import VersoBlueprint.Informal.Block.Assets
 import VersoBlueprint.PreviewManifest
 

--- a/src/VersoBlueprint/Slides/Node.lean
+++ b/src/VersoBlueprint/Slides/Node.lean
@@ -27,6 +27,7 @@ public structure BlueprintSlideNode where
   key : String
   displayLabel? : Option String := none
   compact : Bool := false
+  showHeader : Bool := true
   siteBase? : Option String := none
 deriving Repr, BEq
 
@@ -46,6 +47,7 @@ def BlueprintSlideNode.toAttrs (node : BlueprintSlideNode) : Array (String × St
      , ("data-bp-facet", node.facet)
      , ("data-bp-preview-key", node.key)
      , ("data-bp-compact", if node.compact then "true" else "false")
+     , ("data-bp-show-header", if node.showHeader then "true" else "false")
      ] ++
     (node.displayLabel?.map (fun label => #[("data-bp-display-label", label)] ) |>.getD #[]) ++
     (node.siteBase?.map (fun siteBase => #[("data-bp-site-base", siteBase)] ) |>.getD #[])
@@ -58,8 +60,9 @@ def BlueprintSlideNode.fromAttrs? (attrs : Array (String × String)) : Option Bl
   let key := attrValue? attrs "data-bp-preview-key" |>.getD s!"{label}--{facet}"
   let displayLabel? := attrValue? attrs "data-bp-display-label"
   let compact := attrValue? attrs "data-bp-compact" == some "true"
+  let showHeader := attrValue? attrs "data-bp-show-header" != some "false"
   let siteBase? := attrValue? attrs "data-bp-site-base"
-  some { label, facet, key, displayLabel?, compact, siteBase? }
+  some { label, facet, key, displayLabel?, compact, showHeader, siteBase? }
 
 def BlueprintSlideNode.renderedAttrs (node : BlueprintSlideNode) : Array (String × String) :=
   node.toAttrs ++ #[("data-bp-rendered", "static")]
@@ -72,7 +75,9 @@ public structure BlueprintNodeConfig where
   facet : Option String := none
   displayLabel : Option String := none
   compact : Bool := false
+  showHeader : Bool := true
   siteBase : Option String := none
+deriving Repr, BEq, ToJson, FromJson, Quote
 
 public meta instance : FromArgs BlueprintNodeConfig DocElabM where
   fromArgs :=
@@ -81,6 +86,7 @@ public meta instance : FromArgs BlueprintNodeConfig DocElabM where
       .named `facet .string true <*>
       .named `displayLabel .string true <*>
       .flag `compact false <*>
+      .flag `header true <*>
       .named `siteBase .string true
 
 private def previewKey (label facet : String) : String :=
@@ -98,6 +104,7 @@ def BlueprintNodeConfig.toSlideNode (cfg : BlueprintNodeConfig) : BlueprintSlide
     key := previewKey cfg.label facet
     displayLabel? := cfg.displayLabel
     compact := cfg.compact
+    showHeader := cfg.showHeader
     siteBase? := cfg.siteBase
   }
 

--- a/src/VersoBlueprint/Slides/Node.lean
+++ b/src/VersoBlueprint/Slides/Node.lean
@@ -5,108 +5,30 @@ Author: Emilio J. Gallego Arias
 -/
 
 import VersoSlides
-import Verso.Doc.ArgParse
 import Verso.Doc.Elab
-import VersoBlueprint.LabelNameParsing
-import VersoBlueprint.PreviewCache
+import VersoBlueprint.Graft.Node
 
 namespace Informal.Slides
 
 open Lean
-open Verso Doc Elab ArgParse
+open Verso Doc Elab
 
-private def slideNodeMarkerAttr : String := "data-bp-blueprint-node"
-private def slideNodeMarkerValue : String := "true"
+public abbrev BlueprintSlideNode := Informal.Graft.BlueprintNode
+public abbrev BlueprintNodeConfig := Informal.Graft.BlueprintNodeConfig
 
-private def blueprintSlideNodeMarkerAttrs : Array (String × String) :=
-  #[(slideNodeMarkerAttr, slideNodeMarkerValue)]
+namespace BlueprintSlideNode
 
-public structure BlueprintSlideNode where
-  label : String
-  facet : String := "statement"
-  key : String
-  displayLabel? : Option String := none
-  compact : Bool := false
-  showHeader : Bool := true
-  siteBase? : Option String := none
-deriving Repr, BEq
+def fromAttrs? (attrs : Array (String × String)) : Option BlueprintSlideNode :=
+  Informal.Graft.BlueprintNode.fromAttrs? attrs
 
-private def attrValue? (attrs : Array (String × String)) (name : String) : Option String :=
-  (attrs.find? fun attr => attr.1 == name).map (·.2)
+end BlueprintSlideNode
 
-private def BlueprintSlideNode.className (node : BlueprintSlideNode) : String :=
-  if node.compact then
-    "bp_slide_node bp_slide_node_compact"
-  else
-    "bp_slide_node"
+namespace BlueprintNodeConfig
 
-def BlueprintSlideNode.toAttrs (node : BlueprintSlideNode) : Array (String × String) :=
-  blueprintSlideNodeMarkerAttrs ++
-    #[ ("class", node.className)
-     , ("data-bp-label", node.label)
-     , ("data-bp-facet", node.facet)
-     , ("data-bp-preview-key", node.key)
-     , ("data-bp-compact", if node.compact then "true" else "false")
-     , ("data-bp-show-header", if node.showHeader then "true" else "false")
-     ] ++
-    (node.displayLabel?.map (fun label => #[("data-bp-display-label", label)] ) |>.getD #[]) ++
-    (node.siteBase?.map (fun siteBase => #[("data-bp-site-base", siteBase)] ) |>.getD #[])
+def toSlideNode (cfg : BlueprintNodeConfig) : BlueprintSlideNode :=
+  cfg.toNode
 
-def BlueprintSlideNode.fromAttrs? (attrs : Array (String × String)) : Option BlueprintSlideNode := do
-  let marker ← attrValue? attrs slideNodeMarkerAttr
-  guard (marker == slideNodeMarkerValue)
-  let label ← attrValue? attrs "data-bp-label"
-  let facet := attrValue? attrs "data-bp-facet" |>.getD "statement"
-  let key := attrValue? attrs "data-bp-preview-key" |>.getD s!"{label}--{facet}"
-  let displayLabel? := attrValue? attrs "data-bp-display-label"
-  let compact := attrValue? attrs "data-bp-compact" == some "true"
-  let showHeader := attrValue? attrs "data-bp-show-header" != some "false"
-  let siteBase? := attrValue? attrs "data-bp-site-base"
-  some { label, facet, key, displayLabel?, compact, showHeader, siteBase? }
-
-def BlueprintSlideNode.renderedAttrs (node : BlueprintSlideNode) : Array (String × String) :=
-  node.toAttrs ++ #[("data-bp-rendered", "static")]
-
-def BlueprintSlideNode.fallbackText (node : BlueprintSlideNode) : String :=
-  s!"Loading Blueprint node {node.label}..."
-
-public structure BlueprintNodeConfig where
-  label : String
-  facet : Option String := none
-  displayLabel : Option String := none
-  compact : Bool := false
-  showHeader : Bool := true
-  siteBase : Option String := none
-deriving Repr, BEq, ToJson, FromJson, Quote
-
-public meta instance : FromArgs BlueprintNodeConfig DocElabM where
-  fromArgs :=
-    BlueprintNodeConfig.mk <$>
-      .positional `label .string <*>
-      .named `facet .string true <*>
-      .named `displayLabel .string true <*>
-      .flag `compact false <*>
-      .flag `header true <*>
-      .named `siteBase .string true
-
-private def previewKey (label facet : String) : String :=
-  let label := Informal.LabelNameParsing.parse label
-  match facet with
-  | "statement" => Informal.PreviewCache.key label .statement
-  | "proof" => Informal.PreviewCache.key label .proof
-  | other => s!"{label}--{other}"
-
-def BlueprintNodeConfig.toSlideNode (cfg : BlueprintNodeConfig) : BlueprintSlideNode :=
-  let facet := cfg.facet.getD "statement"
-  {
-    label := cfg.label
-    facet
-    key := previewKey cfg.label facet
-    displayLabel? := cfg.displayLabel
-    compact := cfg.compact
-    showHeader := cfg.showHeader
-    siteBase? := cfg.siteBase
-  }
+end BlueprintNodeConfig
 
 public meta def blueprintNodeBlock (cfg : BlueprintNodeConfig) : DocElabM Term := do
   let node := cfg.toSlideNode

--- a/src/VersoBlueprint/Slides/Node.lean
+++ b/src/VersoBlueprint/Slides/Node.lean
@@ -13,7 +13,16 @@ namespace Informal.Slides
 open Lean
 open Verso Doc Elab
 
+/--
+Compatibility alias for the original slide-node API. New generated consumers
+should use `Informal.Graft.BlueprintNode` directly.
+-/
 public abbrev BlueprintSlideNode := Informal.Graft.BlueprintNode
+
+/--
+Compatibility alias for the original slide-node command config. New generated
+consumers should use `Informal.Graft.BlueprintNodeConfig` directly.
+-/
 public abbrev BlueprintNodeConfig := Informal.Graft.BlueprintNodeConfig
 
 namespace BlueprintSlideNode

--- a/src/VersoBlueprint/Slides/Node.lean
+++ b/src/VersoBlueprint/Slides/Node.lean
@@ -13,35 +13,9 @@ namespace Informal.Slides
 open Lean
 open Verso Doc Elab
 
-/--
-Compatibility alias for the original slide-node API. New generated consumers
-should use `Informal.Graft.BlueprintNode` directly.
--/
-public abbrev BlueprintSlideNode := Informal.Graft.BlueprintNode
-
-/--
-Compatibility alias for the original slide-node command config. New generated
-consumers should use `Informal.Graft.BlueprintNodeConfig` directly.
--/
-public abbrev BlueprintNodeConfig := Informal.Graft.BlueprintNodeConfig
-
-namespace BlueprintSlideNode
-
-def fromAttrs? (attrs : Array (String × String)) : Option BlueprintSlideNode :=
-  Informal.Graft.BlueprintNode.fromAttrs? attrs
-
-end BlueprintSlideNode
-
-namespace BlueprintNodeConfig
-
-def toSlideNode (cfg : BlueprintNodeConfig) : BlueprintSlideNode :=
-  cfg.toNode
-
-end BlueprintNodeConfig
-
-public meta def blueprintNodeBlock (cfg : BlueprintNodeConfig) : DocElabM Term := do
-  let node := cfg.toSlideNode
-  let attrs := node.toAttrs
+public meta def blueprintNodeBlock (cfg : Informal.Graft.BlueprintNodeConfig) : DocElabM Term := do
+  let node := cfg.toNode
+  let attrs := node.slideAttrs
   let fallback := node.fallbackText
   ``(Verso.Doc.Block.other (VersoSlides.BlockExt.wrap $(quote attrs))
       #[Verso.Doc.Block.para #[Verso.Doc.Inline.text $(quote fallback)]])

--- a/src/VersoBlueprint/Slides/Render.lean
+++ b/src/VersoBlueprint/Slides/Render.lean
@@ -58,18 +58,24 @@ private def renderNotice (kind title detail : String) : Html :=
     </div>
   }}
 
-private def renderMissingNode (node : BlueprintSlideNode) (title detail : String) : Html :=
-  .tag "div" node.renderedAttrs (renderNotice "error" title detail)
+private def slideNodeAttrs (node : Informal.Graft.BlueprintNode) : Array (String × String) :=
+  node.slideRenderedAttrs
+
+private def renderMissingNode (node : Informal.Graft.BlueprintNode) (title detail : String) : Html :=
+  .tag "div" (slideNodeAttrs node) (renderNotice "error" title detail)
 
 private def slideManifestRenderConfig : Informal.Graft.ManifestRenderConfig :=
   {
     blockRenderConfig := slideManifestBlockConfig
+    nodeAttrs := slideNodeAttrs
     renderMissingNode := renderMissingNode
     manifestUnavailableDetail :=
       "Pass previewManifest? to slidesMainWithBlueprintPreviews so Blueprint slide nodes can be rendered during slide generation."
   }
 
-public def renderBlueprintSlideNode (ctx : RenderContext) (node : BlueprintSlideNode) : IO Html := do
+public def renderBlueprintSlideNode
+    (ctx : RenderContext)
+    (node : Informal.Graft.BlueprintNode) : IO Html := do
   Informal.Graft.renderNodeFromManifestCache slideManifestRenderConfig ctx node
 
 /--
@@ -79,7 +85,7 @@ Render a Blueprint slide node from the structured attributes carried by the
 public def renderBlueprintSlideNodeFromAttrs?
     (ctx : RenderContext)
     (attrs : Array (String × String)) : Option (IO Html) := do
-  let node ← BlueprintSlideNode.fromAttrs? attrs
+  let node ← Informal.Graft.BlueprintNode.fromAttrs? attrs
   some (renderBlueprintSlideNode ctx node)
 
 def readBlueprintManifest (path : System.FilePath) :

--- a/src/VersoBlueprint/Slides/Render.lean
+++ b/src/VersoBlueprint/Slides/Render.lean
@@ -5,37 +5,26 @@ Author: Emilio J. Gallego Arias
 -/
 
 import Verso.Output.Html
-import VersoBlueprint.PreviewManifest
+import VersoBlueprint.Graft.Render
 import VersoBlueprint.PreviewManifest.BlockRender
 import VersoBlueprint.Slides.Node
 
 namespace Informal.Slides
 
-open Lean
 open Verso.Output
 open Verso.Output.Html
 
-public structure RenderContext where
-  manifest? : Option Informal.PreviewManifest.File := none
-  index : Informal.PreviewManifest.Index := {}
-  htmlCacheIndex : Informal.PreviewManifest.HtmlCache.Index := {}
-  logError : String → IO Unit := fun _ => pure ()
+public abbrev RenderContext := Informal.Graft.RenderContext
 
-def RenderContext.ofPreviewData?
+namespace RenderContext
+
+public def ofPreviewData?
     (manifest? : Option Informal.PreviewManifest.File)
     (htmlCache? : Option Informal.PreviewManifest.HtmlCache.File := none)
     (logError : String → IO Unit := fun _ => pure ()) : RenderContext :=
-  let htmlCache := htmlCache?.getD {}
-  {
-    manifest?
-    index := manifest?.map (·.index) |>.getD {}
-    htmlCacheIndex := htmlCache.index
-    logError
-  }
+  Informal.Graft.RenderContext.ofPreviewData? manifest? htmlCache? logError
 
-private def RenderContext.findEntry? (ctx : RenderContext) (key : String) :
-    Option Informal.PreviewManifest.Entry :=
-  ctx.index.findEntry? key
+end RenderContext
 
 private def slideManifestBlockConfig : Informal.PreviewManifest.BlockRender.RenderConfig :=
   {
@@ -72,52 +61,16 @@ private def renderNotice (kind title detail : String) : Html :=
 private def renderMissingNode (node : BlueprintSlideNode) (title detail : String) : Html :=
   .tag "div" node.renderedAttrs (renderNotice "error" title detail)
 
-private def renderLeanCodeBodies
-    (ctx : RenderContext) (node : BlueprintSlideNode) (entry : Informal.PreviewManifest.Entry) :
-    Array Html :=
-  if node.compact then
-    #[]
-  else
-    (ctx.htmlCacheIndex.codeHtmlBodies entry).map
-      Informal.PreviewManifest.BlockRender.htmlFragment
-
-private def renderEntryContent
-    (ctx : RenderContext) (node : BlueprintSlideNode) (entry : Informal.PreviewManifest.Entry) :
-    IO (Option Informal.PreviewManifest.BlockRender.RenderedContent) := do
-  match ctx.htmlCacheIndex.findHtml? entry.key with
-  | none =>
-      ctx.logError s!"Blueprint HTML cache: missing rendered body for {entry.key}"
-      pure none
-  | some bodyHtml =>
-      pure <| some {
-        body := Informal.PreviewManifest.BlockRender.htmlFragment bodyHtml
-        codeBodies := renderLeanCodeBodies ctx node entry
-      }
+private def slideManifestRenderConfig : Informal.Graft.ManifestRenderConfig :=
+  {
+    blockRenderConfig := slideManifestBlockConfig
+    renderMissingNode := renderMissingNode
+    manifestUnavailableDetail :=
+      "Pass previewManifest? to slidesMainWithBlueprintPreviews so Blueprint slide nodes can be rendered during slide generation."
+  }
 
 public def renderBlueprintSlideNode (ctx : RenderContext) (node : BlueprintSlideNode) : IO Html := do
-  match ctx.manifest? with
-  | none =>
-    pure <| renderMissingNode node "Preview manifest unavailable"
-      "Pass previewManifest? to slidesMainWithBlueprintPreviews so Blueprint slide nodes can be rendered during slide generation."
-  | some _manifest =>
-    match ctx.findEntry? node.key with
-    | none =>
-      pure <| renderMissingNode node "Blueprint node not found" node.key
-    | some entry =>
-      match ← renderEntryContent ctx node entry with
-      | none =>
-          pure <| renderMissingNode node "Blueprint HTML cache entry not found" entry.key
-      | some content =>
-          pure <| .tag "div" node.renderedAttrs <|
-            Informal.PreviewManifest.BlockRender.renderWithRenderedContent
-              slideManifestBlockConfig
-              entry
-              content
-              {
-                displayLabelOverride? := node.displayLabel?
-                compact := node.compact
-                showHeader := node.showHeader
-              }
+  Informal.Graft.renderNodeFromManifestCache slideManifestRenderConfig ctx node
 
 /--
 Render a Blueprint slide node from the structured attributes carried by the
@@ -131,10 +84,10 @@ public def renderBlueprintSlideNodeFromAttrs?
 
 def readBlueprintManifest (path : System.FilePath) :
     IO Informal.PreviewManifest.File :=
-  Informal.PreviewManifest.readFile path
+  Informal.Graft.readBlueprintManifest path
 
 def readBlueprintHtmlCache (path : System.FilePath) :
     IO Informal.PreviewManifest.HtmlCache.File :=
-  Informal.PreviewManifest.HtmlCache.readFile path
+  Informal.Graft.readBlueprintHtmlCache path
 
 end Informal.Slides

--- a/src/VersoBlueprint/Slides/Render.lean
+++ b/src/VersoBlueprint/Slides/Render.lean
@@ -113,7 +113,11 @@ public def renderBlueprintSlideNode (ctx : RenderContext) (node : BlueprintSlide
               slideManifestBlockConfig
               entry
               content
-              { displayLabelOverride? := node.displayLabel?, compact := node.compact }
+              {
+                displayLabelOverride? := node.displayLabel?
+                compact := node.compact
+                showHeader := node.showHeader
+              }
 
 /--
 Render a Blueprint slide node from the structured attributes carried by the

--- a/tests/VersoBlueprintTests/Blueprint.lean
+++ b/tests/VersoBlueprintTests/Blueprint.lean
@@ -11,6 +11,7 @@ import VersoBlueprintTests.BlueprintCodeRenderMatrix
 import VersoBlueprintTests.BlueprintImportedDuplicates.Direct
 import VersoBlueprintTests.BlueprintImportedDuplicates.Transitive
 import VersoBlueprintTests.BlueprintExternalHeadingStatus
+import VersoBlueprintTests.BlueprintGraft
 import VersoBlueprintTests.BlueprintGraph
 import VersoBlueprintTests.BlueprintHeaderExtras
 import VersoBlueprintTests.BlueprintInformal

--- a/tests/VersoBlueprintTests/BlueprintGraft.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraft.lean
@@ -70,8 +70,10 @@ private def graftManifestRenderConfig : Informal.Graft.ManifestRenderConfig :=
       wrapperClass := "bp_test_graft_node_blueprint"
       codeBodyClass := "bp_test_graft_code_body"
     }
+    nodeAttrs := fun node => node.renderedAttrsWithClass "bp_test_graft_node"
     renderMissingNode := fun node title detail =>
-      .tag "div" node.renderedAttrs <| Html.ofString s!"{title}: {detail}"
+      .tag "div" (node.renderedAttrsWithClass "bp_test_graft_notice") <|
+        Html.ofString s!"{title}: {detail}"
   }
 
 /-- info: true -/
@@ -122,6 +124,7 @@ private def graftManifestRenderConfig : Informal.Graft.ManifestRenderConfig :=
     let rendered := renderedHtml.asString
     pure <|
       hasSubstr rendered "data-bp-rendered=\"static\"" &&
+        hasSubstr rendered "bp_slide_node bp_test_graft_node" &&
         hasSubstr rendered "bp_test_graft_node_blueprint" &&
         hasSubstr rendered "bp_test_graft_code_body" &&
         hasSubstr rendered "API view" &&
@@ -129,5 +132,70 @@ private def graftManifestRenderConfig : Informal.Graft.ManifestRenderConfig :=
         hasSubstr rendered "graftManualLeftValue" &&
         hasSubstr rendered "bp_code_panel_wrapper" &&
         !hasSubstr rendered "Blueprint node not found"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  let attrs := (graftNode "def:graft.manual.left").renderedAttrsWithClass "audit_graft_node"
+  attrs.contains ("class", "bp_slide_node audit_graft_node") &&
+    attrs.contains ("data-bp-rendered", "static") &&
+    (attrs.filter (fun attr => attr.1 == "class")).size == 1
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let node := graftNode "def:graft.manual.left"
+    let ctx := Informal.Graft.RenderContext.ofPreviewData? none none
+    let renderedHtml ← Informal.Graft.renderNodeFromManifestCache
+      graftManifestRenderConfig
+      ctx
+      node
+    let rendered := renderedHtml.asString
+    pure <|
+      hasSubstr rendered "Preview manifest unavailable" &&
+        hasSubstr rendered "Provide a Blueprint preview manifest" &&
+        hasSubstr rendered "bp_test_graft_notice" &&
+        hasSubstr rendered "data-bp-rendered=\"static\""
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (_out, st) ← renderManualDocHtmlStringAndState manualImpls manualSideBySideGraftDoc
+    let files ← Informal.PreviewManifest.buildPreviewDataFiles manualImpls (fun _ => pure ()) st
+    let node := graftNode "def:graft.manual.missing"
+    let ctx := Informal.Graft.RenderContext.ofPreviewData? (some files.manifest) (some files.htmlCache)
+    let renderedHtml ← Informal.Graft.renderNodeFromManifestCache
+      graftManifestRenderConfig
+      ctx
+      node
+    let rendered := renderedHtml.asString
+    pure <|
+      hasSubstr rendered "Blueprint node not found" &&
+        hasSubstr rendered node.key &&
+        hasSubstr rendered "bp_test_graft_notice"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (_out, st) ← renderManualDocHtmlStringAndState manualImpls manualSideBySideGraftDoc
+    let files ← Informal.PreviewManifest.buildPreviewDataFiles manualImpls (fun _ => pure ()) st
+    let logs ← IO.mkRef #[]
+    let logError (msg : String) : IO Unit := logs.modify (·.push msg)
+    let node := graftNode "def:graft.manual.left"
+    let ctx := Informal.Graft.RenderContext.ofPreviewData? (some files.manifest) (some {}) logError
+    let renderedHtml ← Informal.Graft.renderNodeFromManifestCache
+      graftManifestRenderConfig
+      ctx
+      node
+    let rendered := renderedHtml.asString
+    let logs ← logs.get
+    pure <|
+      hasSubstr rendered "Blueprint HTML cache entry not found" &&
+        hasSubstr rendered node.key &&
+        logs.any (fun msg => hasSubstr msg "Blueprint HTML cache: missing rendered body") &&
+        logs.any (fun msg => hasSubstr msg node.key)
 
 end Verso.VersoBlueprintTests.BlueprintGraft

--- a/tests/VersoBlueprintTests/BlueprintGraft.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraft.lean
@@ -124,7 +124,8 @@ private def graftManifestRenderConfig : Informal.Graft.ManifestRenderConfig :=
     let rendered := renderedHtml.asString
     pure <|
       hasSubstr rendered "data-bp-rendered=\"static\"" &&
-        hasSubstr rendered "bp_slide_node bp_test_graft_node" &&
+        hasSubstr rendered "bp_graft_manifest_node" &&
+        hasSubstr rendered "bp_test_graft_node" &&
         hasSubstr rendered "bp_test_graft_node_blueprint" &&
         hasSubstr rendered "bp_test_graft_code_body" &&
         hasSubstr rendered "API view" &&
@@ -135,7 +136,7 @@ private def graftManifestRenderConfig : Informal.Graft.ManifestRenderConfig :=
 
 #guard
   let attrs := (graftNode "def:graft.manual.left").renderedAttrsWithClass "audit_graft_node"
-  attrs.contains ("class", "bp_slide_node audit_graft_node") &&
+  attrs.contains ("class", "bp_slide_node bp_graft_manifest_node audit_graft_node") &&
     attrs.contains ("data-bp-rendered", "static") &&
     (attrs.filter (fun attr => attr.1 == "class")).size == 1
 

--- a/tests/VersoBlueprintTests/BlueprintGraft.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraft.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import Verso.Output.Html
+import VersoBlueprint
+import Verso.Doc.Concrete
+import VersoBlueprintTests.Blueprint.Support
+
+namespace Verso.VersoBlueprintTests.BlueprintGraft
+
+open Verso
+open Verso.Genre.Manual
+open Informal
+open Verso.Output
+open Verso.Output.Html
+open Verso.VersoBlueprintTests.Blueprint.Support
+
+def manualImpls : ExtensionImpls := extension_impls%
+
+def graftManualLeftValue : Nat := 2
+
+#docs (Genre.Manual) manualGraftDoc "Manual Blueprint Graft" :=
+:::::::
+:::definition "def:graft.manual.source"
+Manual graft body.
+:::
+
+{blueprint_node "def:graft.manual.source" -header +compact}
+:::::::
+
+#docs (Genre.Manual) manualSideBySideGraftDoc "Manual Side-by-Side Blueprint Graft" :=
+:::::::
+:::definition "def:graft.manual.left" (tags := "graft, source") (effort := "small") (lean := "graftManualLeftValue")
+Manual left graft body with inline math $`x + y = y + x` and an attached Lean preview.
+:::
+
+:::theorem "thm:graft.manual.sum" (uses := "def:graft.manual.left") (priority := "high")
+The grafted theorem states $`(a + b) + c = a + (b + c)`.
+:::
+
+:::proof "thm:graft.manual.sum"
+The proof graft records the same goal and keeps the proof facet selectable.
+:::
+
+:::definition "def:graft.manual.right" (uses := "thm:graft.manual.sum")
+Manual right graft body references {uses "def:graft.manual.left"}[] and includes display math:
+$$`\sum_{i=0}^{n} i = n`.
+:::
+
+:::blueprint_side_by_side +boxed
+{blueprint_node "def:graft.manual.left" (displayLabel := "Featured definition")}
+
+{blueprint_node "thm:graft.manual.sum" (displayLabel := "Theorem view") -header +compact}
+
+{blueprint_node "thm:graft.manual.sum" (facet := "proof") (displayLabel := "Proof view") -header +compact}
+
+{blueprint_node "def:graft.manual.right" (displayLabel := "Uses view") +compact}
+:::
+:::::::
+
+private def graftNode (label : String) : Informal.Graft.BlueprintNode :=
+  ({ label := label } : Informal.Graft.BlueprintNodeConfig).toNode
+
+private def graftManifestRenderConfig : Informal.Graft.ManifestRenderConfig :=
+  {
+    blockRenderConfig := {
+      wrapperClass := "bp_test_graft_node_blueprint"
+      codeBodyClass := "bp_test_graft_code_body"
+    }
+    renderMissingNode := fun node title detail =>
+      .tag "div" node.renderedAttrs <| Html.ofString s!"{title}: {detail}"
+  }
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (html, _st) ← renderManualDocHtmlStringAndState manualImpls manualGraftDoc
+    pure <|
+      hasSubstr html "bp_graft_node" &&
+        countSubstr html "Manual graft body." == 2 &&
+        countSubstr html "class=\"bp_heading " == 1 &&
+        !hasSubstr html "Blueprint node not found"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (html, _st) ← renderManualDocHtmlStringAndState manualImpls manualSideBySideGraftDoc
+    pure <|
+      hasSubstr html "bp_graft_side_by_side" &&
+        hasSubstr html "bp_graft_side_by_side_boxed" &&
+        countSubstr html "data-bp-blueprint-node=\"true\"" == 4 &&
+        countSubstr html "Manual left graft body with inline math" == 2 &&
+        countSubstr html "The grafted theorem states" == 2 &&
+        countSubstr html "The proof graft records" == 2 &&
+        countSubstr html "Manual right graft body references" == 2 &&
+        hasSubstr html "Featured definition" &&
+        hasSubstr html "Uses view" &&
+        hasSubstr html "graftManualLeftValue" &&
+        hasSubstr html "bp_math inline" &&
+        hasSubstr html "bp_math display" &&
+        hasSubstr html "data-bp-facet=\"proof\"" &&
+        hasSubstr html "bp_code_panel_wrapper" &&
+        !hasSubstr html "Blueprint node not found"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (_out, st) ← renderManualDocHtmlStringAndState manualImpls manualSideBySideGraftDoc
+    let files ← Informal.PreviewManifest.buildPreviewDataFiles manualImpls (fun _ => pure ()) st
+    let ctx := Informal.Graft.RenderContext.ofPreviewData? (some files.manifest) (some files.htmlCache)
+    let node := { graftNode "def:graft.manual.left" with displayLabel? := some "API view" }
+    let renderedHtml ← Informal.Graft.renderNodeFromManifestCache
+      graftManifestRenderConfig
+      ctx
+      node
+    let rendered := renderedHtml.asString
+    pure <|
+      hasSubstr rendered "data-bp-rendered=\"static\"" &&
+        hasSubstr rendered "bp_test_graft_node_blueprint" &&
+        hasSubstr rendered "bp_test_graft_code_body" &&
+        hasSubstr rendered "API view" &&
+        hasSubstr rendered "Manual left graft body with inline math" &&
+        hasSubstr rendered "graftManualLeftValue" &&
+        hasSubstr rendered "bp_code_panel_wrapper" &&
+        !hasSubstr rendered "Blueprint node not found"
+
+end Verso.VersoBlueprintTests.BlueprintGraft

--- a/tests/VersoBlueprintTests/BlueprintGraft.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraft.lean
@@ -95,6 +95,7 @@ private def graftManifestRenderConfig : Informal.Graft.ManifestRenderConfig :=
     pure <|
       hasSubstr html "bp_graft_side_by_side" &&
         hasSubstr html "bp_graft_side_by_side_boxed" &&
+        hasSubstr html "bp_graft_manifest_node" &&
         countSubstr html "data-bp-blueprint-node=\"true\"" == 4 &&
         countSubstr html "Manual left graft body with inline math" == 2 &&
         countSubstr html "The grafted theorem states" == 2 &&

--- a/tests/VersoBlueprintTests/BlueprintGraft.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraft.lean
@@ -174,7 +174,7 @@ private def renderAuditNode
 
 #guard
   let attrs := (graftNode "def:graft.manual.left").renderedAttrsWithClass "audit_graft_node"
-  attrs.contains ("class", "bp_slide_node bp_graft_manifest_node audit_graft_node") &&
+  attrs.contains ("class", "bp_graft_manifest_node audit_graft_node") &&
     attrs.contains ("data-bp-rendered", "static") &&
     (attrs.filter (fun attr => attr.1 == "class")).size == 1
 
@@ -218,6 +218,8 @@ private def renderAuditNode
     let rendered := renderedHtml.asString
     pure <|
       hasSubstr rendered "Blueprint node not found" &&
+        hasSubstr rendered "label `def:graft.manual.missing`" &&
+        hasSubstr rendered "facet `statement`" &&
         hasSubstr rendered node.key &&
         hasSubstr rendered "bp_test_graft_notice"
 

--- a/tests/VersoBlueprintTests/BlueprintGraft.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraft.lean
@@ -133,11 +133,17 @@ private def graftManifestRenderConfig : Informal.Graft.ManifestRenderConfig :=
         hasSubstr rendered "bp_code_panel_wrapper" &&
         !hasSubstr rendered "Blueprint node not found"
 
-/-- info: true -/
-#guard_msgs in
-#eval
+#guard
   let attrs := (graftNode "def:graft.manual.left").renderedAttrsWithClass "audit_graft_node"
   attrs.contains ("class", "bp_slide_node audit_graft_node") &&
+    attrs.contains ("data-bp-rendered", "static") &&
+    (attrs.filter (fun attr => attr.1 == "class")).size == 1
+
+#guard
+  let attrs := Informal.Graft.setClassAttr
+    (graftNode "def:graft.manual.left").renderedAttrs
+    "bp_graft_node"
+  attrs.contains ("class", "bp_graft_node") &&
     attrs.contains ("data-bp-rendered", "static") &&
     (attrs.filter (fun attr => attr.1 == "class")).size == 1
 

--- a/tests/VersoBlueprintTests/BlueprintGraft.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraft.lean
@@ -76,6 +76,26 @@ private def graftManifestRenderConfig : Informal.Graft.ManifestRenderConfig :=
         Html.ofString s!"{title}: {detail}"
   }
 
+private def renderAuditNode
+    (manifest : Informal.PreviewManifest.File)
+    (htmlCache : Informal.PreviewManifest.HtmlCache.File)
+    (label : String) : IO Html := do
+  let node :=
+    ({ label, compact := true, showHeader := false } :
+      Informal.Graft.BlueprintNodeConfig).toNode
+  let ctx := Informal.Graft.RenderContext.ofPreviewData? (some manifest) (some htmlCache)
+  Informal.Graft.renderNodeFromManifestCache
+    {
+      blockRenderConfig := {
+        wrapperClass := "audit_blueprint_node"
+        codeBodyClass := "audit_blueprint_code"
+      }
+      nodeAttrs := fun node =>
+        node.renderedAttrsWithClass "audit_graft_node"
+    }
+    ctx
+    node
+
 /-- info: true -/
 #guard_msgs in
 #eval
@@ -133,6 +153,23 @@ private def graftManifestRenderConfig : Informal.Graft.ManifestRenderConfig :=
         hasSubstr rendered "Manual left graft body with inline math" &&
         hasSubstr rendered "graftManualLeftValue" &&
         hasSubstr rendered "bp_code_panel_wrapper" &&
+        !hasSubstr rendered "Blueprint node not found"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (_out, st) ← renderManualDocHtmlStringAndState manualImpls manualSideBySideGraftDoc
+    let files ← Informal.PreviewManifest.buildPreviewDataFiles manualImpls (fun _ => pure ()) st
+    let renderedHtml ← renderAuditNode files.manifest files.htmlCache "def:graft.manual.left"
+    let rendered := renderedHtml.asString
+    pure <|
+      hasSubstr rendered "audit_graft_node" &&
+        hasSubstr rendered "audit_blueprint_node" &&
+        hasSubstr rendered "data-bp-rendered=\"static\"" &&
+        hasSubstr rendered "Manual left graft body with inline math" &&
+        !hasSubstr rendered "bp_heading" &&
+        !hasSubstr rendered "bp_code_panel_wrapper" &&
         !hasSubstr rendered "Blueprint node not found"
 
 #guard

--- a/tests/VersoBlueprintTests/BlueprintSlides.lean
+++ b/tests/VersoBlueprintTests/BlueprintSlides.lean
@@ -20,8 +20,6 @@ open Informal
 open Verso.VersoBlueprintTests.Blueprint.Support
 open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
 
-def graftManualLeftValue : Nat := 2
-
 #docs (Slides) blueprintNodeSlideFixture "Blueprint Node Slide" :=
 :::::::
 # Example Blueprint Node
@@ -51,45 +49,6 @@ def graftManualLeftValue : Nat := 2
 :::::::
 :::definition "def:slide.meta.panel" (tags := "slides, renderer") (effort := "small") (priority := "high")
 Manifest-backed slide rendering should use the standard Blueprint block renderer.
-:::
-:::::::
-
-#docs (Genre.Manual) manualGraftDoc "Manual Blueprint Graft" :=
-:::::::
-:::definition "def:graft.manual.source"
-Manual graft body.
-:::
-
-{blueprint_node "def:graft.manual.source" -header +compact}
-:::::::
-
-#docs (Genre.Manual) manualSideBySideGraftDoc "Manual Side-by-Side Blueprint Graft" :=
-:::::::
-:::definition "def:graft.manual.left" (tags := "graft, source") (effort := "small") (lean := "graftManualLeftValue")
-Manual left graft body with inline math $`x + y = y + x` and an attached Lean preview.
-:::
-
-:::theorem "thm:graft.manual.sum" (uses := "def:graft.manual.left") (priority := "high")
-The grafted theorem states $`(a + b) + c = a + (b + c)`.
-:::
-
-:::proof "thm:graft.manual.sum"
-The proof graft records the same goal and keeps the proof facet selectable.
-:::
-
-:::definition "def:graft.manual.right" (uses := "thm:graft.manual.sum")
-Manual right graft body references {uses "def:graft.manual.left"}[] and includes display math:
-$$`\sum_{i=0}^{n} i = n`.
-:::
-
-:::blueprint_side_by_side +boxed
-{blueprint_node "def:graft.manual.left" (displayLabel := "Featured definition")}
-
-{blueprint_node "thm:graft.manual.sum" (displayLabel := "Theorem view") -header +compact}
-
-{blueprint_node "thm:graft.manual.sum" (facet := "proof") (displayLabel := "Proof view") -header +compact}
-
-{blueprint_node "def:graft.manual.right" (displayLabel := "Uses view") +compact}
 :::
 :::::::
 
@@ -290,39 +249,6 @@ private partial def freshSlidesSmokeRoot : IO System.FilePath := do
         !files.htmlCache.hoverDocs.isEmpty &&
         files.htmlCache.hoverDocs.all (fun doc => doc.id >= Informal.PreviewManifest.HtmlCache.hoverIdStart) &&
         !hasSubstr codeHtml "<pre>def "
-
-/-- info: true -/
-#guard_msgs in
-#eval
-  show IO Bool from do
-    let (html, _st) ← renderManualDocHtmlStringAndState manualImpls manualGraftDoc
-    pure <|
-      hasSubstr html "bp_graft_node" &&
-        countSubstr html "Manual graft body." == 2 &&
-        countSubstr html "class=\"bp_heading " == 1 &&
-        !hasSubstr html "Blueprint node not found"
-
-/-- info: true -/
-#guard_msgs in
-#eval
-  show IO Bool from do
-    let (html, _st) ← renderManualDocHtmlStringAndState manualImpls manualSideBySideGraftDoc
-    pure <|
-      hasSubstr html "bp_graft_side_by_side" &&
-        hasSubstr html "bp_graft_side_by_side_boxed" &&
-        countSubstr html "data-bp-blueprint-node=\"true\"" == 4 &&
-        countSubstr html "Manual left graft body with inline math" == 2 &&
-        countSubstr html "The grafted theorem states" == 2 &&
-        countSubstr html "The proof graft records" == 2 &&
-        countSubstr html "Manual right graft body references" == 2 &&
-        hasSubstr html "Featured definition" &&
-        hasSubstr html "Uses view" &&
-        hasSubstr html "graftManualLeftValue" &&
-        hasSubstr html "bp_math inline" &&
-        hasSubstr html "bp_math display" &&
-        hasSubstr html "data-bp-facet=\"proof\"" &&
-        hasSubstr html "bp_code_panel_wrapper" &&
-        !hasSubstr html "Blueprint node not found"
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/VersoBlueprintTests/BlueprintSlides.lean
+++ b/tests/VersoBlueprintTests/BlueprintSlides.lean
@@ -34,10 +34,58 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
 {blueprint_node "def:code.preview" (siteBase := "blueprint")}
 :::::::
 
+#docs (Slides) sideBySideBlueprintNodeSlideFixture "Side-by-Side Blueprint Node Slide" :=
+:::::::
+# Side-by-Side Blueprint Nodes
+
+:::blueprint_side_by_side
+{blueprint_node "def:graft.slide.left" -header (siteBase := "blueprint")}
+
+{blueprint_node "def:graft.slide.right" -header (siteBase := "blueprint")}
+:::
+:::::::
+
 #docs (Genre.Manual) slideMetadataPanelDoc "Slide Metadata Panel" :=
 :::::::
 :::definition "def:slide.meta.panel" (tags := "slides, renderer") (effort := "small") (priority := "high")
 Manifest-backed slide rendering should use the standard Blueprint block renderer.
+:::
+:::::::
+
+#docs (Genre.Manual) manualGraftDoc "Manual Blueprint Graft" :=
+:::::::
+:::definition "def:graft.manual.source"
+Manual graft body.
+:::
+
+{blueprint_node "def:graft.manual.source" -header +compact}
+:::::::
+
+#docs (Genre.Manual) manualSideBySideGraftDoc "Manual Side-by-Side Blueprint Graft" :=
+:::::::
+:::definition "def:graft.manual.left"
+Manual left graft body.
+:::
+
+:::definition "def:graft.manual.right"
+Manual right graft body.
+:::
+
+:::blueprint_side_by_side
+{blueprint_node "def:graft.manual.left" -header +compact}
+
+{blueprint_node "def:graft.manual.right" -header +compact}
+:::
+:::::::
+
+#docs (Genre.Manual) slideGraftSourceDoc "Slide Blueprint Graft Sources" :=
+:::::::
+:::definition "def:graft.slide.left"
+Slide left graft body.
+:::
+
+:::definition "def:graft.slide.right"
+Slide right graft body.
 :::
 :::::::
 
@@ -116,6 +164,15 @@ private partial def freshSlidesSmokeRoot : IO System.FilePath := do
   Informal.Slides.BlueprintSlideNode.fromAttrs? attrs == some node &&
     attrs.contains ("data-bp-display-label", "Custom slide label") &&
     !(attrs.any (fun attr => attr.1 == "data-bp-title"))
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  let node := { blueprintNode "def:code.preview" "def:code.preview--statement" with
+    showHeader := false }
+  let attrs := node.toAttrs
+  Informal.Slides.BlueprintSlideNode.fromAttrs? attrs == some node &&
+    attrs.contains ("data-bp-show-header", "false")
 
 /-- info: true -/
 #guard_msgs in
@@ -218,6 +275,29 @@ private partial def freshSlidesSmokeRoot : IO System.FilePath := do
         !files.htmlCache.hoverDocs.isEmpty &&
         files.htmlCache.hoverDocs.all (fun doc => doc.id >= Informal.PreviewManifest.HtmlCache.hoverIdStart) &&
         !hasSubstr codeHtml "<pre>def "
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (html, _st) ← renderManualDocHtmlStringAndState manualImpls manualGraftDoc
+    pure <|
+      hasSubstr html "bp_graft_node" &&
+        countSubstr html "Manual graft body." == 2 &&
+        countSubstr html "class=\"bp_heading " == 1 &&
+        !hasSubstr html "Blueprint node not found"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (html, _st) ← renderManualDocHtmlStringAndState manualImpls manualSideBySideGraftDoc
+    pure <|
+      hasSubstr html "bp_graft_side_by_side" &&
+        countSubstr html "data-bp-blueprint-node=\"true\"" == 2 &&
+        countSubstr html "Manual left graft body." == 2 &&
+        countSubstr html "Manual right graft body." == 2 &&
+        !hasSubstr html "Blueprint node not found"
 
 /-- info: true -/
 #guard_msgs in
@@ -373,6 +453,39 @@ private partial def freshSlidesSmokeRoot : IO System.FilePath := do
         hasSubstr index s!"data-bp-preview-key=\"{normalizedKey}\"" &&
         hasSubstr index "data-bp-site-base=\"blueprint\"" &&
         hasSubstr index "href=\"#--informal-preview" &&
+        !hasSubstr index "Loading Blueprint node"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (_out, st) ← renderManualDocHtmlStringAndState manualImpls slideGraftSourceDoc
+    let files ← Informal.PreviewManifest.buildPreviewDataFiles manualImpls (fun _ => pure ()) st
+    let root ← freshSlidesSmokeRoot
+    let outDir := root / "slides"
+    let manifestPath := root / Informal.PreviewManifest.manifestFilename
+    let htmlCachePath := root / Informal.PreviewManifest.htmlCacheFilename
+    if !(← root.pathExists) then
+      IO.FS.createDirAll root
+    IO.FS.writeFile manifestPath (Lean.toJson files.manifest).compress
+    IO.FS.writeFile htmlCachePath (Lean.toJson files.htmlCache).compress
+    let rc ← Informal.Slides.slidesMainWithBlueprintPreviews
+      { outputDir := outDir }
+      (previewManifest? := some manifestPath)
+      sideBySideBlueprintNodeSlideFixture.toPart
+      (quiet := true)
+    if rc != 0 then
+      return false
+    let indexPath := outDir / "index.html"
+    if !(← indexPath.pathExists) then
+      return false
+    let index ← IO.FS.readFile indexPath
+    pure <|
+      hasSubstr index "bp_graft_side_by_side" &&
+        countSubstr index "data-bp-rendered=\"static\"" == 2 &&
+        hasSubstr index "Slide left graft body." &&
+        hasSubstr index "Slide right graft body." &&
+        !hasSubstr index "Blueprint node not found" &&
         !hasSubstr index "Loading Blueprint node"
 
 end Verso.VersoBlueprintTests.BlueprintSlides

--- a/tests/VersoBlueprintTests/BlueprintSlides.lean
+++ b/tests/VersoBlueprintTests/BlueprintSlides.lean
@@ -20,6 +20,8 @@ open Informal
 open Verso.VersoBlueprintTests.Blueprint.Support
 open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
 
+def graftManualLeftValue : Nat := 2
+
 #docs (Slides) blueprintNodeSlideFixture "Blueprint Node Slide" :=
 :::::::
 # Example Blueprint Node
@@ -38,7 +40,7 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
 :::::::
 # Side-by-Side Blueprint Nodes
 
-:::blueprint_side_by_side
+:::blueprint_side_by_side +boxed
 {blueprint_node "def:graft.slide.left" -header (siteBase := "blueprint")}
 
 {blueprint_node "def:graft.slide.right" -header (siteBase := "blueprint")}
@@ -63,18 +65,31 @@ Manual graft body.
 
 #docs (Genre.Manual) manualSideBySideGraftDoc "Manual Side-by-Side Blueprint Graft" :=
 :::::::
-:::definition "def:graft.manual.left"
-Manual left graft body.
+:::definition "def:graft.manual.left" (tags := "graft, source") (effort := "small") (lean := "graftManualLeftValue")
+Manual left graft body with inline math $`x + y = y + x` and an attached Lean preview.
 :::
 
-:::definition "def:graft.manual.right"
-Manual right graft body.
+:::theorem "thm:graft.manual.sum" (uses := "def:graft.manual.left") (priority := "high")
+The grafted theorem states $`(a + b) + c = a + (b + c)`.
 :::
 
-:::blueprint_side_by_side
-{blueprint_node "def:graft.manual.left" -header +compact}
+:::proof "thm:graft.manual.sum"
+The proof graft records the same goal and keeps the proof facet selectable.
+:::
 
-{blueprint_node "def:graft.manual.right" -header +compact}
+:::definition "def:graft.manual.right" (uses := "thm:graft.manual.sum")
+Manual right graft body references {uses "def:graft.manual.left"}[] and includes display math:
+$$`\sum_{i=0}^{n} i = n`.
+:::
+
+:::blueprint_side_by_side +boxed
+{blueprint_node "def:graft.manual.left" (displayLabel := "Featured definition")}
+
+{blueprint_node "thm:graft.manual.sum" (displayLabel := "Theorem view") -header +compact}
+
+{blueprint_node "thm:graft.manual.sum" (facet := "proof") (displayLabel := "Proof view") -header +compact}
+
+{blueprint_node "def:graft.manual.right" (displayLabel := "Uses view") +compact}
 :::
 :::::::
 
@@ -89,7 +104,7 @@ Slide right graft body.
 :::
 :::::::
 
-private def blueprintNode (label key : String) : Informal.Slides.BlueprintSlideNode where
+private def blueprintNode (label key : String) : Informal.Graft.BlueprintNode where
   label := label
   facet := "statement"
   key := key
@@ -153,7 +168,7 @@ private partial def freshSlidesSmokeRoot : IO System.FilePath := do
 #guard_msgs in
 #eval
   let node := blueprintNode "def:code.preview" "def:code.preview--statement"
-  Informal.Slides.BlueprintSlideNode.fromAttrs? node.toAttrs == some node
+  Informal.Graft.BlueprintNode.fromAttrs? node.toAttrs == some node
 
 /-- info: true -/
 #guard_msgs in
@@ -161,7 +176,7 @@ private partial def freshSlidesSmokeRoot : IO System.FilePath := do
   let node := { blueprintNode "def:code.preview" "def:code.preview--statement" with
     displayLabel? := some "Custom slide label" }
   let attrs := node.toAttrs
-  Informal.Slides.BlueprintSlideNode.fromAttrs? attrs == some node &&
+  Informal.Graft.BlueprintNode.fromAttrs? attrs == some node &&
     attrs.contains ("data-bp-display-label", "Custom slide label") &&
     !(attrs.any (fun attr => attr.1 == "data-bp-title"))
 
@@ -171,7 +186,7 @@ private partial def freshSlidesSmokeRoot : IO System.FilePath := do
   let node := { blueprintNode "def:code.preview" "def:code.preview--statement" with
     showHeader := false }
   let attrs := node.toAttrs
-  Informal.Slides.BlueprintSlideNode.fromAttrs? attrs == some node &&
+  Informal.Graft.BlueprintNode.fromAttrs? attrs == some node &&
     attrs.contains ("data-bp-show-header", "false")
 
 /-- info: true -/
@@ -294,9 +309,19 @@ private partial def freshSlidesSmokeRoot : IO System.FilePath := do
     let (html, _st) ← renderManualDocHtmlStringAndState manualImpls manualSideBySideGraftDoc
     pure <|
       hasSubstr html "bp_graft_side_by_side" &&
-        countSubstr html "data-bp-blueprint-node=\"true\"" == 2 &&
-        countSubstr html "Manual left graft body." == 2 &&
-        countSubstr html "Manual right graft body." == 2 &&
+        hasSubstr html "bp_graft_side_by_side_boxed" &&
+        countSubstr html "data-bp-blueprint-node=\"true\"" == 4 &&
+        countSubstr html "Manual left graft body with inline math" == 2 &&
+        countSubstr html "The grafted theorem states" == 2 &&
+        countSubstr html "The proof graft records" == 2 &&
+        countSubstr html "Manual right graft body references" == 2 &&
+        hasSubstr html "Featured definition" &&
+        hasSubstr html "Uses view" &&
+        hasSubstr html "graftManualLeftValue" &&
+        hasSubstr html "bp_math inline" &&
+        hasSubstr html "bp_math display" &&
+        hasSubstr html "data-bp-facet=\"proof\"" &&
+        hasSubstr html "bp_code_panel_wrapper" &&
         !hasSubstr html "Blueprint node not found"
 
 /-- info: true -/

--- a/tests/VersoBlueprintTests/TestBlueprintRegistry.lean
+++ b/tests/VersoBlueprintTests/TestBlueprintRegistry.lean
@@ -13,6 +13,7 @@ import VersoBlueprintTests.BlueprintPreviewSource.Provider
 import VersoBlueprintTests.BlueprintPreviewWiring.Shared
 import VersoBlueprintTests.BlueprintPreviewWiring.StateShowcase
 import VersoBlueprintTests.BlueprintRustCode
+import VersoBlueprintTests.BlueprintSlides
 import VersoBlueprintTests.BlueprintSummaryLinks.Shared
 import VersoBlueprintTests.BlueprintTexMacros
 import VersoBlueprintTests.TestBlueprintRegistryMeta
@@ -38,6 +39,7 @@ private def curatedTestBlueprintDoc? (slug : String) : Option (Doc.VersoDoc Genr
   | "transitive-imported-duplicates" => some Verso.VersoBlueprintTests.BlueprintImportedDuplicates.Transitive.transitiveImportedDuplicateDoc
   | "imported-preview-source" => some Verso.VersoBlueprintTests.BlueprintPreviewSource.Provider.importedPreviewSourceDoc
   | "lean-auto-deps" => some Verso.VersoBlueprintTests.BlueprintAutoDeps.Preview.autoDepsPreviewDoc
+  | "blueprint-grafts" => some Verso.VersoBlueprintTests.BlueprintSlides.manualSideBySideGraftDoc
   | "state-showcase" => some Verso.VersoBlueprintTests.BlueprintPreviewWiring.StateShowcase.stateShowcaseDoc
   | "external-summary-links" => some Verso.VersoBlueprintTests.BlueprintSummaryLinks.Shared.externalSummaryLinksDoc
   | "summary-blockers" => some Verso.VersoBlueprintTests.BlueprintSummaryLinks.Shared.summaryBlockersDoc

--- a/tests/VersoBlueprintTests/TestBlueprintRegistry.lean
+++ b/tests/VersoBlueprintTests/TestBlueprintRegistry.lean
@@ -7,13 +7,13 @@ Author: Emilio J. Gallego Arias
 import VersoBlueprintTests.BlueprintImportedDuplicates.Direct
 import VersoBlueprintTests.BlueprintImportedDuplicates.Transitive
 import VersoBlueprintTests.BlueprintAutoDeps.Preview
+import VersoBlueprintTests.BlueprintGraft
 import VersoBlueprintTests.BlueprintLinkHover
 import VersoBlueprintTests.BlueprintMetadataPanel
 import VersoBlueprintTests.BlueprintPreviewSource.Provider
 import VersoBlueprintTests.BlueprintPreviewWiring.Shared
 import VersoBlueprintTests.BlueprintPreviewWiring.StateShowcase
 import VersoBlueprintTests.BlueprintRustCode
-import VersoBlueprintTests.BlueprintSlides
 import VersoBlueprintTests.BlueprintSummaryLinks.Shared
 import VersoBlueprintTests.BlueprintTexMacros
 import VersoBlueprintTests.TestBlueprintRegistryMeta
@@ -39,7 +39,7 @@ private def curatedTestBlueprintDoc? (slug : String) : Option (Doc.VersoDoc Genr
   | "transitive-imported-duplicates" => some Verso.VersoBlueprintTests.BlueprintImportedDuplicates.Transitive.transitiveImportedDuplicateDoc
   | "imported-preview-source" => some Verso.VersoBlueprintTests.BlueprintPreviewSource.Provider.importedPreviewSourceDoc
   | "lean-auto-deps" => some Verso.VersoBlueprintTests.BlueprintAutoDeps.Preview.autoDepsPreviewDoc
-  | "blueprint-grafts" => some Verso.VersoBlueprintTests.BlueprintSlides.manualSideBySideGraftDoc
+  | "blueprint-grafts" => some Verso.VersoBlueprintTests.BlueprintGraft.manualSideBySideGraftDoc
   | "state-showcase" => some Verso.VersoBlueprintTests.BlueprintPreviewWiring.StateShowcase.stateShowcaseDoc
   | "external-summary-links" => some Verso.VersoBlueprintTests.BlueprintSummaryLinks.Shared.externalSummaryLinksDoc
   | "summary-blockers" => some Verso.VersoBlueprintTests.BlueprintSummaryLinks.Shared.summaryBlockersDoc

--- a/tests/VersoBlueprintTests/TestBlueprintRegistryMeta.lean
+++ b/tests/VersoBlueprintTests/TestBlueprintRegistryMeta.lean
@@ -99,6 +99,14 @@ def curatedTestBlueprintMetas : Array CuratedTestBlueprintMeta := #[
     kind := "curated_doc"
   },
   {
+    slug := "blueprint-grafts"
+    title := "Blueprint Grafts"
+    category := "Preview"
+    summary := "Manual Blueprint node grafts and side-by-side presentation."
+    tags := #["preview", "graft", "manual"]
+    kind := "curated_doc"
+  },
+  {
     slug := "state-showcase"
     title := "Blueprint Graph State Showcase"
     category := "Graph"

--- a/tests/browser/BlueprintSlidesRuntime.lean
+++ b/tests/browser/BlueprintSlidesRuntime.lean
@@ -22,6 +22,14 @@ namespace Verso.VersoBlueprintTests.BlueprintSlidesRuntime
 {blueprint_node "multiplication_one_right" (siteBase := "blueprint")}
 
 {blueprint_node "multiplication_one_right" +compact (facet := "proof") (siteBase := "blueprint")}
+
+# Side-by-Side Grafts
+
+:::blueprint_side_by_side +boxed
+{blueprint_node "collatz_step" -header +compact (siteBase := "blueprint")}
+
+{blueprint_node "multiplication_one_right" -header +compact (facet := "proof") (siteBase := "blueprint")}
+:::
 :::::::
 
 private def usage : IO UInt32 := do

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -21,7 +21,7 @@ DEFAULT_TEST_BLUEPRINT = "preview_runtime_showcase"
 
 def browser_executable(browser_type: str) -> str | None:
     candidates = {
-        "chromium": ["chromium", "chromium-browser", "google-chrome"],
+        "chromium": ["google-chrome", "chromium", "chromium-browser"],
         "firefox": ["firefox"],
     }.get(browser_type, [])
     for candidate in candidates:

--- a/tests/browser/test_blueprint_slides_runtime.py
+++ b/tests/browser/test_blueprint_slides_runtime.py
@@ -325,11 +325,12 @@ class TestBlueprintSlidesRuntime:
 
         page.evaluate("window.Reveal.slide(1)")
         page.wait_for_function("() => window.Reveal.getIndices().h === 1")
-        theorem_node = page.locator(
+        current_slide = page.locator(".reveal .slides section.present").first
+        theorem_node = current_slide.locator(
             ".bp_slide_node[data-bp-label='multiplication_one_right']"
             "[data-bp-facet='statement']"
         )
-        proof_node = page.locator(
+        proof_node = current_slide.locator(
             ".bp_slide_node[data-bp-label='multiplication_one_right']"
             "[data-bp-facet='proof']"
         )
@@ -394,6 +395,37 @@ class TestBlueprintSlidesRuntime:
             "[data-bp-facet='proof'] .bp_slide_node_heading_link",
             "Multiplication/#--informal-preview-multiplication_one_right--proof",
             "/blueprint/Multiplication/#--informal-preview-multiplication_one_right--proof",
+        )
+
+        page.evaluate("window.Reveal.slide(2)")
+        page.wait_for_function("() => window.Reveal.getIndices().h === 2")
+        current_slide = page.locator(".reveal .slides section.present").first
+        graft_grid = current_slide.locator(".bp_graft_side_by_side").first
+        expect(graft_grid).to_be_visible()
+        assert graft_grid.evaluate(
+            """grid => grid.classList.contains("bp_graft_side_by_side_boxed")"""
+        )
+        expect(graft_grid.locator(".bp_slide_node")).to_have_count(2)
+        expect(graft_grid.locator(".bp_heading")).to_have_count(0)
+        expect(graft_grid.locator(".bp_code_panel_wrapper")).to_have_count(0)
+        expect(
+            graft_grid.locator(".bp_slide_node[data-bp-label='collatz_step']")
+        ).to_contain_text("n / 2")
+        expect(
+            graft_grid.locator(
+                ".bp_slide_node[data-bp-label='multiplication_one_right']"
+                "[data-bp-facet='proof']"
+            )
+        ).to_contain_text("Unfold the definition of multiplication")
+        assert graft_grid.evaluate(
+            """grid => getComputedStyle(grid).display"""
+        ) == "grid"
+        expect_slide_link(
+            page,
+            ".bp_graft_side_by_side "
+            ".bp_slide_node[data-bp-label='collatz_step'] .bp_content a[title='multiplication_spec']",
+            "Multiplication/#--informal-preview-multiplication_spec--statement",
+            "/blueprint/Multiplication/#--informal-preview-multiplication_spec--statement",
         )
 
         page.evaluate("window.bpSlideNodeRuntime.hydrate(document)")


### PR DESCRIPTION
This PR adds shared Blueprint graft commands and a reusable manifest/cache rendering path so Manual pages, Slides decks, and generated consumers can render exact Blueprint nodes by label/facet inline or side by side.

- Add `{blueprint_node ...}` and `:::blueprint_side_by_side` for Manual and Slides, including compact/header/display-label/site-base options and boxed side-by-side presentation.
- Share graft selection and manifest-cache rendering under `Informal.Graft`, with class helpers, neutral `bp_graft_manifest_node` selectors, and slide-specific attr helpers layered on top of neutral graft node attrs.
- Cover Manual and Slides rendering, reusable-renderer failure diagnostics, and browser/runtime behavior; document the API for custom consumers such as audit interfaces.

Backport v4.29.0: #128
