### PR TITLE
chore: replace deprecated Verso logError wrappers

### DIFF
--- a/src/VersoBlueprint/Cite.lean
+++ b/src/VersoBlueprint/Cite.lean
@@ -477,7 +477,7 @@ inline_extension Inline.bpCite (citations : List CiteItem) (style : CitationStyl
   data := toJson ({ citations, style, kind, index } : CiteInlineData)
   traverse id data _contents := do
     let .ok cfg := fromJson? (α := CiteInlineData) data
-      | logError "Malformed data in Inline.bpCite.traverse"
+      | Verso.reportError "Malformed data in Inline.bpCite.traverse"
         return none
     let ctxt ← read
     let path := ctxt.path
@@ -519,7 +519,7 @@ inline_extension Inline.bpCite (citations : List CiteItem) (style : CitationStyl
     open Verso.Output.TeX in
     some <| fun go _id data content => do
       let .ok cfg := fromJson? (α := CiteInlineData) data
-        | TeX.logError "Malformed data in Inline.bpCite.toTeX"
+        | Verso.reportError "Malformed data in Inline.bpCite.toTeX"
           pure .empty
       let pieces := cfg.citations.map (fun item => pieceText cfg.style item.citation)
       let body := String.intercalate "; " pieces
@@ -551,7 +551,7 @@ inline_extension Inline.bpCite (citations : List CiteItem) (style : CitationStyl
     open Verso.Output.Html in
     some <| fun goI id data content => do
       let .ok cfg := fromJson? (α := CiteInlineData) data
-        | HtmlT.logError "Malformed data in Inline.bpCite.toHtml"
+        | Verso.reportError "Malformed data in Inline.bpCite.toHtml"
           pure .empty
       let st ← HtmlT.state
       let inPreviewRender ← Informal.HoverRender.inInlinePreviewRender

--- a/src/VersoBlueprint/Commands/Bibliography.lean
+++ b/src/VersoBlueprint/Commands/Bibliography.lean
@@ -34,7 +34,7 @@ block_extension Block.bibliography (biblio : BibliographyData) where
   data := toJson biblio
   traverse id data _contents := do
     let .ok biblio := fromJson? (α := BibliographyData) data
-      | logError "Malformed data in Block.bibliography.traverse"
+      | Verso.reportError "Malformed data in Block.bibliography.traverse"
         return none
     let path ← (·.path) <$> read
     let _ ← Verso.Genre.Manual.externalTag id path s!"--bp-bibliography"
@@ -48,7 +48,7 @@ block_extension Block.bibliography (biblio : BibliographyData) where
     open Verso.Output.Html in
     some <| fun goI _goB _id data _blocks => do
       let .ok data := fromJson? (α := BibliographyData) data
-        | HtmlT.logError "Malformed data in Block.bibliography.toHtml"
+        | Verso.reportError "Malformed data in Block.bibliography.toHtml"
           pure .empty
       let st ← HtmlT.state
       let entries := data.entries.toArray.qsort (fun a b => a.citation.sortKey < b.citation.sortKey)

--- a/src/VersoBlueprint/Commands/Graph.lean
+++ b/src/VersoBlueprint/Commands/Graph.lean
@@ -440,7 +440,7 @@ block_extension Block.graph (graphData : GraphBlockData) where
         match fromJson? (α := GraphBlockData) data with
         | .ok gd => pure gd
         | .error err =>
-          HtmlT.logError s!"Malformed data in Block.graph.toHtml ({err})"
+          Verso.reportError s!"Malformed data in Block.graph.toHtml ({err})"
           pure { graph := #[], options := {}, groupTitles := #[] }
       let s ← HtmlT.state
       let resolveHref : Name → Option String := fun ref =>

--- a/src/VersoBlueprint/Commands/Summary.lean
+++ b/src/VersoBlueprint/Commands/Summary.lean
@@ -1047,7 +1047,7 @@ private def SummaryHtmlContext.sorryRow (ctx : SummaryHtmlContext) (item : Sorry
       pure ("contains sorry", "Declaration with sorry: ", "bp_summary_badge bp_summary_badge_warn",
         item.status.sorryLocationText, refsTxt)
     | .proved =>
-      HtmlT.logError s!"Unexpected proved status in summary sorry details for {item.decl}"
+      Verso.reportError s!"Unexpected proved status in summary sorry details for {item.decl}"
       pure ("proved", "Declaration: ", "bp_summary_badge", "proved", "0")
   let (statusLabel, declPrefix, badgeClass, whereTxt, refsTxt) := statusInfo
   pure {{ <li class="bp_summary_item">
@@ -1725,7 +1725,7 @@ private def summaryStructureSection (data : Summary) (rows : SummaryRows) : Outp
 private def summaryBlockToHtml : BlockToHtml Manual (ReaderT AllRemotes (ReaderT ExtensionImpls (BuildLogT IO))) :=
   fun _goI _goB _id json _blocks => do
     let .ok data := fromJson? (α := Summary) json
-      | HtmlT.logError "Malformed data in Block.summary.toHtml"
+      | Verso.reportError "Malformed data in Block.summary.toHtml"
         pure .empty
     let s ← HtmlT.state
     let previewLookupKeys := (data.previewLabels).foldl (init := ({} : Lean.NameMap String)) fun keys label =>

--- a/src/VersoBlueprint/Graft.lean
+++ b/src/VersoBlueprint/Graft.lean
@@ -79,12 +79,12 @@ private def renderLeanCodePreviewBody?
     Doc.Html.HtmlT Verso.Genre.Manual m (Option Html) := do
   match Informal.TraversalIndex.LeanCodePreviews.object? state key with
   | none =>
-      Doc.Html.HtmlT.logError s!"Blueprint graft: missing Lean-code preview {key}"
+      Verso.reportError s!"Blueprint graft: missing Lean-code preview {key}"
       pure none
   | some obj =>
       match fromJson? (α := Informal.LeanCodePreview.Entry) obj.data with
       | .error err =>
-          Doc.Html.HtmlT.logError s!"Blueprint graft: malformed Lean-code preview {key}: {err}"
+          Verso.reportError s!"Blueprint graft: malformed Lean-code preview {key}: {err}"
           pure none
       | .ok entry =>
           match entry.source with
@@ -157,7 +157,7 @@ block_extension Block.blueprintGraftNode (cfg : Informal.Graft.BlueprintNodeConf
     some <| fun _goI goB _id data _blocks => do
       match fromJson? (α := Informal.Graft.BlueprintNodeConfig) data with
       | .error err =>
-          HtmlT.logError s!"Malformed Blueprint graft node data ({err}): {data}"
+          Verso.reportError s!"Malformed Blueprint graft node data ({err}): {data}"
           pure .empty
       | .ok cfg => renderManualGraftNode goB cfg
 
@@ -175,7 +175,7 @@ block_extension Block.blueprintGraftSideBySide (cfg : Informal.Graft.SideBySideC
       let cfg ←
         match fromJson? (α := Informal.Graft.SideBySideConfig) data with
         | .error err =>
-            HtmlT.logError s!"Malformed Blueprint graft side-by-side data ({err}): {data}"
+            Verso.reportError s!"Malformed Blueprint graft side-by-side data ({err}): {data}"
             pure {}
         | .ok cfg => pure cfg
       let content ← blocks.mapM goB

--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -62,7 +62,7 @@ block_extension Block.informal (data : BlockData) where
     -- XXX: (maybe) lift the Except into the main monad error thread
     match fromJson? (α := BlockData) data with
     | .error err =>
-      logError s!"Malformed data ({err}): {data}"
+      Verso.reportError s!"Malformed data ({err}): {data}"
       pure none
     | .ok blockData =>
       let blockData := blockData.withTraversalNumberingContext (← read)
@@ -78,7 +78,7 @@ block_extension Block.informal (data : BlockData) where
     some <| fun _goI goB id data blocks => do
       match fromJson? (α := BlockData) data with
       | .error err =>
-        HtmlT.logError s!"Malformed data ({err}): {data}"
+        Verso.reportError s!"Malformed data ({err}): {data}"
         pure .empty
       | .ok data =>
         let s ← HtmlT.state

--- a/src/VersoBlueprint/Informal/Code.lean
+++ b/src/VersoBlueprint/Informal/Code.lean
@@ -56,7 +56,7 @@ block_extension Block.informalCode (data : InlineCodeData) where
   data := toJson data
   traverse id data _contents := do
     let .ok cdata := fromJson? (α := InlineCodeData) data
-      | logError s!"Malformed data: {data}"
+      | Verso.reportError s!"Malformed data: {data}"
         pure none
     let label := cdata.label
     if let .some _d := Informal.TraversalIndex.InlineCode.object? (← get) label then
@@ -95,7 +95,7 @@ block_extension Block.informalCode (data : InlineCodeData) where
     open Verso.Output.Html in
     some <| fun _goI goB id data blocks => do
       let .ok { label, definedDefs, definedTheorems, statementUses := _, proofUses := _, foldCodeBlock, foldProofs } := fromJson? (α := InlineCodeData) data
-        | HtmlT.logError s!"Malformed data: {data}"
+        | Verso.reportError s!"Malformed data: {data}"
           pure .empty
       let s ← HtmlT.state
       let ctxt ← HtmlT.context
@@ -272,7 +272,7 @@ block_extension Block.externalMarkup (data : ExternalMarkupBlockData) where
   data := toJson data
   traverse id data _contents := do
     let .ok cdata := fromJson? (α := ExternalMarkupBlockData) data
-      | logError s!"Malformed external markup data: {data}"
+      | Verso.reportError s!"Malformed external markup data: {data}"
         pure none
     let existingData := (Informal.TraversalIndex.ExternalMarkup.data? (← get) cdata.label).getD {
       label := cdata.label
@@ -281,7 +281,7 @@ block_extension Block.externalMarkup (data : ExternalMarkupBlockData) where
     match existing.find? cdata.markup.language cdata.markup.slot with
     | some value =>
         unless value == cdata.markup.value do
-          logError s!"Label {cdata.label} already has associated {cdata.markup.language} external markup in slot '{cdata.markup.slot}'"
+          Verso.reportError s!"Label {cdata.label} already has associated {cdata.markup.language} external markup in slot '{cdata.markup.slot}'"
     | none =>
       let updated : Data.ExternalMarkupData := {
         existingData with
@@ -298,7 +298,7 @@ block_extension Block.externalMarkup (data : ExternalMarkupBlockData) where
     open Verso.Doc.Html in
     some <| fun _goI _goB _id data _blocks => do
       let .ok cdata := fromJson? (α := ExternalMarkupBlockData) data
-        | HtmlT.logError s!"Malformed external markup data: {data}"
+        | Verso.reportError s!"Malformed external markup data: {data}"
           pure .empty
       let summary := externalMarkupSummary cdata.markup.language cdata.markup.slot cdata.markup.location
       pure <|

--- a/src/VersoBlueprint/Informal/Group.lean
+++ b/src/VersoBlueprint/Informal/Group.lean
@@ -47,7 +47,7 @@ block_extension Block.groupMetadata (groupData : GroupBlockData) where
   data := toJson groupData
   traverse _id data _contents := do
     let .ok groupData := fromJson? (α := GroupBlockData) data
-      | logError "Malformed data in Block.groupMetadata.traverse"
+      | Verso.reportError "Malformed data in Block.groupMetadata.traverse"
         return none
     modify fun st =>
       Informal.TraversalIndex.Groups.saveData st groupData.label (toJson groupData)
@@ -58,7 +58,7 @@ block_extension Block.groupMetadata (groupData : GroupBlockData) where
     open Verso.Output.Html in
     some <| fun _ _ _ data _ => do
       let .ok _ := fromJson? (α := GroupBlockData) data
-        | HtmlT.logError "Malformed data in Block.groupMetadata.toHtml"
+        | Verso.reportError "Malformed data in Block.groupMetadata.toHtml"
           pure .empty
       pure .empty
 

--- a/src/VersoBlueprint/Informal/RustBlock.lean
+++ b/src/VersoBlueprint/Informal/RustBlock.lean
@@ -24,7 +24,7 @@ block_extension Block.informalRustCode (data : Informal.Rust.InlineCodeData) whe
   data := toJson data
   traverse id data _contents := do
     let .ok cdata := fromJson? (α := Informal.Rust.InlineCodeData) data
-      | logError s!"Malformed Rust data: {data}"
+      | Verso.reportError s!"Malformed Rust data: {data}"
         pure none
     if let some _ := (← get).getDomainObject? Informal.Rust.informalRustCodeDomain cdata.label.toString then
       pure none
@@ -42,7 +42,7 @@ block_extension Block.informalRustCode (data : Informal.Rust.InlineCodeData) whe
     open Verso.Output.Html in
     some <| fun _goI _goB id data _blocks => do
       let .ok cdata := fromJson? (α := Informal.Rust.InlineCodeData) data
-        | HtmlT.logError s!"Malformed Rust code data: {data}"
+        | Verso.reportError s!"Malformed Rust code data: {data}"
           pure .empty
       let s ← HtmlT.state
       let ctxt ← HtmlT.context

--- a/src/VersoBlueprint/Informal/Uses.lean
+++ b/src/VersoBlueprint/Informal/Uses.lean
@@ -115,7 +115,7 @@ inline_extension Inline.informal (data : InlineData) where
   data := toJson data
   traverse _id data _contents := do
     let .ok _ := fromJson? (α := InlineData) data
-      | logError s!"Malformed data in Inline.informal traversal: {data}"
+      | Verso.reportError s!"Malformed data in Inline.informal traversal: {data}"
         pure none
     pure none
   extraCss := Informal.Commands.withInlinePreviewCssAssets
@@ -125,7 +125,7 @@ inline_extension Inline.informal (data : InlineData) where
     open Verso.Output.Html in
     some <| fun goI _id data inlines => do
       let .ok { label, block } := fromJson? (α := InlineData) data
-        | HtmlT.logError "Malformed data in Inline.informal traversal"
+        | Verso.reportError "Malformed data in Inline.informal traversal"
           pure .empty
       let st ← HtmlT.state
       let storedBlock? := resolveStoredBlockData? st label

--- a/src/VersoBlueprint/Math.lean
+++ b/src/VersoBlueprint/Math.lean
@@ -70,7 +70,7 @@ inline_extension Inline.bpMath (data : BpMathData) where
   data := toJson data
   traverse _id data _contents := do
     let .ok { texPrelude, .. } := fromJson? (α := BpMathData) data
-      | logError s!"Malformed blueprint math payload during traversal: {data}"
+      | Verso.reportError s!"Malformed blueprint math payload during traversal: {data}"
         pure none
     modify fun st =>
       st.modifyHtmlAssets fun assets =>
@@ -85,7 +85,7 @@ inline_extension Inline.bpMath (data : BpMathData) where
     open Verso.Output.TeX in
     some <| fun _go _id data _contents => do
       let .ok { mode, source, .. } := fromJson? (α := BpMathData) data
-        | TeX.logError s!"Malformed blueprint math payload: {data}"
+        | Verso.reportError s!"Malformed blueprint math payload: {data}"
           pure .empty
       pure <| match mode with
         | .inline => .raw s!"${source}$"
@@ -94,7 +94,7 @@ inline_extension Inline.bpMath (data : BpMathData) where
     open Verso.Doc.Html in
     some <| fun _goI _id data _contents => do
       let .ok { mode, source, texPrelude } := fromJson? (α := BpMathData) data
-        | HtmlT.logError s!"Malformed blueprint math payload: {data}"
+        | Verso.reportError s!"Malformed blueprint math payload: {data}"
           pure .empty
       let attrs :=
         if texPrelude.isEmpty then


### PR DESCRIPTION
This PR replaces deprecated Verso logError wrapper calls in Blueprint render and traversal code with the current Verso.reportError API.

- Replace deprecated HtmlT.logError, TeX.logError, and manual logError wrapper calls with Verso.reportError.
- Keep existing error messages and control flow unchanged.

Backport v4.30.0: #146