### PR TITLE
refactor: tighten graft and slide rendering boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Blueprint can render:
 The graph page is interactive rather than static: it can expose a view switcher
 for grouped graphs, a legend popover, a `Graph options` control for direction
 and component-packing switches, and graph-node previews that can be configured
-as click-pinned or transient hover panels with docked or near-node placement.
+as pinned or hover panels with docked or anchored placement.
 
 Progress is computed automatically from the status of the associated Lean code
 and declarations, so the HTML summary and graph views stay aligned with the

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -1,6 +1,6 @@
 # Blueprint Design Rationale
 
-Last updated: 2026-05-04
+Last updated: 2026-06-16
 
 This document records the current architecture boundaries and the reasons the
 Blueprint implementation is shaped the way it is.
@@ -103,6 +103,222 @@ The same Blueprint object data is consumed in three broad ways:
 This split is why one-source-of-truth pressure matters so much: local blocks,
 global pages, and runtime widgets all need to agree on the same semantics while
 projecting them differently.
+
+## Blueprint Data Workflow
+
+Blueprint has one semantic authoring model, but it deliberately crosses several
+phase boundaries before a generated site is interactive. Each boundary exists
+because the next phase owns facts that the previous phase cannot know yet:
+compiled Lean elaboration owns local object semantics, Verso traversal owns
+site-local anchors and numbering, preview-data emission owns whole-site cache
+artifacts, and browser JavaScript owns interaction and hydration.
+
+The current workflow is:
+
+```mermaid
+flowchart TD
+  source["Blueprint source modules<br/>informal directives, Lean code, citations, groups"]
+  elab["Lean / Verso elaboration<br/>directive parsing and local semantic registration"]
+  env["Environment.State<br/>persistent semantic data in oleans"]
+  traverse["Verso traversal<br/>numbering, hrefs, anchors, local preview blocks"]
+  indexes["TraversalIndex domains<br/>Nodes, InlineCode, TraversalPreviews,<br/>LeanCodePreviews, citations, external-decl anchors"]
+  render["HTML page rendering<br/>manual pages, graph, summary, bibliography"]
+  manifest["PreviewManifest extra step<br/>semantic manifest and rendered HTML cache"]
+  artifacts["Generated artifacts<br/>HTML pages, assets, -verso-docs.json,<br/>blueprint-manifest.json, blueprint-html-cache.json"]
+  browser["Browser runtime<br/>bpPreviewUtils, graph/summary/block/slides JS"]
+  consumers["External/custom consumers<br/>Slides, audit views, dashboards, custom wrappers"]
+
+  source --> elab
+  elab --> env
+  env --> traverse
+  traverse --> indexes
+  indexes --> render
+  indexes --> manifest
+  render --> artifacts
+  manifest --> artifacts
+  artifacts --> browser
+  artifacts --> consumers
+  browser --> consumers
+```
+
+The same flow can be read as four contracts:
+
+1. **Elaboration to environment.**
+   Source directives, inline Lean blocks, `@[blueprint "..."]` attributes,
+   external `(lean := "...")` references, group declarations, author
+   declarations, citations, and metadata are elaborated into
+   `Informal.Environment.State`. This is the canonical semantic store for
+   Blueprint-owned facts. It is persisted through Lean environment extensions
+   and imported through compiled oleans, so downstream modules see one merged
+   object database.
+
+2. **Environment to traversal.**
+   During Verso traversal, Blueprint reads the semantic environment and writes
+   render-time indexes into `TraverseState` through `TraversalIndex`. This is
+   where site-local facts are created: rendered anchors, numbering caches,
+   code-panel destinations, group and reverse-use panels, citation use sites,
+   statement/proof preview entries, Lean declaration preview entries, and
+   external declaration row anchors. These facts are intentionally not pushed
+   back into `Environment.State`, because their values depend on the current
+   rendered document and output mode.
+
+3. **Traversal to generated artifacts.**
+   Page rendering and preview-data emission both consume the traversal state.
+   HTML pages get the visible document, graph, summary, bibliography, inline
+   preview triggers, and feature-specific assets. The Blueprint preview-data
+   extra step emits two structured files under `-verso-data/`:
+   `blueprint-manifest.json`, which contains semantic preview entries and
+   metadata, and `blueprint-html-cache.json`, which contains rendered HTML
+   fragments plus the hover side data needed to hydrate those fragments inside
+   generated pages.
+
+4. **Artifacts to runtime and external consumers.**
+   Browser code should treat the generated artifacts as immutable inputs. Page
+   markup carries stable lookup keys and lightweight data attributes. Shared
+   runtime helpers in `bpPreviewUtils` load cache entries, decode cached
+   fragments, hydrate nested preview widgets, render math, and apply panel
+   behavior. Feature-owned JavaScript such as graph, summary, relation-panel,
+   inline-preview, and slide code binds those generic helpers to a concrete UI.
+   Custom consumers should prefer the manifest/cache pair over scraping page
+   HTML or re-solving Blueprint labels.
+
+### Workflow Sources Of Truth
+
+The main rule is: each fact has one owning phase, and later phases project from
+that owner.
+
+| Fact family | Owner | Stored as | Main consumers |
+| --- | --- | --- | --- |
+| Blueprint labels, node kind, declared dependencies, parent/group, owner, tags, priority, effort, PR URL | Elaboration | `Environment.State.data` and related environment maps | traversal, graph, summary, manifest construction |
+| Group and author declarations | Elaboration | `Environment.State.groups` and `Environment.State.authors` | block rendering, summary, graph/group panels |
+| Inline Lean and Rust attachments | Elaboration plus traversal | semantic code refs in environment; render-time code-panel indexes in `TraversalIndex.InlineCode` | block renderers, code panels, manifest entries |
+| External Lean declaration snapshots | Elaboration / declaration snapshot registration | `ExternalRef` records on semantic nodes, enriched with presence/status/source/render data | block renderers, code-summary badges, summary, graph, manifest |
+| Numbering, hrefs, anchors, preview keys | Traversal | `TraverseState` and `TraversalIndex` domains | page rendering, preview manifest, browser triggers |
+| Statement/proof preview source blocks | Traversal | `TraversalIndex.TraversalPreviews` | manifest/cache emission, same-document manual grafts |
+| Lean declaration preview fragments | Traversal | `TraversalIndex.LeanCodePreviews` | Lean links, manifest/cache emission |
+| Rendered preview bodies | Preview-data emission | `blueprint-html-cache.json` | browser runtime, Slides, custom generated consumers |
+| Semantic preview/catalog entries | Preview-data emission | `blueprint-manifest.json` | browser runtime, Slides, audit/custom UIs |
+| Interaction state | Browser runtime | DOM state only | previews, panels, graph controls, custom wrappers |
+
+This is why Blueprint keeps manifest state and traversal state separate even
+when they describe the same object. Traversal state is the live, generator-local
+working set. Manifest state is the serialized interchange artifact for
+generated consumers. A renderer may project traversal state into manifest-shaped
+entries for code reuse, but it should not pretend that generated manifest files
+are the traversal source of truth inside the current generator.
+
+### Render Path Inventory
+
+There are several Blueprint render callers, but only a few true assembly
+layers. The useful split is:
+
+```mermaid
+flowchart TD
+  manualMain["Manual site generator<br/>PreviewManifest.blueprintMainWithPreviewData"]
+  versoEmit["Verso Manual HTML emitters<br/>single-page and multi-page output"]
+  informalManual["Informal Manual block renderer<br/>Informal.Block.toHtml"]
+  commandRenderers["Command/inline renderers<br/>graph, summary, bibliography, math, cite, code"]
+  previewExtra["Preview-data extra step<br/>emitBlueprintPreviewData"]
+  previewFiles["Manifest/cache files<br/>blueprint-manifest.json<br/>blueprint-html-cache.json"]
+
+  manualGraft["Manual graft command<br/>Graft.renderManualGraftNode"]
+  traversalPreview["Traversal preview lookup<br/>PreviewSource / TraversalPreviews"]
+  manualPreviewHtml["Manual preview-body render<br/>renderManualBlocksHtmlWithStateAndHovers"]
+
+  slideMain["Slide deck generator<br/>Slides.slidesMainWithBlueprintPreviews"]
+  slideRender["Slide node render<br/>Slides.Render.renderBlueprintSlideNode"]
+  customRender["Custom generated consumer<br/>audit UI, dashboard, wrapper"]
+  graftCache["Manifest/cache node render<br/>Graft.renderNodeFromManifestCache"]
+  graftContent["Shared node assembly<br/>Graft.renderNodeWithContent"]
+  manifestBlock["Manifest-backed block shell<br/>PreviewManifest.BlockRender.renderWithRenderedContent"]
+  blockShell["Canonical block shell<br/>Informal.Block.Render.renderInformalBlockModel"]
+  browserRuntime["Browser hydration<br/>bpPreviewUtils and feature hydrators"]
+
+  manualMain --> versoEmit
+  versoEmit --> informalManual
+  versoEmit --> commandRenderers
+  manualMain --> previewExtra
+  previewExtra --> previewFiles
+
+  manualGraft --> traversalPreview
+  traversalPreview --> manualPreviewHtml
+  manualPreviewHtml --> graftContent
+
+  previewFiles --> slideMain
+  slideMain --> slideRender
+  slideRender --> graftCache
+  previewFiles --> customRender
+  customRender --> graftCache
+  previewFiles --> graftCache
+  graftCache --> graftContent
+  graftContent --> manifestBlock
+  manifestBlock --> blockShell
+  informalManual --> blockShell
+  previewFiles --> browserRuntime
+```
+
+The current paths are:
+
+| Path | Entry point | Data input | Shared assembly point | Output |
+| --- | --- | --- | --- | --- |
+| Normal Manual site pages | `Informal.PreviewManifest.blueprintMainWithPreviewData` | `Environment.State` plus `TraverseState` | `Informal.Block.Render.renderInformalBlockModel` for informal blocks; command-specific renderers for graph, summary, and bibliography | generated Manual HTML pages and assets |
+| Preview manifest/cache emission | `Informal.PreviewManifest.emitBlueprintPreviewData` via `blueprintMainWithPreviewData` | completed Manual `TraverseState` and `TraversalIndex` domains | Manual preview render helpers plus manifest entry builders | `blueprint-manifest.json`, `blueprint-html-cache.json`, merged hover docs |
+| Manual same-document graft | `Informal.Graft.renderManualGraftNode` through `{blueprint_node}` in Manual | current page traversal preview entry and current `TraverseState` | `Informal.Graft.renderNodeWithContent` | grafted Manual HTML block |
+| Manual side-by-side graft wrapper | `Block.blueprintGraftSideBySide.toHtml` | already elaborated/rendered child blocks | wrapper only; child nodes follow the Manual graft path | side-by-side Manual HTML wrapper |
+| Slides graft node | `Informal.Slides.slidesMainWithBlueprintPreviews` plus `Informal.Slides.renderBlueprintSlideNode` | serialized manifest/cache files copied from the Blueprint site | `Informal.Graft.renderNodeFromManifestCache` then `renderNodeWithContent` | static slide-node HTML plus slide assets |
+| Slides side-by-side wrapper | `VersoSlides.BlockExt.wrap` emitted by `blueprint_side_by_side` in Slides | already rendered child slide blocks | upstream Slides wrapper; child nodes follow the Slides graft-node path | side-by-side slide HTML wrapper |
+| External/custom generated consumers | direct calls to `Informal.Graft.renderNodeFromManifestCache` | serialized manifest/cache files | `Informal.Graft.renderNodeFromManifestCache` then `renderNodeWithContent` | consumer-owned HTML wrapper |
+| Browser preview/panel hydration | `bpPreviewUtils` and registered feature hydrators | generated page markup, manifest/cache files, `-verso-docs.json` | JavaScript hydration only | interactive previews, panels, math, links |
+
+This inventory is also the answer to "how many render contexts do we have?" for
+grafted Blueprint nodes. `VersoBlueprint.Graft.Render` owns the one concrete
+manifest/cache render context, `Informal.Graft.RenderContext`. It stores the
+manifest index, HTML-cache index, and error logger. `VersoBlueprint.Slides.Render`
+only aliases that type and supplies slide-specific render configuration. Manual
+grafts do not use a manifest render context, because they already have the live
+`TraverseState`; they still end at `Informal.Graft.renderNodeWithContent` so the
+block shell is assembled the same way.
+
+### Render-Path Consequences
+
+The workflow implies a few constraints for renderers:
+
+- **Manual rendering can use traversal directly.**
+  Same-document commands such as Manual grafts can resolve the target through
+  traversal indexes because the current page traversal state is available. They
+  may still project the result into the manifest entry shape so the block shell
+  and relationship panels use the same assembly code as generated consumers.
+
+- **Generated consumers use manifest/cache.**
+  Slides, external audit interfaces, and custom dashboards should read
+  `blueprint-manifest.json` plus `blueprint-html-cache.json`. They should not
+  reconstruct relationship panels, code bodies, status badges, or hover payloads
+  by scanning raw document HTML.
+
+- **Browser JavaScript hydrates; it does not own semantics.**
+  Runtime code may load cached HTML, insert it into panels, render math, and
+  bind nested preview handlers. It should not decide whether a node is
+  formalized, which dependencies exist, or how related panels are structured.
+
+- **Fallbacks should be diagnostic, not alternative data paths.**
+  If a manifest entry or HTML-cache body is missing, the UI should expose a
+  clear local diagnostic. Silently falling back to page-local stale templates
+  or ad hoc label scans creates a second source of truth.
+
+### Phase Boundary Checklist
+
+When adding a new Blueprint surface, choose its data boundary explicitly:
+
+1. If the fact is authored by a directive or Lean declaration, put it in
+   `Environment.State` or a typed semantic model referenced from it.
+2. If the fact depends on document placement, rendered numbering, hrefs, or
+   anchors, put it in a `TraversalIndex` domain.
+3. If the fact must be consumed outside the current generator process, emit it
+   through `PreviewManifest` and the HTML cache.
+4. If the fact is only UI interaction state, keep it in browser-owned DOM or JS
+   state.
+5. If two phases need the same shape, share a projection or renderer, not the
+   mutable phase-local store itself.
 
 ## External Declaration Model
 
@@ -231,9 +447,9 @@ layer:
 The important boundary is that Blueprint may adapt `TraverseState` and
 `HtmlAssets` after traversal and before HTML emission, but it should not fork
 Verso's HTML emitters unless upstream APIs leave no alternative. This keeps
-local compatibility workarounds, such as the highlighted-code docstring
-`textContent` asset rewrite, on structured assets rather than on generated HTML
-files.
+local upstream workarounds, such as the highlighted-code docstring
+`textContent` asset rewrite, on structured assets rather than on generated
+HTML files.
 
 The current public-xref filter still has a post-emit component: upstream Verso's
 find-page writer embeds the full xref payload while emitting HTML, so Blueprint
@@ -342,8 +558,7 @@ rendering:
 - `Informal.Environment.State` for canonical semantic data authored in Lean
   modules
 - `TraverseState.contents` for tiny traversal-local scalar state
-- `TraverseState.domains` for link-oriented indexes plus some legacy local
-  caches
+- `TraverseState.domains` for link-oriented indexes plus local runtime caches
 
 That mix is intentional, but the roles should stay explicit:
 
@@ -422,9 +637,8 @@ and block-local rendering inputs, not to the semantic node index itself.
 Most traversal payloads use compact internal JSON to keep repeated preview and
 cross-reference data small. That JSON is not a public interchange schema:
 callers should go through `TraversalIndex` or the relevant typed model module.
-Where a payload replaced a previously derived object encoding, readers keep
-legacy object support so existing cached traversal/domain data can still be
-understood during the transition.
+Internal traversal/domain cache data is regenerated by the current generator;
+old cache files are not a public API contract.
 
 This does not mean every internal store has already moved off traversal
 domains. Under current upstream Verso APIs, domains are still operationally

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -639,7 +639,7 @@ behavior. The default is `pinned`: clicking a node opens a persistent preview
 panel that stays open until closed. `hover` opens a transient preview that
 disappears after the pointer leaves the node and preview panel.
 The `(previewPlacement := docked | anchored)` option chooses where the preview
-panel appears. The default is `docked`, so both click-pinned and hover previews
+panel appears. The default is `docked`, so both pinned and hover previews
 open in the graph corner unless `anchored` is selected to place the panel near
 the active node.
 
@@ -658,8 +658,8 @@ The command-side options and the runtime graph controls are compatible:
 - `(direction := ...)` chooses the initial graph direction when the page first
   loads
 - the rendered `Graph options` control lets readers switch among the supported
-  directions, toggle component packing, and choose between click-pinned and
-  hover previews and docked or near-node placement without regenerating the site
+  directions, toggle component packing, and choose between pinned and
+  hover previews and docked or anchored placement without regenerating the site
 
 Group metadata may be used to organize the presentation, but grouping does not
 change dependency edges.
@@ -856,15 +856,16 @@ interfaces can reuse:
 - `BlueprintNode.toAttrs` and `BlueprintNode.fromAttrs?` encode and decode the
   neutral DOM shell used by generated interfaces. The shell carries the
   `bp_graft_manifest_node` class as a stable selector for custom consumers.
-  Slides use `BlueprintNode.slideAttrs` and `BlueprintNode.slideRenderedAttrs`
-  to add slide-specific classes without making them part of the generic graft
-  contract.
+  Slides use `Informal.Slides.blueprintNodeAttrs` and
+  `Informal.Slides.renderedBlueprintNodeAttrs` to add slide-specific classes
+  without making them part of the generic graft contract.
 - `Informal.Graft.setClassAttr`, `Informal.Graft.appendClassAttr`, and
   `BlueprintNode.renderedAttrsWithClass` let custom renderers replace or extend
   CSS classes without creating duplicate `class` attributes.
 - `Informal.Graft.SideBySideConfig` parses wrapper options such as `+boxed`.
-  Its `attrs` and `slideAttrs` helpers produce the standard wrapper classes,
-  but consumers can also ignore them and arrange nodes in their own UI.
+  Its `attrs` helper produces the standard wrapper classes. Slides layer
+  `Informal.Slides.sideBySideAttrs` on top for deck-specific wrappers, and
+  custom consumers can ignore both helpers and arrange nodes in their own UI.
 - Slide generators and other generated consumers should import and use the
   `Informal.Graft` node/config names directly.
 
@@ -999,6 +1000,13 @@ Blueprint-specific rendered surfaces, applies Blueprint's preview-data and
 public-xref emission policy, and keeps downstream projects from needing to
 remember those dependencies manually.
 
+Blueprint does not keep broad compatibility layers for internal helper names,
+read-through aliases, command aliases, or old rendering paths. Public entry
+points used by real Blueprint projects are different: when such an entry point
+is renamed, keep the old exported name as a deprecated thin forwarder to the
+canonical function until the affected projects migrate. New generators should
+call `Informal.PreviewManifest.blueprintMainWithPreviewData` directly.
+
 Recommended CI usage builds the Lean library or formalization targets needed by
 the document, then runs the generator file directly:
 
@@ -1046,7 +1054,7 @@ Current options:
   - `sub`: prefixed numbering such as `Theorem 1.3.2`; the prefix and counter
     are controlled by the sub-numbering options below
   - `global`: document-order numbering such as `Theorem 27`
-  - `local`: legacy local numbering without a chapter prefix
+  - `local`: unprefixed local numbering without a chapter prefix
 - `verso.blueprint.subNumberingPrefix`
   - default: `full`
   - `full`: use the full numbered section path, such as `1.3`
@@ -1100,12 +1108,11 @@ prefixes with document-order block counts.
 - `verso.blueprint.graph.defaultPreviewMode`
   - default: `pinned`
   - sets the fallback graph-node preview behavior for `blueprint_graph` when
-    `(preview := ...)` is omitted; accepts `pinned`/`click` and `hover`
+    `(preview := ...)` is omitted; accepts `pinned` and `hover`
 - `verso.blueprint.graph.defaultPreviewPlacement`
   - default: `docked`
   - sets the fallback graph-node preview placement for `blueprint_graph` when
-    `(previewPlacement := ...)` is omitted; accepts `docked`/`fixed` and
-    `anchored`/`near-node`
+    `(previewPlacement := ...)` is omitted; accepts `docked` and `anchored`
 - `verso.blueprint.debug.commands`
   - default: `false`
   - emits debug info logs while elaborating Blueprint graph, summary, and

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -36,7 +36,7 @@ Current shape:
 2. Verso still owns traversal, TeX, word counts, search, page shell, and HTML
    emission.
 3. Blueprint owns asset injection, public-xref filtering, preview-data
-   emission, and local compatibility rewrites.
+   emission, and local upstream-workaround rewrites.
 
 Work:
 
@@ -60,12 +60,13 @@ model instead of recomputing similar facts in several layers.
 
 Work:
 
-1. consolidate `Informal.Environment.InProgress` with `Data.Node` or document
-   the remaining phase-specific fields that require a separate elaboration
-   record
-2. consolidate `Informal.Environment.State` with traversal information so node,
-   group, and author data do not drift between environment state and rendered
-   traversal stores
+1. revisit `Informal.Environment.InProgress` after the widget path no longer
+   needs elaboration-time syntax; today it remains separate from `Data.Node`
+   because it owns directive-stack state, preview blocks, and `elabStx`
+2. keep `Informal.Environment.State` as the persisted semantic store and
+   traversal indexes as rendered-site projections; consolidate only if the
+   replacement keeps numbering, hrefs, preview ids, and HTML-cache keys
+   phase-safe
 3. define a shared status record derived from `Data.Node` plus external
    declaration checks, and route graph, summary, and local block badges through
    it

--- a/project_template/ProjectTemplateMain.lean
+++ b/project_template/ProjectTemplateMain.lean
@@ -6,7 +6,7 @@ open Verso Doc
 open Verso.Genre Manual
 
 def main (args : List String) : IO UInt32 :=
-  Informal.PreviewManifest.manualMainWithPreviewData
+  Informal.PreviewManifest.blueprintMainWithPreviewData
     (%doc ProjectTemplate.Blueprint)
     args
     (extensionImpls := by exact extension_impls%)

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -21,8 +21,7 @@ from scripts.blueprint_harness_branches import (
     is_ancestor,
     load_branch_policy,
     local_release_ref,
-    main_sync_status,
-    preferred_main_ref,
+    release_sync_status,
     preferred_release_ref,
     require_checkout_role,
     ref_oid,
@@ -179,7 +178,7 @@ def validate_public_pr_title(title: str) -> str:
 
 def source_commit_series(repo_root: Path, source_branch: str) -> list[str]:
     result = subprocess.run(
-        ["git", "rev-list", "--reverse", f"{preferred_main_ref(repo_root)}..{source_branch}"],
+        ["git", "rev-list", "--reverse", f"{preferred_release_ref(repo_root)}..{source_branch}"],
         cwd=repo_root,
         check=True,
         text=True,
@@ -190,12 +189,12 @@ def source_commit_series(repo_root: Path, source_branch: str) -> list[str]:
 
 def resolve_create_worktree_base(layout, requested_base: str | None) -> str:
     release_branch = active_release_branch(layout.repo_root)
-    preferred_base = preferred_main_ref(layout.repo_root)
+    preferred_base = preferred_release_ref(layout.repo_root)
     if requested_base is None:
         requested_base = preferred_base
 
     if requested_base == release_branch and preferred_base != release_branch:
-        status = main_sync_status(layout.repo_root)
+        status = release_sync_status(layout.repo_root)
         if status.relationship != "in_sync":
             raise SystemExit(
                 f"[blueprint-harness] local `{release_branch}` is {status.relationship} relative to `{status.upstream_ref}`; "
@@ -463,7 +462,7 @@ def command_set_default_dev_branch(args: argparse.Namespace) -> int:
 
 def print_branch_policy_status(layout) -> RefSyncStatus:
     release_branch = active_release_branch(layout.package_root)
-    status = main_sync_status(layout.package_root)
+    status = release_sync_status(layout.package_root)
     print(f"current_branch={current_branch_name(layout.package_root) or ''}")
     print(f"branch_policy={branch_policy_path(layout.package_root)}")
     print(f"default_dev_branch={default_dev_branch(layout.package_root)}")
@@ -526,7 +525,7 @@ def command_create_worktree(args: argparse.Namespace) -> int:
     return 0
 
 
-def command_main_status(args: argparse.Namespace) -> int:
+def command_release_status(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
     release_branch = active_release_branch(layout.package_root)
     status = print_branch_policy_status(layout)
@@ -856,12 +855,12 @@ def cleanup_source_branch(layout, branch: str, *, delete_remote: bool) -> None:
         print(f"[blueprint-harness] deleted remote branch `{branch}`")
 
 
-def command_land_main(args: argparse.Namespace) -> int:
+def command_land_release(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
     release_branch = active_release_branch(layout.package_root)
     if layout.in_linked_worktree:
         raise SystemExit("[blueprint-harness] run `land-release` from the root checkout, not from a linked worktree")
-    status = main_sync_status(layout.repo_root)
+    status = release_sync_status(layout.repo_root)
     tracking_ref = status.local_ref
     if current_branch_name(layout.repo_root) != tracking_ref:
         raise SystemExit(f"[blueprint-harness] root checkout must be on `{tracking_ref}` before landing changes")
@@ -888,7 +887,7 @@ def command_land_main(args: argparse.Namespace) -> int:
     run(["git", "merge", "--ff-only", source_ref], cwd=layout.repo_root)
     print(f"[blueprint-harness] landed `{source_ref}` onto local `{tracking_ref}`")
 
-    if preferred_main_ref(layout.repo_root) == f"origin/{tracking_ref}" and not args.no_push:
+    if preferred_release_ref(layout.repo_root) == f"origin/{tracking_ref}" and not args.no_push:
         run(["git", "push", "origin", tracking_ref], cwd=layout.repo_root)
         print(f"[blueprint-harness] pushed `{tracking_ref}` to origin")
 
@@ -1173,17 +1172,16 @@ def add_release_management_commands(subparsers) -> None:
     )
     set_default_dev_branch.set_defaults(func=command_set_default_dev_branch)
 
-    main_status = subparsers.add_parser(
+    release_status = subparsers.add_parser(
         "release-status",
-        aliases=["main-status"],
         help="Show whether the active local release branch is in sync with its preferred upstream ref.",
     )
-    main_status.add_argument(
+    release_status.add_argument(
         "--require-sync",
         action="store_true",
         help="Exit nonzero when the active local release branch is not in sync with its preferred upstream ref.",
     )
-    main_status.set_defaults(func=command_main_status)
+    release_status.set_defaults(func=command_release_status)
 
 
 def add_pr_preparation_commands(subparsers) -> None:
@@ -1277,31 +1275,30 @@ def add_landing_commands(subparsers) -> None:
     )
     require_role.set_defaults(func=command_require_branch_role)
 
-    land_main = subparsers.add_parser(
+    land_release = subparsers.add_parser(
         "land-release",
-        aliases=["land-main"],
         help="Fast-forward land one reviewed source ref onto the active root release branch, optionally push, and clean up the source branch.",
     )
-    land_main.add_argument(
+    land_release.add_argument(
         "source",
         help="Source ref to land onto the active release branch. This must be a fast-forward descendant of that local release branch.",
     )
-    land_main.add_argument(
+    land_release.add_argument(
         "--no-push",
         action="store_true",
         help="Update the local release branch but do not push the matching `origin/<release>` branch afterward.",
     )
-    land_main.add_argument(
+    land_release.add_argument(
         "--cleanup",
         action="store_true",
         help="After landing, remove the source worktree and delete the source branch when it can be identified safely.",
     )
-    land_main.add_argument(
+    land_release.add_argument(
         "--keep-remote",
         action="store_true",
         help="With `--cleanup`, keep the remote source branch instead of deleting it.",
     )
-    land_main.set_defaults(func=command_land_main)
+    land_release.set_defaults(func=command_land_release)
 
 
 def add_worktree_commands(subparsers) -> None:

--- a/scripts/blueprint_harness_branches.py
+++ b/scripts/blueprint_harness_branches.py
@@ -333,10 +333,6 @@ def is_ancestor(repo_root: Path, ancestor: str, descendant: str) -> bool:
     )
 
 
-def preferred_main_ref(repo_root: Path) -> str:
-    return preferred_release_ref(repo_root)
-
-
 def current_branch_name(repo_root: Path) -> str | None:
     branch = subprocess.run(
         ["git", "branch", "--show-current"],
@@ -376,8 +372,8 @@ def ref_sync_status(repo_root: Path, local_ref: str, upstream_ref: str) -> RefSy
     )
 
 
-def main_sync_status(repo_root: Path) -> RefSyncStatus:
-    upstream_ref = preferred_main_ref(repo_root)
+def release_sync_status(repo_root: Path) -> RefSyncStatus:
+    upstream_ref = preferred_release_ref(repo_root)
     return ref_sync_status(repo_root, local_release_ref(repo_root), upstream_ref)
 
 

--- a/scripts/blueprint_harness_cli.py
+++ b/scripts/blueprint_harness_cli.py
@@ -60,10 +60,9 @@ def add_allow_local_build_argument(command_parser: argparse.ArgumentParser, *, h
     )
 
 
-def add_allow_unsafe_root_main_argument(command_parser: argparse.ArgumentParser) -> None:
+def add_allow_unsafe_root_release_argument(command_parser: argparse.ArgumentParser) -> None:
     command_parser.add_argument(
         "--allow-unsafe-root-release",
-        "--allow-unsafe-root-main",
         dest="allow_unsafe_root_release",
         action="store_true",
         help="Allow this command to run from the root checkout even when the active release branch is dirty or out of sync.",

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -13,14 +13,14 @@ from scripts.blueprint_harness_branches import (
     active_release_branch,
     current_branch_name,
     local_release_ref,
-    main_sync_status,
+    release_sync_status,
     ref_oid,
     ref_sync_status,
     root_checkout_namespace,
 )
 from scripts.blueprint_harness_cli import (
     add_allow_local_build_argument,
-    add_allow_unsafe_root_main_argument,
+    add_allow_unsafe_root_release_argument,
     add_manifest_argument,
     add_output_root_argument,
     add_project_selection_argument,
@@ -550,7 +550,7 @@ def should_use_local_build(layout, allow_local_build: bool) -> bool:
     return (not layout.in_linked_worktree) or allow_local_build
 
 
-def root_main_safety_findings(layout) -> list[str]:
+def root_release_safety_findings(layout) -> list[str]:
     if layout.in_linked_worktree:
         return []
     release_branch = active_release_branch(layout.repo_root)
@@ -560,14 +560,14 @@ def root_main_safety_findings(layout) -> list[str]:
     findings: list[str] = []
     if not worktree_is_clean(layout.package_root):
         findings.append("root checkout has local modifications")
-    status = main_sync_status(layout.repo_root)
+    status = release_sync_status(layout.repo_root)
     if status.relationship != "in_sync":
         findings.append(f"local `{release_branch}` is {status.relationship} relative to `{status.upstream_ref}`")
     return findings
 
 
-def require_safe_root_main(layout, *, allow_unsafe: bool, command_name: str) -> None:
-    findings = root_main_safety_findings(layout)
+def require_safe_root_release(layout, *, allow_unsafe: bool, command_name: str) -> None:
+    findings = root_release_safety_findings(layout)
     if not findings:
         return
 
@@ -717,7 +717,7 @@ def generate_projects(
 
 def command_generate(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
-    require_safe_root_main(layout, allow_unsafe=args.allow_unsafe_root_release, command_name="generate")
+    require_safe_root_release(layout, allow_unsafe=args.allow_unsafe_root_release, command_name="generate")
     output_root = resolve_output_root(selected_output_root(args), Path(__file__))
     manifest_path, _catalog, release_id, projects = select_reference_projects_from_args(layout, args)
     require_checkout_release(layout, release_id, command_name="generate")
@@ -794,7 +794,7 @@ def project_validation_failures(
 
 def command_validate(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
-    require_safe_root_main(layout, allow_unsafe=args.allow_unsafe_root_release, command_name="validate")
+    require_safe_root_release(layout, allow_unsafe=args.allow_unsafe_root_release, command_name="validate")
     output_root = resolve_output_root(selected_output_root(args), Path(__file__))
     _manifest_path, _catalog, release_id, projects = select_reference_projects_from_args(layout, args)
     require_checkout_release(layout, release_id, command_name="validate")
@@ -866,14 +866,14 @@ def command_status(args: argparse.Namespace) -> int:
     release_target = resolve_release_target(catalog, release_id, layout.package_root)
     release_branch = release_target.branch
     upstream_ref = f"origin/{release_branch}"
-    main_status = ref_sync_status(layout.package_root, release_branch, upstream_ref)
+    release_status = ref_sync_status(layout.package_root, release_branch, upstream_ref)
     print(f"project_manifest={manifest_path}")
     print(f"selected_release_target={release_id}")
     print(f"verso_blueprint_ref={release_branch}")
-    print(f"preferred_release_ref={main_status.upstream_ref}")
-    print(f"release_relationship={main_status.relationship}")
-    print(f"release_oid={main_status.local_oid or ''}")
-    print(f"{main_status.upstream_ref}_oid={main_status.upstream_oid or ''}")
+    print(f"preferred_release_ref={release_status.upstream_ref}")
+    print(f"release_relationship={release_status.relationship}")
+    print(f"release_oid={release_status.local_oid or ''}")
+    print(f"{release_status.upstream_ref}_oid={release_status.upstream_oid or ''}")
 
     for project in projects:
         print_reference_project_status(
@@ -934,7 +934,7 @@ def command_release_status(args: argparse.Namespace) -> int:
 
 def command_reference_sync(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
-    require_safe_root_main(layout, allow_unsafe=args.allow_unsafe_root_release, command_name="sync")
+    require_safe_root_release(layout, allow_unsafe=args.allow_unsafe_root_release, command_name="sync")
     _manifest_path, _catalog, release_id, projects = select_reference_projects_from_args(layout, args)
     require_checkout_release(layout, release_id, command_name="sync")
     sync_reference_blueprints(
@@ -1086,7 +1086,7 @@ def add_generation_commands(subparsers) -> None:
         action="store_true",
         help="Skip project builds and only run already-built or command-only generation steps.",
     )
-    add_allow_unsafe_root_main_argument(generate)
+    add_allow_unsafe_root_release_argument(generate)
     add_serial_argument(generate)
     add_allow_local_build_argument(
         generate,
@@ -1118,7 +1118,7 @@ def add_generation_commands(subparsers) -> None:
         action="store_true",
         help="Skip configured Playwright browser regression suites.",
     )
-    add_allow_unsafe_root_main_argument(validate)
+    add_allow_unsafe_root_release_argument(validate)
     add_serial_argument(validate)
     validate.add_argument(
         "--pytest-arg",
@@ -1202,7 +1202,7 @@ def add_checkout_sync_commands(subparsers) -> None:
         action="store_true",
         help="Update and clone the reference projects without warming their build artifacts.",
     )
-    add_allow_unsafe_root_main_argument(sync)
+    add_allow_unsafe_root_release_argument(sync)
     sync.add_argument(
         "--skip-local-checkout",
         action="store_true",

--- a/src/VersoBlueprint/Commands/Common.lean
+++ b/src/VersoBlueprint/Commands/Common.lean
@@ -552,17 +552,8 @@ def previewHoverUtilsJs : String := r##"(function () {
   function normalizePreviewMode(rawMode, fallback) {
     const defaultMode = fallback === "hover" || fallback === "pinned" ? fallback : "hover";
     const mode = String(rawMode || "").trim().toLowerCase();
-    if (mode === "hover" || mode === "transient") return "hover";
-    if (
-      mode === "pinned" ||
-      mode === "pin" ||
-      mode === "click" ||
-      mode === "click-to-pin" ||
-      mode === "click-and-stay" ||
-      mode === "click-to-stay"
-    ) {
-      return "pinned";
-    }
+    if (mode === "hover") return "hover";
+    if (mode === "pinned") return "pinned";
     return defaultMode;
   }
 
@@ -570,23 +561,8 @@ def previewHoverUtilsJs : String := r##"(function () {
     const defaultPlacement =
       fallback === "anchored" || fallback === "docked" ? fallback : "anchored";
     const placement = String(rawPlacement || "").trim().toLowerCase();
-    if (
-      placement === "anchored" ||
-      placement === "anchor" ||
-      placement === "near" ||
-      placement === "near-node" ||
-      placement === "node"
-    ) {
-      return "anchored";
-    }
-    if (
-      placement === "docked" ||
-      placement === "dock" ||
-      placement === "fixed" ||
-      placement === "panel"
-    ) {
-      return "docked";
-    }
+    if (placement === "anchored") return "anchored";
+    if (placement === "docked") return "docked";
     return defaultPlacement;
   }
 
@@ -967,8 +943,6 @@ def previewHoverUtilsJs : String := r##"(function () {
     bindCloseOnce: bindCloseOnce,
     positionAnchoredPanel: positionAnchoredPanel,
     shouldKeepOpen: shouldKeepOpen,
-    normalizePreviewMode: normalizePreviewMode,
-    normalizePreviewPlacement: normalizePreviewPlacement,
     readPanelBehavior: readPanelBehavior,
     resetPanelPosition: resetPanelPosition,
     configureCloseButton: configureCloseButton,

--- a/src/VersoBlueprint/Commands/Graph.lean
+++ b/src/VersoBlueprint/Commands/Graph.lean
@@ -57,12 +57,12 @@ register_option verso.blueprint.graph.defaultPack : Bool := {
 
 register_option verso.blueprint.graph.defaultPreviewMode : String := {
   defValue := "pinned"
-  descr := "Default preview behavior for `blueprint_graph` when `(preview := ...)` is omitted (`pinned`/`click` or `hover`)"
+  descr := "Default preview behavior for `blueprint_graph` when `(preview := ...)` is omitted (`pinned` or `hover`)"
 }
 
 register_option verso.blueprint.graph.defaultPreviewPlacement : String := {
   defValue := "docked"
-  descr := "Default preview panel placement for `blueprint_graph` when `(previewPlacement := ...)` is omitted (`docked`/`fixed` or `anchored`/`near-node`)"
+  descr := "Default preview panel placement for `blueprint_graph` when `(previewPlacement := ...)` is omitted (`docked` or `anchored`)"
 }
 
 structure GraphOptions where
@@ -87,15 +87,14 @@ def graphPackAttr (pack : Bool) : String :=
 
 def parseGraphPreviewMode? (s : String) : Option Informal.HoverRender.PreviewMode :=
   match s.trimAscii.toString.toLower with
-  | "hover" | "transient" => some .hover
-  | "pinned" | "pin" | "click" | "click-to-pin" | "click-and-stay" | "click-to-stay" =>
-      some .pinned
+  | "hover" => some .hover
+  | "pinned" => some .pinned
   | _ => none
 
 def parseGraphPreviewPlacement? (s : String) : Option Informal.HoverRender.PreviewPlacement :=
   match s.trimAscii.toString.toLower with
-  | "docked" | "dock" | "fixed" | "panel" => some .docked
-  | "anchored" | "anchor" | "near" | "near-node" | "node" => some .anchored
+  | "docked" => some .docked
+  | "anchored" => some .anchored
   | _ => none
 
 /-- Common DOT header for rendered Blueprint graphs.
@@ -713,34 +712,34 @@ instance : FromArgVal GraphDirection Verso.Doc.Elab.PartElabM where
 
 instance : FromArgVal Informal.HoverRender.PreviewMode Verso.Doc.Elab.PartElabM where
   fromArgVal := {
-    description := doc!"graph preview mode (`pinned`/`click` or `hover`)"
+    description := doc!"graph preview mode (`pinned` or `hover`)"
     signature := CanMatch.Ident ∪ CanMatch.String
     get := fun
       | .name id =>
         match parseGraphPreviewMode? id.getId.toString with
         | some mode => pure mode
-        | none => throwErrorAt id "Expected `pinned`, `click`, or `hover`"
+        | none => throwErrorAt id "Expected `pinned` or `hover`"
       | .str s =>
         match parseGraphPreviewMode? s.getString with
         | some mode => pure mode
-        | none => throwErrorAt s "Expected \"pinned\", \"click\", or \"hover\""
+        | none => throwErrorAt s "Expected \"pinned\" or \"hover\""
       | other =>
         throwError "Expected a preview mode identifier or string, got {toMessageData other}"
   }
 
 instance : FromArgVal Informal.HoverRender.PreviewPlacement Verso.Doc.Elab.PartElabM where
   fromArgVal := {
-    description := doc!"graph preview placement (`docked`/`fixed` or `anchored`/`near-node`)"
+    description := doc!"graph preview placement (`docked` or `anchored`)"
     signature := CanMatch.Ident ∪ CanMatch.String
     get := fun
       | .name id =>
         match parseGraphPreviewPlacement? id.getId.toString with
         | some placement => pure placement
-        | none => throwErrorAt id "Expected `docked`, `fixed`, `anchored`, or `near-node`"
+        | none => throwErrorAt id "Expected `docked` or `anchored`"
       | .str s =>
         match parseGraphPreviewPlacement? s.getString with
         | some placement => pure placement
-        | none => throwErrorAt s "Expected \"docked\", \"fixed\", \"anchored\", or \"near-node\""
+        | none => throwErrorAt s "Expected \"docked\" or \"anchored\""
       | other =>
         throwError "Expected a preview placement identifier or string, got {toMessageData other}"
   }
@@ -793,7 +792,7 @@ def parseGraphPreviewMode
     match parseGraphPreviewMode? configured with
     | some mode => pure mode
     | none =>
-      logWarning m!"Invalid value '{configured}' for option 'verso.blueprint.graph.defaultPreviewMode'; expected pinned, click, or hover. Falling back to pinned."
+      logWarning m!"Invalid value '{configured}' for option 'verso.blueprint.graph.defaultPreviewMode'; expected pinned or hover. Falling back to pinned."
       pure .pinned
   | some mode => pure mode
 
@@ -808,7 +807,7 @@ def parseGraphPreviewPlacement
     match parseGraphPreviewPlacement? configured with
     | some placement => pure placement
     | none =>
-      logWarning m!"Invalid value '{configured}' for option 'verso.blueprint.graph.defaultPreviewPlacement'; expected docked, fixed, anchored, or near-node. Falling back to docked."
+      logWarning m!"Invalid value '{configured}' for option 'verso.blueprint.graph.defaultPreviewPlacement'; expected docked or anchored. Falling back to docked."
       pure .docked
   | some placement => pure placement
 

--- a/src/VersoBlueprint/Data.lean
+++ b/src/VersoBlueprint/Data.lean
@@ -533,8 +533,9 @@ inductive CodeRef where
   - informal object labels are blueprint-owned metadata;
   - `(lean := "...")` declaration names are Lean-owned and must not be rewritten by blueprint label policies.
 
-  TODO (external-definitions task): complete and encode the intended behavior from
-  the "We'd like to:" portion of the design spec.
+  External-definition metadata should be attached to `ExternalRef` or a sibling
+  external-declaration record. The `.external` names themselves remain Lean
+  declaration names, not Blueprint labels.
   -/
   | external (decls : Array ExternalRef)
   | literate (code : Code)

--- a/src/VersoBlueprint/Environment.lean
+++ b/src/VersoBlueprint/Environment.lean
@@ -14,7 +14,14 @@ namespace Informal.Environment
 open Lean
 open Informal.Data
 
--- TODO: Consolidate with Data.Node
+/--
+Elaboration-time builder for a node that is currently open on the directive
+stack.
+
+This intentionally stays separate from `Data.Node`: it carries phase-specific
+inputs such as preview blocks and elaboration syntax before the final persisted
+semantic node can be assembled.
+-/
 structure InProgress where
   label : Label
   kind : Data.InProgressKind := .proof
@@ -41,7 +48,14 @@ structure ImportedConflict where
   label : Name
 deriving Inhabited, Repr, DecidableEq
 
--- TODO: Consolidate with traversal information
+/--
+Persisted semantic state collected during elaboration.
+
+Rendered traversal stores project from this state and add site-local facts such
+as numbering, hrefs, preview ids, and HTML-cache keys. Keep those traversal
+facts out of this environment extension unless they become stable semantic
+data.
+-/
 structure State where
   data : Data := Data.empty
   localData : NameMap Node := {}

--- a/src/VersoBlueprint/ExternalDeclRender.lean
+++ b/src/VersoBlueprint/ExternalDeclRender.lean
@@ -493,14 +493,6 @@ def renderDeclHtmlDirectFromInfoE
   catch ex =>
     return .error (.exception decl (← ex.toMessageData.toString))
 
-/--
-String compatibility wrapper over `renderDeclHtmlDirectFromInfoE`.
-Core external-rendering dataflow should use typed HTML payloads.
--/
-def renderDeclHtmlStringDirectFromInfoE
-    (decl : Name) (cinfo : ConstantInfo) : MetaM (Except ExternalDeclRenderError String) := do
-  return (← renderDeclHtmlDirectFromInfoE decl cinfo).map (·.selfContained)
-
 /-- Render one declaration directly from the in-memory `Environment` (no database, no source parsing). -/
 def renderDeclHtmlNodeDirect? (decl : Name) : MetaM (Option ExternalDeclHtml) := do
   let decl := decl.eraseMacroScopes
@@ -516,12 +508,6 @@ def renderDeclHtmlNodeDirect? (decl : Name) : MetaM (Option ExternalDeclHtml) :=
   catch ex =>
     logError m!"External declaration rendering failed for {decl}: {← ex.toMessageData.toString}"
     return none
-
-/-- String wrapper over `renderDeclHtmlNodeDirect?`. -/
-def renderDeclHtmlStringDirect? (decl : Name) : MetaM (Option String) := do
-  match ← renderDeclHtmlNodeDirect? decl with
-  | some html => return some html.asString
-  | none => return none
 
 /--
 Optional fallback path for non-`MetaM` contexts.

--- a/src/VersoBlueprint/Graft.lean
+++ b/src/VersoBlueprint/Graft.lean
@@ -26,14 +26,6 @@ open Verso.Genre Manual
 open Verso.Output
 open Verso.Output.Html
 
-private def renderNotice (kind title detail : String) : Html :=
-  {{
-    <div class={{"bp_graft_node_notice bp_graft_node_notice_" ++ kind}}>
-      <strong>{{Html.ofString title}}</strong><br/>
-      {{Html.ofString detail}}
-    </div>
-  }}
-
 private def manualNodeClass (node : Informal.Graft.BlueprintNode) : String :=
   if node.compact then
     "bp_graft_node bp_graft_manifest_node bp_graft_node_compact"
@@ -125,11 +117,13 @@ private def renderManualGraftNode
   match Informal.PreviewManifest.findTraversalBlockEntry? state node.key with
   | none =>
       pure <| Html.tag "div" (manualNodeAttrs node) <|
-        renderNotice "error" "Blueprint node not found" node.selectionDescription
+        renderNotice "bp_graft_node_notice" "error" "Blueprint node not found"
+          node.selectionDescription
   | some (preview, entry) =>
       if preview.blocks.isEmpty then
         pure <| Html.tag "div" (manualNodeAttrs node) <|
-          renderNotice "error" "Blueprint node has no cached content" node.key
+          renderNotice "bp_graft_node_notice" "error"
+            "Blueprint node has no cached content" node.key
       else
         let body ← renderManualBlocks goB preview.blocks
         let codeBodies ←
@@ -214,7 +208,7 @@ public meta def blueprintSideBySide : DirectiveExpanderOf Informal.Graft.SideByS
             (Informal.Graft.Block.blueprintGraftSideBySide $(quote cfg))
             #[$contents,*])
       else if ← inSlidesGenre then
-        let attrs := cfg.slideAttrs
+        let attrs := Informal.Slides.sideBySideAttrs cfg
         ``(Verso.Doc.Block.other
             (VersoSlides.BlockExt.wrap $(quote attrs))
             #[$contents,*])

--- a/src/VersoBlueprint/Graft/Node.lean
+++ b/src/VersoBlueprint/Graft/Node.lean
@@ -104,16 +104,6 @@ def BlueprintNode.fromAttrs? (attrs : Array (String × String)) : Option Bluepri
 def BlueprintNode.renderedAttrs (node : BlueprintNode) : Array (String × String) :=
   node.toAttrs ++ #[("data-bp-rendered", "static")]
 
-def BlueprintNode.slideAttrs (node : BlueprintNode) : Array (String × String) :=
-  appendClassAttr node.toAttrs <|
-    if node.compact then
-      "bp_slide_node bp_slide_node_compact"
-    else
-      "bp_slide_node"
-
-def BlueprintNode.slideRenderedAttrs (node : BlueprintNode) : Array (String × String) :=
-  node.slideAttrs ++ #[("data-bp-rendered", "static")]
-
 /-- Rendered DOM attributes with one additional CSS class. -/
 def BlueprintNode.renderedAttrsWithClass (node : BlueprintNode) (className : String) :
     Array (String × String) :=
@@ -180,14 +170,8 @@ public def className (cfg : SideBySideConfig) : String :=
   else
     "bp_graft_side_by_side"
 
-public def slideClassName (cfg : SideBySideConfig) : String :=
-  cfg.className ++ " bp_slide_graft_side_by_side"
-
 public def attrs (cfg : SideBySideConfig) : Array (String × String) :=
   #[("class", cfg.className)]
-
-public def slideAttrs (cfg : SideBySideConfig) : Array (String × String) :=
-  #[("class", cfg.slideClassName)]
 
 end SideBySideConfig
 

--- a/src/VersoBlueprint/Graft/Render.lean
+++ b/src/VersoBlueprint/Graft/Render.lean
@@ -15,8 +15,7 @@ open Verso.Output
 open Verso.Output.Html
 
 public structure RenderContext where
-  manifest? : Option Informal.PreviewManifest.File := none
-  index : Informal.PreviewManifest.Index := {}
+  manifestIndex? : Option Informal.PreviewManifest.Index := none
   htmlCacheIndex : Informal.PreviewManifest.HtmlCache.Index := {}
   logError : String → IO Unit := fun _ => pure ()
 
@@ -28,15 +27,10 @@ public def ofPreviewData?
     (logError : String → IO Unit := fun _ => pure ()) : RenderContext :=
   let htmlCache := htmlCache?.getD {}
   {
-    manifest?
-    index := manifest?.map (·.index) |>.getD {}
+    manifestIndex? := manifest?.map (·.index)
     htmlCacheIndex := htmlCache.index
     logError
   }
-
-public def findEntry? (ctx : RenderContext) (key : String) :
-    Option Informal.PreviewManifest.Entry :=
-  ctx.index.findEntry? key
 
 public def renderedContent?
     (ctx : RenderContext)
@@ -61,11 +55,17 @@ public def renderedContent?
 
 end RenderContext
 
-private def defaultRenderMissingNode (node : BlueprintNode) (title detail : String) : Html :=
-  .tag "div" node.renderedAttrs <| {{
-    <strong>{{Html.ofString title}}</strong><br/>
-    {{Html.ofString detail}}
+public def renderNotice (baseClass kind title detail : String) : Html :=
+  {{
+    <div class={{baseClass ++ " " ++ baseClass ++ "_" ++ kind}}>
+      <strong>{{Html.ofString title}}</strong><br/>
+      {{Html.ofString detail}}
+    </div>
   }}
+
+private def defaultRenderMissingNode (node : BlueprintNode) (title detail : String) : Html :=
+  .tag "div" node.renderedAttrs <|
+    renderNotice "bp_graft_node_notice" "error" title detail
 
 public structure ManifestRenderConfig where
   blockRenderConfig : Informal.PreviewManifest.BlockRender.RenderConfig := {}
@@ -101,20 +101,20 @@ public def renderNodeFromManifestCache
     (cfg : ManifestRenderConfig)
     (ctx : RenderContext)
     (node : BlueprintNode) : IO Html := do
-  match ctx.manifest? with
+  match ctx.manifestIndex? with
   | none =>
-      pure <| cfg.renderMissingNode node "Preview manifest unavailable"
-        cfg.manifestUnavailableDetail
-  | some _manifest =>
-      match ctx.findEntry? node.key with
-      | none =>
-          pure <| cfg.renderMissingNode node "Blueprint node not found" node.selectionDescription
-      | some entry =>
-          match ← ctx.renderedContent? node entry with
-          | none =>
-              pure <| cfg.renderMissingNode node "Blueprint HTML cache entry not found" entry.key
-          | some content =>
-              pure <| renderNodeWithContent cfg node entry content
+    pure <| cfg.renderMissingNode node "Preview manifest unavailable"
+      cfg.manifestUnavailableDetail
+  | some index =>
+    match index.findEntry? node.key with
+    | none =>
+        pure <| cfg.renderMissingNode node "Blueprint node not found" node.selectionDescription
+    | some entry =>
+        match ← ctx.renderedContent? node entry with
+        | none =>
+            pure <| cfg.renderMissingNode node "Blueprint HTML cache entry not found" entry.key
+        | some content =>
+            pure <| renderNodeWithContent cfg node entry content
 
 public def readBlueprintManifest (path : System.FilePath) :
     IO Informal.PreviewManifest.File :=

--- a/src/VersoBlueprint/Graph.lean
+++ b/src/VersoBlueprint/Graph.lean
@@ -18,7 +18,7 @@ See `doc/DESIGN_RATIONALE.md` for the human-readable graph
 status/completion and warning/color mapping rationale.
 -/
 
-/-- Upstream-compatible statement-track status (node border). -/
+/-- Upstream-aligned statement-track status (node border). -/
 inductive StatementStatus where
   | blocked
   | ready
@@ -26,7 +26,7 @@ inductive StatementStatus where
   | mathlib
 deriving Inhabited, Repr, DecidableEq, ToJson, FromJson
 
-/-- Upstream-compatible background status (proof-track for theorem-like nodes). -/
+/-- Upstream-aligned background status (proof-track for theorem-like nodes). -/
 inductive ProofStatus where
   | none
   | ready

--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -104,7 +104,7 @@ block_extension Block.informal (data : BlockData) where
         let getDeclHref (decl : Name) : Option String :=
           Resolve.resolveInformalDeclHref? s data.label decl
         let getDeclAnchorAttrs (decl : Data.ExternalRef) : Array (String × String) :=
-          Informal.TraversalIndex.ExternalDeclAnchors.refHtmlIdAttrs s data.label decl
+          Informal.TraversalIndex.ExternalDeclAnchors.htmlIdAttrs s data.label decl.canonical
         let cdata := {
           codeHref
           source := codeSource

--- a/src/VersoBlueprint/Informal/Block/Assets.lean
+++ b/src/VersoBlueprint/Informal/Block/Assets.lean
@@ -69,7 +69,7 @@ span[class$="_thmlabel"]::after {
 
 .bp_extras {
   --bp-extra-group-col: minmax(5rem, max-content);
-  --bp-extra-uses-col: minmax(4.2rem, max-content);
+  --bp-extra-uses-col: minmax(5.2rem, max-content);
   --bp-extra-used-by-col: minmax(7.2rem, max-content);
   --bp-extra-code-col: max-content;
   --bp-extra-code-placeholder-col: minmax(3.35rem, max-content);
@@ -105,20 +105,6 @@ span[class$="_thmlabel"]::after {
     var(--bp-extra-used-by-col)
     var(--bp-extra-code-col);
   grid-template-areas: "group used code";
-}
-
-.bp_extras_with_uses {
-  grid-template-columns: minmax(5.2rem, max-content) max-content minmax(7.2rem, max-content);
-  grid-template-areas: "uses used code";
-}
-
-.bp_extras_with_group.bp_extras_with_uses {
-  grid-template-columns:
-    minmax(5rem, max-content)
-    minmax(5.2rem, max-content)
-    minmax(7.2rem, max-content)
-    max-content;
-  grid-template-areas: "group uses used code";
 }
 
 .bp_extras_with_group.bp_extras_with_uses {

--- a/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
+++ b/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
@@ -146,8 +146,6 @@ private def usesPanelConfigForScope (sourceLabel : Data.Label) (scope : UsesScop
     s!"{scope.titlecase} dependency preview"
   previewEmptyText :=
     s!"{scope.titlecase} dependency preview content is loaded from the Blueprint HTML cache."
-  chipClass := "bp_relation_chip bp_uses_chip"
-  emptyChipClass := "bp_relation_chip bp_relation_chip_empty bp_uses_chip"
 }
 
 /-- Standard forward-dependency panel presentation for statement dependencies. -/
@@ -342,24 +340,24 @@ private def groupPreviewId (targetLabel sourceLabel : Data.Label) : String :=
 private def previewLookupKey (source : BlockData) : String :=
   PreviewCache.key source.label (PreviewCache.Facet.ofInProgressKind source.kind)
 
-/-- Render a relation-row badge with both legacy and semantic styling classes. -/
+/-- Render a relation-row badge with semantic relation styling classes. -/
 private def relationBadge (className title text : String) : Output.Html :=
   open Verso.Output.Html in
   {{<span class={{className}} title={{title}}>{{.text true text}}</span>}}
 
 private def useOriginBadgeClass : Data.UseOrigin → String
   | .manual =>
-    "bp_relation_axis_badge bp_relation_badge_origin bp_uses_origin_badge bp_relation_badge_origin_manual"
+    "bp_relation_axis_badge bp_relation_badge_origin bp_relation_badge_origin_manual"
   | .automatic =>
-    "bp_relation_axis_badge bp_relation_badge_origin bp_uses_origin_badge bp_relation_badge_origin_automatic"
+    "bp_relation_axis_badge bp_relation_badge_origin bp_relation_badge_origin_automatic"
 
 private def useIntentBadgeClass : Data.UseIntent → String
   | .regular =>
-    "bp_relation_axis_badge bp_relation_badge_intent bp_uses_intent_badge bp_relation_badge_intent_regular"
+    "bp_relation_axis_badge bp_relation_badge_intent bp_relation_badge_intent_regular"
   | .auxiliary =>
-    "bp_relation_axis_badge bp_relation_badge_intent bp_uses_intent_badge bp_relation_badge_intent_auxiliary"
+    "bp_relation_axis_badge bp_relation_badge_intent bp_relation_badge_intent_auxiliary"
   | .technical =>
-    "bp_relation_axis_badge bp_relation_badge_intent bp_uses_intent_badge bp_relation_badge_intent_technical"
+    "bp_relation_axis_badge bp_relation_badge_intent bp_relation_badge_intent_technical"
 
 private def renderAxisBadges (inStatement inProof : Bool) : Output.Html :=
   let statementBadge : Array Output.Html :=

--- a/src/VersoBlueprint/Informal/ExternalCode.lean
+++ b/src/VersoBlueprint/Informal/ExternalCode.lean
@@ -177,23 +177,35 @@ private def externalDeclGapStatusText? (item : LinkedExternalDecl) : Option Stri
   else
     none
 
-private def externalDeclStatusClass (item : LinkedExternalDecl) : String :=
-  if !item.decl.present then
-    "bp_external_decl_missing"
-  else if (externalRenderFailure? item.decl).isSome then
-    "bp_external_decl_error"
-  else if externalDeclHasGap item.decl then
-    "bp_external_decl_sorry"
-  else
-    "bp_external_decl_ok"
+/--
+Status-derived rendering data for one linked external declaration.
 
-private def externalDeclPanelStatusText (item : LinkedExternalDecl) : String :=
-  if !item.decl.present then
-    "missing declaration"
-  else if (externalRenderFailure? item.decl).isSome then
-    "render failed"
-  else
-    (externalDeclGapStatusText? item).getD "complete"
+The panel badge and rendered footer intentionally share one view so status
+wording and CSS classification cannot drift between compact and expanded rows.
+-/
+private structure ExternalDeclStatusView where
+  className : String
+  panelText : String
+  renderedMetaText : String
+
+private def externalDeclStatusView (item : LinkedExternalDecl) : ExternalDeclStatusView :=
+  let className :=
+    if !item.decl.present then
+      "bp_external_decl_missing"
+    else if (externalRenderFailure? item.decl).isSome then
+      "bp_external_decl_error"
+    else if externalDeclHasGap item.decl then
+      "bp_external_decl_sorry"
+    else
+      "bp_external_decl_ok"
+  let panelText :=
+    if !item.decl.present then
+      "missing declaration"
+    else if (externalRenderFailure? item.decl).isSome then
+      "render failed"
+    else
+      (externalDeclGapStatusText? item).getD "complete"
+  { className, panelText, renderedMetaText := panelText }
 
 private def externalDeclNode (item : LinkedExternalDecl) : Output.Html :=
   open Verso.Output.Html in
@@ -219,41 +231,25 @@ private structure ExternalDeclRowData where
   body : Output.Html := .empty
   footer : Output.Html := .empty
 
-private def externalDeclHead (item : LinkedExternalDecl) (statusTxt : String) : Output.Html :=
+private def externalDeclHead (item : LinkedExternalDecl) (status : ExternalDeclStatusView) : Output.Html :=
   open Verso.Output.Html in
-  let statusClass := externalDeclStatusClass item
   {{
     <div class="bp_external_decl_head">
       {{externalDeclNode item}}
-      <span class={{statusClass}}>{{.text true statusTxt}}</span>
+      <span class={{status.className}}>{{.text true status.panelText}}</span>
     </div>
   }}
 
-/--
-TODO(external-code): revisit footer/status semantics once we surface real
-out-of-workspace declarations and can distinguish "declaration complete" from
-"declaration plus dependencies complete". For now, keep the footer minimal and
-avoid repeating declaration kind/provenance that is either redundant or
-misleading in Noperthedron.
--/
-private def externalDeclRenderedMetaText (_item : LinkedExternalDecl) (statusTxt : String) : String :=
-  let parts :=
-    #[
-      some statusTxt
-    ].filterMap id
-  String.intercalate " · " parts.toList
-
 private def externalDeclRenderedMeta
-    (item : LinkedExternalDecl) (statusTxt : String) (includeStatus : Bool := true) : Output.Html :=
+    (item : LinkedExternalDecl) (status : ExternalDeclStatusView) (includeStatus : Bool := true) : Output.Html :=
   open Verso.Output.Html in
   if !includeStatus then
     .empty
   else
-  let metaText := externalDeclRenderedMetaText item statusTxt
-  let statusClass := externalDeclStatusClass item
+  let metaText := status.renderedMetaText
   let statusBadge : Output.Html :=
     if !metaText.isEmpty then
-      {{<span class={{s!"bp_external_status_badge bp_external_decl_footer_status {statusClass}"}}>{{.text true metaText}}</span>}}
+      {{<span class={{s!"bp_external_status_badge bp_external_decl_footer_status {status.className}"}}>{{.text true metaText}}</span>}}
     else
       .empty
   let sourceRef? := externalDeclSourceRef? item
@@ -331,11 +327,11 @@ private def missingExternalDeclBody : Output.Html :=
 private def externalDeclRowDataWith [Monad m]
     (renderBody : LinkedExternalDecl → m Output.Html)
     (item : LinkedExternalDecl) : m ExternalDeclRowData := do
-  let statusTxt := externalDeclPanelStatusText item
+  let status := externalDeclStatusView item
   if !item.decl.present then
     pure {
       liAttrs := #[("class", "bp_external_decl_item")] ++ item.anchorAttrs
-      head := externalDeclHead item statusTxt
+      head := externalDeclHead item status
       body := missingExternalDeclBody
     }
   else
@@ -343,15 +339,15 @@ private def externalDeclRowDataWith [Monad m]
     if (externalRenderFailure? item.decl).isSome then
       pure {
         liAttrs := #[("class", "bp_external_decl_item")] ++ item.anchorAttrs
-        head := externalDeclHead item statusTxt
+        head := externalDeclHead item status
         body
-        footer := externalDeclRenderedMeta item statusTxt
+        footer := externalDeclRenderedMeta item status
       }
     else
       pure {
         liAttrs := #[("class", "bp_external_decl_item bp_external_decl_item_rendered")] ++ item.anchorAttrs
         body
-        footer := externalDeclRenderedMeta item statusTxt (includeStatus := false)
+        footer := externalDeclRenderedMeta item status (includeStatus := false)
       }
 
 private def renderExternalDeclRow (row : ExternalDeclRowData) : Output.Html :=

--- a/src/VersoBlueprint/PreviewCache.lean
+++ b/src/VersoBlueprint/PreviewCache.lean
@@ -31,9 +31,12 @@ def key (label : Name) (facet : Facet) : String :=
 /--
 Preview payload stored during traversal.
 `blocks` are already in the Manual genre and can be rendered by later HTML consumers.
+
+This is a traversal-phase cache, not the canonical semantic node record. The
+interactive widget path still reads syntax from `Environment.InProgress`
+because it needs elaboration-time data before Manual preview blocks are
+available.
 -/
--- TODO: long-term, consider a single shared preview representation that can also
--- serve the widget path (currently fed from `elabStx`) in a phase-safe way.
 structure Entry where
   label : Name
   facet : Facet

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -1622,6 +1622,8 @@ def blueprintMainWithPreviewData
   blueprintMain text (extensionImpls := extensionImpls) (options := options) (config := config)
     (extraSteps := emitBlueprintPreviewData extensionImpls :: extraSteps)
 
+-- Compatibility for reference generators pinned before preview data was renamed.
+@[deprecated blueprintMainWithPreviewData (since := "2026-06-08")]
 def manualMainWithPreviewData
     (text : Part Manual)
     (options : List String)
@@ -1630,14 +1632,13 @@ def manualMainWithPreviewData
     (extraSteps : List ExtraStep := []) : IO UInt32 :=
   blueprintMainWithPreviewData text options extensionImpls config extraSteps
 
--- Compatibility for reference generators pinned before preview data was renamed.
-@[deprecated manualMainWithPreviewData (since := "2026-06-08")]
+@[deprecated blueprintMainWithPreviewData (since := "2026-06-08")]
 def manualMainWithSharedPreviewManifest
     (text : Part Manual)
     (options : List String)
     (extensionImpls : ExtensionImpls)
     (config : RenderConfig := {})
     (extraSteps : List ExtraStep := []) : IO UInt32 :=
-  manualMainWithPreviewData text options extensionImpls config extraSteps
+  blueprintMainWithPreviewData text options extensionImpls config extraSteps
 
 end Informal.PreviewManifest

--- a/src/VersoBlueprint/Slides.lean
+++ b/src/VersoBlueprint/Slides.lean
@@ -34,9 +34,9 @@ open Verso Doc Elab
   }
 
 /--
-Local compatibility layer pending the upstream Verso Slides `Block.ofHtml`
-constructor tracked in `doc/UPSTREAM_BACKLOG.md`: keep this close to upstream
-`slidesMain` so the copied asset/write loop can disappear.
+Local upstream workaround pending the Verso Slides `Block.ofHtml` constructor
+tracked in `doc/UPSTREAM_BACKLOG.md`: keep this close to upstream `slidesMain`
+so the copied asset/write loop can disappear.
 -/
 private def slidesMainWithBlueprintRenderer
     (config : VersoSlides.Config)
@@ -102,8 +102,8 @@ public def slidesMainWithBlueprintPreviews
   let config := withBlueprintSlidesAssets config
   let htmlCachePath? := previewHtmlCache? <|> previewManifest?.map (fun path =>
     path.parent.getD "." / Informal.PreviewManifest.htmlCacheFilename)
-  let manifest? ← previewManifest?.mapM readBlueprintManifest
-  let htmlCache? ← htmlCachePath?.mapM readBlueprintHtmlCache
+  let manifest? ← previewManifest?.mapM Informal.Graft.readBlueprintManifest
+  let htmlCache? ← htmlCachePath?.mapM Informal.Graft.readBlueprintHtmlCache
   let rc ← slidesMainWithBlueprintRenderer config manifest? htmlCache? doc (quiet := quiet)
   if rc == 0 then
     writeBlueprintSlidesJs config.outputDir

--- a/src/VersoBlueprint/Slides/Node.lean
+++ b/src/VersoBlueprint/Slides/Node.lean
@@ -13,9 +13,25 @@ namespace Informal.Slides
 open Lean
 open Verso Doc Elab
 
+public def blueprintNodeAttrs (node : Informal.Graft.BlueprintNode) :
+    Array (String × String) :=
+  Informal.Graft.appendClassAttr node.toAttrs <|
+    if node.compact then
+      "bp_slide_node bp_slide_node_compact"
+    else
+      "bp_slide_node"
+
+public def renderedBlueprintNodeAttrs (node : Informal.Graft.BlueprintNode) :
+    Array (String × String) :=
+  blueprintNodeAttrs node ++ #[("data-bp-rendered", "static")]
+
+public def sideBySideAttrs (cfg : Informal.Graft.SideBySideConfig) :
+    Array (String × String) :=
+  #[("class", cfg.className ++ " bp_slide_graft_side_by_side")]
+
 public meta def blueprintNodeBlock (cfg : Informal.Graft.BlueprintNodeConfig) : DocElabM Term := do
   let node := cfg.toNode
-  let attrs := node.slideAttrs
+  let attrs := blueprintNodeAttrs node
   let fallback := node.fallbackText
   ``(Verso.Doc.Block.other (VersoSlides.BlockExt.wrap $(quote attrs))
       #[Verso.Doc.Block.para #[Verso.Doc.Inline.text $(quote fallback)]])

--- a/src/VersoBlueprint/Slides/Render.lean
+++ b/src/VersoBlueprint/Slides/Render.lean
@@ -50,19 +50,12 @@ private def slideManifestBlockConfig : Informal.PreviewManifest.BlockRender.Rend
     }
   }
 
-private def renderNotice (kind title detail : String) : Html :=
-  {{
-    <div class={{"bp_slide_node_notice bp_slide_node_notice_" ++ kind}}>
-      <strong>{{Html.ofString title}}</strong><br/>
-      {{Html.ofString detail}}
-    </div>
-  }}
-
 private def slideNodeAttrs (node : Informal.Graft.BlueprintNode) : Array (String × String) :=
-  node.slideRenderedAttrs
+  renderedBlueprintNodeAttrs node
 
 private def renderMissingNode (node : Informal.Graft.BlueprintNode) (title detail : String) : Html :=
-  .tag "div" (slideNodeAttrs node) (renderNotice "error" title detail)
+  .tag "div" (slideNodeAttrs node) <|
+    Informal.Graft.renderNotice "bp_slide_node_notice" "error" title detail
 
 private def slideManifestRenderConfig : Informal.Graft.ManifestRenderConfig :=
   {
@@ -87,13 +80,5 @@ public def renderBlueprintSlideNodeFromAttrs?
     (attrs : Array (String × String)) : Option (IO Html) := do
   let node ← Informal.Graft.BlueprintNode.fromAttrs? attrs
   some (renderBlueprintSlideNode ctx node)
-
-def readBlueprintManifest (path : System.FilePath) :
-    IO Informal.PreviewManifest.File :=
-  Informal.Graft.readBlueprintManifest path
-
-def readBlueprintHtmlCache (path : System.FilePath) :
-    IO Informal.PreviewManifest.HtmlCache.File :=
-  Informal.Graft.readBlueprintHtmlCache path
 
 end Informal.Slides

--- a/src/VersoBlueprint/TraversalIndex.lean
+++ b/src/VersoBlueprint/TraversalIndex.lean
@@ -288,21 +288,6 @@ def htmlIdAttrs (state : TraverseState) (label decl : Name) : Array (String × S
     | some targetId => state.htmlId targetId
     | none => #[]
 
-/--
-HTML `id` attributes for an external reference row.
-
-Rendered external-declaration rows are keyed by canonical declaration names.
-The written-name fallback keeps links stable for older traversal objects that
-were stored before canonicalization became the convention.
--/
-def refHtmlIdAttrs (state : TraverseState) (label : Name)
-    (decl : Informal.Data.ExternalRef) : Array (String × String) :=
-  let canonicalAttrs := htmlIdAttrs state label decl.canonical
-  if canonicalAttrs.isEmpty then
-    htmlIdAttrs state label decl.written
-  else
-    canonicalAttrs
-
 def saveId
     (state : TraverseState) (targetKey : String) (id : Verso.Multi.InternalId) : TraverseState :=
   saveObjectId state domainName targetKey id

--- a/tests/VersoBlueprintTests/Blueprint/Support.lean
+++ b/tests/VersoBlueprintTests/Blueprint/Support.lean
@@ -61,6 +61,14 @@ def renderManualDocHtmlString (impls : ExtensionImpls) (doc : Doc.VersoDoc Genre
   let html ← renderManualDocHtml impls doc
   pure html.asString
 
+def buildManualPreviewDataFiles
+    (impls : ExtensionImpls)
+    (doc : Doc.VersoDoc Genre.Manual)
+    (logError : String → IO Unit := fun _ => pure ()) :
+    IO Informal.PreviewManifest.Files := do
+  let (_html, st) ← renderManualDocHtmlStringAndState impls doc
+  Informal.PreviewManifest.buildPreviewDataFiles impls logError st
+
 def findExtraJsContaining? (st : TraverseState) (needle : String) : Option String :=
   st.toHtmlAssets.extraJs.toArray.findSome? fun js =>
     if hasSubstr js.js needle then some js.js else none

--- a/tests/VersoBlueprintTests/BlueprintGraft.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraft.lean
@@ -134,8 +134,7 @@ private def renderAuditNode
 #guard_msgs in
 #eval
   show IO Bool from do
-    let (_out, st) ← renderManualDocHtmlStringAndState manualImpls manualSideBySideGraftDoc
-    let files ← Informal.PreviewManifest.buildPreviewDataFiles manualImpls (fun _ => pure ()) st
+    let files ← buildManualPreviewDataFiles manualImpls manualSideBySideGraftDoc
     let ctx := Informal.Graft.RenderContext.ofPreviewData? (some files.manifest) (some files.htmlCache)
     let node := { graftNode "def:graft.manual.left" with displayLabel? := some "API view" }
     let renderedHtml ← Informal.Graft.renderNodeFromManifestCache
@@ -159,8 +158,7 @@ private def renderAuditNode
 #guard_msgs in
 #eval
   show IO Bool from do
-    let (_out, st) ← renderManualDocHtmlStringAndState manualImpls manualSideBySideGraftDoc
-    let files ← Informal.PreviewManifest.buildPreviewDataFiles manualImpls (fun _ => pure ()) st
+    let files ← buildManualPreviewDataFiles manualImpls manualSideBySideGraftDoc
     let renderedHtml ← renderAuditNode files.manifest files.htmlCache "def:graft.manual.left"
     let rendered := renderedHtml.asString
     pure <|
@@ -207,8 +205,7 @@ private def renderAuditNode
 #guard_msgs in
 #eval
   show IO Bool from do
-    let (_out, st) ← renderManualDocHtmlStringAndState manualImpls manualSideBySideGraftDoc
-    let files ← Informal.PreviewManifest.buildPreviewDataFiles manualImpls (fun _ => pure ()) st
+    let files ← buildManualPreviewDataFiles manualImpls manualSideBySideGraftDoc
     let node := graftNode "def:graft.manual.missing"
     let ctx := Informal.Graft.RenderContext.ofPreviewData? (some files.manifest) (some files.htmlCache)
     let renderedHtml ← Informal.Graft.renderNodeFromManifestCache
@@ -227,10 +224,9 @@ private def renderAuditNode
 #guard_msgs in
 #eval
   show IO Bool from do
-    let (_out, st) ← renderManualDocHtmlStringAndState manualImpls manualSideBySideGraftDoc
-    let files ← Informal.PreviewManifest.buildPreviewDataFiles manualImpls (fun _ => pure ()) st
     let logs ← IO.mkRef #[]
     let logError (msg : String) : IO Unit := logs.modify (·.push msg)
+    let files ← buildManualPreviewDataFiles manualImpls manualSideBySideGraftDoc
     let node := graftNode "def:graft.manual.left"
     let ctx := Informal.Graft.RenderContext.ofPreviewData? (some files.manifest) (some {}) logError
     let renderedHtml ← Informal.Graft.renderNodeFromManifestCache

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
@@ -53,6 +53,16 @@ Base statement for graph preview mode option coverage.
 {blueprint_graph}
 :::::::
 
+#guard (Informal.Commands.parseGraphPreviewMode? "hover").map (·.dataValue) == some "hover"
+#guard (Informal.Commands.parseGraphPreviewMode? "pinned").map (·.dataValue) == some "pinned"
+#guard (Informal.Commands.parseGraphPreviewMode? "transient").isNone
+#guard (Informal.Commands.parseGraphPreviewMode? "click").isNone
+#guard (Informal.Commands.parseGraphPreviewMode? "click-to-pin").isNone
+#guard (Informal.Commands.parseGraphPreviewPlacement? "docked").map (·.dataValue) == some "docked"
+#guard (Informal.Commands.parseGraphPreviewPlacement? "anchored").map (·.dataValue) == some "anchored"
+#guard (Informal.Commands.parseGraphPreviewPlacement? "fixed").isNone
+#guard (Informal.Commands.parseGraphPreviewPlacement? "near-node").isNone
+
 /-- info: true -/
 #guard_msgs in
 #eval

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
@@ -68,6 +68,9 @@ private def samplePanelEntry : Informal.RelatedPanel.PanelEntry := {
       hasSubstr out "bp_relation_badge_origin_automatic" &&
       hasSubstr out "bp_relation_badge_intent_technical" &&
       hasSubstr out "bp_relation_badge_intent_auxiliary" &&
+      !hasSubstr out "bp_uses_chip" &&
+      !hasSubstr out "bp_uses_origin_badge" &&
+      !hasSubstr out "bp_uses_intent_badge" &&
       hasExtraCss st ".content-wrapper > section:has(.bp_relation_panel)" &&
       hasExtraCss st ".bp_preview_header_label" &&
       hasExtraCss st ".bp_relation_badge_origin::before" &&
@@ -128,7 +131,7 @@ private def samplePanelEntry : Informal.RelatedPanel.PanelEntry := {
     pure (
       hasSubstr out "uses 2" &&
       hasSubstr out "class=\"bp_extra_slot bp_extra_slot_uses\"" &&
-      hasSubstr out "class=\"bp_relation_chip bp_uses_chip\"" &&
+      hasSubstr out "class=\"bp_relation_chip\"" &&
       hasSubstr out "class=\"bp_relation_panel\"" &&
       hasSubstr out "Statement uses 2" &&
       hasSubstr out "Statement dependency previews" &&
@@ -153,6 +156,9 @@ private def samplePanelEntry : Informal.RelatedPanel.PanelEntry := {
       hasSubstr out "bp_relation_badge_origin_automatic" &&
       hasSubstr out "bp_relation_badge_intent_technical" &&
       hasSubstr out "bp_relation_badge_intent_auxiliary" &&
+      !hasSubstr out "bp_uses_chip" &&
+      !hasSubstr out "bp_uses_origin_badge" &&
+      !hasSubstr out "bp_uses_intent_badge" &&
       appearsBefore out "class=\"bp_extra_slot bp_extra_slot_uses\"" "class=\"bp_extra_slot bp_extra_slot_used_by\"" &&
       appearsBefore out "class=\"bp_extra_slot bp_extra_slot_used_by\"" "class=\"bp_extra_slot bp_extra_slot_code\"" &&
       match relationJs? with

--- a/tests/VersoBlueprintTests/BlueprintSlides.lean
+++ b/tests/VersoBlueprintTests/BlueprintSlides.lean
@@ -105,6 +105,21 @@ private partial def freshSlidesSmokeRoot : IO System.FilePath := do
   else
     pure root
 
+private def buildPreviewDataFor
+    (doc : Doc.VersoDoc Genre.Manual) : IO Informal.PreviewManifest.Files :=
+  buildManualPreviewDataFiles manualImpls doc
+
+private def writeSlidesPreviewDataFiles
+    (root : System.FilePath)
+    (files : Informal.PreviewManifest.Files) : IO System.FilePath := do
+  let manifestPath := root / Informal.PreviewManifest.manifestFilename
+  let htmlCachePath := root / Informal.PreviewManifest.htmlCacheFilename
+  if !(← root.pathExists) then
+    IO.FS.createDirAll root
+  IO.FS.writeFile manifestPath (Lean.toJson files.manifest).compress
+  IO.FS.writeFile htmlCachePath (Lean.toJson files.htmlCache).compress
+  pure manifestPath
+
 /-- info: true -/
 #guard_msgs in
 #eval
@@ -206,8 +221,7 @@ private partial def freshSlidesSmokeRoot : IO System.FilePath := do
 #guard_msgs in
 #eval
   show IO Bool from do
-    let (_out, st) ← renderManualDocHtmlStringAndState manualImpls leanCodeLinkPreviewDoc
-    let files ← Informal.PreviewManifest.buildPreviewDataFiles manualImpls (fun _ => pure ()) st
+    let files ← buildPreviewDataFor leanCodeLinkPreviewDoc
     let file := files.manifest
     let cache := files.htmlCache
     let blockKey := Informal.PreviewCache.key (Lean.Name.mkSimple "def:code.preview") .statement
@@ -235,8 +249,7 @@ private partial def freshSlidesSmokeRoot : IO System.FilePath := do
 #guard_msgs in
 #eval
   show IO Bool from do
-    let (_out, st) ← renderManualDocHtmlStringAndState manualImpls usedByPreviewDoc
-    let files ← Informal.PreviewManifest.buildPreviewDataFiles manualImpls (fun _ => pure ()) st
+    let files ← buildPreviewDataFor usedByPreviewDoc
     let cache := files.htmlCache
     let codeKey := Informal.TraversalIndex.LeanCodePreviews.lookupKey
       `Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared.usedByPreviewTarget
@@ -254,8 +267,7 @@ private partial def freshSlidesSmokeRoot : IO System.FilePath := do
 #guard_msgs in
 #eval
   show IO Bool from do
-    let (_out, st) ← renderManualDocHtmlStringAndState manualImpls usedByPreviewDoc
-    let files ← Informal.PreviewManifest.buildPreviewDataFiles manualImpls (fun _ => pure ()) st
+    let files ← buildPreviewDataFor usedByPreviewDoc
     let file := files.manifest
     let blockKey := Informal.PreviewCache.key (Lean.Name.mkSimple "def:used.target") .statement
     let codeKey := Informal.TraversalIndex.LeanCodePreviews.lookupKey
@@ -268,8 +280,7 @@ private partial def freshSlidesSmokeRoot : IO System.FilePath := do
 #guard_msgs in
 #eval
   show IO Bool from do
-    let (_out, st) ← renderManualDocHtmlStringAndState manualImpls leanCodeLinkPreviewDoc
-    let files ← Informal.PreviewManifest.buildPreviewDataFiles manualImpls (fun _ => pure ()) st
+    let files ← buildPreviewDataFor leanCodeLinkPreviewDoc
     let key := Informal.PreviewCache.key (Lean.Name.mkSimple "def:code.preview") .statement
     let ctx := Informal.Slides.RenderContext.ofPreviewData? (some files.manifest) (some files.htmlCache)
     let renderedHtml ← Informal.Slides.renderBlueprintSlideNode ctx
@@ -288,8 +299,7 @@ private partial def freshSlidesSmokeRoot : IO System.FilePath := do
 #guard_msgs in
 #eval
   show IO Bool from do
-    let (_out, st) ← renderManualDocHtmlStringAndState manualImpls slideMetadataPanelDoc
-    let files ← Informal.PreviewManifest.buildPreviewDataFiles manualImpls (fun _ => pure ()) st
+    let files ← buildPreviewDataFor slideMetadataPanelDoc
     let key := Informal.PreviewCache.key (Lean.Name.mkSimple "def:slide.meta.panel") .statement
     let ctx := Informal.Slides.RenderContext.ofPreviewData? (some files.manifest) (some files.htmlCache)
     let renderedHtml ← Informal.Slides.renderBlueprintSlideNode ctx
@@ -308,8 +318,7 @@ private partial def freshSlidesSmokeRoot : IO System.FilePath := do
 #guard_msgs in
 #eval
   show IO Bool from do
-    let (_out, st) ← renderManualDocHtmlStringAndState manualImpls groupPreviewDoc
-    let files ← Informal.PreviewManifest.buildPreviewDataFiles manualImpls (fun _ => pure ()) st
+    let files ← buildPreviewDataFor groupPreviewDoc
     let file := files.manifest
     let key := Informal.PreviewCache.key (Lean.Name.mkSimple "def:group.target") .statement
     let some entry := file.previews.find? (fun entry => entry.key == key)
@@ -346,8 +355,7 @@ private partial def freshSlidesSmokeRoot : IO System.FilePath := do
 #guard_msgs in
 #eval
   show IO Bool from do
-    let (_out, st) ← renderManualDocHtmlStringAndState manualImpls missingGroupPreviewDoc
-    let files ← Informal.PreviewManifest.buildPreviewDataFiles manualImpls (fun _ => pure ()) st
+    let files ← buildPreviewDataFor missingGroupPreviewDoc
     let file := files.manifest
     let key := Informal.PreviewCache.key (Lean.Name.mkSimple "def:group.missing.target") .statement
     let some entry := file.previews.find? (fun entry => entry.key == key)
@@ -371,16 +379,10 @@ private partial def freshSlidesSmokeRoot : IO System.FilePath := do
 #guard_msgs in
 #eval
   show IO Bool from do
-    let (_out, st) ← renderManualDocHtmlStringAndState manualImpls leanCodeLinkPreviewDoc
-    let files ← Informal.PreviewManifest.buildPreviewDataFiles manualImpls (fun _ => pure ()) st
+    let files ← buildPreviewDataFor leanCodeLinkPreviewDoc
     let root ← freshSlidesSmokeRoot
     let outDir := root / "slides"
-    let manifestPath := root / Informal.PreviewManifest.manifestFilename
-    let htmlCachePath := root / Informal.PreviewManifest.htmlCacheFilename
-    if !(← root.pathExists) then
-      IO.FS.createDirAll root
-    IO.FS.writeFile manifestPath (Lean.toJson files.manifest).compress
-    IO.FS.writeFile htmlCachePath (Lean.toJson files.htmlCache).compress
+    let manifestPath ← writeSlidesPreviewDataFiles root files
     let rc ← Informal.Slides.slidesMainWithBlueprintPreviews
       { outputDir := outDir }
       (previewManifest? := some manifestPath)
@@ -410,16 +412,10 @@ private partial def freshSlidesSmokeRoot : IO System.FilePath := do
 #guard_msgs in
 #eval
   show IO Bool from do
-    let (_out, st) ← renderManualDocHtmlStringAndState manualImpls slideGraftSourceDoc
-    let files ← Informal.PreviewManifest.buildPreviewDataFiles manualImpls (fun _ => pure ()) st
+    let files ← buildPreviewDataFor slideGraftSourceDoc
     let root ← freshSlidesSmokeRoot
     let outDir := root / "slides"
-    let manifestPath := root / Informal.PreviewManifest.manifestFilename
-    let htmlCachePath := root / Informal.PreviewManifest.htmlCacheFilename
-    if !(← root.pathExists) then
-      IO.FS.createDirAll root
-    IO.FS.writeFile manifestPath (Lean.toJson files.manifest).compress
-    IO.FS.writeFile htmlCachePath (Lean.toJson files.htmlCache).compress
+    let manifestPath ← writeSlidesPreviewDataFiles root files
     let rc ← Informal.Slides.slidesMainWithBlueprintPreviews
       { outputDir := outDir }
       (previewManifest? := some manifestPath)

--- a/tests/browser/test_graph_layout_runtime.py
+++ b/tests/browser/test_graph_layout_runtime.py
@@ -274,7 +274,7 @@ class TestGraphLayoutRuntime:
         assert switched["width"] > switched["height"]
         assert_graph_is_well_placed(page)
 
-    def test_graph_preview_defaults_to_click_to_pin(self, server: str, page: Page):
+    def test_graph_preview_defaults_to_pinned(self, server: str, page: Page):
         page.set_viewport_size({"width": 1400, "height": 900})
         page.goto(f"{server}/Dependency-Graph/")
         wait_for_graph(page)
@@ -308,7 +308,7 @@ class TestGraphLayoutRuntime:
             }"""
         )
 
-    def test_preview_utils_normalize_graph_preview_aliases(self, server: str, page: Page):
+    def test_preview_utils_read_graph_preview_behavior(self, server: str, page: Page):
         page.set_viewport_size({"width": 1400, "height": 900})
         page.goto(f"{server}/Dependency-Graph/")
         wait_for_graph(page)
@@ -318,25 +318,38 @@ class TestGraphLayoutRuntime:
                 const utils = window.bpPreviewUtils;
                 if (
                     !utils ||
-                    typeof utils.normalizePreviewMode !== "function" ||
-                    typeof utils.normalizePreviewPlacement !== "function" ||
+                    typeof utils.normalizePreviewMode !== "undefined" ||
+                    typeof utils.normalizePreviewPlacement !== "undefined" ||
                     typeof utils.readPanelBehavior !== "function"
                 ) {
                     return false;
                 }
-                const behavior = utils.readPanelBehavior(null, {
-                    mode: "click-and-stay",
-                    placement: "near-node",
+                const defaultBehavior = utils.readPanelBehavior(null, {
+                    mode: "pinned",
+                    placement: "anchored",
+                });
+                const fallbackBehavior = utils.readPanelBehavior(null, {
+                    mode: "invalid",
+                    placement: "invalid",
+                });
+                const panel = document.createElement("div");
+                panel.setAttribute("data-bp-preview-mode", "hover");
+                panel.setAttribute("data-bp-preview-placement", "docked");
+                const panelBehavior = utils.readPanelBehavior(panel, {
+                    mode: "pinned",
+                    placement: "anchored",
                 });
                 return (
-                    utils.normalizePreviewMode("transient", "pinned") === "hover" &&
-                    utils.normalizePreviewMode("click-to-pin", "hover") === "pinned" &&
-                    utils.normalizePreviewPlacement("fixed", "anchored") === "docked" &&
-                    utils.normalizePreviewPlacement("near-node", "docked") === "anchored" &&
-                    behavior.mode === "pinned" &&
-                    behavior.placement === "anchored" &&
-                    behavior.isPinned &&
-                    behavior.isAnchored
+                    defaultBehavior.mode === "pinned" &&
+                    defaultBehavior.placement === "anchored" &&
+                    defaultBehavior.isPinned &&
+                    defaultBehavior.isAnchored &&
+                    fallbackBehavior.mode === "hover" &&
+                    fallbackBehavior.placement === "anchored" &&
+                    panelBehavior.mode === "hover" &&
+                    panelBehavior.placement === "docked" &&
+                    panelBehavior.isHover &&
+                    panelBehavior.isDocked
                 );
             }"""
         )

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -258,10 +258,11 @@ class TestPreviewRuntimeRegressions:
         expect(trigger).to_have_count(1)
         trigger.hover()
 
-        summary_panel = wrapper.locator(
-            ".bp_extra_slot_code .bp_code_summary_preview_panel"
-        ).first
+        summary_panel = page.locator(".bp_code_summary_preview_panel:not([hidden])").first
         expect(summary_panel).to_be_visible()
+        expect(summary_panel.locator(".bp_code_summary_preview_title")).to_have_text(
+            "panel_external_short_name_definition"
+        )
         expect(summary_panel.locator(".bp_code_decl_item").first).to_contain_text(
             "previewExternalDefinition"
         )
@@ -374,7 +375,10 @@ class TestPreviewRuntimeRegressions:
         assert previews["proof"]["facet"] == "proof"
         assert previews["statement"]["href"].startswith("Preview-Relationships/")
         assert "#--informal-preview-" in previews["statement"]["href"]
-        assert previews["proof"]["href"] == previews["statement"]["href"]
+        assert previews["proof"]["href"].startswith("Preview-Relationships/")
+        assert previews["proof"]["href"] != previews["statement"]["href"]
+        assert previews["statement"]["href"].endswith("preview_facets--statement")
+        assert previews["proof"]["href"].endswith("preview_facets--proof")
         assert "bp_label_preview_tpl" not in page.content()
 
         assert_no_runtime_errors(errors)

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -38,6 +38,10 @@ def patched_attrs(target: object, **replacements: object) -> Iterator[None]:
 
 
 class BlueprintHarnessCliTests(unittest.TestCase):
+    def assertParseFails(self, parser: argparse.ArgumentParser, argv: list[str]) -> None:
+        with redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+            parser.parse_args(argv)
+
     def test_create_worktree_sync_policy_respects_lightweight_mode(self) -> None:
         args = argparse.Namespace(skip_sync=False, skip_reference_sync=False, lightweight=True)
         self.assertEqual(create_worktree_sync_policy(args), (True, True))
@@ -51,6 +55,10 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         args = parser.parse_args(["generate", "--allow-unsafe-root-release", "--release", "v4.29.0"])
         self.assertTrue(args.allow_unsafe_root_release)
         self.assertEqual(args.release, "v4.29.0")
+
+    def test_reference_generate_rejects_allow_unsafe_root_main_alias(self) -> None:
+        parser = reference_harness_mod.build_parser()
+        self.assertParseFails(parser, ["generate", "--allow-unsafe-root-main"])
 
     def test_reference_generate_accepts_named_output_root(self) -> None:
         parser = reference_harness_mod.build_parser()
@@ -95,7 +103,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertEqual(args.release, "v4.28.0")
         self.assertTrue(args.outdated_only)
 
-    def test_main_status_parses_require_sync(self) -> None:
+    def test_release_status_parses_require_sync(self) -> None:
         parser = build_parser()
         args = parser.parse_args(["release-status", "--require-sync"])
         self.assertTrue(args.require_sync)
@@ -183,8 +191,15 @@ class BlueprintHarnessCliTests(unittest.TestCase):
 
     def test_worktree_sync_alias_is_retired(self) -> None:
         parser = build_parser()
-        with self.assertRaises(SystemExit):
-            parser.parse_args(["worktree-sync"])
+        self.assertParseFails(parser, ["worktree-sync"])
+
+    def test_release_status_alias_is_retired(self) -> None:
+        parser = build_parser()
+        self.assertParseFails(parser, ["main-status"])
+
+    def test_land_release_alias_is_retired(self) -> None:
+        parser = build_parser()
+        self.assertParseFails(parser, ["land-main", "feat/demo"])
 
     def test_worktree_claim_parses_lock_flags(self) -> None:
         parser = build_parser()
@@ -195,7 +210,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertFalse(unlock_args.lock)
         self.assertTrue(unlock_args.unlock)
 
-    def test_land_main_parses_cleanup_flags(self) -> None:
+    def test_land_release_parses_cleanup_flags(self) -> None:
         parser = build_parser()
         args = parser.parse_args(["land-release", "feat/demo", "--cleanup", "--keep-remote", "--no-push"])
         self.assertEqual(args.source, "feat/demo")
@@ -295,22 +310,22 @@ class BlueprintHarnessCliTests(unittest.TestCase):
 
         self.assertIsNone(pin)
 
-    def test_create_worktree_uses_preferred_main_ref_by_default(self) -> None:
+    def test_create_worktree_uses_preferred_release_ref_by_default(self) -> None:
         layout = SimpleNamespace(repo_root=Path("/tmp/repo"))
         with patched_attrs(
             harness_mod,
-            preferred_main_ref=lambda _repo_root: "origin/v4.29.0",
+            preferred_release_ref=lambda _repo_root: "origin/v4.29.0",
             active_release_branch=lambda _repo_root: "v4.29.0",
         ):
             self.assertEqual(harness_mod.resolve_create_worktree_base(layout, None), "origin/v4.29.0")
 
-    def test_create_worktree_rejects_unsynced_local_main_base(self) -> None:
+    def test_create_worktree_rejects_unsynced_local_release_base(self) -> None:
         layout = SimpleNamespace(repo_root=Path("/tmp/repo"))
         with patched_attrs(
             harness_mod,
-            preferred_main_ref=lambda _repo_root: "origin/v4.29.0",
+            preferred_release_ref=lambda _repo_root: "origin/v4.29.0",
             active_release_branch=lambda _repo_root: "v4.29.0",
-            main_sync_status=lambda _repo_root: harness_mod.RefSyncStatus(
+            release_sync_status=lambda _repo_root: harness_mod.RefSyncStatus(
                 local_ref="v4.29.0",
                 upstream_ref="origin/v4.29.0",
                 local_oid="abc",
@@ -389,13 +404,13 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertEqual(seen["resolve_args"], (catalog, None, new_layout.package_root, None))
         self.assertEqual(seen["sync_args"], (new_layout, [project], True, True))
 
-    def test_main_status_require_sync_returns_nonzero_when_unsynced(self) -> None:
+    def test_release_status_require_sync_returns_nonzero_when_unsynced(self) -> None:
         args = argparse.Namespace(require_sync=True)
         layout = SimpleNamespace(repo_root=Path("/tmp/repo"), package_root=Path("/tmp/worktree"))
         with patched_attrs(
             harness_mod,
             detect_harness_layout=lambda _start=None: layout,
-            main_sync_status=lambda _repo_root: harness_mod.RefSyncStatus(
+            release_sync_status=lambda _repo_root: harness_mod.RefSyncStatus(
                 local_ref="v4.29.0",
                 upstream_ref="origin/v4.29.0",
                 local_oid="abc",
@@ -409,7 +424,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             checkout_branch_role=lambda _repo_root: "default_dev",
             checkout_is_backport_only=lambda _repo_root: False,
         ):
-            self.assertEqual(harness_mod.command_main_status(args), 1)
+            self.assertEqual(harness_mod.command_release_status(args), 1)
 
     def test_release_status_reports_backport_policy_fields(self) -> None:
         args = argparse.Namespace(require_sync=False)
@@ -418,7 +433,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         with patched_attrs(
             harness_mod,
             detect_harness_layout=lambda _start=None: layout,
-            main_sync_status=lambda _repo_root: harness_mod.RefSyncStatus(
+            release_sync_status=lambda _repo_root: harness_mod.RefSyncStatus(
                 local_ref="v4.28.0",
                 upstream_ref="origin/v4.28.0",
                 local_oid="abc",
@@ -433,7 +448,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             checkout_is_backport_only=lambda _repo_root: True,
         ):
             with redirect_stdout(out):
-                self.assertEqual(harness_mod.command_main_status(args), 0)
+                self.assertEqual(harness_mod.command_release_status(args), 0)
 
         output = out.getvalue()
         self.assertIn("current_branch=fix/backport", output)
@@ -681,7 +696,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertIn("paired_label=backport-v4.27.0", output)
         self.assertIn("\n---\n", output)
 
-    def test_land_main_rejects_unsynced_main(self) -> None:
+    def test_land_release_rejects_unsynced_release(self) -> None:
         args = argparse.Namespace(source="feat/demo", no_push=False, cleanup=False, keep_remote=False)
         layout = SimpleNamespace(repo_root=Path("/tmp/repo"), package_root=Path("/tmp/repo"), in_linked_worktree=False)
         with patched_attrs(
@@ -689,7 +704,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             detect_harness_layout=lambda _start=None: layout,
             current_branch_name=lambda _repo_root: "v4.29.0",
             worktree_is_clean=lambda _path: True,
-            main_sync_status=lambda _repo_root: harness_mod.RefSyncStatus(
+            release_sync_status=lambda _repo_root: harness_mod.RefSyncStatus(
                 local_ref="v4.29.0",
                 upstream_ref="origin/v4.29.0",
                 local_oid="abc",
@@ -699,9 +714,9 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             active_release_branch=lambda _repo_root: "v4.29.0",
         ):
             with self.assertRaisesRegex(SystemExit, "sync `v4.29.0` before landing"):
-                harness_mod.command_land_main(args)
+                harness_mod.command_land_release(args)
 
-    def test_land_main_fast_forwards_and_pushes(self) -> None:
+    def test_land_release_fast_forwards_and_pushes(self) -> None:
         args = argparse.Namespace(source="feat/demo", no_push=False, cleanup=False, keep_remote=False)
         layout = SimpleNamespace(repo_root=Path("/tmp/repo"), package_root=Path("/tmp/repo"), in_linked_worktree=False)
         commands: list[list[str]] = []
@@ -710,7 +725,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             detect_harness_layout=lambda _start=None: layout,
             current_branch_name=lambda _repo_root: "v4.29.0",
             worktree_is_clean=lambda _path: True,
-            main_sync_status=lambda _repo_root: harness_mod.RefSyncStatus(
+            release_sync_status=lambda _repo_root: harness_mod.RefSyncStatus(
                 local_ref="v4.29.0",
                 upstream_ref="origin/v4.29.0",
                 local_oid="abc",
@@ -719,15 +734,15 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             ),
             ref_oid=lambda _repo_root, ref: "deadbeef" if ref == "feat/demo" else None,
             is_ancestor=lambda _repo_root, ancestor, descendant: (ancestor, descendant) == ("v4.29.0", "feat/demo"),
-            preferred_main_ref=lambda _repo_root: "origin/v4.29.0",
+            preferred_release_ref=lambda _repo_root: "origin/v4.29.0",
             active_release_branch=lambda _repo_root: "v4.29.0",
             run=lambda command, *, cwd: commands.append(command),
         ):
-            self.assertEqual(harness_mod.command_land_main(args), 0)
+            self.assertEqual(harness_mod.command_land_release(args), 0)
 
         self.assertEqual(commands, [["git", "merge", "--ff-only", "feat/demo"], ["git", "push", "origin", "v4.29.0"]])
 
-    def test_land_main_cleanup_removes_branch_worktree_and_remote(self) -> None:
+    def test_land_release_cleanup_removes_branch_worktree_and_remote(self) -> None:
         args = argparse.Namespace(source="feat/demo", no_push=False, cleanup=True, keep_remote=False)
         layout = SimpleNamespace(repo_root=Path("/tmp/repo"), package_root=Path("/tmp/repo"), in_linked_worktree=False)
         demo_worktree = GitWorktree(
@@ -743,7 +758,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             detect_harness_layout=lambda _start=None: layout,
             current_branch_name=lambda _repo_root: "v4.29.0",
             worktree_is_clean=lambda _path: True,
-            main_sync_status=lambda _repo_root: harness_mod.RefSyncStatus(
+            release_sync_status=lambda _repo_root: harness_mod.RefSyncStatus(
                 local_ref="v4.29.0",
                 upstream_ref="origin/v4.29.0",
                 local_oid="abc",
@@ -754,14 +769,14 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 "deadbeef" if ref in {"feat/demo", "refs/heads/feat/demo", "refs/remotes/origin/feat/demo"} else None
             ),
             is_ancestor=lambda _repo_root, ancestor, descendant: (ancestor, descendant) == ("v4.29.0", "feat/demo"),
-            preferred_main_ref=lambda _repo_root: "origin/v4.29.0",
+            preferred_release_ref=lambda _repo_root: "origin/v4.29.0",
             active_release_branch=lambda _repo_root: "v4.29.0",
             run=lambda command, *, cwd: commands.append(command),
             branch_worktrees=lambda _repo_root, branch: [demo_worktree] if branch == "feat/demo" else [],
             local_branch_ref=lambda _repo_root, branch: branch if branch == "feat/demo" else None,
             origin_branch_exists=lambda _repo_root, branch: branch == "feat/demo",
         ):
-            self.assertEqual(harness_mod.command_land_main(args), 0)
+            self.assertEqual(harness_mod.command_land_release(args), 0)
 
         self.assertEqual(
             commands,
@@ -774,7 +789,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             ],
         )
 
-    def test_reference_generate_rejects_unsafe_root_main_without_override(self) -> None:
+    def test_reference_generate_rejects_unsafe_root_release_without_override(self) -> None:
         args = argparse.Namespace(
             output_root=None,
             manifest=None,
@@ -797,7 +812,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         with patched_attrs(
             reference_harness_mod,
             detect_harness_layout=lambda _start=None: layout,
-            require_safe_root_main=fake_require,
+            require_safe_root_release=fake_require,
         ):
             with self.assertRaisesRegex(SystemExit, "blocked"):
                 reference_harness_mod.command_generate(args)
@@ -821,7 +836,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         with patched_attrs(
             reference_harness_mod,
             detect_harness_layout=lambda _start=None: layout,
-            require_safe_root_main=lambda _layout, *, allow_unsafe, command_name: None,
+            require_safe_root_release=lambda _layout, *, allow_unsafe, command_name: None,
             resolve_output_root=lambda _path_text, _start=None: Path("/tmp/out"),
             resolve_manifest_path=lambda _path_text, _package_root: Path("/tmp/projects.json"),
             load_project_catalog=lambda _manifest_path: SimpleNamespace(projects=(), release_targets=()),
@@ -1577,7 +1592,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         ):
             self.assertEqual(reference_harness_mod.command_validate(args), 0)
 
-    def test_reference_validate_rejects_unsafe_root_main_without_override(self) -> None:
+    def test_reference_validate_rejects_unsafe_root_release_without_override(self) -> None:
         args = argparse.Namespace(
             output_root=None,
             manifest=None,
@@ -1604,7 +1619,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         with patched_attrs(
             reference_harness_mod,
             detect_harness_layout=lambda _start=None: layout,
-            require_safe_root_main=fake_require,
+            require_safe_root_release=fake_require,
         ):
             with self.assertRaisesRegex(SystemExit, "blocked"):
                 reference_harness_mod.command_validate(args)
@@ -1613,7 +1628,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertFalse(seen["allow_unsafe"])
         self.assertEqual(seen["command_name"], "validate")
 
-    def test_reference_sync_allows_unsafe_root_main_with_override(self) -> None:
+    def test_reference_sync_allows_unsafe_root_release_with_override(self) -> None:
         args = argparse.Namespace(
             manifest=None,
             project=None,
@@ -1640,7 +1655,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         with patched_attrs(
             reference_harness_mod,
             detect_harness_layout=lambda _start=None: layout,
-            require_safe_root_main=fake_require,
+            require_safe_root_release=fake_require,
             resolve_manifest_path=lambda _path_text, _package_root: Path("/tmp/projects.json"),
             load_project_catalog=lambda _manifest_path: SimpleNamespace(projects=(), release_targets=()),
             select_release_projects=lambda _catalog, *, release, project_ids, package_root: ("v4.29.0", []),


### PR DESCRIPTION
This PR tightens the boundary between neutral graft rendering and slide-specific rendering. It moves slide-only attributes into `Informal.Slides`, removes unused compatibility wrappers while keeping the deprecated preview-manifest entry point for real blueprints, deduplicates relation-panel styling classes, and aligns browser expectations with canonical preview anchors.

Backport v4.29.0: exempt: v4.30-only change; v4.31 support will be handled separately