### PR TITLE
refactor: use Verso Slides ofHtml for Blueprint nodes

### DIFF
--- a/doc/UPSTREAM_BACKLOG.md
+++ b/doc/UPSTREAM_BACKLOG.md
@@ -66,18 +66,18 @@ pull requests unless that upstream write action is explicitly requested.
 
 ## Runtime Assets and Browser Rendering
 
-- [ ] Add a Verso Slides `Block.ofHtml` constructor.
+- [ ] Expose Verso Slides hooks for quiet rendering and initial hover state.
   - current Blueprint workaround:
-    `VersoBlueprint.Slides.slidesMainWithBlueprintPreviews` supplies a local
-    `GenreHtml Slides IO` instance so slide graft blocks elaborated through
-    `{blueprint_node}` render from the Blueprint manifest/cache data before the
-    HTML document is serialized; because `VersoSlides.slidesMain` owns both
-    rendering and file emission, Blueprint also mirrors the small config-asset
-    plan and write loop
+    `VersoBlueprint.Slides.slidesMainWithBlueprintPreviews` rewrites
+    `{blueprint_node}` blocks from Blueprint manifest/cache data to
+    `VersoSlides.BlockExt.ofHtml` during Slides traversal, then mirrors the
+    small `slidesMain` output loop so `quiet := true` remains honored and the
+    generated `-verso-docs.json` starts from the rendered HTML cache's hover
+    payload table
   - desired upstream behavior:
-    downstream packages should be able to elaborate a slide block to an
-    already-rendered HTML body, while reusing the upstream `slidesMain` asset
-    validation and output writer
+    downstream packages should be able to call upstream `slidesMain` with an
+    optional initial hover state and quiet-output behavior, while still reusing
+    the upstream asset validation and output writer
   - removable Blueprint code:
     local `SlideAssetPayload`, `recordSlideAsset`, `collectSlideAssets`, and
     the copied `slidesMain` output loop in `VersoBlueprint.Slides`

--- a/project_template/ProjectTemplate/Chapters/Collatz.lean
+++ b/project_template/ProjectTemplate/Chapters/Collatz.lean
@@ -8,6 +8,26 @@ open Informal
 
 #doc (Manual) "Collatz" =>
 
+# Side-by-Side Views
+
+These grafts reuse the Collatz entries below. A full card keeps the explanatory
+definition together with its attached Lean code, while compact cards keep the
+statement and proof facets easy to compare.
+
+:::blueprint_side_by_side +boxed
+{blueprint_node "collatz_step" (displayLabel := "Step")}
+
+{blueprint_node "collatz_conjecture" (displayLabel := "Conjecture") -header +compact}
+:::
+
+:::blueprint_side_by_side
+{blueprint_node "collatz_conjecture" (displayLabel := "Statement") -header +compact}
+
+{blueprint_node "collatz_conjecture" (facet := "proof") (displayLabel := "Proof status") -header +compact}
+:::
+
+# Source Entries
+
 :::group "collatz_core"
 A small exploratory chapter about the Collatz iteration on natural numbers.
 :::

--- a/src/VersoBlueprint/ExternalDeclRender.lean
+++ b/src/VersoBlueprint/ExternalDeclRender.lean
@@ -520,32 +520,4 @@ def renderDeclHtmlNodeDirect? (decl : Name) : MetaM (Option ExternalDeclHtml) :=
     logError m!"External declaration rendering failed for {decl}: {← ex.toMessageData.toString}"
     return none
 
-/--
-Optional fallback path for non-`MetaM` contexts.
-Database fallback is currently unavailable, so this returns `none`.
--/
-def renderDeclHtmlNodeFromDb? (_dbPath : System.FilePath) (_decl : Name) :
-    IO (Option ExternalDeclHtml) := do
-  IO.eprintln "[external render db] fallback unavailable"
-  return none
-
-/-- Smoke demo targets: theorem/def (`Nat.add`), structure (`Prod`), and a missing name. -/
-def externalDeclRenderSmokeDecls : Array Name := #[`Nat.add, `Prod, `No.Such.Declaration]
-
-/-- Measure textual payload length in rendered declaration HTML. -/
-def ExternalDeclHtml.textLength : ExternalDeclHtml → Nat
-  | .text _ s => s.length
-  | .tag _ _ content => textLength content
-  | .seq contents => contents.foldl (fun acc child => acc + textLength child) 0
-
-/-- Smoke demo helper for quick direct-path checks. -/
-def runExternalDeclRenderSmokeDirect : MetaM (Array (Name × Option ExternalDeclHtml)) := do
-  externalDeclRenderSmokeDecls.mapM fun decl => do
-    let rendered? ← renderDeclHtmlNodeDirect? decl
-    if let some html := rendered? then
-      logInfo m!"[external decl render smoke] {decl}: rendered ({ExternalDeclHtml.textLength html} chars)"
-    else
-      logInfo m!"[external decl render smoke] {decl}: none"
-    pure (decl, rendered?)
-
 end Informal

--- a/src/VersoBlueprint/Graft/Assets.lean
+++ b/src/VersoBlueprint/Graft/Assets.lean
@@ -60,6 +60,34 @@ def css : String := r##"
 .bp_graft_side_by_side .bp_extras {
   margin-left: 0;
 }
+
+.bp_graft_side_by_side .bp_code_block summary {
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.bp_graft_side_by_side .bp_code_summary_text {
+  white-space: normal;
+}
+
+.bp_graft_side_by_side .bp_code_summary_indicator {
+  margin-left: 0;
+  width: 100%;
+  max-width: 100%;
+}
+
+.bp_graft_side_by_side .bp_code_summary_indicator .bp_code_summary_preview_root,
+.bp_graft_side_by_side .bp_code_summary_indicator .bp_code_summary_preview_wrap {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+}
+
+.bp_graft_side_by_side .bp_code_progress {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+}
 "##
 
 def cssAssets : List String := [css]

--- a/src/VersoBlueprint/Lib/PreviewSource.lean
+++ b/src/VersoBlueprint/Lib/PreviewSource.lean
@@ -51,12 +51,6 @@ deriving Inhabited, Repr
 private def nonEmptyOrNone {α} (xs : Array α) : Option (Array α) :=
   if xs.isEmpty then none else some xs
 
-private def firstNonEmptyFacet? {α}
-    (fetch : PreviewCache.Facet → Option (Array α)) : Option (Array α) :=
-  match (fetch .statement).bind nonEmptyOrNone with
-  | some xs => some xs
-  | none => (fetch .proof).bind nonEmptyOrNone
-
 private def firstNonEmptyEntry?
     (fetch : PreviewCache.Facet → Option PreviewCache.Entry) : Option PreviewCache.Entry :=
   match fetch .statement with
@@ -99,19 +93,6 @@ def traversalPreview?
   let entry ← traversalEntry? s label
   return { blocks := entry.blocks }
 
-def traversalBlocks?
-    (s : Verso.Genre.Manual.TraverseState) (label : Name) : Option (Array ManualBlock) :=
-  (traversalPreview? s label).map (·.blocks)
-
-def renderTraversalPreview? {m} [Monad m]
-    (s : Verso.Genre.Manual.TraverseState)
-    (renderBlock : ManualBlock → m Verso.Output.Html)
-    (label : Name) : m (Option (Array Verso.Output.Html)) := do
-  match traversalPreview? s label with
-  | none => pure none
-  | some preview =>
-    pure <| some (← preview.blocks.mapM renderBlock)
-
 private def envFacetPreview? (node : Data.Node) (facet : PreviewCache.Facet) : Option Preview := do
   let informalData ←
     match facet with
@@ -133,11 +114,6 @@ private def firstNonEmptyPreview?
     else
       fetch .proof
   | none => fetch .proof
-
-private def envFacetStxs? (node : Data.Node) (facet : PreviewCache.Facet) : Option (Array Syntax) :=
-  match facet with
-  | .statement => node.statement.bind (nonEmptyOrNone ·.elabStx)
-  | .proof => node.proof.bind (nonEmptyOrNone ·.elabStx)
 
 def fromEnvironment? (env : Environment) (label : Name) : Option Preview := do
   let state := informalExt.getState env

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -1625,23 +1625,4 @@ def blueprintMainWithPreviewData
   blueprintMain text (extensionImpls := extensionImpls) (options := options) (config := config)
     (extraSteps := emitBlueprintPreviewData extensionImpls :: extraSteps)
 
--- Compatibility for reference generators pinned before preview data was renamed.
-@[deprecated blueprintMainWithPreviewData (since := "2026-06-08")]
-def manualMainWithPreviewData
-    (text : Part Manual)
-    (options : List String)
-    (extensionImpls : ExtensionImpls)
-    (config : RenderConfig := {})
-    (extraSteps : List ExtraStep := []) : IO UInt32 :=
-  blueprintMainWithPreviewData text options extensionImpls config extraSteps
-
-@[deprecated blueprintMainWithPreviewData (since := "2026-06-08")]
-def manualMainWithSharedPreviewManifest
-    (text : Part Manual)
-    (options : List String)
-    (extensionImpls : ExtensionImpls)
-    (config : RenderConfig := {})
-    (extraSteps : List ExtraStep := []) : IO UInt32 :=
-  blueprintMainWithPreviewData text options extensionImpls config extraSteps
-
 end Informal.PreviewManifest

--- a/src/VersoBlueprint/Slides.lean
+++ b/src/VersoBlueprint/Slides.lean
@@ -15,28 +15,46 @@ namespace Informal.Slides
 
 open Verso Doc Elab
 
-@[reducible] private def defaultSlidesGenreHtml :
-    Verso.Doc.Html.GenreHtml VersoSlides.Slides (Verso.BuildLogT IO) :=
+@[reducible] private def defaultSlidesTraverse :
+    Verso.Doc.Traverse VersoSlides.Slides VersoSlides.TraverseM :=
   inferInstance
 
-@[reducible] private def blueprintSlidesGenreHtml
+/--
+During the normal Verso Slides traversal, turn `{blueprint_node}` placeholders
+into already-rendered HTML blocks.
+
+`blueprint_node` elaboration only knows the requested label/options, so it emits
+a `BlockExt.wrap` placeholder. At `slidesMainWithBlueprintPreviews` time we also
+have the Blueprint manifest/cache and can render that placeholder to static
+Blueprint HTML. `BlockExt.ofHtml` is the 4.31 handoff back to the normal Slides
+renderer.
+-/
+@[reducible] private def blueprintSlidesTraverse
     (renderContext : Informal.Slides.RenderContext) :
-    Verso.Doc.Html.GenreHtml VersoSlides.Slides (Verso.BuildLogT IO) :=
-  { defaultSlidesGenreHtml with
-    block := fun inlineHtml blockHtml container contents => do
+    Verso.Doc.Traverse VersoSlides.Slides VersoSlides.TraverseM :=
+  { defaultSlidesTraverse with
+    genreBlock := fun container contents => do
       match container with
       | .wrap attrs =>
-        match renderBlueprintSlideNodeFromAttrs? renderContext attrs with
-        | some render => render
-        | none => defaultSlidesGenreHtml.block inlineHtml blockHtml container contents
+          match Informal.Graft.BlueprintNode.fromAttrs? attrs with
+          | some node =>
+              let html ← renderBlueprintSlideNode renderContext node
+              pure <| some <| .other (VersoSlides.BlockExt.ofHtml html) #[]
+          | none =>
+              defaultSlidesTraverse.genreBlock container contents
       | _ =>
-        defaultSlidesGenreHtml.block inlineHtml blockHtml container contents
+          defaultSlidesTraverse.genreBlock container contents
   }
 
 /--
-Local upstream workaround pending the Verso Slides `Block.ofHtml` constructor
-tracked in `doc/UPSTREAM_BACKLOG.md`: keep this close to upstream `slidesMain`
-so the copied asset/write loop can disappear.
+Render Blueprint slide-node carriers to `VersoSlides.BlockExt.ofHtml` during
+the normal Verso Slides traversal.
+
+The 4.30 branch keeps the older compatibility path that overrides
+`GenreHtml.block`, because `verso-slides` 4.30 does not provide
+`BlockExt.ofHtml`. This 4.31 path still mirrors the small `slidesMain` output
+loop so `quiet := true` remains supported and the rendered HTML cache can seed
+the generated hover table.
 -/
 private def slidesMainWithBlueprintRenderer
     (config : VersoSlides.Config)
@@ -60,8 +78,11 @@ private def slidesMainWithBlueprintRenderer
   }
   let renderContext := Informal.Slides.RenderContext.ofPreviewData? manifest? htmlCache?
     (logError := logError)
-  let (doc, traverseState) ←
-    (VersoSlides.Slides.traverse doc : VersoSlides.TraverseM (Verso.Doc.Part VersoSlides.Slides)) () {}
+  let traverseDoc : VersoSlides.TraverseM (Verso.Doc.Part VersoSlides.Slides) :=
+    let _ : Verso.Doc.Traverse VersoSlides.Slides VersoSlides.TraverseM :=
+      blueprintSlidesTraverse renderContext
+    VersoSlides.Slides.traverse doc
+  let (doc, traverseState) ← traverseDoc () {}
   let ctx : Verso.Doc.Html.HtmlT.Context VersoSlides.Slides := {
     options := {}
     traverseContext := ()
@@ -72,8 +93,6 @@ private def slidesMainWithBlueprintRenderer
   }
   let initialHoverState := htmlCache?.map (·.hoverState) |>.getD {}
   let render : Verso.Doc.Html.HtmlT VersoSlides.Slides (Verso.BuildLogT IO) Verso.Output.Html :=
-    let _ : Verso.Doc.Html.GenreHtml VersoSlides.Slides (Verso.BuildLogT IO) :=
-      blueprintSlidesGenreHtml renderContext
     VersoSlides.renderDocument config doc
   let (slidesHtml, hoverState) ←
     ((render.run ctx).run initialHoverState).run logger

--- a/src/VersoBlueprint/Slides/Assets.lean
+++ b/src/VersoBlueprint/Slides/Assets.lean
@@ -42,9 +42,6 @@ def blueprintSlidesJs : String :=
       , slideNodeHydrationJs
       ]
 
-public def blueprintSlidesExtraJs : Array String :=
-  #[blueprintSlidesJsFilename]
-
 private def pushIfMissing [BEq α] (values : Array α) (value : α) : Array α :=
   if values.contains value then values else values.push value
 

--- a/src/VersoBlueprint/Slides/Render.lean
+++ b/src/VersoBlueprint/Slides/Render.lean
@@ -73,7 +73,11 @@ public def renderBlueprintSlideNode
 
 /--
 Render a Blueprint slide node from the structured attributes carried by the
-`VersoSlides.BlockExt.wrap` emitted by `blueprint_node`.
+legacy `VersoSlides.BlockExt.wrap` carrier emitted by `blueprint_node`.
+
+The Lean 4.31 slide path rewrites these carriers to
+`VersoSlides.BlockExt.ofHtml` during Slides traversal; the 4.30 maintenance line
+keeps the older HTML-renderer interception path.
 -/
 public def renderBlueprintSlideNodeFromAttrs?
     (ctx : RenderContext)

--- a/src/VersoBlueprint/Slides/Render.lean
+++ b/src/VersoBlueprint/Slides/Render.lean
@@ -78,6 +78,8 @@ legacy `VersoSlides.BlockExt.wrap` carrier emitted by `blueprint_node`.
 The Lean 4.31 slide path rewrites these carriers to
 `VersoSlides.BlockExt.ofHtml` during Slides traversal; the 4.30 maintenance line
 keeps the older HTML-renderer interception path.
+
+Remove this helper once the 4.30 maintenance line is retired.
 -/
 public def renderBlueprintSlideNodeFromAttrs?
     (ctx : RenderContext)

--- a/src/VersoBlueprint/Slides/blueprint-slides.css
+++ b/src/VersoBlueprint/Slides/blueprint-slides.css
@@ -436,3 +436,84 @@
 .bp_slide_node_compact .bp_code_panel_wrapper {
   display: none;
 }
+
+.bp_graft_side_by_side {
+  gap: 0.68rem;
+  margin: 0.55rem auto 0;
+  width: min(100%, 1220px);
+}
+
+.bp_graft_side_by_side_boxed > * {
+  padding: 0.5rem;
+}
+
+.bp_graft_side_by_side .bp_slide_node {
+  width: 100%;
+  margin: 0;
+  font-size: 0.96em;
+  --bp-slide-code-pre-max-height: 7.2rem;
+  --bp-slide-code-pre-font-size: 0.94rem;
+}
+
+.bp_graft_side_by_side .bp_slide_node .bp_wrapper {
+  padding: 0.48rem 0.62rem 0.56rem;
+}
+
+.bp_graft_side_by_side .bp_slide_node .bp_heading {
+  gap: 0.5rem;
+  padding-bottom: 0.36rem;
+}
+
+.bp_graft_side_by_side .bp_slide_node .bp_caption,
+.bp_graft_side_by_side .bp_slide_node .bp_label {
+  font-size: 1.12rem;
+}
+
+.bp_graft_side_by_side .bp_slide_node .bp_content {
+  margin-top: 0.24rem;
+  padding-left: 0.34rem;
+  line-height: 1.32;
+}
+
+.bp_graft_side_by_side .bp_slide_node .bp_content,
+.bp_graft_side_by_side .bp_slide_node .bp_content p {
+  font-size: 0.72em !important;
+  line-height: 1.32;
+}
+
+.bp_graft_side_by_side .bp_slide_node .bp_relation_chip,
+.bp_graft_side_by_side .bp_slide_node .bp_code_link,
+.bp_graft_side_by_side .bp_slide_node .bp_external_status_badge,
+.bp_graft_side_by_side .bp_slide_node .bp_extras .bp_code_summary_preview_root,
+.bp_graft_side_by_side .bp_slide_node .bp_extras .bp_code_summary_preview_wrap,
+.bp_graft_side_by_side .bp_slide_node .bp_extras .bp_inline_preview_ref {
+  font-size: 0.68rem;
+}
+
+.bp_graft_side_by_side:has(> :nth-child(4)) {
+  gap: 0.56rem;
+}
+
+.bp_graft_side_by_side:has(> :nth-child(4)).bp_graft_side_by_side_boxed > * {
+  padding: 0.4rem;
+}
+
+.bp_graft_side_by_side:has(> :nth-child(4)) .bp_slide_node {
+  font-size: 0.88em;
+  --bp-slide-code-pre-max-height: 5.6rem;
+  --bp-slide-code-pre-font-size: 0.82rem;
+}
+
+.bp_graft_side_by_side:has(> :nth-child(4)) .bp_slide_node .bp_wrapper {
+  padding: 0.34rem 0.44rem 0.4rem;
+}
+
+.bp_graft_side_by_side:has(> :nth-child(4)) .bp_slide_node .bp_content {
+  padding-left: 0.28rem;
+}
+
+.bp_graft_side_by_side:has(> :nth-child(4)) .bp_slide_node .bp_content,
+.bp_graft_side_by_side:has(> :nth-child(4)) .bp_slide_node .bp_content p {
+  font-size: 0.68em !important;
+  line-height: 1.26;
+}

--- a/src/VersoBlueprint/StyleSwitcher.lean
+++ b/src/VersoBlueprint/StyleSwitcher.lean
@@ -487,8 +487,6 @@ def js (cfg : JsConfig := {}) : String :=
   (jsTemplate.replace "__BP_ENABLE_PROOF_HIDER__" (boolLit cfg.proofHider)).replace
     "__BP_ENABLE_HASH_REVEAL__" (boolLit cfg.hashReveal)
 
-def jsBasic : String := js {}
-
 def jsInteractive : String := js { proofHider := true, hashReveal := true }
 
 end Informal.StyleSwitcher

--- a/tests/browser/BlueprintSlidesRuntime.lean
+++ b/tests/browser/BlueprintSlidesRuntime.lean
@@ -30,6 +30,34 @@ namespace Verso.VersoBlueprintTests.BlueprintSlidesRuntime
 
 {blueprint_node "multiplication_one_right" -header +compact (facet := "proof") (siteBase := "blueprint")}
 :::
+
+# Side-by-Side Full Cards
+
+:::blueprint_side_by_side
+{blueprint_node "addition_right_identity" (displayLabel := "Addition identity") (siteBase := "blueprint")}
+
+{blueprint_node "addition_right_identity" (facet := "proof") (displayLabel := "Proof sketch") (siteBase := "blueprint")}
+:::
+
+# Side-by-Side Compact Statements
+
+:::blueprint_side_by_side +boxed
+{blueprint_node "addition_spec" -header +compact (displayLabel := "Addition") (siteBase := "blueprint")}
+
+{blueprint_node "multiplication_spec" -header +compact (displayLabel := "Multiplication") (siteBase := "blueprint")}
+:::
+
+# Four-Up Compact Grafts
+
+:::blueprint_side_by_side +boxed
+{blueprint_node "addition_assoc" -header +compact (displayLabel := "Add assoc") (siteBase := "blueprint")}
+
+{blueprint_node "multiplication_assoc" -header +compact (displayLabel := "Mul assoc") (siteBase := "blueprint")}
+
+{blueprint_node "collatz_step" -header +compact (displayLabel := "Step") (siteBase := "blueprint")}
+
+{blueprint_node "collatz_conjecture" -header +compact (facet := "proof") (displayLabel := "Open proof") (siteBase := "blueprint")}
+:::
 :::::::
 
 private def usage : IO UInt32 := do

--- a/tests/browser/test_blueprint_slides_runtime.py
+++ b/tests/browser/test_blueprint_slides_runtime.py
@@ -428,6 +428,89 @@ class TestBlueprintSlidesRuntime:
             "/blueprint/Multiplication/#--informal-preview-multiplication_spec--statement",
         )
 
+        page.evaluate("window.Reveal.slide(3)")
+        page.wait_for_function("() => window.Reveal.getIndices().h === 3")
+        current_slide = page.locator(".reveal .slides section.present").first
+        full_grid = current_slide.locator(".bp_graft_side_by_side").first
+        expect(full_grid).to_be_visible()
+        assert not full_grid.evaluate(
+            """grid => grid.classList.contains("bp_graft_side_by_side_boxed")"""
+        )
+        full_statement = full_grid.locator(
+            ".bp_slide_node[data-bp-label='addition_right_identity']"
+            "[data-bp-facet='statement']"
+        )
+        full_proof = full_grid.locator(
+            ".bp_slide_node[data-bp-label='addition_right_identity']"
+            "[data-bp-facet='proof']"
+        )
+        expect(full_grid.locator(".bp_slide_node")).to_have_count(2)
+        expect(full_statement).to_have_attribute(
+            "data-bp-display-label", "Addition identity"
+        )
+        expect(full_statement).to_have_attribute("data-bp-show-header", "true")
+        expect(full_statement).to_contain_text("adding zero on the right")
+        expect(full_proof).to_have_attribute("data-bp-display-label", "Proof sketch")
+        expect(full_proof).to_contain_text("Induct on")
+        expect(full_statement.locator(".bp_kind_theorem_heading")).to_have_count(1)
+        expect(full_proof.locator(".bp_kind_proof_heading")).to_have_count(1)
+
+        page.evaluate("window.Reveal.slide(4)")
+        page.wait_for_function("() => window.Reveal.getIndices().h === 4")
+        current_slide = page.locator(".reveal .slides section.present").first
+        compact_grid = current_slide.locator(".bp_graft_side_by_side").first
+        expect(compact_grid).to_be_visible()
+        assert compact_grid.evaluate(
+            """grid => grid.classList.contains("bp_graft_side_by_side_boxed")"""
+        )
+        expect(compact_grid.locator(".bp_slide_node")).to_have_count(2)
+        expect(compact_grid.locator(".bp_heading")).to_have_count(0)
+        for label, display_label in [
+            ("addition_spec", "Addition"),
+            ("multiplication_spec", "Multiplication"),
+        ]:
+            compact_node = compact_grid.locator(
+                f".bp_slide_node[data-bp-label='{label}']"
+            )
+            expect(compact_node).to_have_attribute("data-bp-compact", "true")
+            expect(compact_node).to_have_attribute("data-bp-show-header", "false")
+            expect(compact_node).to_have_attribute("data-bp-display-label", display_label)
+
+        page.evaluate("window.Reveal.slide(5)")
+        page.wait_for_function("() => window.Reveal.getIndices().h === 5")
+        current_slide = page.locator(".reveal .slides section.present").first
+        four_up_grid = current_slide.locator(".bp_graft_side_by_side").first
+        expect(four_up_grid).to_be_visible()
+        expect(four_up_grid.locator(".bp_slide_node")).to_have_count(4)
+        expect(four_up_grid.locator(".bp_heading")).to_have_count(0)
+        expect(
+            four_up_grid.locator(
+                ".bp_slide_node[data-bp-label='collatz_conjecture']"
+                "[data-bp-facet='proof']"
+            )
+        ).to_contain_text("No proof is currently known")
+        expect(
+            four_up_grid.locator(
+                ".bp_slide_node[data-bp-label='multiplication_assoc']"
+                "[data-bp-display-label='Mul assoc']"
+            )
+        ).to_contain_text("multiplication is associative")
+        four_up_metrics = four_up_grid.evaluate(
+            """grid => {
+              const boxes = [...grid.querySelectorAll(".bp_slide_node")].map(node =>
+                node.getBoundingClientRect()
+              );
+              const content = grid.querySelector(".bp_content");
+              return {
+                maxBottom: Math.max(...boxes.map(box => box.bottom)),
+                viewportHeight: window.innerHeight,
+                contentFontSize: parseFloat(getComputedStyle(content).fontSize)
+              };
+            }"""
+        )
+        assert four_up_metrics["maxBottom"] <= four_up_metrics["viewportHeight"] - 24
+        assert four_up_metrics["contentFontSize"] >= 12
+
         page.evaluate("window.bpSlideNodeRuntime.hydrate(document)")
         expect_slide_link(
             page,


### PR DESCRIPTION
This PR uses the Verso Slides 4.31 `BlockExt.ofHtml` hook for Blueprint slide nodes, replacing the local `GenreHtml.block` override while keeping the small output loop needed for quiet rendering and cached hover payload seeding.

It also prunes unused preview/slides helper APIs and marks the legacy slide-attr renderer for removal once the 4.30 maintenance line is retired.

Backport v4.30.0: exempt: partial v4.30 backport lives in #137; v4.30 does not provide `BlockExt.ofHtml` and keeps the older compatibility/API surface.
