### PR TITLE
chore: remove ineffective expose attributes

### DIFF
--- a/src/VersoBlueprint/Data.lean
+++ b/src/VersoBlueprint/Data.lean
@@ -41,18 +41,15 @@ set_option doc.verso true
 -- set_option pp.rawOnError true
 
 -- informal object labels are names for now, but that could change
-@[expose]
 def Label := Name
 deriving Repr, Inhabited, DecidableEq, ToString, ToMessageData, ToJson, FromJson, Quote
 
-@[expose] def LabelMap A := NameMap A
+def LabelMap A := NameMap A
 
 instance [Repr A] : Repr (LabelMap A) := inferInstanceAs <| Repr (NameMap A)
 
-@[expose]
 abbrev Parent := Label
 
-@[expose]
 abbrev AuthorId := Label
 
 /-- Where a declared dependency edge came from. -/


### PR DESCRIPTION
This PR removes ineffective @[expose] attributes from Blueprint data aliases so the v4.31 build no longer reports no-op attribute warnings in this module.

- Remove four @[expose] attributes from Label, LabelMap, Parent, and AuthorId declarations.
- Leave the declarations and derived instances unchanged.

Backport v4.30.0: exempt: v4.30 does not emit this warning with its toolchain, and the change has no runtime or rendering effect.