### PR TITLE
refactor: reuse HtmlId for hover preview ids

### DIFF
--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -361,8 +361,9 @@ python3 -m scripts.blueprint_harness create-worktree <name>
 
 That command is intentionally heavyweight by default: after `git worktree add`
 it syncs the root checkout's `.lake/` and warms the shared and per-worktree
-reference blueprint clones. New worktrees now base off the preferred active
-release ref, typically something like `origin/v4.30.0`.
+reference blueprint clones. New worktrees now base off the branch policy's
+preferred default-development ref, typically something like `origin/v4.31.0`.
+Pass `--base <release-ref>` explicitly for backport-only work.
 
 If you want to verify that the root checkout has not drifted before branching
 or landing, use:

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -191,7 +191,14 @@ def resolve_create_worktree_base(layout, requested_base: str | None) -> str:
     release_branch = active_release_branch(layout.repo_root)
     preferred_base = preferred_release_ref(layout.repo_root)
     if requested_base is None:
-        requested_base = preferred_base
+        default_branch = default_dev_branch(layout.repo_root)
+        remote_default_branch = f"origin/{default_branch}"
+        if ref_oid(layout.repo_root, remote_default_branch) is not None:
+            requested_base = remote_default_branch
+        elif ref_oid(layout.repo_root, default_branch) is not None:
+            requested_base = default_branch
+        else:
+            requested_base = remote_default_branch
 
     if requested_base == release_branch and preferred_base != release_branch:
         status = release_sync_status(layout.repo_root)

--- a/src/VersoBlueprint/Cite.lean
+++ b/src/VersoBlueprint/Cite.lean
@@ -36,6 +36,13 @@ private def parseBibLabel (s : String) : Name :=
 def normalizeLabel (label : String) : String :=
   (parseBibLabel label).toString
 
+/--
+Stable slug used in bibliography fragment URLs and citation preview keys.
+
+This intentionally keeps the historical lowercase, hyphen-separated bibliography
+anchor form instead of `Informal.HtmlId.key`. Use the `HtmlId` encoder for
+opaque generated element ids; citation anchors are user-visible URL fragments.
+-/
 def citationAnchorId (label : String) : String :=
   let base := normalizeLabel label
   base.foldl (init := "") fun acc c =>

--- a/src/VersoBlueprint/Lib/HoverRender.lean
+++ b/src/VersoBlueprint/Lib/HoverRender.lean
@@ -7,6 +7,7 @@ Author: Emilio J. Gallego Arias
 import Lean
 import Verso
 import VersoManual
+import VersoBlueprint.Lib.HtmlId
 import VersoBlueprint.TraversalIndex
 
 namespace Informal.HoverRender
@@ -50,38 +51,11 @@ def PreviewPlacement.dataValue : PreviewPlacement → String
   | .anchored => "anchored"
   | .docked => "docked"
 
-private def hexDigits : Array Char := "0123456789ABCDEF".toList.toArray
-
-private theorem hexDigits_size : hexDigits.size = 16 := by
-  native_decide
-
-private def toHex (n : Nat) : String := Id.run do
-  let mut n := n
-  let mut digits := #[]
-  repeat
-    if h : n < 16 then
-      digits := digits.push <| hexDigits[n]'(by
-        simpa [hexDigits_size] using h)
-      break
-    else
-      digits := digits.push <| hexDigits[n % 16]'(by
-        simpa [hexDigits_size] using Nat.mod_lt n (by decide : 0 < 16))
-      n := n >>> 4
-  let padding := (4 - digits.size).fold (init := "") (fun _ _ p => p.push '0')
-  digits.foldr (init := padding) fun c s => s.push c
-
 def previewKey (s : String) : String :=
-  s.foldl (init := "") fun acc c =>
-    if c.isAlphanum then
-      acc.push c
-    else if c == '-' then
-      acc |>.push '-' |>.push '-'
-    else
-      acc ++ s!"-{toHex c.toNat}"
+  Informal.HtmlId.key s
 
 def previewId (idPrefix value : String) : String :=
-  let body := previewKey value
-  if body.isEmpty then idPrefix else s!"{idPrefix}-{body}"
+  Informal.HtmlId.prefixed idPrefix value
 
 def inlinePreviewRenderProperty : Name := Name.mkSimple "Informal.inlinePreview.rendering"
 

--- a/tests/VersoBlueprintTests/BlueprintLinkHover.lean
+++ b/tests/VersoBlueprintTests/BlueprintLinkHover.lean
@@ -5,6 +5,7 @@ Author: Emilio J. Gallego Arias
 -/
 
 import VersoBlueprintTests.Blueprint.Support
+import VersoBlueprint.Lib.HtmlId
 import VersoManual.Bibliography
 
 namespace Verso.VersoBlueprintTests.BlueprintLinkHover
@@ -35,6 +36,13 @@ private def hoverCitePreviewKey : String :=
     Informal.Cite.CitationStyle.textual
     (some Informal.Cite.CitePartKind.lemma)
     (some "3")
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  Informal.Cite.citationAnchorId "hover.cite" == "hover-cite" &&
+  Informal.Cite.citationAnchorId "Hover.Cite" == "hover-cite" &&
+  Informal.HtmlId.key "hover.cite" == "hover-002Ecite"
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/VersoBlueprintTests/BlueprintPreviewPanels.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewPanels.lean
@@ -5,12 +5,16 @@ Author: Emilio J. Gallego Arias
 -/
 
 import VersoBlueprint.Lib.HoverRender
+import VersoBlueprint.Lib.HtmlId
 import VersoBlueprintTests.Blueprint.Support
 
 namespace Verso.VersoBlueprintTests.BlueprintPreviewPanels
 
 open Informal.HoverRender
 open Verso.VersoBlueprintTests.Blueprint.Support
+
+#guard previewKey "alpha.beta" == Informal.HtmlId.key "alpha.beta"
+#guard previewId "bp-preview" "alpha.beta" == Informal.HtmlId.prefixed "bp-preview" "alpha.beta"
 
 private def hasSharedPanelScaffolding (html rootClass headerClass titleClass closeClass bodyClass closeLabel : String) : Bool :=
   hasSubstr html s!"class=\"{rootClass}\"" &&

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -17,6 +17,15 @@ from scripts.blueprint_harness_paths import (
 
 
 DEFAULT_TEST_BLUEPRINT = "preview_runtime_showcase"
+DEFAULT_BROWSER_TYPES = {"chromium"}
+
+
+def selected_browser_types(selected) -> set[str]:
+    if isinstance(selected, (list, tuple, set)):
+        return set(selected) or set(DEFAULT_BROWSER_TYPES)
+    if selected in (None, ""):
+        return set(DEFAULT_BROWSER_TYPES)
+    return {selected}
 
 
 def browser_executable(browser_type: str) -> str | None:
@@ -133,13 +142,7 @@ def playwright_instance():
 @pytest.fixture(scope="session", params=["chromium", "firefox"])
 def browser(request, playwright_instance):
     browser_type = request.param
-    selected = request.config.getoption("browser")
-    if isinstance(selected, (list, tuple, set)):
-        selected_browsers = set(selected)
-    elif selected in (None, ""):
-        selected_browsers = {"chromium"}
-    else:
-        selected_browsers = {selected}
+    selected_browsers = selected_browser_types(request.config.getoption("browser"))
     if browser_type not in selected_browsers:
         pytest.skip(f"browser {browser_type} not selected")
     launcher = getattr(playwright_instance, browser_type)

--- a/tests/browser/test_browser_selection.py
+++ b/tests/browser/test_browser_selection.py
@@ -1,0 +1,15 @@
+from conftest import selected_browser_types
+
+
+def test_empty_playwright_browser_option_uses_default_browser():
+    assert selected_browser_types([]) == {"chromium"}
+
+
+def test_missing_browser_option_uses_default_browser():
+    assert selected_browser_types(None) == {"chromium"}
+    assert selected_browser_types("") == {"chromium"}
+
+
+def test_explicit_browser_selection_is_preserved():
+    assert selected_browser_types("firefox") == {"firefox"}
+    assert selected_browser_types(["chromium", "firefox"]) == {"chromium", "firefox"}

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -310,14 +310,16 @@ class BlueprintHarnessCliTests(unittest.TestCase):
 
         self.assertIsNone(pin)
 
-    def test_create_worktree_uses_preferred_release_ref_by_default(self) -> None:
+    def test_create_worktree_uses_default_dev_ref_by_default(self) -> None:
         layout = SimpleNamespace(repo_root=Path("/tmp/repo"))
         with patched_attrs(
             harness_mod,
+            default_dev_branch=lambda _repo_root: "v4.30.0",
+            ref_oid=lambda _repo_root, ref: "abc" if ref == "origin/v4.30.0" else None,
             preferred_release_ref=lambda _repo_root: "origin/v4.29.0",
             active_release_branch=lambda _repo_root: "v4.29.0",
         ):
-            self.assertEqual(harness_mod.resolve_create_worktree_base(layout, None), "origin/v4.29.0")
+            self.assertEqual(harness_mod.resolve_create_worktree_base(layout, None), "origin/v4.30.0")
 
     def test_create_worktree_rejects_unsynced_local_release_base(self) -> None:
         layout = SimpleNamespace(repo_root=Path("/tmp/repo"))


### PR DESCRIPTION
This PR fixes local browser test defaults, documents citation anchor slug behavior, bases new worktrees on the default-development branch, and reuses the shared `HtmlId` encoder for hover preview ids.

Backport v4.30.0: #139