### PR TITLE
fix: speed up worktree reference preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,17 +208,17 @@ you want to enable it.
 ## Reference Blueprints
 
 The repository also tracks a release-versioned reference catalog. On the
-current `v4.31.0` line, the in-repo starter template is the active reference
-target. Larger external blueprints keep their last published release links until
-their upstream repositories have been updated and validated for the new Lean
-release.
+current `v4.31.0` line, the in-repo starter template, Noperthedron, and FLT are
+active reference targets. Other external blueprints keep their last published
+release links until their upstream repositories have been updated and validated
+for the new Lean release.
 
 - [project_template/](./project_template/), the in-repo starter template,
   [rendered site](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.31.0/project-template/)
-- [`ejgallego/verso-sphere-packing`](https://github.com/ejgallego/verso-sphere-packing),
-  [rendered site for v4.30.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.30.0/spherepackingblueprint/)
 - [`ejgallego/verso-noperthedron`](https://github.com/ejgallego/verso-noperthedron),
   [rendered site for v4.31.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.31.0/noperthedron/)
+- [`ejgallego/verso-sphere-packing`](https://github.com/ejgallego/verso-sphere-packing),
+  [rendered site for v4.30.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.30.0/spherepackingblueprint/)
 - [`ejgallego/verso-flt`](https://github.com/ejgallego/verso-flt),
   [rendered site for v4.31.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.31.0/verso-flt/)
 - [`ejgallego/verso-carleson`](https://github.com/ejgallego/verso-carleson),

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -389,9 +389,9 @@ the root checkout as the stable base:
 python3 -m scripts.blueprint_harness create-worktree <name>
 ```
 
-That command is intentionally heavyweight by default: after `git worktree add`
-it syncs the root checkout's `.lake/` and warms the shared and per-worktree
-reference blueprint clones. New worktrees now base off the branch policy's
+After `git worktree add`, that command syncs the root checkout's `.lake/` and
+prepares the shared and per-worktree reference blueprint clones without running
+external reference project builds. New worktrees now base off the branch policy's
 preferred default-development ref, typically something like `origin/v4.31.0`.
 Pass `--base <release-ref>` explicitly for backport-only work.
 

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -512,7 +512,7 @@ def command_create_worktree(args: argparse.Namespace) -> int:
             _release_target, projects = resolve_release_projects(catalog, None, new_layout.package_root, None)
         except (FileNotFoundError, ValueError) as err:
             raise SystemExit(f"[blueprint-harness] {err}") from err
-        sync_reference_blueprints(new_layout, projects, warm_build=True, prepare_local_checkout=True)
+        sync_reference_blueprints(new_layout, projects, warm_build=False, prepare_local_checkout=True)
     if any(value is not None for value in (args.owner, args.priority, args.summary, args.status, args.scope)) or args.lock:
         update_worktree_record(
             layout.repo_root,
@@ -1318,7 +1318,7 @@ def add_create_worktree_command(subparsers) -> None:
         "create-worktree",
         help=(
             "Create a linked worktree under `.worktrees/<name>`, then by default "
-            "sync the root `.lake/` and warm the reference blueprint clones."
+            "sync the root `.lake/` and prepare the reference blueprint clones."
         ),
     )
     create_worktree.add_argument("name", help="Worktree directory name under `.worktrees/`.")
@@ -1340,12 +1340,12 @@ def add_create_worktree_command(subparsers) -> None:
     create_worktree.add_argument(
         "--skip-reference-sync",
         action="store_true",
-        help="Do not warm the shared and per-worktree reference blueprint clones after creating the worktree.",
+        help="Do not prepare the shared and per-worktree reference blueprint clones after creating the worktree.",
     )
     create_worktree.add_argument(
         "--lightweight",
         action="store_true",
-        help="Create only the git worktree and skip both `.lake/` sync and reference-cache warm-up.",
+        help="Create only the git worktree and skip both `.lake/` sync and reference-checkout preparation.",
     )
     create_worktree.add_argument("--owner", default=None, help="Owner or agent responsible for the worktree.")
     create_worktree.add_argument("--lock", action="store_true", help="Mark the worktree as locked for active exclusive work.")

--- a/scripts/blueprint_harness_project_commands.py
+++ b/scripts/blueprint_harness_project_commands.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from contextlib import contextmanager
-import os
 from pathlib import Path
 import re
 import subprocess
@@ -63,8 +62,8 @@ def rewrite_local_blueprint_dependency(project_dir: Path, package_root: Path) ->
         project_dir,
         action="inject the local path override automatically",
     )
-    relative_path = os.path.relpath(package_root, start=project_dir)
-    replacement = f'{match.group("indent")}require VersoBlueprint from "{relative_path}"'
+    local_path = str(package_root.resolve())
+    replacement = f'{match.group("indent")}require VersoBlueprint from "{local_path}"'
     rewritten = text[: match.start()] + replacement + text[match.end() :]
     rewritten = disable_header_linter_for_mathlib_blueprint_lakefile(rewritten)
     lakefile.write_text(rewritten, encoding="utf-8")

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -42,13 +42,75 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         with redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
             parser.parse_args(argv)
 
-    def test_create_worktree_sync_policy_respects_lightweight_mode(self) -> None:
-        args = argparse.Namespace(skip_sync=False, skip_reference_sync=False, lightweight=True)
-        self.assertEqual(create_worktree_sync_policy(args), (True, True))
+    def create_worktree_args(self, **overrides: object) -> argparse.Namespace:
+        values = {
+            "name": "demo",
+            "branch": None,
+            "base": None,
+            "skip_sync": False,
+            "skip_reference_sync": False,
+            "lightweight": False,
+            "owner": None,
+            "priority": None,
+            "summary": None,
+            "status": None,
+            "scope": None,
+            "lock": False,
+        }
+        values.update(overrides)
+        return argparse.Namespace(**values)
 
-    def test_create_worktree_sync_policy_preserves_explicit_flags(self) -> None:
-        args = argparse.Namespace(skip_sync=True, skip_reference_sync=False, lightweight=False)
-        self.assertEqual(create_worktree_sync_policy(args), (True, False))
+    def demo_worktree_layouts(self) -> tuple[SimpleNamespace, SimpleNamespace]:
+        root_layout = SimpleNamespace(repo_root=Path("/tmp/repo"), package_root=Path("/tmp/repo"))
+        new_layout = SimpleNamespace(
+            repo_root=Path("/tmp/repo"),
+            package_root=Path("/tmp/repo/.worktrees/demo"),
+            artifact_root=Path("/tmp/repo/_out/demo"),
+            in_linked_worktree=True,
+        )
+        return root_layout, new_layout
+
+    def published_git_project(self) -> HarnessProject:
+        return HarnessProject(
+            project_id="published",
+            source_kind="git_checkout",
+            project_root=".",
+            build_target=None,
+            generator=None,
+            repository="https://github.com/example/published.git",
+            ref="published-ref",
+            build_command=("lake", "build"),
+            generate_command=("lake", "exe", "blueprint-gen"),
+            site_subdir="html-multi",
+            panel_regression_script=None,
+            browser_tests_path=None,
+            description=None,
+            selected_release="v4.30.0",
+        )
+
+    def test_create_worktree_sync_policy_matrix(self) -> None:
+        cases = (
+            (False, False, False, (False, False)),
+            (True, False, False, (True, False)),
+            (False, True, False, (False, True)),
+            (True, True, False, (True, True)),
+            (False, False, True, (True, True)),
+            (True, False, True, (True, True)),
+            (False, True, True, (True, True)),
+            (True, True, True, (True, True)),
+        )
+        for skip_sync, skip_reference_sync, lightweight, expected in cases:
+            with self.subTest(
+                skip_sync=skip_sync,
+                skip_reference_sync=skip_reference_sync,
+                lightweight=lightweight,
+            ):
+                args = argparse.Namespace(
+                    skip_sync=skip_sync,
+                    skip_reference_sync=skip_reference_sync,
+                    lightweight=lightweight,
+                )
+                self.assertEqual(create_worktree_sync_policy(args), expected)
 
     def test_reference_generate_parses_allow_unsafe_root_release(self) -> None:
         parser = reference_harness_mod.build_parser()
@@ -338,73 +400,56 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             with self.assertRaisesRegex(SystemExit, "refusing to use local `v4.29.0` as the worktree base"):
                 harness_mod.resolve_create_worktree_base(layout, "v4.29.0")
 
-    def test_create_worktree_syncs_resolved_release_projects(self) -> None:
-        args = argparse.Namespace(
-            name="demo",
-            branch=None,
-            base=None,
-            skip_sync=True,
-            skip_reference_sync=False,
-            lightweight=False,
-            owner=None,
-            priority=None,
-            summary=None,
-            status=None,
-            scope=None,
-            lock=False,
+    def test_create_worktree_preparation_matrix(self) -> None:
+        cases = (
+            ("default", {}, True, True),
+            ("skip-sync", {"skip_sync": True}, False, True),
+            ("skip-reference-sync", {"skip_reference_sync": True}, True, False),
+            ("skip-both", {"skip_sync": True, "skip_reference_sync": True}, False, False),
+            ("lightweight", {"lightweight": True}, False, False),
         )
-        root_layout = SimpleNamespace(repo_root=Path("/tmp/repo"), package_root=Path("/tmp/repo"))
-        new_layout = SimpleNamespace(
-            repo_root=Path("/tmp/repo"),
-            package_root=Path("/tmp/repo/.worktrees/demo"),
-            artifact_root=Path("/tmp/repo/_out/demo"),
-            in_linked_worktree=True,
-        )
-        project = HarnessProject(
-            project_id="published",
-            source_kind="git_checkout",
-            project_root=".",
-            build_target=None,
-            generator=None,
-            repository="https://github.com/example/published.git",
-            ref="published-ref",
-            build_command=("lake", "build"),
-            generate_command=("lake", "exe", "blueprint-gen"),
-            site_subdir="html-multi",
-            panel_regression_script=None,
-            browser_tests_path=None,
-            description=None,
-            selected_release="v4.30.0",
-        )
-        catalog = SimpleNamespace(projects=())
-        seen: dict[str, object] = {}
+        for label, overrides, expected_lake_sync, expected_reference_sync in cases:
+            with self.subTest(label=label):
+                args = self.create_worktree_args(**overrides)
+                root_layout, new_layout = self.demo_worktree_layouts()
+                project = self.published_git_project()
+                catalog = SimpleNamespace(projects=())
+                seen: dict[str, object] = {}
 
-        def fake_resolve(_catalog, release, package_root, selected_ids):
-            seen["resolve_args"] = (_catalog, release, package_root, selected_ids)
-            return SimpleNamespace(release_id="v4.30.0"), [project]
+                def fake_resolve(_catalog, release, package_root, selected_ids):
+                    seen["resolve_args"] = (_catalog, release, package_root, selected_ids)
+                    return SimpleNamespace(release_id="v4.30.0"), [project]
 
-        def fake_sync(_layout, projects, *, warm_build, prepare_local_checkout):
-            seen["sync_args"] = (_layout, projects, warm_build, prepare_local_checkout)
+                def fake_sync(_layout, projects, *, warm_build, prepare_local_checkout):
+                    seen["sync_args"] = (_layout, projects, warm_build, prepare_local_checkout)
 
-        with patched_attrs(
-            harness_mod,
-            detect_harness_layout=lambda start=None: new_layout if start == Path("/tmp/repo/.worktrees/demo") else root_layout,
-            resolve_create_worktree_base=lambda _layout, _base: "origin/v4.30.0",
-            branch_exists=lambda _repo_root, _branch: False,
-            run=lambda command, *, cwd: seen.setdefault("commands", []).append(command),
-            resolve_manifest_path=lambda _path_text, _package_root: Path("/tmp/projects.json"),
-            load_project_catalog_manifest=lambda _manifest_path: catalog,
-            resolve_release_projects=fake_resolve,
-            sync_reference_blueprints=fake_sync,
-        ):
-            self.assertEqual(harness_mod.command_create_worktree(args), 0)
+                with patched_attrs(
+                    harness_mod,
+                    detect_harness_layout=lambda start=None: (
+                        new_layout if start == Path("/tmp/repo/.worktrees/demo") else root_layout
+                    ),
+                    resolve_create_worktree_base=lambda _layout, _base: "origin/v4.30.0",
+                    branch_exists=lambda _repo_root, _branch: False,
+                    run=lambda command, *, cwd: seen.setdefault("commands", []).append(command),
+                    sync_root_worktree_lake=lambda _layout: seen.setdefault("lake_syncs", []).append(_layout),
+                    resolve_manifest_path=lambda _path_text, _package_root: Path("/tmp/projects.json"),
+                    load_project_catalog_manifest=lambda _manifest_path: catalog,
+                    resolve_release_projects=fake_resolve,
+                    sync_reference_blueprints=fake_sync,
+                ):
+                    self.assertEqual(harness_mod.command_create_worktree(args), 0)
 
-        self.assertEqual(
-            seen["commands"],
-            [["git", "worktree", "add", "-b", "feat/demo", "/tmp/repo/.worktrees/demo", "origin/v4.30.0"]],
-        )
-        self.assertEqual(seen["resolve_args"], (catalog, None, new_layout.package_root, None))
-        self.assertEqual(seen["sync_args"], (new_layout, [project], True, True))
+                self.assertEqual(
+                    seen["commands"],
+                    [["git", "worktree", "add", "-b", "feat/demo", "/tmp/repo/.worktrees/demo", "origin/v4.30.0"]],
+                )
+                self.assertEqual(seen.get("lake_syncs", []), [new_layout] if expected_lake_sync else [])
+                if expected_reference_sync:
+                    self.assertEqual(seen["resolve_args"], (catalog, None, new_layout.package_root, None))
+                    self.assertEqual(seen["sync_args"], (new_layout, [project], False, True))
+                else:
+                    self.assertNotIn("resolve_args", seen)
+                    self.assertNotIn("sync_args", seen)
 
     def test_release_status_require_sync_returns_nonzero_when_unsynced(self) -> None:
         args = argparse.Namespace(require_sync=True)

--- a/tests/harness/test_blueprint_harness_project_commands.py
+++ b/tests/harness/test_blueprint_harness_project_commands.py
@@ -44,7 +44,7 @@ class BlueprintHarnessProjectCommandTests(unittest.TestCase):
             self.assertEqual(result, lakefile)
             text = lakefile.read_text(encoding="utf-8")
             self.assertNotIn(OFFICIAL_BLUEPRINT_REQUIRE, text)
-            self.assertIn('require VersoBlueprint from "', text)
+            self.assertIn(f'require VersoBlueprint from "{PACKAGE_ROOT.resolve()}"', text)
 
     def test_rewrite_local_blueprint_dependency_accepts_official_repo_with_non_main_ref(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -1061,6 +1061,70 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             self.assertEqual(seen["package_root"], layout.package_root)
             self.assertEqual(lakefile.read_text(encoding="utf-8"), OFFICIAL_BLUEPRINT_REQUIRE + "\n")
 
+    def test_reference_cache_checkout_rewrites_override_to_absolute_linked_worktree_path(self) -> None:
+        import scripts.blueprint_harness_references as refs_mod
+
+        project = HarnessProject(
+            project_id="external-blueprint",
+            source_kind="git_checkout",
+            project_root=".",
+            build_target=None,
+            generator=None,
+            repository="https://github.com/example/external-blueprint.git",
+            ref="main",
+            build_command=None,
+            generate_command=("lake", "exe", "blueprint-gen"),
+            site_subdir="html-multi",
+            panel_regression_script=None,
+            browser_tests_path=None,
+            description=None,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            worktrees_root = root / ".worktrees"
+            package_root = worktrees_root / "docs-431-reference-catalog"
+            cache_dir = worktrees_root / "_reference-blueprints" / "cache" / reference_dependency_cache_key(project)
+            cache_dir.mkdir(parents=True)
+            (cache_dir / ".git").mkdir()
+            lakefile = cache_dir / "lakefile.lean"
+            lakefile.write_text(OFFICIAL_BLUEPRINT_REQUIRE + "\n", encoding="utf-8")
+            package_root.mkdir(parents=True)
+            layout = SimpleNamespace(
+                package_root=package_root,
+                repo_root=root,
+                reference_source_cache_root=worktrees_root / "_reference-blueprints" / "cache",
+                reference_dependency_cache_root=worktrees_root / "_reference-blueprints" / "deps",
+            )
+
+            originals = {
+                "update_git_checkout": refs_mod.update_git_checkout,
+                "bootstrap_reference_checkout": refs_mod.bootstrap_reference_checkout,
+                "project_lake_update_command": refs_mod.project_lake_update_command,
+                "run": refs_mod.run,
+            }
+            seen: dict[str, str] = {}
+
+            def fake_run(command, *, cwd):
+                if command == ["lake", "update"]:
+                    seen["lakefile_during_update"] = lakefile.read_text(encoding="utf-8")
+                    return
+                raise AssertionError(f"unexpected command: {command}")
+
+            try:
+                refs_mod.update_git_checkout = lambda _project, _cache_dir: None
+                refs_mod.bootstrap_reference_checkout = lambda *, project_dir: None
+                refs_mod.project_lake_update_command = lambda _package_root, _project_dir: ["lake", "update"]
+                refs_mod.run = fake_run
+
+                refs_mod.sync_reference_cache_checkout(layout, project, warm_build=False)
+            finally:
+                for name, value in originals.items():
+                    setattr(refs_mod, name, value)
+
+            self.assertIn(f'require VersoBlueprint from "{package_root.resolve()}"', seen["lakefile_during_update"])
+            self.assertNotIn("../../../docs-431-reference-catalog", seen["lakefile_during_update"])
+            self.assertEqual(lakefile.read_text(encoding="utf-8"), OFFICIAL_BLUEPRINT_REQUIRE + "\n")
+
     def test_reference_cache_warm_build_failure_reports_recovery_hints(self) -> None:
         import scripts.blueprint_harness_references as refs_mod
 


### PR DESCRIPTION
Keep the 4.31 reference-maintenance workflow fast and compatible with the updated catalog.

- Keep `create-worktree` reference preparation enabled by default, but skip external reference project builds during worktree creation.
- Stabilize local `VersoBlueprint` overrides for shared reference-cache checkouts by using absolute package paths.
- Refresh the README reference catalog wording for the current 4.31 targets.

Backport v4.30.0: exempt: maintainer harness optimization and v4.31 reference-catalog documentation only