### PR TITLE
feat: add public graph data API

### DIFF
--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -1,6 +1,6 @@
 # Blueprint Design Rationale
 
-Last updated: 2026-06-16
+Last updated: 2026-06-20
 
 This document records the current architecture boundaries and the reasons the
 Blueprint implementation is shaped the way it is.
@@ -49,6 +49,12 @@ rather than invent parallel sources of truth.
 
 Command modules are split by concern:
 
+- `VersoBlueprint/Graph.lean` owns the shared graph data model, finalized
+  `GraphData` projection helpers, DOT rendering helpers, and graph-view
+  variant construction used by page graphs and compact widgets
+- `VersoBlueprint/GraphApi.lean` owns the traversal/cache-facing API for
+  storing semantic graph data and finalizing it against completed traversal
+  state
 - `VersoBlueprint/Commands/Graph.lean`
 - `VersoBlueprint/Commands/Summary.lean`
 - `VersoBlueprint/Commands/Bibliography.lean`
@@ -167,20 +173,20 @@ The same flow can be read as four contracts:
    render-time indexes into `TraverseState` through `TraversalIndex`. This is
    where site-local facts are created: rendered anchors, numbering caches,
    code-panel destinations, group and reverse-use panels, citation use sites,
-   statement/proof preview entries, Lean declaration preview entries, and
-   external declaration row anchors. These facts are intentionally not pushed
-   back into `Environment.State`, because their values depend on the current
-   rendered document and output mode.
+   statement/proof preview entries, Lean declaration preview entries,
+   public graph data records, and external declaration row anchors. These
+   facts are intentionally not pushed back into `Environment.State`, because
+   their values depend on the current rendered document and output mode.
 
 3. **Traversal to generated artifacts.**
    Page rendering and preview-data emission both consume the traversal state.
    HTML pages get the visible document, graph, summary, bibliography, inline
    preview triggers, and feature-specific assets. The Blueprint preview-data
    extra step emits two structured files under `-verso-data/`:
-   `blueprint-manifest.json`, which contains semantic preview entries and
-   metadata, and `blueprint-html-cache.json`, which contains opaque rendered
-   fragments plus the hover side data needed to hydrate those fragments inside
-   generated pages.
+   `blueprint-manifest.json`, which contains semantic preview entries, public
+   graph data, and metadata, and `blueprint-html-cache.json`, which contains
+   opaque rendered fragments plus the hover side data needed to hydrate those
+   fragments inside generated pages.
 
 4. **Artifacts to runtime and external consumers.**
    Browser code should treat the generated artifacts as immutable inputs. Page
@@ -209,6 +215,7 @@ that owner.
 | External Lean declaration snapshots | Elaboration / declaration snapshot registration | `ExternalRef` records on semantic nodes, enriched with presence/status/source/render data | block renderers, code-summary badges, summary, graph, manifest |
 | Numbering, hrefs, anchors, preview keys | Traversal | `TraverseState` and `TraversalIndex` domains | page rendering, preview manifest, browser triggers |
 | Statement/proof preview source blocks | Traversal | `TraversalIndex.TraversalPreviews` | manifest/cache emission, same-document manual grafts |
+| Public graph data | Elaboration plus completed traversal | semantic `Informal.Graph.GraphData` cached in `TraversalIndex.Graphs`, then finalized through `Informal.GraphApi.finalData` for `blueprint-manifest.json.graphs`, page JSON, and bundled graph rendering | graph command rendering, browser runtime, custom graph consumers |
 | Lean declaration preview fragments | Traversal | `TraversalIndex.LeanCodePreviews` | Lean links, manifest/cache emission |
 | Rendered preview bodies | Preview-data emission | `blueprint-html-cache.json` | browser runtime, Slides, custom generated consumers |
 | Semantic preview/catalog entries | Preview-data emission | `blueprint-manifest.json` | browser runtime, Slides, audit/custom UIs |

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -669,6 +669,81 @@ The command-side options and the runtime graph controls are compatible:
 Group metadata may be used to organize the presentation, but grouping does not
 change dependency edges.
 
+Graph data is available through stable Lean, manifest, and browser APIs:
+
+- Lean callers can build the semantic graph object from elaboration state with
+  `Informal.Graph.buildData`. Once traversal has completed,
+  `Informal.GraphApi.finalDataForBlock` finalizes one rendered block from its
+  block id and semantic graph data, while `Informal.GraphApi.cachedData` reads
+  every traversal-cached graph in the same finalized public shape.
+- Generated `blueprint-manifest.json` includes a `graphs` array. Each entry
+  contains `schemaVersion`, `nodes`, `edges`, and `groups`, with status enums,
+  dependency axes, preview keys, hrefs when traversal resolved them, and visual
+  metadata for renderers that want Blueprint's default styling.
+- The bundled graph renderer uses that finalized graph data as its block-level
+  source of truth and derives DOT render variants with
+  `Informal.Graph.GraphData.renderVariants`, so page rendering and custom
+  clients exercise the same graph record shape.
+- Browser callers can use `api.getGraphData(element)` from
+  `window.VersoBlueprint.onRenderReady` for a rendered graph block, or
+  `api.loadGraphs()` for standalone clients that want the manifest `graphs`
+  array without requiring a graph block on the current page. The same helpers
+  are also exposed on `window.bpGraphApi` for graph-specific clients.
+
+Lean-side consumers should choose the API that matches their phase. Before
+Verso traversal finishes, graph data is semantic and may not yet include
+rendered hrefs or display titles:
+
+```lean
+import VersoBlueprint.Graph
+
+def semanticGraph (state : Informal.Environment.State) :
+    Informal.Graph.GraphData :=
+  let roots := state.data.toArray.map (·.1)
+  Informal.Graph.buildData state roots
+```
+
+After traversal has completed, use `Informal.GraphApi` to finalize either one
+rendered graph block or every graph cached during traversal:
+
+```lean
+import VersoBlueprint.GraphApi
+
+def graphForRenderedBlock
+    (state : Verso.Genre.Manual.TraverseState)
+    (blockId : Verso.Multi.InternalId)
+    (semantic : Informal.Graph.GraphData) : Informal.Graph.GraphData :=
+  Informal.GraphApi.finalDataForBlock state blockId semantic
+
+def allRenderedGraphs
+    (state : Verso.Genre.Manual.TraverseState) :
+    Array Informal.Graph.GraphData :=
+  Informal.GraphApi.cachedData state
+```
+
+Browser consumers should wait for the shared runtime and read graph data from
+the render API. A page-local graph block exposes its finalized embedded record:
+
+```javascript
+window.VersoBlueprint.onRenderReady((api) => {
+  const block = document.querySelector(".bp_graph_fullwidth");
+  const graph = api.getGraphData(block);
+  console.log(graph?.nodes.length ?? 0);
+});
+```
+
+Standalone clients that do not render a graph block on the current page can
+load the manifest graph records instead:
+
+```javascript
+window.VersoBlueprint.onRenderReady(async (api) => {
+  const graphs = await api.loadGraphs();
+  for (const graph of graphs) {
+    console.log(graph.key, graph.nodes.length, graph.edges.length);
+  }
+});
+```
+
 The graph uses two orthogonal status tracks:
 
 - statement border:
@@ -1016,7 +1091,9 @@ window.VersoBlueprint.onRenderReady(async function (api) {
 ```
 
 The in-repo `preview_runtime_showcase` test blueprint includes the same pattern
-as a standalone browser client on its `Custom Render Client` page. The client
+as a standalone browser client on its `Custom Render Client` page. It also
+includes a graph-data card that calls `api.loadGraphs()` to read
+`blueprint-manifest.json.graphs` without embedding a rendered graph. The client
 asset lives in
 `tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/custom-render-client.js`,
 with the page shell in
@@ -1070,6 +1147,8 @@ Stable custom-client entrypoints:
 | `api.loadManifest()` / `api.loadHtmlCache()` | Load the generated `Map` values keyed by preview key. |
 | `api.readManifestStatus()` / `api.readHtmlCacheStatus()` | Inspect diagnostics such as `idle`, `loading`, `ready`, and `error`. |
 | `api.loadManifestEntry(key)` / `api.loadHtmlCacheEntry(key)` | Read one generated entry by key. |
+| `api.getGraphData(element)` / `api.getGraphVariants(element)` | Read page-embedded graph data and render variants from a rendered graph block. |
+| `api.graphsFromManifest(manifestJson)` / `api.loadManifestGraphs(url, options)` / `api.loadGraphs()` | Decode or fetch finalized graph records from `blueprint-manifest.json.graphs`; `loadGraphs` uses the current page's generated manifest URL. |
 | `api.previewKey(label, facet)` / `api.statementPreviewKey(label)` | Build normalized preview keys for custom render targets. |
 | `api.resolvePreview(key)` | Resolve manifest data and a rendered body fragment together, returning `{ ok, key, reason, manifestEntry, htmlCacheEntry, html, diagnosticHtml }`. |
 | `api.renderPreviewInto(element, key, options)` | Write the rendered body fragment or diagnostic HTML into `element`, then hydrate nested previews and math. |

--- a/src/VersoBlueprint.lean
+++ b/src/VersoBlueprint.lean
@@ -28,6 +28,7 @@ import VersoBlueprint.DependencyAnalysis
 import VersoBlueprint.Attribute
 import VersoBlueprint.Cite
 import VersoBlueprint.Commands.Graph
+import VersoBlueprint.GraphApi
 import VersoBlueprint.Commands.Summary
 import VersoBlueprint.Commands.Bibliography
 import VersoBlueprint.Informal.Block.Assets

--- a/src/VersoBlueprint/Commands/Graph.lean
+++ b/src/VersoBlueprint/Commands/Graph.lean
@@ -10,6 +10,7 @@ import VersoManual
 import VersoBlueprint.Commands.Common
 import VersoBlueprint.Environment
 import VersoBlueprint.Graph
+import VersoBlueprint.GraphApi
 import VersoBlueprint.Lib.HoverRender
 import VersoBlueprint.Lib.HtmlId
 import VersoBlueprint.PreviewCache
@@ -21,30 +22,7 @@ namespace Informal.Commands
 
 open Lean Elab Command
 open Informal Data Environment
-
-abbrev GraphNode := Informal.Graph.GraphNode Name
-abbrev Graph := Informal.Graph.Graph Name
-
-inductive GraphDirection where
-  | LR
-  | RL
-  | TB
-  | BT
-deriving Inhabited, Repr, BEq, FromJson, ToJson, Quote
-
-def GraphDirection.rankdir : GraphDirection → String
-  | .LR => "LR"
-  | .RL => "RL"
-  | .TB => "TB"
-  | .BT => "BT"
-
-def GraphDirection.parse? (s : String) : Option GraphDirection :=
-  match s.toLower with
-  | "lr" | "left-right" | "horizontal" => some .LR
-  | "rl" | "right-left" => some .RL
-  | "tb" | "top-bottom" | "vertical" => some .TB
-  | "bt" | "bottom-top" => some .BT
-  | _ => none
+open Informal.Graph
 
 register_option verso.blueprint.graph.defaultDirection : String := {
   defValue := "TB"
@@ -66,25 +44,12 @@ register_option verso.blueprint.graph.defaultPreviewPlacement : String := {
   descr := "Default preview panel placement for `blueprint_graph` when `(previewPlacement := ...)` is omitted (`docked` or `anchored`)"
 }
 
-structure GraphOptions where
-  direction : GraphDirection := .TB
-  /--
-  Ask Graphviz to compact disconnected graph components before d3-graphviz fits
-  the SVG into the canvas.
-  -/
-  pack : Bool := false
-deriving Inhabited, BEq, FromJson, ToJson, Quote
-
 structure GraphBlockData where
-  graph : Graph
+  semanticGraphData : Informal.Graph.GraphData := {}
   options : GraphOptions := {}
   previewMode : Informal.HoverRender.PreviewMode := .pinned
   previewPlacement : Informal.HoverRender.PreviewPlacement := .docked
-  groupTitles : Array (Name × String) := #[]
 deriving Inhabited, FromJson, ToJson, Quote
-
-def graphPackAttr (pack : Bool) : String :=
-  if pack then "true" else "false"
 
 def parseGraphPreviewMode? (s : String) : Option Informal.HoverRender.PreviewMode :=
   match s.trimAscii.toString.toLower with
@@ -98,45 +63,6 @@ def parseGraphPreviewPlacement? (s : String) : Option Informal.HoverRender.Previ
   | "anchored" => some .anchored
   | _ => none
 
-/-- Common DOT header for rendered Blueprint graphs.
-
-`pack=true` keeps disconnected graph components compact before d3-graphviz fits
-the SVG into the canvas. Without it, sparse multi-component graphs can be
-placed far from the top of the viewport after variant or direction switches.
--/
-def graphDotHeader (options : GraphOptions := {}) : String :=
-  "strict digraph \"\" {\n" ++
-  s!"    rankdir={options.direction.rankdir};\n" ++
-  "    bgcolor=\"white\";\n" ++
-  s!"    pack={graphPackAttr options.pack};\n" ++
-  "    splines=true;\n" ++
-  "    nodesep=0.35;\n" ++
-  "    ranksep=0.45;\n" ++
-  "    node [shape=box, style=\"rounded,filled\", fontname=\"Helvetica\", fontsize=10, margin=\"0.08,0.04\", color=\"#6b7280\", penwidth=1.8];\n" ++
-  "    edge [color=\"#6b7280\", arrowhead=vee, arrowsize=0.6, penwidth=1];\n" ++
-  "    graph [fontname=\"Helvetica\"];\n" ++
-  "  "
-
-def graphToDot (g : Graph) (options : GraphOptions := {})
-    (resolveHref : Name → Option String := fun _ => none)
-    (resolveGroupTitle : Name → Option String := fun _ => none) : String :=
-  Informal.Graph.Graph.toDot g (graphDotHeader options)
-    (groupLabel? := some resolveGroupTitle)
-    (refAttrs? := some fun ref =>
-    (resolveHref ref).map (fun href => s!"URL=\"{href}\", target=\"_self\""))
-
-structure GraphRenderVariant where
-  key : String
-  label : String
-  dot : String
-  options : GraphOptions := {}
-  selectOnNodeId : Array (String × String) := #[]
-  hoverOnNodeId : Array (String × String) := #[]
-  previewKeyByNodeId : Array (String × String) := #[]
-deriving Inhabited, ToJson
-
-def allGraphDirections : Array GraphDirection := #[.TB, .LR, .RL, .BT]
-
 -- Keep this module rebuilt when the embedded graph assets change.
 -- This module owns the embedded graph CSS/JS boundary, so adjacent edits here
 -- should land whenever graph runtime assets are intentionally refreshed.
@@ -144,278 +70,6 @@ def graphCss := include_str "graph.css"
 
 def fallbackGraphControlId (id : Verso.Multi.InternalId) (suffix : String) : String :=
   s!"{Informal.HtmlId.prefixed "bp-graph" (toString id)}{suffix}"
-
-def groupVariantKey : String := "group"
-def parentVariantKey (parent : Name) : String := s!"parent:{parent}"
-
-def graphParentChildren (graph : Graph) : Lean.NameMap (Array Name) :=
-  graph.foldl (init := ({} : Lean.NameMap (Array Name))) fun acc node =>
-    match node.parent? with
-    | none => acc
-    | some parent =>
-      let children := acc.getD parent #[]
-      acc.insert parent (children.push node.label)
-
-def graphNodeParents (graph : Graph) : Lean.NameMap Name :=
-  graph.foldl (init := ({} : Lean.NameMap Name)) fun acc node =>
-    match node.parent? with
-    | none => acc
-    | some parent => acc.insert node.label parent
-
-def graphParentTitle (groupTitles : Lean.NameMap String) (parent : Name) : String :=
-  let title := (groupTitles.getD parent parent.toString).trimAscii.toString
-  if title.isEmpty then parent.toString else title
-
-partial def wrapGraphLabelWords (words : List String) (lineWidth maxLines : Nat)
-    (current : String) (lines : Array String) : Array String :=
-  match words with
-  | [] =>
-    if current.isEmpty then lines else lines.push current
-  | word :: rest =>
-    if lines.size + 1 == maxLines then
-      let finalLine :=
-        if current.isEmpty then
-          String.intercalate " " (word :: rest)
-        else
-          String.intercalate " " (current :: word :: rest)
-      lines.push finalLine
-    else
-      let candidate := if current.isEmpty then word else current ++ " " ++ word
-      if !current.isEmpty && candidate.length > lineWidth then
-        wrapGraphLabelWords words lineWidth maxLines "" (lines.push current)
-      else
-        wrapGraphLabelWords rest lineWidth maxLines candidate lines
-
-def wrapGraphLabel (title : String) (lineWidth : Nat := 26) (maxLines : Nat := 3) : String :=
-  let words :=
-    (title.splitOn " ").foldr (init := ([] : List String)) fun word acc =>
-      let word := word.trimAscii.toString
-      if word.isEmpty then acc else word :: acc
-  match words with
-  | [] => title.trimAscii.toString
-  | _ =>
-    let lines := wrapGraphLabelWords words lineWidth maxLines "" #[]
-    String.intercalate "\n" lines.toList
-
-def graphParentDisplayLabel (groupTitles : Lean.NameMap String) (parent : Name) : String :=
-  wrapGraphLabel (graphParentTitle groupTitles parent)
-
-def hexNibble? (c : Char) : Option Nat :=
-  match c with
-  | '0' => some 0
-  | '1' => some 1
-  | '2' => some 2
-  | '3' => some 3
-  | '4' => some 4
-  | '5' => some 5
-  | '6' => some 6
-  | '7' => some 7
-  | '8' => some 8
-  | '9' => some 9
-  | 'a' | 'A' => some 10
-  | 'b' | 'B' => some 11
-  | 'c' | 'C' => some 12
-  | 'd' | 'D' => some 13
-  | 'e' | 'E' => some 14
-  | 'f' | 'F' => some 15
-  | _ => none
-
-def parseHexByte? (c1 c2 : Char) : Option Nat := do
-  let hi ← hexNibble? c1
-  let lo ← hexNibble? c2
-  return hi * 16 + lo
-
-def parseHexColor? (s : String) : Option (Nat × Nat × Nat) := do
-  let chars :=
-    match s.trimAscii.toString.toList with
-    | '#' :: rest => rest
-    | xs => xs
-  match chars with
-  | r1 :: r2 :: g1 :: g2 :: b1 :: b2 :: [] =>
-    return (← parseHexByte? r1 r2, ← parseHexByte? g1 g2, ← parseHexByte? b1 b2)
-  | _ => none
-
-def hexChar (n : Nat) : Char :=
-  if n < 10 then
-    Char.ofNat ('0'.toNat + n)
-  else
-    Char.ofNat ('a'.toNat + (n - 10))
-
-def byteToHex (n : Nat) : String :=
-  let n := n % 256
-  let hi := n / 16
-  let lo := n % 16
-  String.ofList [hexChar hi, hexChar lo]
-
-def rgbToHex (r g b : Nat) : String :=
-  "#" ++ byteToHex r ++ byteToHex g ++ byteToHex b
-
-def primaryColorToken (s : String) : String :=
-  match s.splitOn ":" with
-  | token :: _ => token.trimAscii.toString
-  | [] => s.trimAscii.toString
-
-def averageHexColor (colors : Array (Nat × Nat × Nat)) (fallback : String) : String :=
-  if colors.isEmpty then
-    fallback
-  else
-    let (sumR, sumG, sumB) := colors.foldl (init := (0, 0, 0)) fun (r, g, b) (r', g', b') =>
-      (r + r', g + g', b + b')
-    let n := colors.size
-    rgbToHex (sumR / n) (sumG / n) (sumB / n)
-
-def mixedNodeColor (nodes : Array GraphNode) (colorOf : GraphNode → String) (fallback : String) : String :=
-  let colors := nodes.foldl (init := (#[] : Array (Nat × Nat × Nat))) fun acc node =>
-    match parseHexColor? (primaryColorToken (colorOf node)) with
-    | some rgb => acc.push rgb
-    | Option.none => acc
-  averageHexColor colors fallback
-
-def fontColorForFill (fillColor : String) : String :=
-  match parseHexColor? fillColor with
-  | some (r, g, b) =>
-    -- Relative luminance approximation, keeps labels readable on dark mixes.
-    if (299 * r + 587 * g + 114 * b) < 140000 then "#f8fafc" else "#0f172a"
-  | Option.none => "#0f172a"
-
-def nodeHasAncestorParent (parentMap : Lean.NameMap Name) (label ancestor : Name) : Bool :=
-  Id.run <| do
-    let mut current := label
-    let mut seen : Lean.NameSet := {}
-    let mut fuel := parentMap.toArray.size + 1
-    while fuel > 0 do
-      fuel := fuel - 1
-      match parentMap.get? current with
-      | none => return false
-      | some parent =>
-        if parent == ancestor then
-          return true
-        if seen.contains parent then
-          return false
-        seen := seen.insert parent
-        current := parent
-    return false
-
-def subgraphForParent (graph : Graph) (parent : Name) : Graph :=
-  let parentMap := graphNodeParents graph
-  graph.filter fun node =>
-    node.label == parent || nodeHasAncestorParent parentMap node.label parent
-
-def mkParentOverviewGraph (graph : Graph) (parents : Array Name)
-    (groupTitles : Lean.NameMap String) : Graph :=
-  let parentChildren := graphParentChildren graph
-  let nodeByLabel : Lean.NameMap GraphNode :=
-    graph.foldl (init := ({} : Lean.NameMap GraphNode)) fun acc node =>
-      acc.insert node.label node
-  let parentSet : Lean.NameSet :=
-    parents.foldl (init := ({} : Lean.NameSet)) fun acc parent => acc.insert parent
-  let parentMap := graphNodeParents graph
-  let addParentDep (acc : Lean.NameMap (Array Name)) (target source : Name) : Lean.NameMap (Array Name) :=
-    let deps := acc.getD target #[]
-    if deps.contains source then
-      acc
-    else
-      acc.insert target (deps.push source)
-  let collectParentDeps (depsOf : GraphNode → Array Name) :=
-    graph.foldl (init := ({} : Lean.NameMap (Array Name))) fun acc node =>
-      match node.parent? with
-      | none => acc
-      | some target =>
-        if !parentSet.contains target then
-          acc
-        else
-          (depsOf node).foldl (init := acc) fun acc dep =>
-            match parentMap.get? dep with
-            | some source =>
-              if parentSet.contains source && source != target then
-                addParentDep acc target source
-              else
-                acc
-            | none => acc
-  let parentStatementDeps := collectParentDeps (·.deps)
-  let parentProofDeps := collectParentDeps (·.proofDeps)
-  parents.map fun parent =>
-    let childNodes :=
-      (parentChildren.getD parent #[]).foldl (init := (#[] : Array GraphNode)) fun acc child =>
-        match nodeByLabel.get? child with
-        | some node => acc.push node
-        | Option.none => acc
-    let mixedFillColor := mixedNodeColor childNodes (·.fillcolor) "#e2e8f0"
-    let mixedBorderColor := mixedNodeColor childNodes (·.color) "#475569"
-    let title := graphParentTitle groupTitles parent
-    {
-      label := parent
-      displayLabel? := some (graphParentDisplayLabel groupTitles parent)
-      deps := parentStatementDeps.getD parent #[]
-      proofDeps := parentProofDeps.getD parent #[]
-      shape := "tab"
-      style := "filled"
-      fillcolor := mixedFillColor
-      color := mixedBorderColor
-      penwidth := "2.4"
-      fontcolor := fontColorForFill mixedFillColor
-      tooltip? := some s!"Group View: {title} ({childNodes.size} nodes)"
-      ref? := none
-    }
-
-def mkGraphVariants (graphData : GraphBlockData) (resolveHref : Name → Option String)
-    (groupTitles : Lean.NameMap String) : Array GraphRenderVariant :=
-  let previewKeyByNodeId (graph : Graph) : Array (String × String) :=
-    graph.map fun node =>
-      (Informal.Graph.graphNodeSvgId node.label, PreviewCache.key node.label .statement)
-  let resolveGroupTitle : Name → Option String := fun group =>
-    groupTitles.get? group
-  let parentChildren := graphParentChildren graphData.graph
-  let parents :=
-    parentChildren.toArray
-      |>.filter (fun (_, children) => children.size > 1)
-      |>.map (·.1)
-      |>.qsort (fun a b => graphParentTitle groupTitles a < graphParentTitle groupTitles b)
-  if parents.isEmpty then
-    #[{
-      key := "full"
-      label := "Full Graph"
-      dot := graphToDot graphData.graph graphData.options resolveHref resolveGroupTitle
-      options := graphData.options
-      selectOnNodeId := #[]
-      hoverOnNodeId := #[]
-      previewKeyByNodeId := previewKeyByNodeId graphData.graph
-    }]
-  else
-    let parentVariantRefs := parents.map (fun parent => (Informal.Graph.graphNodeSvgId parent, parentVariantKey parent))
-    let groupVariant : GraphRenderVariant := {
-      key := groupVariantKey
-      label := "Group View"
-      dot := graphToDot (mkParentOverviewGraph graphData.graph parents groupTitles)
-        graphData.options (fun _ => none) (fun _ => none)
-      options := graphData.options
-      selectOnNodeId := parentVariantRefs
-      hoverOnNodeId := parentVariantRefs
-      previewKeyByNodeId := #[]
-    }
-    let fullVariant : GraphRenderVariant := {
-      key := "full"
-      label := "Full Graph"
-      dot := graphToDot graphData.graph graphData.options resolveHref resolveGroupTitle
-      options := graphData.options
-      selectOnNodeId := #[]
-      hoverOnNodeId := #[]
-      previewKeyByNodeId := previewKeyByNodeId graphData.graph
-    }
-    let parentVariants := parents.map fun parent =>
-      let parentSubgraph := subgraphForParent graphData.graph parent
-      let title := graphParentTitle groupTitles parent
-      {
-        key := parentVariantKey parent
-        label := title
-        dot := graphToDot parentSubgraph
-          graphData.options resolveHref resolveGroupTitle
-        options := graphData.options
-        selectOnNodeId := #[]
-        hoverOnNodeId := #[]
-        previewKeyByNodeId := previewKeyByNodeId parentSubgraph
-      }
-    #[fullVariant, groupVariant] ++ parentVariants
 
 -- Keep this binding in Lean so asset updates flow through the command module rebuild.
 -- Updated when the runtime asset changes; current runtime leaves block placement to CSS
@@ -429,7 +83,12 @@ block_extension Block.graph (graphData : GraphBlockData) where
   -- for TOC
   -- localContentItem _ _ _ := none
   data := toJson graphData
-  traverse _id _data _contents := do
+  traverse id data _contents := do
+      match fromJson? (α := GraphBlockData) data with
+      | .ok graphData =>
+        modify fun state => Informal.GraphApi.saveData state id graphData.semanticGraphData
+      | .error _ =>
+        Verso.reportError "Malformed data in Block.graph.traverse"
       return none
   toTeX := none
   toHtml :=
@@ -441,23 +100,19 @@ block_extension Block.graph (graphData : GraphBlockData) where
         | .ok gd => pure gd
         | .error err =>
           Verso.reportError s!"Malformed data in Block.graph.toHtml ({err})"
-          pure { graph := #[], options := {}, groupTitles := #[] }
+          pure { semanticGraphData := {}, options := {} }
       let s ← HtmlT.state
-      let resolveHref : Name → Option String := fun ref =>
-        Informal.TraversalIndex.Nodes.href? s ref
-      let groupTitles : Lean.NameMap String :=
-        graphData.groupTitles.foldl (init := ({} : Lean.NameMap String)) fun acc (group, title) =>
-          acc.insert group title
-      let resolveGroupTitle : Name → Option String := fun group =>
-        groupTitles.get? group
-      let graphVariants := mkGraphVariants graphData resolveHref groupTitles
+      let publicGraphData := Informal.GraphApi.finalDataForBlock s id graphData.semanticGraphData
+      let publicGraphDataJson : String := Lean.Json.compress (toJson publicGraphData)
+      let graphVariants := publicGraphData.renderVariants graphData.options
       let hasGroupVariant := graphVariants.any (fun variant => variant.key == groupVariantKey)
       let graphVariantJson : String := Lean.Json.compress (toJson graphVariants)
       let graphVariantOptions : Array Output.Html :=
         graphVariants.map fun variant => {{
           <option value={{variant.key}}>{{variant.label}}</option>
         }}
-      let includeMathlibLegend := graphData.graph.any (fun node => node.color == Informal.Graph.statementBorderMathlibColor)
+      let includeMathlibLegend :=
+        publicGraphData.nodes.any (fun node => node.visual.color == Informal.Graph.statementBorderMathlibColor)
       let renderLegend (kind : String) (groups : Array Informal.Graph.LegendGroup)
           (note? : Option String := none) (hidden : Bool := false) : Output.Html :=
         let legendGroupHtml : Array Output.Html :=
@@ -548,7 +203,7 @@ block_extension Block.graph (graphData : GraphBlockData) where
             {{ <option value={{direction.rankdir}}>{{direction.rankdir}}</option> }}
       let graphPackChecked : Array (String × String) :=
         if graphData.options.pack then #[("checked", "checked")] else #[]
-      let graphPackDefault : String := graphPackAttr graphData.options.pack
+      let graphPackDefault : String := if graphData.options.pack then "true" else "false"
       let previewModeDefault : String := graphData.previewMode.dataValue
       let graphPreviewModeOptions : Array Output.Html := #[
         if graphData.previewMode == .pinned then
@@ -574,7 +229,7 @@ block_extension Block.graph (graphData : GraphBlockData) where
       let fallbackDot : String :=
         match graphVariants[0]? with
         | some variant => variant.dot
-        | Option.none => graphToDot graphData.graph graphData.options resolveHref resolveGroupTitle
+        | Option.none => publicGraphData.toDotWith graphData.options
       let previewPanel :=
         Informal.HoverRender.graphPreviewPanel
           graphData.previewMode
@@ -666,6 +321,9 @@ block_extension Block.graph (graphData : GraphBlockData) where
             "data-bp-graph-direction"={{graphData.options.direction.rankdir}}
             "data-bp-graph-pack"={{graphPackDefault}}
           >
+            <script type="application/json" class="bp-graph-data">
+              {{.text false s!"{publicGraphDataJson}"}}
+            </script>
             <script type="application/json" class="bp-graph-variants">
               {{.text false s!"{graphVariantJson}"}}
             </script>
@@ -680,13 +338,14 @@ block_extension Block.graph (graphData : GraphBlockData) where
   extraCss := withPreviewPanelCssAssets [graphCss]
   extraJs := withPreviewRuntimeJsAssets [] [loadD3Dot]
 
-def buildAll : CoreM (Graph × Array (Name × String)) := do
+def buildAll : CoreM Informal.Graph.GraphData := do
   reportImportedConflicts
   let env ← getEnv
   let state := informalExt.getState env
   let roots : Array Name := state.data.toArray.map (·.1)
-  let graph := Informal.Graph.build state roots (resolveRef? := some)
-  return (graph, state.groups.toArray)
+  let groupTitles := state.groups.toArray
+  let semanticGraphData := Informal.Graph.buildData state roots (groupTitles := groupTitles)
+  return semanticGraphData
 
 open Verso.ArgParse
 
@@ -817,10 +476,10 @@ def mkGraphPart (stx : Syntax) (endPos : String.Pos.Raw) (options : GraphOptions
   let titleInlines ← `(inline | "Dependency Graph")
   let expandedTitle ← #[titleInlines].mapM (elabInline ·)
   let metadata : Option (TSyntax `term) := some (← `(term| { number := false }))
-  let (graph, groupTitles) ← buildAll
+  let semanticGraphData ← buildAll
   if verso.blueprint.debug.commands.get (← Lean.getOptions) then
-    logInfo m!"Adding {graph.size} nodes"
-  let graphData : GraphBlockData := { graph, options, previewMode, previewPlacement, groupTitles }
+    logInfo m!"Adding {semanticGraphData.nodes.size} graph nodes"
+  let graphData : GraphBlockData := { semanticGraphData, options, previewMode, previewPlacement }
   let block ← ``(Verso.Doc.Block.other (Informal.Commands.Block.graph $(quote graphData)) #[])
   let subParts := #[]
   pure <| FinishedPart.mk stx stx expandedTitle titlePreview metadata #[block] subParts endPos

--- a/src/VersoBlueprint/Commands/graph.js
+++ b/src/VersoBlueprint/Commands/graph.js
@@ -131,20 +131,13 @@
     );
   }
 
-  function collectGraphVariants(graphContainer) {
-    const payloadNode = graphContainer.select("script.bp-graph-variants").node();
-    if (payloadNode) {
-      try {
-        const parsed = JSON.parse((payloadNode.textContent || "").trim());
-        if (Array.isArray(parsed) && parsed.length > 0) {
-          return parsed;
-        }
-      } catch (_err) {}
-    }
-    const dotTxt = graphContainer.select("script.dot-source").text().trim();
+  function legacyGraphVariants(graphRoot) {
+    if (!(graphRoot instanceof Element)) return [];
+    const dotSource = graphRoot.querySelector("script.dot-source");
+    const dotTxt = dotSource ? (dotSource.textContent || "").trim() : "";
     if (!dotTxt) return [];
-    const fallbackDirection = normalizeGraphDirection(graphContainer.attr("data-bp-graph-direction"));
-    const fallbackPack = normalizeGraphPack(graphContainer.attr("data-bp-graph-pack"));
+    const fallbackDirection = normalizeGraphDirection(graphRoot.getAttribute("data-bp-graph-direction"));
+    const fallbackPack = normalizeGraphPack(graphRoot.getAttribute("data-bp-graph-pack"));
     return [{
       key: "full",
       label: "Full Graph",
@@ -153,6 +146,33 @@
       selectOnNodeId: [],
       hoverOnNodeId: []
     }];
+  }
+
+  function readPublicGraphData(previewUtils, root) {
+    if (previewUtils && typeof previewUtils.getGraphData === "function") {
+      return previewUtils.getGraphData(root);
+    }
+    const api = window.bpGraphApi;
+    if (api && typeof api.getGraphData === "function") {
+      return api.getGraphData(root);
+    }
+    return null;
+  }
+
+  function readPublicGraphVariants(previewUtils, root, graphRoot) {
+    let variants = [];
+    if (previewUtils && typeof previewUtils.getGraphVariants === "function") {
+      variants = previewUtils.getGraphVariants(root);
+    } else {
+      const api = window.bpGraphApi;
+      if (api && typeof api.getGraphVariants === "function") {
+        variants = api.getGraphVariants(root);
+      }
+    }
+    if (Array.isArray(variants) && variants.length > 0) {
+      return variants;
+    }
+    return legacyGraphVariants(graphRoot);
   }
 
   function dotWithGraphAttribute(dot, name, value) {
@@ -211,6 +231,7 @@
       groupHoverController: null,
       groupHoverShownKey: "",
       groupHoverShownNodeId: "",
+      graphData: null,
       graphviz: null,
       renderedVariantKey: "",
       renderedOptionsKey: "",
@@ -546,13 +567,13 @@
   }
 
   window.VersoBlueprint.onRenderReady(function (previewUtils) {
-    Promise.resolve()
+    function bindGraphs() {
+      const graphBlocks = Array.from(document.querySelectorAll(".bp_graph_fullwidth"));
+      if (graphBlocks.length === 0) return;
+      Promise.resolve()
       .then(function () { return load("https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js"); })
       .then(function () { return load("https://cdn.jsdelivr.net/npm/d3-graphviz@5.6.0/build/d3-graphviz.min.js"); })
       .then(function () {
-      const graphBlocks = Array.from(document.querySelectorAll(".bp_graph_fullwidth"));
-      if (graphBlocks.length === 0) return;
-
       function initGraphBlock(graphBlock) {
         if (!(graphBlock instanceof Element)) return;
         const graphRoot = graphBlock.querySelector(".bp_graph_canvas");
@@ -560,6 +581,11 @@
         const graphContainer = d3.select(graphRoot);
         if (graphContainer.empty()) return;
         const graphState = ensureGraphBlockState(graphBlock);
+        const graphApiData = readPublicGraphData(previewUtils, graphBlock);
+        if (graphApiData) {
+          graphState.graphData = graphApiData;
+          graphBlock.__bpGraphData = graphApiData;
+        }
         const selector = graphBlock.querySelector(".bp_graph_view_select");
         const directionSelector = graphBlock.querySelector(".bp_graph_direction_select");
         const packInput = graphBlock.querySelector(".bp_graph_pack_input");
@@ -625,7 +651,7 @@
           { keepOpen: true }
         );
 
-        const rawVariants = collectGraphVariants(graphContainer);
+        const rawVariants = readPublicGraphVariants(previewUtils, graphBlock, graphRoot);
         if (!Array.isArray(rawVariants) || rawVariants.length === 0) return;
         const variantsByKey = new Map();
         rawVariants.forEach(function (variant) {
@@ -654,6 +680,7 @@
         });
         const variants = Array.from(variantsByKey.values());
         if (variants.length === 0) return;
+        graphBlock.__bpGraphVariants = variants;
 
         if (selector && selector.options.length === 0) {
           variants.forEach(function (variant) {
@@ -1012,5 +1039,12 @@
 
       graphBlocks.forEach(initGraphBlock);
       });
+    }
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", bindGraphs, { once: true });
+    } else {
+      bindGraphs();
+    }
   });
 })();

--- a/src/VersoBlueprint/Commands/preview-runtime.js
+++ b/src/VersoBlueprint/Commands/preview-runtime.js
@@ -171,6 +171,81 @@
     return blueprintDataUrl("blueprint-manifest.json");
   }
 
+  function graphCanvasFor(root) {
+    const node = root || document;
+    if (node instanceof Element) {
+      if (node.matches(".bp_graph_canvas")) return node;
+      const ownCanvas = node.querySelector(".bp_graph_canvas");
+      if (ownCanvas instanceof Element) return ownCanvas;
+      const block = node.closest(".bp_graph_fullwidth");
+      if (block instanceof Element) {
+        const blockCanvas = block.querySelector(".bp_graph_canvas");
+        if (blockCanvas instanceof Element) return blockCanvas;
+      }
+      return null;
+    }
+    if (node instanceof Document || node instanceof DocumentFragment) {
+      const canvas = node.querySelector(".bp_graph_canvas");
+      return canvas instanceof Element ? canvas : null;
+    }
+    return null;
+  }
+
+  function readGraphJsonScript(root, selector) {
+    const container = graphCanvasFor(root);
+    if (!(container instanceof Element)) return null;
+    const payloadNode = container.querySelector(selector);
+    if (!(payloadNode instanceof HTMLScriptElement)) return null;
+    try {
+      return JSON.parse((payloadNode.textContent || "").trim());
+    } catch (_err) {
+      return null;
+    }
+  }
+
+  function normalizeGraphDataPayload(rawData) {
+    if (!rawData || typeof rawData !== "object" || Array.isArray(rawData)) return null;
+    return {
+      schemaVersion: Number.isFinite(rawData.schemaVersion) ? rawData.schemaVersion : 1,
+      key: typeof rawData.key === "string" ? rawData.key : "graph",
+      nodes: Array.isArray(rawData.nodes) ? rawData.nodes : [],
+      edges: Array.isArray(rawData.edges) ? rawData.edges : [],
+      groups: Array.isArray(rawData.groups) ? rawData.groups : []
+    };
+  }
+
+  function graphDataFromManifest(manifest) {
+    if (!manifest || typeof manifest !== "object" || !Array.isArray(manifest.graphs)) {
+      return [];
+    }
+    return manifest.graphs
+      .map(normalizeGraphDataPayload)
+      .filter(function (graphData) { return !!graphData; });
+  }
+
+  function collectGraphData(root) {
+    return normalizeGraphDataPayload(readGraphJsonScript(root, "script.bp-graph-data"));
+  }
+
+  function collectGraphVariants(root) {
+    const parsed = readGraphJsonScript(root, "script.bp-graph-variants");
+    return Array.isArray(parsed) ? parsed : [];
+  }
+
+  function loadManifestGraphs(url, options) {
+    const manifestUrl = typeof url === "string" && url.trim() ? url : blueprintManifestUrl();
+    return fetch(manifestUrl, options).then(function (response) {
+      if (!response.ok) {
+        throw new Error("Could not load Blueprint graph manifest: " + response.status);
+      }
+      return response.json();
+    }).then(graphDataFromManifest);
+  }
+
+  function loadBlueprintGraphs() {
+    return loadManifestGraphs(blueprintManifestUrl());
+  }
+
   function missingPreviewKeyDiagnosticHtml() {
     return (
       "<div class=\"bp_html_cache_preview_notice\">" +
@@ -1942,6 +2017,11 @@
     loadHtmlCache: loadBlueprintHtmlCache,
     readHtmlCacheStatus: readBlueprintHtmlCacheStatus,
     loadHtmlCacheEntry: loadBlueprintHtmlCacheEntry,
+    getGraphData: collectGraphData,
+    getGraphVariants: collectGraphVariants,
+    graphsFromManifest: graphDataFromManifest,
+    loadManifestGraphs: loadManifestGraphs,
+    loadGraphs: loadBlueprintGraphs,
     previewKey: previewKey,
     statementPreviewKey: statementPreviewKey,
     resolvePreview: resolveBlueprintPreview,
@@ -1986,6 +2066,11 @@
     loadHtmlCache: previewDataApi.loadHtmlCache,
     readHtmlCacheStatus: previewDataApi.readHtmlCacheStatus,
     loadHtmlCacheEntry: previewDataApi.loadHtmlCacheEntry,
+    getGraphData: previewDataApi.getGraphData,
+    getGraphVariants: previewDataApi.getGraphVariants,
+    graphsFromManifest: previewDataApi.graphsFromManifest,
+    loadManifestGraphs: previewDataApi.loadManifestGraphs,
+    loadGraphs: previewDataApi.loadGraphs,
     previewKey: previewDataApi.previewKey,
     statementPreviewKey: previewDataApi.statementPreviewKey,
     resolvePreview: previewDataApi.resolvePreview,
@@ -2013,6 +2098,16 @@
     stableCustomClientApi,
     bundledFeatureRenderHelpers
   );
+
+  const graphApi =
+    window.bpGraphApi && typeof window.bpGraphApi === "object" ? window.bpGraphApi : {};
+  graphApi.version = 1;
+  graphApi.getGraphData = previewDataApi.getGraphData;
+  graphApi.getGraphVariants = previewDataApi.getGraphVariants;
+  graphApi.graphsFromManifest = previewDataApi.graphsFromManifest;
+  graphApi.loadManifestGraphs = previewDataApi.loadManifestGraphs;
+  graphApi.loadGraphs = previewDataApi.loadGraphs;
+  window.bpGraphApi = graphApi;
 
   function reportRenderReadyError(err) {
     window.setTimeout(function () {

--- a/src/VersoBlueprint/Graph.lean
+++ b/src/VersoBlueprint/Graph.lean
@@ -7,6 +7,7 @@ Author: Emilio J. Gallego Arias
 import VersoBlueprint.Environment
 import VersoBlueprint.Informal.Block.Model
 import VersoBlueprint.Lib.HtmlId
+import VersoBlueprint.PreviewCache
 import VersoBlueprint.ProvedStatus
 
 namespace Informal.Graph
@@ -25,7 +26,7 @@ inductive StatementStatus where
   | ready
   | formalized
   | mathlib
-deriving Inhabited, Repr, DecidableEq, ToJson, FromJson
+deriving Inhabited, Repr, DecidableEq, ToJson, FromJson, Quote
 
 /-- Upstream-aligned background status (proof-track for theorem-like nodes). -/
 inductive ProofStatus where
@@ -34,13 +35,13 @@ inductive ProofStatus where
   | incomplete
   | formalized
   | formalizedWithAncestors
-deriving Inhabited, Repr, DecidableEq, ToJson, FromJson
+deriving Inhabited, Repr, DecidableEq, ToJson, FromJson, Quote
 
 structure WarningFlags where
   unknownRef : Bool := false
   leanOnlyNoStatement : Bool := false
   missingExternalDecl : Bool := false
-deriving Inhabited, Repr, ToJson, FromJson
+deriving Inhabited, Repr, DecidableEq, ToJson, FromJson, Quote
 
 structure GraphNode (Ref : Type) where
   label : Name
@@ -72,6 +73,221 @@ abbrev Graph (Ref : Type) := Array (GraphNode Ref)
 
 def GraphNode.displayLabel (node : GraphNode Ref) : String :=
   node.displayLabel?.getD (toString node.label)
+
+/-- Graphviz rank direction used by rendered Blueprint graph layouts. -/
+inductive GraphDirection where
+  | LR
+  | RL
+  | TB
+  | BT
+deriving Inhabited, Repr, BEq, FromJson, ToJson, Quote
+
+/-- DOT `rankdir` token corresponding to a graph direction. -/
+def GraphDirection.rankdir : GraphDirection → String
+  | .LR => "LR"
+  | .RL => "RL"
+  | .TB => "TB"
+  | .BT => "BT"
+
+/-- Parse user-facing direction aliases accepted by `blueprint_graph`. -/
+def GraphDirection.parse? (s : String) : Option GraphDirection :=
+  match s.toLower with
+  | "lr" | "left-right" | "horizontal" => some .LR
+  | "rl" | "right-left" => some .RL
+  | "tb" | "top-bottom" | "vertical" => some .TB
+  | "bt" | "bottom-top" => some .BT
+  | _ => none
+
+/--
+Options that affect Graphviz layout for rendered Blueprint graphs.
+
+These options are stored in graph block payloads and serialized with render
+variants, so keep changes compatible with existing generated sites.
+-/
+structure GraphOptions where
+  /-- Graphviz rank direction. -/
+  direction : GraphDirection := .TB
+  /--
+  Ask Graphviz to compact disconnected graph components before d3-graphviz fits
+  the SVG into the canvas.
+  -/
+  pack : Bool := false
+deriving Inhabited, BEq, FromJson, ToJson, Quote
+
+private def graphPackAttr (pack : Bool) : String :=
+  if pack then "true" else "false"
+
+/--
+DOT rendering style knobs shared by page graphs and compact widget graphs.
+
+This is a rendering implementation detail, not part of the public graph-data
+schema. It lets all DOT emitters share one header template while preserving
+surface-specific sizing.
+-/
+structure GraphDotStyle where
+  /-- Node font size used in the DOT header. -/
+  nodeFontSize : String := "10"
+  /-- Node margin used in the DOT header. -/
+  nodeMargin : String := "0.08,0.04"
+  /-- Default node stroke width used in the DOT header. -/
+  nodePenwidth : String := "1.8"
+  /-- Default edge arrow size used in the DOT header. -/
+  edgeArrowsize : String := "0.6"
+  /-- Default edge stroke width used in the DOT header. -/
+  edgePenwidth : String := "1"
+  /-- Whether to emit the Graphviz `pack` attribute. -/
+  includePack : Bool := true
+deriving Inhabited, BEq
+
+/-- Smaller DOT styling for embedded graph panels. -/
+def GraphDotStyle.compact : GraphDotStyle := {
+  nodeFontSize := "9"
+  nodeMargin := "0.05,0.03"
+  nodePenwidth := "1.4"
+  edgeArrowsize := "0.5"
+  edgePenwidth := "0.9"
+  includePack := false
+}
+
+/--
+One rendered graph view.
+
+The bundled renderer uses variants for the full graph, the synthetic group
+overview, and per-group subgraphs. The `selectOnNodeId` and `hoverOnNodeId`
+arrays describe variant transitions keyed by SVG node id, and
+`previewKeyByNodeId` maps SVG nodes to preview-cache keys.
+-/
+structure GraphRenderVariant where
+  /-- Stable key used by the graph view selector and variant links. -/
+  key : String
+  /-- Human-readable view label. -/
+  label : String
+  /-- DOT source for this view. -/
+  dot : String
+  /-- Initial layout options used to build the DOT source. -/
+  options : GraphOptions := {}
+  /-- Node ids that switch to another variant when selected. -/
+  selectOnNodeId : Array (String × String) := #[]
+  /-- Node ids that preview another variant on hover. -/
+  hoverOnNodeId : Array (String × String) := #[]
+  /-- Node ids that open Blueprint preview-cache entries. -/
+  previewKeyByNodeId : Array (String × String) := #[]
+deriving Inhabited, ToJson
+
+/-- Direction order used by the bundled graph controls. -/
+def allGraphDirections : Array GraphDirection := #[.TB, .LR, .RL, .BT]
+
+/--
+Stable visual metadata for a graph node.
+
+This mirrors the render-facing DOT attributes without exposing the generic
+`GraphNode Ref` type in cached/public JSON schemas.
+-/
+structure NodeVisual where
+  shape : String := "box"
+  style : String := "filled"
+  fillcolor : String
+  color : String := "#6b7280"
+  penwidth : String := "1.8"
+  fontcolor : String := "#111827"
+  peripheries : Nat := 1
+  gradientangle? : Option String := none
+  tooltip? : Option String := none
+deriving Inhabited, Repr, DecidableEq, ToJson, FromJson, Quote
+
+def NodeVisual.ofGraphNode (node : GraphNode Ref) : NodeVisual := {
+  shape := node.shape
+  style := node.style
+  fillcolor := node.fillcolor
+  color := node.color
+  penwidth := node.penwidth
+  fontcolor := node.fontcolor
+  peripheries := node.peripheries
+  gradientangle? := node.gradientangle?
+  tooltip? := node.tooltip?
+}
+
+/-- Axis represented by a dependency edge in the public graph API. -/
+inductive EdgeAxis where
+  | statement
+  | proof
+deriving Inhabited, Repr, DecidableEq, ToJson, FromJson, Quote
+
+/-- Public dependency edge data. Edges point from dependency source to dependent target. -/
+structure EdgeData where
+  source : Name
+  target : Name
+  axes : Array EdgeAxis := #[]
+deriving Inhabited, Repr, DecidableEq, ToJson, FromJson, Quote
+
+/-- Public group/parent metadata for graph consumers. -/
+structure GroupData where
+  label : Name
+  title : String
+  declared : Bool := false
+  children : Array Name := #[]
+deriving Inhabited, Repr, DecidableEq, ToJson, FromJson, Quote
+
+/--
+Stable per-node graph data for Lean, manifest, and browser consumers.
+
+Use `statementStatus`, `proofStatus`, and `warnings` for semantics. `visual`
+is provided only for renderers that want to reuse Blueprint's current graph
+styling without reverse-engineering colors into statuses.
+-/
+structure NodeData where
+  label : Name
+  title : String
+  displayLabel : String
+  kind : Option Data.NodeKind := none
+  parent : Option Name := none
+  href : Option String := none
+  previewKey : String
+  statementUses : Array Data.UseRef := #[]
+  proofUses : Array Data.UseRef := #[]
+  statementStatus : StatementStatus := .blocked
+  proofStatus : ProofStatus := .none
+  warnings : WarningFlags := {}
+  visual : NodeVisual
+deriving Inhabited, Repr, ToJson, FromJson, Quote
+
+/--
+Stable graph data shared by Lean, generated manifests, and browser runtime code.
+
+`schemaVersion` is bumped only for incompatible public-shape changes.
+-/
+structure GraphData where
+  schemaVersion : Nat := 1
+  key : String := "graph"
+  nodes : Array NodeData := #[]
+  edges : Array EdgeData := #[]
+  groups : Array GroupData := #[]
+deriving Inhabited, Repr, ToJson, FromJson, Quote
+
+def NodeData.toGraphNode (node : NodeData) : GraphNode String := {
+  label := node.label
+  displayLabel? := some node.displayLabel
+  deps := node.statementUses.map (fun useRef => (useRef.label : Name))
+  proofDeps := node.proofUses.map (fun useRef => (useRef.label : Name))
+  parent? := node.parent
+  shape := node.visual.shape
+  style := node.visual.style
+  fillcolor := node.visual.fillcolor
+  color := node.visual.color
+  penwidth := node.visual.penwidth
+  fontcolor := node.visual.fontcolor
+  peripheries := node.visual.peripheries
+  gradientangle? := node.visual.gradientangle?
+  tooltip? := node.visual.tooltip?
+  ref? := node.href
+}
+
+def GraphData.toGraph (data : GraphData) : Graph String :=
+  data.nodes.map NodeData.toGraphNode
+
+def GraphData.groupTitleMap (data : GraphData) : Lean.NameMap String :=
+  data.groups.foldl (init := ({} : Lean.NameMap String)) fun acc group =>
+    acc.insert group.label group.title
 
 structure LegendSwatch where
   background : String := "#ffffff"
@@ -632,6 +848,134 @@ def buildWithExternal (state : Environment.State) (roots : Array Name)
   let labels := expandLabels state roots
   labels.map (mkNode external state resolveRef?)
 
+private def edgeAxes (isStatement isProof : Bool) : Array EdgeAxis :=
+  let axes := #[]
+  let axes := if isStatement then axes.push .statement else axes
+  if isProof then axes.push .proof else axes
+
+def edgesForNode (node : GraphNode Ref) : Array EdgeData :=
+  let stmtDeps := eraseDups node.deps
+  let proofDeps := eraseDups node.proofDeps
+  let deps := proofDeps.foldl (init := stmtDeps) fun deps dep =>
+    if deps.contains dep then deps else deps.push dep
+  deps.map fun dep => {
+    source := dep
+    target := node.label
+    axes := edgeAxes (stmtDeps.contains dep) (proofDeps.contains dep)
+  }
+
+def edgesForGraph (graph : Graph Ref) : Array EdgeData :=
+  let known : NameSet := graph.foldl (init := {}) fun acc node => acc.insert node.label
+  graph.foldl (init := #[]) fun edges node =>
+    edges ++ (edgesForNode node).filter (fun edge => known.contains edge.source)
+
+def graphParentChildren (graph : Graph Ref) : Lean.NameMap (Array Name) :=
+  graph.foldl (init := ({} : Lean.NameMap (Array Name))) fun acc node =>
+    match node.parent? with
+    | none => acc
+    | some parent =>
+      let children := acc.getD parent #[]
+      acc.insert parent (children.push node.label)
+
+def graphNodeParents (graph : Graph Ref) : Lean.NameMap Name :=
+  graph.foldl (init := ({} : Lean.NameMap Name)) fun acc node =>
+    match node.parent? with
+    | none => acc
+    | some parent => acc.insert node.label parent
+
+private def groupTitleMap (groupTitles : Array (Name × String)) : Lean.NameMap String :=
+  groupTitles.foldl (init := ({} : Lean.NameMap String)) fun acc (group, title) =>
+    acc.insert group title
+
+def groupTitle (groupTitles : Lean.NameMap String) (parent : Name) : String :=
+  let title := (groupTitles.getD parent parent.toString).trimAscii.toString
+  if title.isEmpty then parent.toString else title
+
+def groupDataForGraph (graph : Graph Ref) (groupTitles : Array (Name × String) := #[]) :
+    Array GroupData :=
+  let titleMap := groupTitleMap groupTitles
+  graphParentChildren graph |>.toArray
+    |>.map (fun (parent, children) => {
+      label := parent
+      title := groupTitle titleMap parent
+      declared := titleMap.contains parent
+      children
+    })
+    |>.qsort (fun a b => a.title < b.title)
+
+private def nodeTitle (resolveTitle? : Name → Option String) (label : Name) : String :=
+  match resolveTitle? label with
+  | some title =>
+    let title := title.trimAscii.toString
+    if title.isEmpty then label.toString else title
+  | none => label.toString
+
+def nodeDataWithExternal
+    (external : ExternalCodeStatus)
+    (state : Environment.State)
+    (resolveHref? : Name → Option String)
+    (resolveTitle? : Name → Option String)
+    (graphNode : GraphNode String) : NodeData :=
+  let label := graphNode.label
+  match state.data.get? label with
+  | some node =>
+    let statement := statementStatus external state label node
+    let proof := proofStatus external state label node
+    let warnings := nodeWarnings external state label node
+    {
+      label
+      title := nodeTitle resolveTitle? label
+      displayLabel := graphNode.displayLabel
+      kind := some node.kind
+      parent := node.parent
+      href := resolveHref? label
+      previewKey := PreviewCache.key label .statement
+      statementUses := statementUses node
+      proofUses := proofUses node
+      statementStatus := statement
+      proofStatus := proof
+      warnings
+      visual := NodeVisual.ofGraphNode graphNode
+    }
+  | none =>
+    {
+      label
+      title := nodeTitle resolveTitle? label
+      displayLabel := graphNode.displayLabel
+      kind := none
+      parent := none
+      href := resolveHref? label
+      previewKey := PreviewCache.key label .statement
+      statementUses := #[]
+      proofUses := #[]
+      statementStatus := .blocked
+      proofStatus := .none
+      warnings := { unknownRef := true }
+      visual := NodeVisual.ofGraphNode graphNode
+    }
+
+def buildDataWithExternal
+    (state : Environment.State)
+    (roots : Array Name)
+    (external : ExternalCodeStatus)
+    (resolveHref? : Name → Option String := fun _ => none)
+    (resolveTitle? : Name → Option String := fun _ => none)
+    (groupTitles : Array (Name × String) := #[]) : GraphData :=
+  let graph := buildWithExternal state roots external resolveHref?
+  {
+    nodes := graph.map (nodeDataWithExternal external state resolveHref? resolveTitle?)
+    edges := edgesForGraph graph
+    groups := groupDataForGraph graph groupTitles
+  }
+
+def buildData
+    (state : Environment.State)
+    (roots : Array Name)
+    (resolveHref? : Name → Option String := fun _ => none)
+    (resolveTitle? : Name → Option String := fun _ => none)
+    (groupTitles : Array (Name × String) := #[]) : GraphData :=
+  buildDataWithExternal state roots {} resolveHref? resolveTitle? groupTitles
+
 def escapeDotString (s : String) : String :=
   let s := s.replace "\\" "\\\\"
   let s := s.replace "\"" "\\\""
@@ -809,5 +1153,321 @@ def Graph.toDot (g : Graph Ref) (header : String)
   let lines := lines.push "}"
   lines.foldl (init := "") fun acc line =>
     if acc.isEmpty then line else acc ++ "\n" ++ line
+
+/-- Common DOT header for rendered Blueprint graphs.
+
+`pack=true` keeps disconnected graph components compact before d3-graphviz fits
+the SVG into the canvas. Without it, sparse multi-component graphs can be
+placed far from the top of the viewport after variant or direction switches.
+-/
+def graphDotHeader (options : GraphOptions := {}) (style : GraphDotStyle := {}) : String :=
+  "strict digraph \"\" {\n" ++
+  s!"    rankdir={options.direction.rankdir};\n" ++
+  "    bgcolor=\"white\";\n" ++
+  (if style.includePack then s!"    pack={graphPackAttr options.pack};\n" else "") ++
+  "    splines=true;\n" ++
+  "    nodesep=0.35;\n" ++
+  "    ranksep=0.45;\n" ++
+  s!"    node [shape=box, style=\"rounded,filled\", fontname=\"Helvetica\", fontsize={style.nodeFontSize}, margin=\"{style.nodeMargin}\", color=\"#6b7280\", penwidth={style.nodePenwidth}];\n" ++
+  s!"    edge [color=\"#6b7280\", arrowhead=vee, arrowsize={style.edgeArrowsize}, penwidth={style.edgePenwidth}];\n" ++
+  "    graph [fontname=\"Helvetica\"];\n" ++
+  "  "
+
+/--
+Render a graph to DOT using the shared Blueprint graph header.
+
+Use `graphToDot` for the usual page-graph case where refs are href strings.
+`graphToDotWith` is for renderers such as widgets that need a different ref
+type or compact DOT styling.
+-/
+def graphToDotWith (g : Graph Ref) (options : GraphOptions := {}) (style : GraphDotStyle := {})
+    (resolveGroupTitle : Name → Option String := fun _ => none)
+    (refAttrs? : Option (Ref → Option String) := none) : String :=
+  Graph.toDot g (graphDotHeader options style)
+    (groupLabel? := some resolveGroupTitle)
+    (refAttrs? := refAttrs?)
+
+/-- Render a page graph with string refs interpreted as same-page hrefs. -/
+def graphToDot (g : Graph String) (options : GraphOptions := {})
+    (resolveGroupTitle : Name → Option String := fun _ => none) : String :=
+  graphToDotWith g options {} resolveGroupTitle
+    (some fun href => some s!"URL=\"{href}\", target=\"_self\"")
+
+/-- Render finalized graph data to DOT using its href and group-title fields. -/
+def GraphData.toDotWith (data : GraphData) (options : GraphOptions := {})
+    (style : GraphDotStyle := {}) : String :=
+  graphToDotWith data.toGraph options style (fun group => data.groupTitleMap.get? group)
+    (some fun href => some s!"URL=\"{href}\", target=\"_self\"")
+
+/-- Stable key for the synthetic group overview variant. -/
+def groupVariantKey : String := "group"
+private def parentVariantKey (parent : Name) : String := s!"parent:{parent}"
+
+private partial def wrapGraphLabelWords (words : List String) (lineWidth maxLines : Nat)
+    (current : String) (lines : Array String) : Array String :=
+  match words with
+  | [] =>
+    if current.isEmpty then lines else lines.push current
+  | word :: rest =>
+    if lines.size + 1 == maxLines then
+      let finalLine :=
+        if current.isEmpty then
+          String.intercalate " " (word :: rest)
+        else
+          String.intercalate " " (current :: word :: rest)
+      lines.push finalLine
+    else
+      let candidate := if current.isEmpty then word else current ++ " " ++ word
+      if !current.isEmpty && candidate.length > lineWidth then
+        wrapGraphLabelWords words lineWidth maxLines "" (lines.push current)
+      else
+        wrapGraphLabelWords rest lineWidth maxLines candidate lines
+
+private def wrapGraphLabel (title : String) (lineWidth : Nat := 26) (maxLines : Nat := 3) : String :=
+  let words :=
+    (title.splitOn " ").foldr (init := ([] : List String)) fun word acc =>
+      let word := word.trimAscii.toString
+      if word.isEmpty then acc else word :: acc
+  match words with
+  | [] => title.trimAscii.toString
+  | _ =>
+    let lines := wrapGraphLabelWords words lineWidth maxLines "" #[]
+    String.intercalate "\n" lines.toList
+
+private def graphParentDisplayLabel (groupTitles : Lean.NameMap String) (parent : Name) : String :=
+  wrapGraphLabel (groupTitle groupTitles parent)
+
+private def hexNibble? (c : Char) : Option Nat :=
+  match c with
+  | '0' => some 0
+  | '1' => some 1
+  | '2' => some 2
+  | '3' => some 3
+  | '4' => some 4
+  | '5' => some 5
+  | '6' => some 6
+  | '7' => some 7
+  | '8' => some 8
+  | '9' => some 9
+  | 'a' | 'A' => some 10
+  | 'b' | 'B' => some 11
+  | 'c' | 'C' => some 12
+  | 'd' | 'D' => some 13
+  | 'e' | 'E' => some 14
+  | 'f' | 'F' => some 15
+  | _ => none
+
+private def parseHexByte? (c1 c2 : Char) : Option Nat := do
+  let hi ← hexNibble? c1
+  let lo ← hexNibble? c2
+  return hi * 16 + lo
+
+private def parseHexColor? (s : String) : Option (Nat × Nat × Nat) := do
+  let chars :=
+    match s.trimAscii.toString.toList with
+    | '#' :: rest => rest
+    | xs => xs
+  match chars with
+  | r1 :: r2 :: g1 :: g2 :: b1 :: b2 :: [] =>
+    return (← parseHexByte? r1 r2, ← parseHexByte? g1 g2, ← parseHexByte? b1 b2)
+  | _ => none
+
+private def hexChar (n : Nat) : Char :=
+  if n < 10 then
+    Char.ofNat ('0'.toNat + n)
+  else
+    Char.ofNat ('a'.toNat + (n - 10))
+
+private def byteToHex (n : Nat) : String :=
+  let n := n % 256
+  let hi := n / 16
+  let lo := n % 16
+  String.ofList [hexChar hi, hexChar lo]
+
+private def rgbToHex (r g b : Nat) : String :=
+  "#" ++ byteToHex r ++ byteToHex g ++ byteToHex b
+
+private def primaryColorToken (s : String) : String :=
+  match s.splitOn ":" with
+  | token :: _ => token.trimAscii.toString
+  | [] => s.trimAscii.toString
+
+private def averageHexColor (colors : Array (Nat × Nat × Nat)) (fallback : String) : String :=
+  if colors.isEmpty then
+    fallback
+  else
+    let (sumR, sumG, sumB) := colors.foldl (init := (0, 0, 0)) fun (r, g, b) (r', g', b') =>
+      (r + r', g + g', b + b')
+    let n := colors.size
+    rgbToHex (sumR / n) (sumG / n) (sumB / n)
+
+private def mixedNodeColor (nodes : Array (GraphNode String)) (colorOf : GraphNode String → String)
+    (fallback : String) : String :=
+  let colors := nodes.foldl (init := (#[] : Array (Nat × Nat × Nat))) fun acc node =>
+    match parseHexColor? (primaryColorToken (colorOf node)) with
+    | some rgb => acc.push rgb
+    | none => acc
+  averageHexColor colors fallback
+
+private def fontColorForFill (fillColor : String) : String :=
+  match parseHexColor? fillColor with
+  | some (r, g, b) =>
+    -- Relative luminance approximation, keeps labels readable on dark mixes.
+    if (299 * r + 587 * g + 114 * b) < 140000 then "#f8fafc" else "#0f172a"
+  | none => "#0f172a"
+
+private def nodeHasAncestorParent (parentMap : Lean.NameMap Name) (label ancestor : Name) : Bool :=
+  Id.run <| do
+    let mut current := label
+    let mut seen : Lean.NameSet := {}
+    let mut fuel := parentMap.toArray.size + 1
+    while fuel > 0 do
+      fuel := fuel - 1
+      match parentMap.get? current with
+      | none => return false
+      | some parent =>
+        if parent == ancestor then
+          return true
+        if seen.contains parent then
+          return false
+        seen := seen.insert parent
+        current := parent
+    return false
+
+private def subgraphForParent (graph : Graph Ref) (parent : Name) : Graph Ref :=
+  let parentMap := graphNodeParents graph
+  graph.filter fun node =>
+    node.label == parent || nodeHasAncestorParent parentMap node.label parent
+
+/--
+Build the synthetic group overview graph used by graph view variants.
+
+Each parent with multiple children becomes one aggregate node whose colors are
+derived from its children and whose edges summarize cross-group dependencies.
+-/
+def mkParentOverviewGraph (graph : Graph String) (parents : Array Name)
+    (groupTitles : Lean.NameMap String) : Graph String :=
+  let parentChildren := graphParentChildren graph
+  let nodeByLabel : Lean.NameMap (GraphNode String) :=
+    graph.foldl (init := ({} : Lean.NameMap (GraphNode String))) fun acc node =>
+      acc.insert node.label node
+  let parentSet : Lean.NameSet :=
+    parents.foldl (init := ({} : Lean.NameSet)) fun acc parent => acc.insert parent
+  let parentMap := graphNodeParents graph
+  let addParentDep (acc : Lean.NameMap (Array Name)) (target source : Name) : Lean.NameMap (Array Name) :=
+    let deps := acc.getD target #[]
+    if deps.contains source then
+      acc
+    else
+      acc.insert target (deps.push source)
+  let collectParentDeps (depsOf : GraphNode String → Array Name) :=
+    graph.foldl (init := ({} : Lean.NameMap (Array Name))) fun acc node =>
+      match node.parent? with
+      | none => acc
+      | some target =>
+        if !parentSet.contains target then
+          acc
+        else
+          (depsOf node).foldl (init := acc) fun acc dep =>
+            match parentMap.get? dep with
+            | some source =>
+              if parentSet.contains source && source != target then
+                addParentDep acc target source
+              else
+                acc
+            | none => acc
+  let parentStatementDeps := collectParentDeps (·.deps)
+  let parentProofDeps := collectParentDeps (·.proofDeps)
+  parents.map fun parent =>
+    let childNodes :=
+      (parentChildren.getD parent #[]).foldl (init := (#[] : Array (GraphNode String))) fun acc child =>
+        match nodeByLabel.get? child with
+        | some node => acc.push node
+        | none => acc
+    let mixedFillColor := mixedNodeColor childNodes (·.fillcolor) "#e2e8f0"
+    let mixedBorderColor := mixedNodeColor childNodes (·.color) "#475569"
+    let title := groupTitle groupTitles parent
+    {
+      label := parent
+      displayLabel? := some (graphParentDisplayLabel groupTitles parent)
+      deps := parentStatementDeps.getD parent #[]
+      proofDeps := parentProofDeps.getD parent #[]
+      shape := "tab"
+      style := "filled"
+      fillcolor := mixedFillColor
+      color := mixedBorderColor
+      penwidth := "2.4"
+      fontcolor := fontColorForFill mixedFillColor
+      tooltip? := some s!"Group View: {title} ({childNodes.size} nodes)"
+      ref? := none
+    }
+
+/--
+Build the render variants for the bundled graph UI.
+
+Graphs without multi-child groups produce just the full graph variant. Grouped
+graphs additionally produce a synthetic group overview and one focused subgraph
+per parent group.
+-/
+def mkGraphVariants (graph : Graph String) (options : GraphOptions)
+    (groupTitles : Lean.NameMap String) : Array GraphRenderVariant :=
+  let previewKeyByNodeId (graph : Graph String) : Array (String × String) :=
+    graph.map fun node =>
+      (graphNodeSvgId node.label, PreviewCache.key node.label .statement)
+  let resolveGroupTitle : Name → Option String := fun group =>
+    groupTitles.get? group
+  let parentChildren := graphParentChildren graph
+  let parents :=
+    parentChildren.toArray
+      |>.filter (fun (_, children) => children.size > 1)
+      |>.map (·.1)
+      |>.qsort (fun a b => groupTitle groupTitles a < groupTitle groupTitles b)
+  if parents.isEmpty then
+    #[{
+      key := "full"
+      label := "Full Graph"
+      dot := graphToDot graph options resolveGroupTitle
+      options
+      selectOnNodeId := #[]
+      hoverOnNodeId := #[]
+      previewKeyByNodeId := previewKeyByNodeId graph
+    }]
+  else
+    let parentVariantRefs := parents.map (fun parent => (graphNodeSvgId parent, parentVariantKey parent))
+    let groupVariant : GraphRenderVariant := {
+      key := groupVariantKey
+      label := "Group View"
+      dot := graphToDot (mkParentOverviewGraph graph parents groupTitles) options (fun _ => none)
+      options
+      selectOnNodeId := parentVariantRefs
+      hoverOnNodeId := parentVariantRefs
+      previewKeyByNodeId := #[]
+    }
+    let fullVariant : GraphRenderVariant := {
+      key := "full"
+      label := "Full Graph"
+      dot := graphToDot graph options resolveGroupTitle
+      options
+      selectOnNodeId := #[]
+      hoverOnNodeId := #[]
+      previewKeyByNodeId := previewKeyByNodeId graph
+    }
+    let parentVariants := parents.map fun parent =>
+      let parentSubgraph := subgraphForParent graph parent
+      let title := groupTitle groupTitles parent
+      {
+        key := parentVariantKey parent
+        label := title
+        dot := graphToDot parentSubgraph options resolveGroupTitle
+        options
+        selectOnNodeId := #[]
+        hoverOnNodeId := #[]
+        previewKeyByNodeId := previewKeyByNodeId parentSubgraph
+      }
+    #[fullVariant, groupVariant] ++ parentVariants
+
+/-- Build the bundled renderer's DOT variants from finalized public graph data. -/
+def GraphData.renderVariants (data : GraphData) (options : GraphOptions) : Array GraphRenderVariant :=
+  mkGraphVariants data.toGraph options data.groupTitleMap
 
 end Informal.Graph

--- a/src/VersoBlueprint/GraphApi.lean
+++ b/src/VersoBlueprint/GraphApi.lean
@@ -1,0 +1,112 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoBlueprint.Graph
+import VersoBlueprint.Informal.Block.Store
+import VersoBlueprint.TraversalIndex
+
+/-!
+Public graph-data helpers.
+
+`Informal.Graph` owns the stable graph data structures and the semantic
+environment builder. This module adds the traversal-state bridge: graph blocks
+store semantic `GraphData` during traversal, and renderers/manifests finalize
+that cached object against the completed traversal state to add hrefs and
+display titles.
+-/
+
+namespace Informal.GraphApi
+
+open Lean
+open Verso
+open Verso.Genre Manual
+
+/-- Stable traversal-cache key for a rendered graph block. -/
+def cacheKey (id : Verso.Multi.InternalId) : String :=
+  s!"graph:{id}"
+
+/-- Attach the rendered block key to graph data. -/
+def keyedData (id : Verso.Multi.InternalId) (data : Informal.Graph.GraphData) :
+    Informal.Graph.GraphData :=
+  { data with key := cacheKey id }
+
+private def nodeTitle? (state : TraverseState) (label : Name) : Option String :=
+  (Informal.TraversalIndex.Nodes.data? state label).map fun data =>
+    data.displayTitle state
+
+private def nodeHref? (state : TraverseState) (label : Name) : Option String :=
+  Informal.TraversalIndex.Nodes.href? state label
+
+private def groupTitle? (state : TraverseState) (label : Name) : Option String :=
+  (Informal.TraversalIndex.Groups.data? state label).bind fun groupData =>
+    let title := groupData.header.trimAscii.toString
+    if title.isEmpty then none else some title
+
+private def enrichNode (state : TraverseState) (node : Informal.Graph.NodeData) :
+    Informal.Graph.NodeData :=
+  let title := (nodeTitle? state node.label).getD node.title
+  let href := nodeHref? state node.label <|> node.href
+  { node with title, href }
+
+private def enrichGroup (state : TraverseState) (group : Informal.Graph.GroupData) :
+    Informal.Graph.GroupData :=
+  match groupTitle? state group.label with
+  | some title => { group with title, declared := true }
+  | none => group
+
+/--
+Finalize graph data against a completed traversal state.
+
+This is the single projection from semantic graph data to public graph data:
+rendered page JSON and manifest/cache output both use it so href, title, and
+group metadata stay consistent.
+-/
+def finalData (state : TraverseState) (data : Informal.Graph.GraphData) :
+    Informal.Graph.GraphData :=
+  {
+    data with
+      nodes := data.nodes.map (enrichNode state)
+      groups := data.groups.map (enrichGroup state)
+  }
+
+/--
+Finalize a graph block's semantic graph data for public page JSON.
+
+Use this when rendering one graph block from its block payload and rendered
+block id.
+-/
+def finalDataForBlock
+    (state : TraverseState)
+    (id : Verso.Multi.InternalId)
+    (data : Informal.Graph.GraphData) : Informal.Graph.GraphData :=
+  finalData state (keyedData id data)
+
+/--
+Store graph block data during traversal.
+
+The cached payload deliberately remains semantic data plus the stable block key;
+call `cachedData` after traversal finishes to read the public, finalized form.
+-/
+def saveData
+    (state : TraverseState)
+    (id : Verso.Multi.InternalId)
+    (data : Informal.Graph.GraphData) : TraverseState :=
+  let key := cacheKey id
+  let data := keyedData id data
+  state
+    |> (fun state => Informal.TraversalIndex.Graphs.saveId state key id)
+    |> (fun state => Informal.TraversalIndex.Graphs.saveData state key data)
+
+/--
+Read every traversal-cached graph and finalize it for public manifest/API use.
+
+Call this only with the completed traversal state for the document/site being
+emitted.
+-/
+def cachedData (state : TraverseState) : Array Informal.Graph.GraphData :=
+  Informal.TraversalIndex.Graphs.allData state |>.map (finalData state)
+
+end Informal.GraphApi

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -18,6 +18,7 @@ import VersoBlueprint.Informal.LeanCodePreview
 import VersoBlueprint.Lib.PreviewSource
 import VersoBlueprint.PreviewCache
 import VersoBlueprint.PreviewRender
+import VersoBlueprint.GraphApi
 import VersoBlueprint.Git
 import VersoBlueprint.Html
 import VersoBlueprint.Process
@@ -688,6 +689,13 @@ structure File where
   Lean preview key, or citation key.
   -/
   previews : Array Entry := #[]
+  /--
+  Public graph data captured from rendered `{blueprint_graph}` blocks.
+
+  These entries share the same schema as the page-embedded graph data used by
+  the browser runtime.
+  -/
+  graphs : Array Informal.Graph.GraphData := #[]
 deriving Inhabited, Repr, ToJson, FromJson
 
 /-
@@ -1434,8 +1442,9 @@ def buildPreviewDataFiles
   let (citationPreviews, citationHtml, hoverState) ← buildCitationEntries impls logError state hoverState
   let previews := (traversalPreviews ++ externalMarkupPreviews ++ leanCodePreviews ++ citationPreviews).qsort (fun a b => a.key < b.key)
   let htmlEntries := (traversalHtml ++ leanCodeHtml ++ citationHtml).qsort (fun a b => a.key < b.key)
+  let graphs := Informal.GraphApi.cachedData state
   pure {
-    manifest := { previews }
+    manifest := { previews, graphs }
     htmlCache := {
       entries := htmlEntries
       hoverDocs := HtmlCache.HoverDoc.ofDedup hoverState.dedup

--- a/src/VersoBlueprint/Resolve.lean
+++ b/src/VersoBlueprint/Resolve.lean
@@ -35,6 +35,7 @@ attach markup to preview-backed block entries, or to emit semantic-only
 def externalMarkupDomainName : Name := Name.mkSimple "Informal.Block.externalMarkup"
 def informalPreviewDomainName : Name := Name.mkSimple "Informal.Block.informalPreview"
 def informalGroupDomainName : Name := Name.mkSimple "Informal.Block.group"
+def graphDomainName : Name := Name.mkSimple "Informal.Block.graph"
 /- 
 Domain that stores anchors for rendered external declaration rows.
 

--- a/src/VersoBlueprint/TraversalIndex.lean
+++ b/src/VersoBlueprint/TraversalIndex.lean
@@ -9,6 +9,7 @@ import VersoManual
 import VersoBlueprint.Informal.Block.Model
 import VersoBlueprint.Informal.GroupData
 import VersoBlueprint.Informal.LeanDeclPreviewKey
+import VersoBlueprint.Graph
 import VersoBlueprint.PreviewCache
 import VersoBlueprint.Resolve
 
@@ -187,6 +188,47 @@ def saveData (state : TraverseState) (label : Name) (data : Json) : TraverseStat
   saveObjectData state domainName label.toString data
 
 end Groups
+
+namespace Graphs
+
+def spec : StoreSpec := {
+  name := Resolve.graphDomainName
+  kind := .runtimeCache
+  key := "graph block key"
+  value := "semantic GraphData plus graph block anchor ids"
+  summary := "Traversal-cached Blueprint graph data finalized by GraphApi for manifest and browser consumers."
+}
+
+def domainName : Name := spec.name
+
+def object? (state : TraverseState) (key : String) : Option Verso.Multi.Object :=
+  state.getDomainObject? domainName key
+
+def data? (state : TraverseState) (key : String) : Option Informal.Graph.GraphData :=
+  objectData? state domainName key
+
+def saveId
+    (state : TraverseState) (key : String) (id : Verso.Multi.InternalId) : TraverseState :=
+  saveObjectId state domainName key id
+
+def saveData (state : TraverseState) (key : String) (data : Informal.Graph.GraphData) :
+    TraverseState :=
+  saveObjectData state domainName key (toJson data)
+
+def domain? (state : TraverseState) : Option Verso.Multi.Domain :=
+  state.domains.get? domainName
+
+def allData (state : TraverseState) : Array Informal.Graph.GraphData :=
+  match domain? state with
+  | none => #[]
+  | some domain =>
+    domain.objects.foldl (init := #[]) fun acc _key obj =>
+      match fromJson? (α := Informal.Graph.GraphData) obj.data with
+      | .ok data => acc.push data
+      | .error _ => acc
+    |>.qsort (fun a b => a.key < b.key)
+
+end Graphs
 
 namespace TraversalPreviews
 
@@ -375,6 +417,7 @@ def allSpecs : Array StoreSpec := #[
   InlineCode.spec,
   ExternalMarkup.spec,
   Groups.spec,
+  Graphs.spec,
   TraversalPreviews.spec,
   LeanCodePreviews.spec,
   ExternalDeclAnchors.spec,

--- a/src/VersoBlueprint/Widget.lean
+++ b/src/VersoBlueprint/Widget.lean
@@ -266,22 +266,6 @@ def blueprintWidget : Component GraphParams where
 
 end BlueprintWidget
 
-abbrev GraphNode := Informal.Graph.GraphNode Unit
-abbrev Graph := Informal.Graph.Graph Unit
-
-def graphDotHeader : String := r##"strict digraph "" {
-  rankdir=LR;
-  bgcolor="white";
-  splines=true;
-  nodesep=0.35;
-  ranksep=0.45;
-  node [shape=box, style="rounded,filled", fontname="Helvetica", fontsize=9, margin="0.05,0.03", color="#6b7280", penwidth=1.4];
-  edge [color="#6b7280", arrowhead=vee, arrowsize=0.5, penwidth=0.9];
-  graph [fontname="Helvetica"];"##
-
-def Graph.toDot (g : Graph) (resolveGroupTitle : Name → Option String := fun _ => none) : String :=
-  Informal.Graph.Graph.toDot g graphDotHeader (groupLabel? := some resolveGroupTitle)
-
 open Informal Data Environment
 structure BuildResult where
   dot : String
@@ -298,10 +282,11 @@ def buildFor [Monad m] [MonadEnv m] [MonadError m] (label : Name) : m BuildResul
           |>.map (·.1.toString)
           |>.take 12
       throwError m!"No Label Found for '{label}'. Known labels (first {available.size}): {String.intercalate ", " available.toList}"
-  let graph : Graph := Informal.Graph.build state #[label]
-  let dot := graph.toDot (fun group => state.groups.get? group)
+  let graphData := Informal.Graph.buildData state #[label] (groupTitles := state.groups.toArray)
+  let dot := graphData.toDotWith { direction := .LR } Informal.Graph.GraphDotStyle.compact
   let statementPreview? := Informal.PreviewSource.fromEnvironment? env label
-  let includeMathlibLegend := graph.any (fun node => node.color == Informal.Graph.statementBorderMathlibColor)
+  let includeMathlibLegend :=
+    graphData.nodes.any (fun node => node.visual.color == Informal.Graph.statementBorderMathlibColor)
   let legend := toJson (Informal.Graph.graphLegendGroups includeMathlibLegend)
   pure { dot, statementPreview?, legend }
 

--- a/tests/VersoBlueprintTests/BlueprintGraph/Groups.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraph/Groups.lean
@@ -9,11 +9,10 @@ import VersoBlueprintTests.BlueprintGraph.Shared
 namespace Verso.VersoBlueprintTests.BlueprintGraph.Groups
 
 open Lean
-open Informal.Commands
 open Informal.Graph
 open Verso.VersoBlueprintTests.BlueprintGraph.Shared
 
-def groupedGraphInput : Informal.Commands.Graph := #[
+def groupedGraphInput : Informal.Graph.Graph String := #[
   {
     label := `ga_stmt
     deps := #[`gb_source]
@@ -65,13 +64,20 @@ def groupedGraphTitleMap : Lean.NameMap String :=
   groupedGraphTitles.foldl (init := ({} : Lean.NameMap String)) fun acc (group, title) =>
     acc.insert group title
 
-def groupedOverview : Informal.Commands.Graph :=
-  Informal.Commands.mkParentOverviewGraph groupedGraphInput #[`group_alpha, `group_beta] groupedGraphTitleMap
+def groupedOverview : Informal.Graph.Graph String :=
+  Informal.Graph.mkParentOverviewGraph groupedGraphInput #[`group_alpha, `group_beta] groupedGraphTitleMap
 
-def groupedVariants : Array Informal.Commands.GraphRenderVariant :=
-  Informal.Commands.mkGraphVariants
-    { graph := groupedGraphInput, options := { direction := .TB, pack := true }, groupTitles := groupedGraphTitles }
-    (fun _ => none)
+def groupedGraphData : Informal.Graph.GraphData :=
+  {
+    nodes := #[]
+    edges := Informal.Graph.edgesForGraph groupedGraphInput
+    groups := Informal.Graph.groupDataForGraph groupedGraphInput groupedGraphTitles
+  }
+
+def groupedVariants : Array Informal.Graph.GraphRenderVariant :=
+  Informal.Graph.mkGraphVariants
+    groupedGraphInput
+    { direction := .TB, pack := true }
     groupedGraphTitleMap
 
 /-- info: true -/
@@ -79,7 +85,7 @@ def groupedVariants : Array Informal.Commands.GraphRenderVariant :=
 #eval
   hasNodeWith groupedOverview `group_alpha (fun n =>
     n.shape == "tab" &&
-    n.displayLabel? == some (Informal.Commands.graphParentDisplayLabel groupedGraphTitleMap `group_alpha) &&
+    n.displayLabel? == some "Readable Alpha Group Title" &&
     n.deps.contains `group_beta &&
     n.proofDeps.contains `group_beta &&
     n.tooltip?.getD "" == "Group View: Readable Alpha Group Title (2 nodes)")
@@ -88,13 +94,14 @@ def groupedVariants : Array Informal.Commands.GraphRenderVariant :=
 #guard_msgs in
 #eval
   graphNodeSvgId `group_alpha == "bp-node-group-005Falpha" &&
-  match groupedVariants.find? (·.key == Informal.Commands.groupVariantKey) with
+  match groupedVariants.find? (·.key == Informal.Graph.groupVariantKey) with
   | none => false
   | some variant =>
     let expectedId := graphNodeSvgId `group_alpha
-    let expectedLabel := escapeDotString (Informal.Commands.graphParentDisplayLabel groupedGraphTitleMap `group_alpha)
-    variant.selectOnNodeId.contains (expectedId, Informal.Commands.parentVariantKey `group_alpha) &&
-    variant.hoverOnNodeId.contains (expectedId, Informal.Commands.parentVariantKey `group_alpha) &&
+    let expectedLabel := escapeDotString "Readable Alpha Group Title"
+    let expectedVariantKey := s!"parent:{`group_alpha}"
+    variant.selectOnNodeId.contains (expectedId, expectedVariantKey) &&
+    variant.hoverOnNodeId.contains (expectedId, expectedVariantKey) &&
     variant.dot.contains s!"id=\"{expectedId}\"" &&
     variant.dot.contains s!"label=\"{expectedLabel}\"" &&
     !variant.dot.contains "label=\"group_alpha\""
@@ -102,11 +109,26 @@ def groupedVariants : Array Informal.Commands.GraphRenderVariant :=
 /-- info: true -/
 #guard_msgs in
 #eval
-  Informal.Commands.graphDotHeader |>.contains "pack=false;"
+  Informal.Graph.graphDotHeader |>.contains "pack=false;"
 
 /-- info: true -/
 #guard_msgs in
 #eval
-  Informal.Commands.graphDotHeader { direction := .TB, pack := true } |>.contains "pack=true;"
+  Informal.Graph.graphDotHeader { direction := .TB, pack := true } |>.contains "pack=true;"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  groupedGraphData.edges.any (fun edge =>
+    edge.source == `gb_source &&
+    edge.target == `ga_stmt &&
+    edge.axes == #[Informal.Graph.EdgeAxis.statement]) &&
+  match groupedGraphData.groups.find? (·.label == `group_alpha) with
+  | none => false
+  | some group =>
+    group.title == "Readable Alpha Group Title" &&
+    group.declared &&
+    group.children.contains `ga_stmt &&
+    group.children.contains `ga_proof
 
 end Verso.VersoBlueprintTests.BlueprintGraph.Groups

--- a/tests/VersoBlueprintTests/BlueprintGraph/NodeStatus.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraph/NodeStatus.lean
@@ -59,6 +59,16 @@ def stateStatus : Environment.State := mkState [
 def graphStatus : Graph Unit :=
   build stateStatus #[`def_formal, `def_ready, `def_blocked, `thm_ready, `lean_only, `local_sorry, `thm_type_sorry]
 
+def graphDataStatus : GraphData :=
+  buildData stateStatus
+    #[`def_formal, `def_ready, `def_blocked, `thm_ready, `lean_only, `local_sorry, `thm_type_sorry]
+    (resolveHref? := fun
+      | `def_formal => some "#def-formal"
+      | _ => none)
+    (resolveTitle? := fun
+      | `def_formal => some "Definition 1"
+      | _ => none)
+
 /-- info: true -/
 #guard_msgs in
 #eval
@@ -103,6 +113,23 @@ def graphStatus : Graph Unit :=
     n.color == unresolvedBorderColor &&
     n.fillcolor == unresolvedFillColor &&
     n.fontcolor == unresolvedFontColor)
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  hasGraphDataNodeWith graphDataStatus `def_formal (fun n =>
+    n.title == "Definition 1" &&
+    n.href == some "#def-formal" &&
+    n.previewKey == "def_formal--statement" &&
+    n.kind == some Data.NodeKind.definition &&
+    n.statementStatus == .formalized &&
+    n.proofStatus == .formalizedWithAncestors &&
+    n.visual.fillcolor == proofBackgroundFormalizedAncColor) &&
+  hasGraphDataNodeWith graphDataStatus `missing_dep (fun n =>
+    n.warnings.unknownRef &&
+    n.kind.isNone &&
+    n.statementStatus == .blocked) &&
+  hasGraphDataEdge graphDataStatus `missing_dep `def_blocked #[.statement]
 
 def stateAncestorsOk : Environment.State := mkState [
   (`def_ok,

--- a/tests/VersoBlueprintTests/BlueprintGraph/Shared.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraph/Shared.lean
@@ -48,6 +48,15 @@ def hasNodeWith {Ref : Type} (g : Graph Ref) (label : Name) (p : GraphNode Ref �
   | some node => p node
   | none => false
 
+def hasGraphDataNodeWith (g : GraphData) (label : Name) (p : NodeData → Bool) : Bool :=
+  match g.nodes.find? (·.label == label) with
+  | some node => p node
+  | none => false
+
+def hasGraphDataEdge (g : GraphData) (source target : Name) (axes : Array EdgeAxis) : Bool :=
+  g.edges.any fun edge =>
+    edge.source == source && edge.target == target && edge.axes == axes
+
 def styleHasToken (style token : String) : Bool :=
   (style.splitOn ",").any (fun part => part.trimAscii.toString == token)
 

--- a/tests/browser/test_graph_layout_runtime.py
+++ b/tests/browser/test_graph_layout_runtime.py
@@ -128,6 +128,66 @@ def first_preview_node(page: Page):
 
 
 class TestGraphLayoutRuntime:
+    def test_public_graph_api_exposes_rendered_page_and_manifest_data(self, server: str, page: Page):
+        page.set_viewport_size({"width": 1400, "height": 900})
+        page.goto(f"{server}/Dependency-Graph/")
+        wait_for_graph(page)
+
+        graph_data = page.evaluate(
+            blueprint_render_api_script(
+                """
+                const block = document.querySelector(".bp_graph_fullwidth");
+                const pageGraph = api.getGraphData(block);
+                const globalPageGraph = window.bpGraphApi.getGraphData(block);
+                const manifestGraphs = await api.loadGraphs();
+                const manifestGraph = manifestGraphs.find((graph) => graph.key === pageGraph.key) || null;
+                const variants = api.getGraphVariants(block);
+                const globalVariants = window.bpGraphApi.getGraphVariants(block);
+                const sample = pageGraph.nodes.find((node) => node.label === "used_target") || null;
+                const manifestSample = manifestGraph
+                    ? manifestGraph.nodes.find((node) => node.label === "used_target") || null
+                    : null;
+                return {
+                    apiVersion: window.bpGraphApi.version,
+                    sameGlobalKey: !!globalPageGraph && globalPageGraph.key === pageGraph.key,
+                    pageKey: pageGraph.key,
+                    manifestGraphs: manifestGraphs.length,
+                    manifestKey: manifestGraph ? manifestGraph.key : "",
+                    pageNodes: pageGraph.nodes.length,
+                    pageEdges: pageGraph.edges.length,
+                    pageGroups: pageGraph.groups.length,
+                    manifestNodes: manifestGraph ? manifestGraph.nodes.length : 0,
+                    manifestEdges: manifestGraph ? manifestGraph.edges.length : 0,
+                    manifestGroups: manifestGraph ? manifestGraph.groups.length : 0,
+                    variantKeys: variants.map((variant) => variant.key),
+                    globalVariantKeys: globalVariants.map((variant) => variant.key),
+                    sampleTitle: sample ? sample.title : "",
+                    sampleHref: sample ? sample.href : "",
+                    manifestSampleTitle: manifestSample ? manifestSample.title : "",
+                    manifestSampleHref: manifestSample ? manifestSample.href : ""
+                };
+                """
+            )
+        )
+
+        assert graph_data["apiVersion"] == 1
+        assert graph_data["sameGlobalKey"]
+        assert graph_data["pageKey"].startswith("graph:#<")
+        assert graph_data["manifestGraphs"] == 1
+        assert graph_data["manifestKey"] == graph_data["pageKey"]
+        assert graph_data["pageNodes"] == 55
+        assert graph_data["pageEdges"] == 13
+        assert graph_data["pageGroups"] == 3
+        assert graph_data["manifestNodes"] == graph_data["pageNodes"]
+        assert graph_data["manifestEdges"] == graph_data["pageEdges"]
+        assert graph_data["manifestGroups"] == graph_data["pageGroups"]
+        assert {"full", "group"}.issubset(set(graph_data["variantKeys"]))
+        assert set(graph_data["variantKeys"]) == set(graph_data["globalVariantKeys"])
+        assert graph_data["sampleTitle"].startswith("Definition")
+        assert graph_data["sampleHref"] == "Preview-Relationships/#--informal-preview-used_target--statement"
+        assert graph_data["manifestSampleTitle"] == graph_data["sampleTitle"]
+        assert graph_data["manifestSampleHref"] == graph_data["sampleHref"]
+
     def test_graph_legend_is_collapsed_by_default_and_tracks_variant_switch(self, server: str, page: Page):
         page.set_viewport_size({"width": 1400, "height": 900})
         page.goto(f"{server}/Dependency-Graph/")

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -417,6 +417,24 @@ class TestPreviewRuntimeRegressions:
         client = page.locator("#custom-render-client-example").first
         expect(client).to_have_attribute("data-bp-custom-client-status", "ready")
         expect(client.locator("[data-bp-custom-client-example]")).to_have_count(8)
+        graph_card = client.locator("[data-bp-custom-client-graph]").first
+        expect(graph_card.locator("[data-bp-custom-client-title]").first).to_have_text(
+            "Graph manifest data"
+        )
+        expect(graph_card).to_have_attribute("data-bp-graph-ok", "true")
+        expect(graph_card).to_have_attribute("data-bp-graph-count", "1")
+        expect(graph_card).to_have_attribute("data-bp-graph-key", re.compile(r"^graph:#<"))
+        expect(graph_card).to_have_attribute("data-bp-graph-node-count", "55")
+        expect(graph_card).to_have_attribute("data-bp-graph-edge-count", "13")
+        expect(graph_card).to_have_attribute("data-bp-graph-group-count", "3")
+        expect(graph_card.locator("[data-bp-custom-client-graph-summary]").first).to_contain_text(
+            "Nodes 55"
+        )
+        used_target_link = graph_card.locator('[data-bp-graph-node-label="used_target"]').first
+        expect(used_target_link).to_have_text(re.compile(r"Definition"))
+        expect(used_target_link).to_have_attribute(
+            "href", re.compile(r"Preview-Relationships/#--informal-preview-used_target--statement")
+        )
         expect(page.locator("body")).not_to_contain_text(
             "end PreviewRuntimeShowcase.Chapters.CustomRenderClient"
         )

--- a/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/CustomRenderClient.lean
+++ b/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/CustomRenderClient.lean
@@ -115,6 +115,38 @@ def customRenderClientCss : String := r##"
   color: var(--bp-color-text-strong);
 }
 
+.bp_custom_render_client_graph {
+  background: var(--bp-color-surface);
+  border: 1px solid var(--bp-color-border-soft);
+  border-radius: var(--bp-radius-sm);
+  padding: 0.9rem;
+}
+
+.bp_custom_render_client_graph h3 {
+  font-size: 0.9rem;
+  margin: 0 0 0.5rem;
+}
+
+.bp_custom_render_client_graph_nodes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.65rem;
+}
+
+.bp_custom_render_client_graph_node {
+  background: var(--bp-color-background);
+  border: 1px solid var(--bp-color-border-soft);
+  border-radius: var(--bp-radius-sm);
+  color: var(--bp-color-text);
+  padding: 0.18rem 0.4rem;
+  text-decoration: none;
+}
+
+.bp_custom_render_client_graph_node:hover {
+  border-color: var(--bp-color-accent, var(--bp-color-border));
+}
+
 .bp_custom_render_client_body {
   min-height: 8rem;
 }
@@ -186,6 +218,26 @@ private def clientExample
     (Verso.Output.Html.seq
       (#[titleNode, noteNode, summaryNode] ++ extras ++ #[previewHeaderNode, bodyNode]))
 
+private def graphDataExample : Verso.Output.Html :=
+  let titleNode :=
+    clientTag "h3" #[("data-bp-custom-client-title", "true")] (clientText "Graph manifest data")
+  let noteNode :=
+    clientTag "p" #[("class", "bp_custom_render_client_note")]
+      (clientText "Standalone manifest access with api.loadGraphs; no rendered graph block is required on this page.")
+  let summaryNode :=
+    clientTag "div"
+      #[("class", "bp_custom_render_client_summary"), ("data-bp-custom-client-graph-summary", "true")]
+      (clientText "Waiting for graph data.")
+  let nodeList :=
+    clientTag "div"
+      #[("class", "bp_custom_render_client_graph_nodes"), ("data-bp-custom-client-graph-nodes", "true")]
+      .empty
+  clientTag "article"
+    #[ ("class", "bp_custom_render_client_graph"),
+       ("data-bp-custom-client-graph", "true"),
+       ("data-bp-graph-ok", "false") ]
+    (Verso.Output.Html.seq #[titleNode, noteNode, summaryNode, nodeList])
+
 def customRenderClientHtml : Verso.Output.Html :=
   let heading := clientTag "h2" #[] (clientText "Standalone Render Client")
   let status :=
@@ -224,7 +276,8 @@ def customRenderClientHtml : Verso.Output.Html :=
         clientExample "render-canonical-preview-into" "missing_custom_client_target" "statement" "Missing preview diagnostic"
           "missing"
           "An expected miss that demonstrates the runtime diagnostic branch for custom clients."
-          false
+          false,
+        graphDataExample
       ])
   clientTag "section"
     #[ ("class", "bp_custom_render_client"),

--- a/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/custom-render-client.js
+++ b/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/custom-render-client.js
@@ -112,6 +112,69 @@
     appendFact(facts, "Code previews", Array.isArray(entry.leanCodePreviewKeys) ? entry.leanCodePreviewKeys.length : 0);
   }
 
+  function graphSampleNodes(graph) {
+    if (!graph || !Array.isArray(graph.nodes)) return [];
+    const preferred = ["used_target", "used_grouped_proof_panel", "preview_final"];
+    const selected = [];
+    preferred.forEach(function (label) {
+      const node = graph.nodes.find(function (node) { return node && node.label === label; });
+      if (node && !selected.includes(node)) selected.push(node);
+    });
+    graph.nodes.forEach(function (node) {
+      if (selected.length >= 5) return;
+      if (node && !selected.includes(node)) selected.push(node);
+    });
+    return selected;
+  }
+
+  function renderGraphNodeLink(parent, node) {
+    const tagName = node && node.href ? "a" : "span";
+    const item = appendTextNode(
+      parent,
+      tagName,
+      "bp_custom_render_client_graph_node",
+      node && node.title ? node.title : (node && node.label ? node.label : "node")
+    );
+    if (tagName === "a") item.href = node.href;
+    if (node && node.label) item.dataset.bpGraphNodeLabel = node.label;
+    return item;
+  }
+
+  async function renderGraphData(api, root) {
+    const card = root.querySelector("[data-bp-custom-client-graph]");
+    if (!card) return { ok: true };
+    const summary = card.querySelector("[data-bp-custom-client-graph-summary]");
+    const nodesTarget = card.querySelector("[data-bp-custom-client-graph-nodes]");
+    if (summary) summary.replaceChildren();
+    if (nodesTarget) nodesTarget.replaceChildren();
+    const graphs = typeof api.loadGraphs === "function" ? await api.loadGraphs() : [];
+    const graph = graphs[0] || null;
+    card.dataset.bpGraphOk = graph ? "true" : "false";
+    card.dataset.bpGraphCount = String(graphs.length);
+    card.dataset.bpGraphKey = graph && graph.key ? graph.key : "";
+    card.dataset.bpGraphNodeCount = graph && Array.isArray(graph.nodes) ? String(graph.nodes.length) : "0";
+    card.dataset.bpGraphEdgeCount = graph && Array.isArray(graph.edges) ? String(graph.edges.length) : "0";
+    card.dataset.bpGraphGroupCount = graph && Array.isArray(graph.groups) ? String(graph.groups.length) : "0";
+    if (!graph) {
+      if (summary) appendFact(summary, "Status", "no graph data");
+      return { ok: false };
+    }
+    if (summary) {
+      const facts = appendTextNode(summary, "div", "bp_custom_render_client_facts", "");
+      appendFact(facts, "Graphs", graphs.length);
+      appendFact(facts, "Key", graph.key);
+      appendFact(facts, "Nodes", graph.nodes.length);
+      appendFact(facts, "Edges", graph.edges.length);
+      appendFact(facts, "Groups", graph.groups.length);
+    }
+    if (nodesTarget) {
+      graphSampleNodes(graph).forEach(function (node) {
+        renderGraphNodeLink(nodesTarget, node);
+      });
+    }
+    return { ok: true, graph: graph, graphs: graphs };
+  }
+
   async function renderExample(api, example) {
     const body = example.querySelector("[data-bp-custom-client-body]");
     if (!body) return null;
@@ -145,9 +208,10 @@
       const results = await Promise.all(examples.map(function (example) {
         return renderExample(api, example);
       }));
+      const graphResult = await renderGraphData(api, root);
       const ok = results.every(function (result, index) {
         return result && result.ok === expectedOk(examples[index]);
-      });
+      }) && graphResult.ok;
       root.dataset.bpCustomClientStatus = ok ? "ready" : "error";
       setText(root, "[data-bp-custom-client-status-text]", ok ? "Ready" : "Incomplete");
     } catch (err) {


### PR DESCRIPTION
This PR adds stable Lean, manifest, and browser APIs for Blueprint graph data, including a standalone browser-client example that reads finalized graph records from `blueprint-manifest.json`.

Backport v4.30.0: exempt: #153 is the release-line-compatible backport; v4.30.0 already carries compatibility shims (`VersoBlueprint.Compat` and the `FinishedPart.mk` compatibility shape), so its patch-id cannot match the default-dev commit exactly.