### PR TITLE
Update reference blueprint catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,9 @@ release.
 - [`ejgallego/verso-sphere-packing`](https://github.com/ejgallego/verso-sphere-packing),
   [rendered site for v4.30.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.30.0/spherepackingblueprint/)
 - [`ejgallego/verso-noperthedron`](https://github.com/ejgallego/verso-noperthedron),
-  [rendered site for v4.30.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.30.0/noperthedron/)
+  [rendered site for v4.31.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.31.0/noperthedron/)
 - [`ejgallego/verso-flt`](https://github.com/ejgallego/verso-flt),
-  [rendered site for v4.30.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.30.0/verso-flt/)
+  [rendered site for v4.31.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.31.0/verso-flt/)
 - [`ejgallego/verso-carleson`](https://github.com/ejgallego/verso-carleson),
   [rendered site for v4.30.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.30.0/verso-carleson/)
 

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -10,9 +10,6 @@
       },
       "targets": [
         {
-          "release": "v4.30.0"
-        },
-        {
           "release": "v4.31.0",
           "publish_reference": true
         }
@@ -32,7 +29,7 @@
       "targets": [
         {
           "release": "v4.31.0",
-          "ref": "65c76fcd50d405bd0ce4bef8178c665ef1273cea",
+          "ref": "a8e00a25ee048b68c792052d816b4605abf430f9",
           "publish_reference": true
         }
       ],
@@ -69,9 +66,8 @@
       },
       "targets": [
         {
-          "release": "v4.30.0",
-          "ref": "13bcd04fc6a7a63e5b351c1cf104205022e23813",
-          "publish_reference": true
+          "release": "v4.31.0",
+          "ref": "68c0c0bc1a3a668e6c5d72e53085821ee5bc474e"
         }
       ],
       "build_command": ["lake", "build", "FLTBlueprint"],

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -47,9 +47,8 @@
       },
       "targets": [
         {
-          "release": "v4.31.0",
-          "ref": "caa4d8950fa8c390ea0a191c8b1ad687a8841ddb",
-          "publish_reference": true
+          "release": "v4.30.0",
+          "ref": "516bab06c7f65aa60e265e56edc42acf75b51cf9"
         }
       ],
       "build_command": ["bash", "scripts/ci-reference-build.sh"],
@@ -85,7 +84,7 @@
       "targets": [
         {
           "release": "v4.30.0",
-          "ref": "b64f286038f7b8e1d35d0ba67a6027074158db85",
+          "ref": "73c4bac9073120109e2338e545c945d0fb87323e",
           "rc": "4.30-rc2",
           "publish_reference": true
         }

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -10,6 +10,9 @@
       },
       "targets": [
         {
+          "release": "v4.30.0"
+        },
+        {
           "release": "v4.31.0",
           "publish_reference": true
         }
@@ -48,7 +51,8 @@
       "targets": [
         {
           "release": "v4.30.0",
-          "ref": "516bab06c7f65aa60e265e56edc42acf75b51cf9"
+          "ref": "516bab06c7f65aa60e265e56edc42acf75b51cf9",
+          "publish_reference": true
         }
       ],
       "build_command": ["bash", "scripts/ci-reference-build.sh"],
@@ -66,7 +70,8 @@
       "targets": [
         {
           "release": "v4.31.0",
-          "ref": "68c0c0bc1a3a668e6c5d72e53085821ee5bc474e"
+          "ref": "68c0c0bc1a3a668e6c5d72e53085821ee5bc474e",
+          "publish_reference": true
         }
       ],
       "build_command": ["lake", "build", "FLTBlueprint"],

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -148,8 +148,8 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertTrue(current_release.deploy_pages)
         expected_external_releases = {
             "noperthedron": "v4.31.0",
-            "spherepackingblueprint": "v4.31.0",
-            "verso-flt": "v4.30.0",
+            "spherepackingblueprint": "v4.30.0",
+            "verso-flt": "v4.31.0",
             "verso-carleson": "v4.30.0",
         }
         self.assertTrue(projects[1].git_checkout)


### PR DESCRIPTION
Updates the reference blueprint catalog for the current maintenance pass.

Catalog updates:
- verso-flt v4.31.0 -> ejgallego/verso-flt@68c0c0bc1a3a668e6c5d72e53085821ee5bc474e.
- noperthedron v4.31.0 -> ejgallego/verso-noperthedron@a8e00a25ee048b68c792052d816b4605abf430f9.
- spherepackingblueprint v4.30.0 -> ejgallego/verso-sphere-packing@516bab06c7f65aa60e265e56edc42acf75b51cf9.
- verso-carleson v4.30.0 / rc 4.30-rc2 -> ejgallego/verso-carleson@73c4bac9073120109e2338e545c945d0fb87323e.
- Keeps the v4.30.0 project-template compatibility target and updates README/reference harness expectations for the new catalog.

Backport v4.30.0: exempt: catalog-only reference updates for v4.30 blueprints on the v4.31 catalog branch.

Reference-blueprints validation:
- verso-flt: compute-repair-work --build, all 14 direct-port chapters done.
- verso-noperthedron: validate, site generation, and compute-repair-work --build, all 8 direct-port chapters done.
- verso-carleson: build-backed repair analysis already passed.
- verso-sphere-packing: build-backed repair analysis already passed.

Local VBP verification:
- python3 -m unittest tests.harness.test_blueprint_harness_projects.BlueprintHarnessProjectsTests.test_default_manifest_contains_release_projects tests.harness.test_prepare_reference_blueprints_pages.PrepareReferenceBlueprintPagesTests.test_readme_uses_release_namespaced_reference_links
- python3 -m unittest tests.harness.test_blueprint_harness_projects tests.harness.test_prepare_reference_blueprints_pages