### PR TITLE
fix: publish v4.31 project-template reference

### DIFF
--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -13,7 +13,8 @@
           "release": "v4.30.0"
         },
         {
-          "release": "v4.31.0"
+          "release": "v4.31.0",
+          "publish_reference": true
         }
       ],
       "build_command": ["lake", "build", "ProjectTemplate"],

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -140,6 +140,9 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         )
         expected_template_targets = [target.release_id for target in branch_policy.release_targets]
         self.assertEqual([target.release for target in projects[0].targets], expected_template_targets)
+        default_template_target = projects[0].target_for_release(branch_policy.default_dev_branch)
+        self.assertIsNotNone(default_template_target)
+        self.assertTrue(default_template_target.publish_reference)
         self.assertEqual(current_release.release_toolchain, current_release.toolchain)
         self.assertEqual(current_release.release_verso_ref, current_release.verso_ref)
         self.assertTrue(current_release.deploy_pages)


### PR DESCRIPTION
Publish the v4.31 project-template reference target so the release catalog and README link agree.

- Mark the v4.31 project-template target as publish_reference
- Assert the default-development template target remains publishable

Backport v4.30.0: exempt: v4.31 reference-catalog publication only