### PR TITLE
Update FLT and Noperthedron reference refs

### DIFF
--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -32,7 +32,7 @@
       "targets": [
         {
           "release": "v4.31.0",
-          "ref": "a8e00a25ee048b68c792052d816b4605abf430f9",
+          "ref": "023ba906e2977186e863472393e4251b2477bfd6",
           "publish_reference": true
         }
       ],
@@ -70,7 +70,7 @@
       "targets": [
         {
           "release": "v4.31.0",
-          "ref": "68c0c0bc1a3a668e6c5d72e53085821ee5bc474e",
+          "ref": "d0a3dea89451218916bfd4a29e07ea5c557f6d0b",
           "publish_reference": true
         }
       ],


### PR DESCRIPTION
Updates the external reference catalog after consolidating the FLT and Noperthedron wrapper pins on their default branches.

Backport v4.30.0: exempt: catalog-only reference updates for v4.31 blueprints.