### PR TITLE
fix: disable header linter for harnessed blueprints

### DIFF
--- a/scripts/blueprint_harness_project_commands.py
+++ b/scripts/blueprint_harness_project_commands.py
@@ -29,6 +29,10 @@ OFFICIAL_BLUEPRINT_REQUIRE_PATTERN = re.compile(
     r'^(?P<indent>\s*)require\s+VersoBlueprint\s+from\s+git\s+"(?P<url>[^"]+)"(?:\s*@\s*"(?P<ref>[^"]+)")?\s*$',
     re.MULTILINE,
 )
+MATHLIB_STANDARD_LINTER_OPTION_PATTERN = re.compile(
+    r"^(?P<indent>\s*)⟨`weak\.linter\.mathlibStandardSet,\s*true⟩",
+    re.MULTILINE,
+)
 
 
 def _require_official_blueprint_git_dependency(project_dir: Path, *, action: str) -> tuple[Path, str, re.Match[str]]:
@@ -62,8 +66,25 @@ def rewrite_local_blueprint_dependency(project_dir: Path, package_root: Path) ->
     relative_path = os.path.relpath(package_root, start=project_dir)
     replacement = f'{match.group("indent")}require VersoBlueprint from "{relative_path}"'
     rewritten = text[: match.start()] + replacement + text[match.end() :]
+    rewritten = disable_header_linter_for_mathlib_blueprint_lakefile(rewritten)
     lakefile.write_text(rewritten, encoding="utf-8")
     return lakefile
+
+
+def disable_header_linter_for_mathlib_blueprint_lakefile(text: str) -> str:
+    # The Mathlib header linter parses the leading file text as Lean commands.
+    # Top-level Verso documents contain non-command markup, so keep the rest of
+    # the Mathlib linter set while disabling only that header check.
+    if "`weak.linter.style.header" in text:
+        return text
+
+    match = MATHLIB_STANDARD_LINTER_OPTION_PATTERN.search(text)
+    if match is None:
+        return text
+
+    indent = match.group("indent")
+    replacement = f"{indent}⟨`weak.linter.style.header, false⟩,\n{match.group(0)}"
+    return text[: match.start()] + replacement + text[match.end() :]
 
 
 def rewrite_pinned_blueprint_dependency(project_dir: Path, ref: str) -> tuple[Path, str | None]:

--- a/tests/harness/test_blueprint_harness_project_commands.py
+++ b/tests/harness/test_blueprint_harness_project_commands.py
@@ -61,6 +61,58 @@ class BlueprintHarnessProjectCommandTests(unittest.TestCase):
             self.assertIn('require VersoBlueprint from "', text)
             self.assertNotIn('from git "https://github.com/leanprover/verso-blueprint.git"', text)
 
+    def test_rewrite_local_blueprint_dependency_disables_mathlib_header_linter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            lakefile = project_dir / "lakefile.lean"
+            lakefile.write_text(
+                "\n".join(
+                    [
+                        "import Lake",
+                        "open Lake DSL",
+                        OFFICIAL_BLUEPRINT_REQUIRE,
+                        "",
+                        "package Blueprint where",
+                        "  leanOptions := #[",
+                        "    ⟨`autoImplicit, false⟩,",
+                        "    ⟨`weak.linter.mathlibStandardSet, true⟩",
+                        "  ]",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            rewrite_local_blueprint_dependency(project_dir, PACKAGE_ROOT)
+
+            text = lakefile.read_text(encoding="utf-8")
+            self.assertIn("    ⟨`weak.linter.style.header, false⟩,\n", text)
+            self.assertIn("    ⟨`weak.linter.mathlibStandardSet, true⟩\n", text)
+
+    def test_rewrite_local_blueprint_dependency_does_not_duplicate_header_linter_option(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            lakefile = project_dir / "lakefile.lean"
+            lakefile.write_text(
+                "\n".join(
+                    [
+                        OFFICIAL_BLUEPRINT_REQUIRE,
+                        "package Blueprint where",
+                        "  leanOptions := #[",
+                        "    ⟨`weak.linter.style.header, false⟩,",
+                        "    ⟨`weak.linter.mathlibStandardSet, true⟩",
+                        "  ]",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            rewrite_local_blueprint_dependency(project_dir, PACKAGE_ROOT)
+
+            text = lakefile.read_text(encoding="utf-8")
+            self.assertEqual(text.count("`weak.linter.style.header"), 1)
+
     def test_rewrite_local_blueprint_dependency_rejects_unofficial_source(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             project_dir = Path(tmp)


### PR DESCRIPTION
This PR disables the Lean header linter for harnessed Blueprint modules so harness-created Blueprint projects can run without generated file-header failures.

Backport v4.29.0: exempt: skipped by maintainer decision; this mitigation targets current harnessed reference-blueprint builds.