### PR TITLE
[backport v4.30.0] doc: add Collatz side-by-side graft example

### DIFF
--- a/project_template/ProjectTemplate/Chapters/Collatz.lean
+++ b/project_template/ProjectTemplate/Chapters/Collatz.lean
@@ -8,6 +8,26 @@ open Informal
 
 #doc (Manual) "Collatz" =>
 
+# Side-by-Side Views
+
+These grafts reuse the Collatz entries below. A full card keeps the explanatory
+definition together with its attached Lean code, while compact cards keep the
+statement and proof facets easy to compare.
+
+:::blueprint_side_by_side +boxed
+{blueprint_node "collatz_step" (displayLabel := "Step")}
+
+{blueprint_node "collatz_conjecture" (displayLabel := "Conjecture") -header +compact}
+:::
+
+:::blueprint_side_by_side
+{blueprint_node "collatz_conjecture" (displayLabel := "Statement") -header +compact}
+
+{blueprint_node "collatz_conjecture" (facet := "proof") (displayLabel := "Proof status") -header +compact}
+:::
+
+# Source Entries
+
 :::group "collatz_core"
 A small exploratory chapter about the Collatz iteration on natural numbers.
 :::

--- a/src/VersoBlueprint/Graft/Assets.lean
+++ b/src/VersoBlueprint/Graft/Assets.lean
@@ -60,6 +60,34 @@ def css : String := r##"
 .bp_graft_side_by_side .bp_extras {
   margin-left: 0;
 }
+
+.bp_graft_side_by_side .bp_code_block summary {
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.bp_graft_side_by_side .bp_code_summary_text {
+  white-space: normal;
+}
+
+.bp_graft_side_by_side .bp_code_summary_indicator {
+  margin-left: 0;
+  width: 100%;
+  max-width: 100%;
+}
+
+.bp_graft_side_by_side .bp_code_summary_indicator .bp_code_summary_preview_root,
+.bp_graft_side_by_side .bp_code_summary_indicator .bp_code_summary_preview_wrap {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+}
+
+.bp_graft_side_by_side .bp_code_progress {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+}
 "##
 
 def cssAssets : List String := [css]


### PR DESCRIPTION
## Summary
Backport the v4.30-compatible part of #133 to `v4.30.0`.

## Primary Review
- Primary review: #133
- Keep review comments on #133 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.30.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- Partial backport only: excludes the 4.31-only Verso Slides `BlockExt.ofHtml` traversal change because v4.30 does not provide that API.
- Includes the Collatz side-by-side graft example and scoped Manual graft CSS hardening from #133.
