### PR TITLE
fix: label external declaration subsections without h1

### DIFF
--- a/src/VersoBlueprint/Commands/Graph.lean
+++ b/src/VersoBlueprint/Commands/Graph.lean
@@ -11,6 +11,7 @@ import VersoBlueprint.Commands.Common
 import VersoBlueprint.Environment
 import VersoBlueprint.Graph
 import VersoBlueprint.Lib.HoverRender
+import VersoBlueprint.Lib.HtmlId
 import VersoBlueprint.PreviewCache
 import VersoBlueprint.Lib.PreviewSource
 import VersoBlueprint.Resolve
@@ -142,10 +143,7 @@ def allGraphDirections : Array GraphDirection := #[.TB, .LR, .RL, .BT]
 def graphCss := include_str "graph.css"
 
 def fallbackGraphControlId (id : Verso.Multi.InternalId) (suffix : String) : String :=
-  let raw := toString id
-  let sanitized := raw.foldl (init := "") fun acc c =>
-    acc.push <| if c.isAlphanum then c else '-'
-  s!"bp-graph-{sanitized}{suffix}"
+  s!"{Informal.HtmlId.prefixed "bp-graph" (toString id)}{suffix}"
 
 def groupVariantKey : String := "group"
 def parentVariantKey (parent : Name) : String := s!"parent:{parent}"

--- a/src/VersoBlueprint/ExternalDeclRender.lean
+++ b/src/VersoBlueprint/ExternalDeclRender.lean
@@ -7,6 +7,7 @@ Author: Emilio J. Gallego Arias
 import Lean
 import Verso
 import VersoManual
+import VersoBlueprint.Lib.HtmlId
 import VersoBlueprint.Lib.HoverInline
 
 open Lean Meta
@@ -198,15 +199,21 @@ private def docsHtml (docs? : Option String) : ExternalDeclHtml :=
   open Verso.Output.Html in
   {{<div class="docs">{{plainDocstringHtml docs?}}</div>}}
 
-private def renderTitledSection? (title : String) (rows : Array ExternalDeclHtml) :
+private def externalDeclSectionLabelId (decl : Name) (title : String) : String :=
+  Informal.HtmlId.prefixed "bp-external-decl-section" s!"{decl.toString}:{title}"
+
+private def renderTitledSection? (decl : Name) (title : String) (rows : Array ExternalDeclHtml) :
     Option ExternalDeclHtml :=
   open Verso.Output.Html in
   if rows.isEmpty then
     none
   else
+    let labelId := externalDeclSectionLabelId decl title
     some {{
-      <h1>{{.text true title}}</h1>
-      {{rows}}
+      <div class="bp_external_decl_section" role="group" aria-labelledby={{labelId}}>
+        <p class="bp_external_decl_section_label" id={{labelId}}>{{.text true title}}</p>
+        {{rows}}
+      </div>
     }}
 
 private def kindMarkerOfDeclType : Verso.Genre.Manual.Block.Docstring.DeclType → String
@@ -365,6 +372,7 @@ private def renderFieldSignature (field : Verso.Genre.Manual.Block.Docstring.Fie
   }}
 
 private def renderParentsSection
+    (decl : Name)
     (parents : Array Verso.Genre.Manual.Block.Docstring.ParentInfo) :
     ExternalDeclHighlightRender (Option ExternalDeclHtml) :=
   open Verso.Output.Html in do
@@ -374,9 +382,12 @@ private def renderParentsSection
     let rows ← parents.mapM fun parent => do
       let parentHtml ← highlightedToHtml parent.parent
       pure {{<li><code class="hl lean inline">{{parentHtml}}</code></li>}}
+    let labelId := externalDeclSectionLabelId decl "Extends"
     pure <| some {{
-      <h1>"Extends"</h1>
-      <ul class="extends">{{rows}}</ul>
+      <div class="bp_external_decl_section" role="group" aria-labelledby={{labelId}}>
+        <p class="bp_external_decl_section_label" id={{labelId}}>"Extends"</p>
+        <ul class="extends">{{rows}}</ul>
+      </div>
     }}
 
 private def safetyHeaderMeta (cinfo : ConstantInfo) : Array String :=
@@ -432,7 +443,7 @@ private def renderDeclHtmlDocstringFromInfoE
         | some ctor =>
           let title := if isClass then "Instance Constructor" else "Constructor"
           let ctorHtml ← renderDocNameCtor ctor
-          pure <| renderTitledSection? title #[ctorHtml]
+          pure <| renderTitledSection? decl title #[ctorHtml]
         | none => pure none
       | _ => pure none
 
@@ -440,19 +451,19 @@ private def renderDeclHtmlDocstringFromInfoE
       match declType with
       | .structure isClass _ _ fieldInfo _ _ =>
         let rows ← fieldInfo.filter (fun f => f.subobject?.isNone) |>.mapM renderFieldSignature
-        pure <| renderTitledSection? (if isClass then "Methods" else "Fields") rows
+        pure <| renderTitledSection? decl (if isClass then "Methods" else "Fields") rows
       | _ => pure none
 
     let parentsSection? : Option ExternalDeclHtml ←
       match declType with
-      | .structure _ _ _ _ parents _ => renderParentsSection parents
+      | .structure _ _ _ _ parents _ => renderParentsSection decl parents
       | _ => pure none
 
     let inductiveCtorsSection? : Option ExternalDeclHtml ←
       match declType with
       | .inductive ctors _ _ =>
         let rows ← ctors.mapM renderDocNameCtor
-        pure <| renderTitledSection? "Constructors" rows
+        pure <| renderTitledSection? decl "Constructors" rows
       | _ => pure none
 
     let mut sections : Array ExternalDeclHtml := #[]

--- a/src/VersoBlueprint/Graph.lean
+++ b/src/VersoBlueprint/Graph.lean
@@ -6,6 +6,7 @@ Author: Emilio J. Gallego Arias
 
 import VersoBlueprint.Environment
 import VersoBlueprint.Informal.Block.Model
+import VersoBlueprint.Lib.HtmlId
 import VersoBlueprint.ProvedStatus
 
 namespace Informal.Graph
@@ -639,17 +640,8 @@ def escapeDotString (s : String) : String :=
 
 def dotIndent (n : Nat) : String := String.ofList (List.replicate n ' ')
 
-private def graphSvgIdPiece (c : Char) : String :=
-  if c.isAlphanum || c == '-' || c == '_' then
-    String.singleton c
-  else
-    s!"x{c.toNat}x"
-
 def graphNodeSvgId (label : Name) : String :=
-  let escaped :=
-    (toString label).toList.foldl (init := "") fun acc c =>
-      acc ++ graphSvgIdPiece c
-  s!"bp-node-{escaped}"
+  Informal.HtmlId.prefixed "bp-node" (toString label)
 
 partial def emitGroupClusterLines (nodeDefs : NameMap String) (groupMembers : NameMap (Array Name))
     (groupChildren : NameMap (Array Name)) (groupIds : NameMap Nat)

--- a/src/VersoBlueprint/Informal/Block/Assets.lean
+++ b/src/VersoBlueprint/Informal/Block/Assets.lean
@@ -1229,8 +1229,12 @@ a.bp_external_decl_source_path:hover {
   margin-bottom: 0;
 }
 
-.bp_external_decl_rendered .bp_external_decl_body h1 {
-  margin: 0.75rem 0 0.4rem;
+.bp_external_decl_rendered .bp_external_decl_section + .bp_external_decl_section {
+  margin-top: 0.75rem;
+}
+
+.bp_external_decl_rendered .bp_external_decl_section_label {
+  margin: 0 0 0.4rem;
   padding-bottom: 0.18rem;
   border-bottom: 1px solid var(--bp-color-border-soft);
   color: var(--bp-color-text-muted);

--- a/src/VersoBlueprint/Lib/HtmlId.lean
+++ b/src/VersoBlueprint/Lib/HtmlId.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import Lean
+
+namespace Informal.HtmlId
+
+private def hexDigits : Array Char := "0123456789ABCDEF".toList.toArray
+
+private theorem hexDigits_size : hexDigits.size = 16 := by
+  native_decide
+
+private def toHex (n : Nat) : String := Id.run do
+  let mut n := n
+  let mut digits := #[]
+  repeat
+    if h : n < 16 then
+      digits := digits.push <| hexDigits[n]'(by
+        simpa [hexDigits_size] using h)
+      break
+    else
+      digits := digits.push <| hexDigits[n % 16]'(by
+        simpa [hexDigits_size] using Nat.mod_lt n (by decide : 0 < 16))
+      n := n >>> 4
+  let padding := (4 - digits.size).fold (init := "") (fun _ _ p => p.push '0')
+  digits.foldr (init := padding) fun c s => s.push c
+
+/--
+Encode arbitrary text as a stable DOM-id suffix.
+
+This preserves distinctions that `String.sluggify` intentionally normalizes
+away, which matters for ids derived from declaration names.
+-/
+def key (s : String) : String :=
+  s.foldl (init := "") fun acc c =>
+    if c.isAlphanum then
+      acc.push c
+    else if c == '-' then
+      acc |>.push '-' |>.push '-'
+    else
+      acc ++ s!"-{toHex c.toNat}"
+
+/-- Build a DOM id from a fixed prefix and an encoded value. -/
+def prefixed (idPrefix value : String) : String :=
+  let body := key value
+  if body.isEmpty then idPrefix else s!"{idPrefix}-{body}"
+
+end Informal.HtmlId

--- a/tests/VersoBlueprintTests/BlueprintGraph/Groups.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraph/Groups.lean
@@ -87,6 +87,7 @@ def groupedVariants : Array Informal.Commands.GraphRenderVariant :=
 /-- info: true -/
 #guard_msgs in
 #eval
+  graphNodeSvgId `group_alpha == "bp-node-group-005Falpha" &&
   match groupedVariants.find? (·.key == Informal.Commands.groupVariantKey) with
   | none => false
   | some variant =>

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
@@ -62,6 +62,9 @@ Base statement for graph preview mode option coverage.
 #guard (Informal.Commands.parseGraphPreviewPlacement? "anchored").map (·.dataValue) == some "anchored"
 #guard (Informal.Commands.parseGraphPreviewPlacement? "fixed").isNone
 #guard (Informal.Commands.parseGraphPreviewPlacement? "near-node").isNone
+#guard
+  Informal.Commands.fallbackGraphControlId (default : Verso.Multi.InternalId) "--view" ==
+    "bp-graph--0023-003C0-003E--view"
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -116,6 +116,24 @@ class TestPreviewRuntimeRegressions:
         expect(cls.locator(".bp_external_decl_body").first).to_contain_text("Methods")
         expect(cls.locator(".bp_external_decl_body").first).to_contain_text("The neutral preview value")
 
+    def test_issue_130_showcase_labels_external_decl_subsections_without_h1(
+        self, server: str, page: Page
+    ):
+        page.goto(f"{server}/External-Declaration-Heading-Repro/Nested-External-Declaration-Panels/")
+
+        expect(
+            page.get_by_role("heading", name=re.compile("Nested External Declaration Panels"))
+        ).to_be_visible()
+        expect(page.locator(".bp_external_decl_body h1")).to_have_count(0)
+
+        section_labels = page.locator(".bp_external_decl_section_label")
+        expect(page.locator("p.bp_external_decl_section_label")).to_have_count(section_labels.count())
+        labels = {label.strip() for label in section_labels.all_text_contents()}
+        assert {"Fields", "Methods", "Constructors", "Extends"} <= labels
+
+        groups = page.locator(".bp_external_decl_section[role='group'][aria-labelledby]")
+        expect(groups).to_have_count(section_labels.count())
+
     def test_inline_docstringed_constructs_showcase(self, server: str, page: Page):
         errors = record_runtime_errors(page)
         page.goto(f"{server}/Code-Panels/")

--- a/tests/harness/preview_runtime_showcase/check_blueprint_code_panels.py
+++ b/tests/harness/preview_runtime_showcase/check_blueprint_code_panels.py
@@ -24,6 +24,65 @@ def load(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def require_contains(haystack: str, needle: str, description: str) -> None:
+    if needle not in haystack:
+        fail(f"Missing {description}: {needle!r}")
+
+
+def find_issue_130_page(out_root: Path) -> tuple[Path, str]:
+    matches: list[tuple[Path, str]] = []
+    for path in out_root.rglob("index.html"):
+        html = load(path)
+        if "Issue #130 heading-outline reproduction" in html:
+            matches.append((path, html))
+
+    if not matches:
+        fail("Could not find issue #130 external declaration heading reproduction page")
+
+    if len(matches) > 1:
+        locations = ", ".join(str(path.relative_to(out_root)) for path, _ in matches)
+        fail(f"Expected one issue #130 reproduction page, found {len(matches)}: {locations}")
+
+    return matches[0]
+
+
+def check_external_decl_section_label(
+    html: str,
+    label: str,
+    description: str,
+) -> None:
+    pattern = (
+        r'<div class="bp_external_decl_section" role="group" aria-labelledby="([^"]+)">\s*'
+        r'<p class="bp_external_decl_section_label" id="\1">\s*'
+        + re.escape(label)
+        + r"\s*</p>"
+    )
+    if not re.search(pattern, html, re.S):
+        fail(f"Missing named external declaration subsection group for {description}: {label}")
+
+
+def check_issue_130_external_decl_headings(out_root: Path) -> tuple[Path, list[str]]:
+    issue_page, issue_html = find_issue_130_page(out_root)
+    expected_labels = ["Fields", "Methods", "Constructors", "Extends"]
+
+    raw_heading_re = r"<h1>\s*(?:Fields|Methods|Constructors|Extends|Constructor|Instance Constructor)\s*</h1>"
+    if re.search(raw_heading_re, issue_html):
+        fail("Issue #130 reproduction still renders external declaration subsection labels as h1")
+
+    for label in expected_labels:
+        check_external_decl_section_label(issue_html, label, f"issue #130 {label}")
+
+    for definition_name in [
+        "h1_repro_structure",
+        "h1_repro_class",
+        "h1_repro_inductive",
+        "h1_repro_extends",
+    ]:
+        require_contains(issue_html, definition_name, f"{definition_name} reproduction node")
+
+    return issue_page, expected_labels
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Static regression checks for generated local code-panel showcase pages."
@@ -134,6 +193,11 @@ def main() -> int:
         re.S,
     ):
         fail("external declaration signature still nests wide-only markup inside <pre>")
+    if re.search(
+        r"<h1>\s*(?:Fields|Methods|Constructors|Extends|Constructor|Instance Constructor)\s*</h1>",
+        code_panels,
+    ):
+        fail("external declaration subsection labels should not render as h1")
 
     panel_re = re.compile(r'<details class="bp_code_block bp_code_panel"[^>]*>.*?</details>', re.S)
     external_panels = [p for p in panel_re.findall(code_panels) if "bp_external_status_badge_summary" in p]
@@ -284,6 +348,7 @@ def main() -> int:
         fail("external inductive panel missing visible inductive kind marker")
     if "Constructors" not in inductive_panel:
         fail("external inductive panel missing constructor section")
+    check_external_decl_section_label(inductive_panel, "Constructors", "external inductive panel")
     if "2 constructors" not in inductive_panel:
         fail("external inductive panel missing constructor-count metadata chip")
     if "PreviewStage.initial" not in inductive_panel or "PreviewStage.step" not in inductive_panel:
@@ -309,6 +374,7 @@ def main() -> int:
         fail("external class panel missing visible class kind marker")
     if "Methods" not in class_panel:
         fail("external class panel missing methods section")
+    check_external_decl_section_label(class_panel, "Methods", "external class panel")
     if "2 methods" not in class_panel:
         fail("external class panel missing method-count metadata chip")
     if "PreviewFold.neutral" not in class_panel or "PreviewFold.combine" not in class_panel:
@@ -334,6 +400,7 @@ def main() -> int:
         fail("external structure panel missing visible structure kind marker")
     if "Fields" not in structure_panel:
         fail("external structure panel missing fields section")
+    check_external_decl_section_label(structure_panel, "Fields", "external structure panel")
     if "6 fields" not in structure_panel:
         fail("external structure panel missing field-count metadata chip")
     if "PreviewFreyPackage.hFLT" not in structure_panel:
@@ -413,10 +480,14 @@ def main() -> int:
     if "Inline mixed fold class docstring." not in code_panels:
         fail("missing mixed inline class docstring")
 
+    issue_page, issue_labels = check_issue_130_external_decl_headings(out_root)
+
     print(
         "[blueprint-panel-regression] OK:",
         f"external_panels={len(external_panels)}",
         f"literate_panels={len(literate_panels)}",
+        f"issue130_page={issue_page.relative_to(out_root)}",
+        f"issue130_section_labels={','.join(issue_labels)}",
     )
     return 0
 

--- a/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Blueprint.lean
+++ b/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Blueprint.lean
@@ -5,6 +5,7 @@ import VersoBlueprint.Commands.Graph
 import VersoBlueprint.Commands.Summary
 import PreviewRuntimeShowcase.Chapters.CodePanels
 import PreviewRuntimeShowcase.Chapters.CorePreviews
+import PreviewRuntimeShowcase.Chapters.ExternalDeclHeadings
 import PreviewRuntimeShowcase.Chapters.GroupPreviews
 import PreviewRuntimeShowcase.Chapters.InlineHoverPreviews
 import PreviewRuntimeShowcase.Chapters.PreviewRelationships
@@ -21,6 +22,7 @@ generator checks can run against a focused, synthetic site.
 
 {include 0 PreviewRuntimeShowcase.Chapters.CorePreviews}
 {include 0 PreviewRuntimeShowcase.Chapters.CodePanels}
+{include 0 PreviewRuntimeShowcase.Chapters.ExternalDeclHeadings}
 {include 0 PreviewRuntimeShowcase.Chapters.GroupPreviews}
 {include 0 PreviewRuntimeShowcase.Chapters.PreviewRelationships}
 {include 0 PreviewRuntimeShowcase.Chapters.InlineHoverPreviews}

--- a/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/ExternalDeclHeadings.lean
+++ b/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/ExternalDeclHeadings.lean
@@ -1,0 +1,9 @@
+import PreviewRuntimeShowcase.Chapters.ExternalDeclHeadings.Nested
+
+open Verso.Genre Manual
+
+#doc (Manual) "External Declaration Heading Repro" =>
+This chapter isolates external declaration panels on a nested page, making it
+easier to inspect how their subsection labels affect the document outline.
+
+{include 1 PreviewRuntimeShowcase.Chapters.ExternalDeclHeadings.Nested}

--- a/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/ExternalDeclHeadings/Nested.lean
+++ b/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/ExternalDeclHeadings/Nested.lean
@@ -1,0 +1,46 @@
+import PreviewRuntimeShowcase.Chapters.CodePanels
+
+open Verso.Genre
+open Verso.Genre.Manual
+open Informal
+
+namespace PreviewRuntimeShowcase.ExternalDeclHeadingDecls
+
+/-- A base structure used to reproduce inherited-field rendering in external declaration panels. -/
+structure HeadingBase where
+  /-- A base field that should appear through the extending declaration's parent section. -/
+  base : Nat
+
+/-- An extending structure used to exercise the `Extends` subsection label. -/
+structure HeadingExtends extends HeadingBase where
+  /-- A field owned by the extending structure. -/
+  extra : Nat
+
+end PreviewRuntimeShowcase.ExternalDeclHeadingDecls
+
+#doc (Manual) "Nested External Declaration Panels" =>
+%%%
+tag := "issue-130-external-decl-heading-repro"
+%%%
+
+Issue #130 heading-outline reproduction.
+
+These Blueprint nodes live on a nested Manual page so the generated page has
+real surrounding headings. The external declaration subsection labels below
+should be visible without entering the page heading outline.
+
+:::definition "h1_repro_structure" (lean := "PreviewRuntimeShowcase.CodePanelDecls.PreviewFreyPackage")
+Structure panel that renders the `Fields` label inside the declaration body.
+:::
+
+:::definition "h1_repro_class" (lean := "PreviewRuntimeShowcase.CodePanelDecls.PreviewFold")
+Class panel that renders the `Methods` label inside the declaration body.
+:::
+
+:::definition "h1_repro_inductive" (lean := "PreviewRuntimeShowcase.CodePanelDecls.PreviewStage")
+Inductive panel that renders the `Constructors` label inside the declaration body.
+:::
+
+:::definition "h1_repro_extends" (lean := "PreviewRuntimeShowcase.ExternalDeclHeadingDecls.HeadingExtends")
+Extending structure panel that renders the `Extends` label inside the declaration body.
+:::


### PR DESCRIPTION
This PR fixes external declaration subsection labels so `Fields`, `Methods`, `Constructors`, and `Extends` remain visible without entering the page heading outline. It wraps rendered declaration subsections in named groups, reuses the shared HTML ID encoder for external declaration section and graph IDs, and adds preview-runtime regression coverage for issue #130.

Backport v4.30.0: #136