### PR TITLE
Update reference blueprint catalog for v4.30 wrappers

### DIFF
--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -47,9 +47,8 @@
       },
       "targets": [
         {
-          "release": "v4.31.0",
-          "ref": "caa4d8950fa8c390ea0a191c8b1ad687a8841ddb",
-          "publish_reference": true
+          "release": "v4.30.0",
+          "ref": "516bab06c7f65aa60e265e56edc42acf75b51cf9"
         }
       ],
       "build_command": ["bash", "scripts/ci-reference-build.sh"],

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -10,9 +10,6 @@
       },
       "targets": [
         {
-          "release": "v4.30.0"
-        },
-        {
           "release": "v4.31.0",
           "publish_reference": true
         }
@@ -70,7 +67,7 @@
       "targets": [
         {
           "release": "v4.30.0",
-          "ref": "13bcd04fc6a7a63e5b351c1cf104205022e23813",
+          "ref": "f406aed2feca812917b62b5e2654de29cbc3dae1",
           "publish_reference": true
         }
       ],
@@ -89,7 +86,7 @@
       "targets": [
         {
           "release": "v4.30.0",
-          "ref": "b64f286038f7b8e1d35d0ba67a6027074158db85",
+          "ref": "73c4bac9073120109e2338e545c945d0fb87323e",
           "rc": "4.30-rc2",
           "publish_reference": true
         }


### PR DESCRIPTION
## Summary

- update the reference blueprint catalog to the current v4.30 reference wrapper refs
- point `spherepackingblueprint` at the published SpherePacking wrapper commit `516bab0`
- keep SpherePacking on the upstream official Lean 4.30 formalization branch instead of the experimental 4.31 bump branch

This branch is based on the existing aggregate v4.30 catalog branch, so it also includes the pending FLT/Carleson reference catalog updates from that branch.

## Validation

- `python3 scripts/meta_checkout.py report verso-sphere-packing`
- `lake exe cache get`
- `python3 scripts/meta_checkout.py compute-repair-work verso-sphere-packing --build`

SpherePacking repair analysis is build-backed complete: all 8 direct-port chapters are `done`, with 0 build failures and 0 metadata/LT issues.
