### PR TITLE
refactor: tighten preview maintenance workflows

### DIFF
--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -159,7 +159,7 @@ generated HTML or browser tests:
 ./scripts/validate-branch.sh
 ```
 
-The tracked owner inventory lives in `EMBEDDED_ASSET_OWNER_PATHS` in
+The tracked owner inventory lives in `EMBEDDED_ASSET_OWNERS` in
 `scripts/blueprint_harness_utils.py`. When adding a new `include_str` browser
 asset, add it to that inventory and cover the mapping in the harness tests so
 artifact generation rebuilds the right Lean owner.
@@ -463,8 +463,11 @@ python3 -m scripts.blueprint_harness prepare-backport-pr v4.30.0 --main-pr <pr>
 
 That helper prints a standardized paired branch name, a title of the form
 `[backport v4.30.0] ...`, a `backport-v4.30.0` release label, and a PR body
-that points back to the primary
-default-development review.
+that points back to the primary default-development review. By default the
+title after the backport prefix is read from the GitHub title of `--main-pr`,
+which keeps multi-commit backports from inheriting the last local commit
+subject. Use `--main-title '<type>: <subject>'` only when the GitHub lookup is
+not available or you intentionally need to override the public title.
 
 When several backport releases are required, use:
 

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -46,19 +46,20 @@ Work:
    phase-safe representation
 3. define one canonical API for preview labels and titles; avoid mixing raw
    labels, resolved titles, and local fallbacks across renderers
-4. keep future graph, summary, relation-panel, and inline-reference behavior on
-   shared browser helpers where the interaction model is genuinely shared; the
-   current graph, relation-panel, and inline-preview surfaces plus trigger,
-   dismiss, popover, slide cleanup, and resize/scroll lifecycles already use
-   bundled runtime helpers
+4. keep graph, summary, relation-panel, Slides, custom-client, and
+   inline-reference behavior on shared browser helpers where the interaction
+   model is genuinely shared; the current surfaces, descriptors, trigger
+   binding, dismissal, popover, slide cleanup, and resize/scroll lifecycles
+   already use bundled runtime helpers
 5. evaluate a lighter preview delivery path so a page does not always fetch and
    decode the full shared manifest for a small number of previews
 6. remove remaining browser timing workarounds only after targeted browser tests
    prove the replacement path; panel lifecycle workarounds should stay behind
    runtime helpers rather than feature-local listeners
-7. keep shaping bundled JavaScript helpers around component-like surfaces
-   before a future React implementation, so data/cache lookup, content
-   rendering, local UI state, and lifecycle binding remain separate concerns
+7. split the large preview runtime only along the component-like boundaries now
+   encoded in its API tiers: data/cache lookup, fragment rendering and
+   hydration, template descriptors, preview surface state, lifecycle binding,
+   and readiness/debug hooks
 
 ### Data Model and Status Semantics
 
@@ -108,8 +109,9 @@ Work:
    practical release mechanism
 2. replace the mtime workaround with a durable generated-or-staged Lean
    dependency edge for browser assets
-3. keep graph, summary, bibliography, slides, block, and shared static-web
-   assets under one inventory so asset ownership is not rediscovered per feature
+3. keep the structured embedded-asset inventory covered against discovered
+   browser `include_str` references so graph, summary, bibliography, slides,
+   block, and shared static-web ownership is not rediscovered per feature
 4. add a build-level or generated-output check that fails when emitted browser
    assets drift from their source files
 
@@ -176,9 +178,10 @@ Work:
    checkout or an external Blueprint project without hand-editing manifests
 8. retire local workaround branches promptly once their content is either
    landed, deliberately ported, or recorded in this roadmap
-9. improve `prepare-pr` scaffolds for multi-commit work so generated PR titles
-   and bodies describe the branch-level change instead of inheriting misleading
-   last-commit metadata
+9. keep PR and backport scaffolds branch-level: default-development PRs should
+   pass an intentional branch title to `prepare-pr`, and paired backport
+   scaffolds should read the public title of `--main-pr` instead of inheriting
+   the last local commit subject
 
 ## Design Candidates
 

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -157,6 +157,36 @@ def current_commit_subject(repo_root: Path) -> str:
     return subject
 
 
+def github_pr_title(repo_root: Path, pr_number: int) -> str | None:
+    result = subprocess.run(
+        ["gh", "pr", "view", str(pr_number), "--repo", PUBLIC_REPOSITORY, "--json", "title"],
+        cwd=repo_root,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    title = payload.get("title") if isinstance(payload, dict) else None
+    return title if isinstance(title, str) and title.strip() else None
+
+
+def resolve_main_pr_title(repo_root: Path, args: argparse.Namespace) -> str:
+    if args.main_title is not None:
+        return validate_public_pr_title(args.main_title)
+    title = github_pr_title(repo_root, args.main_pr)
+    if title is None:
+        raise SystemExit(
+            "[blueprint-harness] unable to read the default-development PR title from GitHub; "
+            "pass `--main-title '<type>: <subject>'` explicitly."
+        )
+    return validate_public_pr_title(title)
+
+
 def validate_public_pr_title(title: str) -> str:
     normalized = title.strip()
     if normalized != title or not normalized:
@@ -794,7 +824,7 @@ def command_prepare_backport_pr(args: argparse.Namespace) -> int:
     if not source_branch:
         raise SystemExit("[blueprint-harness] unable to determine a source branch; pass `--source-branch` explicitly")
 
-    main_title = validate_public_pr_title(args.main_title or current_commit_subject(layout.package_root))
+    main_title = resolve_main_pr_title(layout.package_root, args)
     source_commits = source_commit_series(layout.package_root, source_branch)
     default_dev = default_dev_branch(layout.package_root)
 
@@ -1260,7 +1290,7 @@ def add_pr_preparation_commands(subparsers) -> None:
     prepare_backport_pr.add_argument(
         "--main-title",
         default=None,
-        help="Override the default-development PR title. Defaults to the current commit subject.",
+        help="Override the default-development PR title. Defaults to the title of `--main-pr` from GitHub.",
     )
     prepare_backport_pr.add_argument(
         "--source-branch",

--- a/scripts/blueprint_harness_utils.py
+++ b/scripts/blueprint_harness_utils.py
@@ -6,22 +6,32 @@ import subprocess
 import sys
 from pathlib import Path
 import shutil
+import re
 
 
-EMBEDDED_ASSET_OWNER_PATHS: tuple[tuple[str, str, str], ...] = (
-    ("src/VersoBlueprint/Commands/open-target-details.js", "src/VersoBlueprint/Commands/Common.lean", "VersoBlueprint.Commands.Common"),
-    ("src/VersoBlueprint/Commands/preview-ready.js", "src/VersoBlueprint/Commands/Common.lean", "VersoBlueprint.Commands.Common"),
-    ("src/VersoBlueprint/Commands/preview-runtime.js", "src/VersoBlueprint/Commands/Common.lean", "VersoBlueprint.Commands.Common"),
-    ("src/VersoBlueprint/Commands/inline-preview.js", "src/VersoBlueprint/Commands/Common.lean", "VersoBlueprint.Commands.Common"),
-    ("src/VersoBlueprint/Commands/graph.css", "src/VersoBlueprint/Commands/Graph.lean", "VersoBlueprint.Commands.Graph"),
-    ("src/VersoBlueprint/Commands/graph.js", "src/VersoBlueprint/Commands/Graph.lean", "VersoBlueprint.Commands.Graph"),
-    ("src/VersoBlueprint/Commands/summary.css", "src/VersoBlueprint/Commands/Summary.lean", "VersoBlueprint.Commands.Summary"),
-    ("src/VersoBlueprint/Commands/bibliography.css", "src/VersoBlueprint/Commands/Bibliography.lean", "VersoBlueprint.Commands.Bibliography"),
-    ("src/VersoBlueprint/Informal/Block/relation-panel.js", "src/VersoBlueprint/Informal/Block/Assets.lean", "VersoBlueprint.Informal.Block.Assets"),
-    ("src/VersoBlueprint/Slides/blueprint-slides.css", "src/VersoBlueprint/Slides/Assets.lean", "VersoBlueprint.Slides.Assets"),
-    ("src/VersoBlueprint/Slides/blueprint-slides.js", "src/VersoBlueprint/Slides/Assets.lean", "VersoBlueprint.Slides.Assets"),
-    ("static-web/math.js", "src/VersoBlueprint/Macros.lean", "VersoBlueprint.Macros"),
+@dataclass(frozen=True)
+class EmbeddedAssetOwner:
+    asset: str
+    owner: str
+    target: str
+
+
+EMBEDDED_ASSET_OWNERS: tuple[EmbeddedAssetOwner, ...] = (
+    EmbeddedAssetOwner("src/VersoBlueprint/Commands/open-target-details.js", "src/VersoBlueprint/Commands/Common.lean", "VersoBlueprint.Commands.Common"),
+    EmbeddedAssetOwner("src/VersoBlueprint/Commands/preview-ready.js", "src/VersoBlueprint/Commands/Common.lean", "VersoBlueprint.Commands.Common"),
+    EmbeddedAssetOwner("src/VersoBlueprint/Commands/preview-runtime.js", "src/VersoBlueprint/Commands/Common.lean", "VersoBlueprint.Commands.Common"),
+    EmbeddedAssetOwner("src/VersoBlueprint/Commands/inline-preview.js", "src/VersoBlueprint/Commands/Common.lean", "VersoBlueprint.Commands.Common"),
+    EmbeddedAssetOwner("src/VersoBlueprint/Commands/graph.css", "src/VersoBlueprint/Commands/Graph.lean", "VersoBlueprint.Commands.Graph"),
+    EmbeddedAssetOwner("src/VersoBlueprint/Commands/graph.js", "src/VersoBlueprint/Commands/Graph.lean", "VersoBlueprint.Commands.Graph"),
+    EmbeddedAssetOwner("src/VersoBlueprint/Commands/summary.css", "src/VersoBlueprint/Commands/Summary.lean", "VersoBlueprint.Commands.Summary"),
+    EmbeddedAssetOwner("src/VersoBlueprint/Commands/bibliography.css", "src/VersoBlueprint/Commands/Bibliography.lean", "VersoBlueprint.Commands.Bibliography"),
+    EmbeddedAssetOwner("src/VersoBlueprint/Informal/Block/relation-panel.js", "src/VersoBlueprint/Informal/Block/Assets.lean", "VersoBlueprint.Informal.Block.Assets"),
+    EmbeddedAssetOwner("src/VersoBlueprint/Slides/blueprint-slides.css", "src/VersoBlueprint/Slides/Assets.lean", "VersoBlueprint.Slides.Assets"),
+    EmbeddedAssetOwner("src/VersoBlueprint/Slides/blueprint-slides.js", "src/VersoBlueprint/Slides/Assets.lean", "VersoBlueprint.Slides.Assets"),
+    EmbeddedAssetOwner("static-web/math.js", "src/VersoBlueprint/Macros.lean", "VersoBlueprint.Macros"),
 )
+
+INCLUDE_STR_RE = re.compile(r'include_str\s+"([^"]+)"')
 
 
 @dataclass(frozen=True)
@@ -120,6 +130,30 @@ def _target_from_source(package_root: Path, source: Path) -> str:
     return ".".join(source.relative_to(source_root).with_suffix("").parts)
 
 
+def _normalized_relative_path(package_root: Path, path: Path) -> str:
+    return path.resolve().relative_to(package_root.resolve()).as_posix()
+
+
+def discover_embedded_asset_owners(package_root: Path) -> tuple[EmbeddedAssetOwner, ...]:
+    discovered: list[EmbeddedAssetOwner] = []
+    for owner in sorted((package_root / "src" / "VersoBlueprint").rglob("*.lean")):
+        source = owner.read_text(encoding="utf-8")
+        owner_rel = _normalized_relative_path(package_root, owner)
+        target = _target_from_source(package_root, owner)
+        for include_path in INCLUDE_STR_RE.findall(source):
+            asset = (owner.parent / include_path).resolve()
+            if asset.suffix not in {".css", ".js"}:
+                continue
+            discovered.append(
+                EmbeddedAssetOwner(
+                    asset=_normalized_relative_path(package_root, asset),
+                    owner=owner_rel,
+                    target=target,
+                )
+            )
+    return tuple(discovered)
+
+
 def _local_olean_source(package_root: Path, olean: Path) -> Path | None:
     lean_build_root = package_root / ".lake" / "build" / "lib" / "lean"
     try:
@@ -213,22 +247,22 @@ def _materialize_module_owner(package_root: Path, owner_rel: str, target: str) -
 def ensure_embedded_asset_owner_outputs(package_root: Path) -> list[str]:
     materialized_targets: list[str] = []
     seen_targets: set[str] = set()
-    for asset_rel, owner_rel, target in EMBEDDED_ASSET_OWNER_PATHS:
-        asset = package_root / asset_rel
-        owner = package_root / owner_rel
-        if not asset.exists() or not owner.exists() or target in seen_targets:
+    for asset_owner in EMBEDDED_ASSET_OWNERS:
+        asset = package_root / asset_owner.asset
+        owner = package_root / asset_owner.owner
+        if not asset.exists() or not owner.exists() or asset_owner.target in seen_targets:
             continue
-        if _materialize_module_owner(package_root, owner_rel, target):
-            materialized_targets.append(target)
-        seen_targets.add(target)
+        if _materialize_module_owner(package_root, asset_owner.owner, asset_owner.target):
+            materialized_targets.append(asset_owner.target)
+        seen_targets.add(asset_owner.target)
     return materialized_targets
 
 
 def refresh_embedded_asset_owner_mtimes(package_root: Path) -> list[Path]:
     touched: list[Path] = []
-    for asset_rel, owner_rel, _target in EMBEDDED_ASSET_OWNER_PATHS:
-        asset = package_root / asset_rel
-        owner = package_root / owner_rel
+    for asset_owner in EMBEDDED_ASSET_OWNERS:
+        asset = package_root / asset_owner.asset
+        owner = package_root / asset_owner.owner
         if not asset.exists() or not owner.exists():
             continue
         if asset.stat().st_mtime_ns <= owner.stat().st_mtime_ns:
@@ -242,17 +276,17 @@ def rebuild_embedded_asset_owners(package_root: Path) -> list[str]:
     touched_targets: list[str] = []
     owners_by_target: dict[str, str] = {}
     seen_targets: set[str] = set()
-    for asset_rel, owner_rel, target in EMBEDDED_ASSET_OWNER_PATHS:
-        asset = package_root / asset_rel
-        owner = package_root / owner_rel
+    for asset_owner in EMBEDDED_ASSET_OWNERS:
+        asset = package_root / asset_owner.asset
+        owner = package_root / asset_owner.owner
         if not asset.exists() or not owner.exists():
             continue
         os.utime(owner, None)
-        _remove_module_artifacts(package_root, target)
-        if target not in seen_targets:
-            touched_targets.append(target)
-            owners_by_target[target] = owner_rel
-            seen_targets.add(target)
+        _remove_module_artifacts(package_root, asset_owner.target)
+        if asset_owner.target not in seen_targets:
+            touched_targets.append(asset_owner.target)
+            owners_by_target[asset_owner.target] = asset_owner.owner
+            seen_targets.add(asset_owner.target)
     if touched_targets:
         run(lean_low_priority_command(package_root, "lake", "build", *touched_targets), cwd=package_root)
         for target in touched_targets:

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/LeanStatus.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/LeanStatus.lean
@@ -16,7 +16,7 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
 #eval
   show IO Bool from do
     let (out, st) ← renderManualDocHtmlStringAndState manualImpls leanStatusChipDoc
-    let legacyTemplateBinderJs? := findLegacyTemplatePreviewBinderJs? st
+    let removedTemplateBinderJs? := findRemovedTemplatePreviewBinderJs? st
     pure (
       hasSubstr out "bp_code_link_status_proved" &&
       hasSubstr out "bp_code_link_status_warning" &&
@@ -41,7 +41,7 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
         ".bp_code_summary_preview_body"
         ".bp_code_summary_preview_close" &&
       hasSubstr out "data-bp-template-preview-title-attr=\"data-bp-preview-title\"" &&
-      legacyTemplateBinderJs?.isNone
+      removedTemplateBinderJs?.isNone
     )
 
 end Verso.VersoBlueprintTests.BlueprintPreviewWiring.LeanStatus

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/Shared.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/Shared.lean
@@ -59,7 +59,7 @@ def findInlinePreviewJs? (st : TraverseState) : Option String :=
 def findMathPreludeJs? (st : TraverseState) : Option String :=
   findExtraJsContaining? st "window.bpTexPreludeTable"
 
-def findLegacyTemplatePreviewBinderJs? (st : TraverseState) : Option String :=
+def findRemovedTemplatePreviewBinderJs? (st : TraverseState) : Option String :=
   findExtraJsContaining? st "previewUtils.bindTemplatePreviewRoots({"
 
 def findRelationPanelJs? (st : TraverseState) : Option String :=

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/Summary.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/Summary.lean
@@ -17,7 +17,7 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
 #eval
   show IO Bool from do
     let (out, st) ← renderManualDocHtmlStringAndState manualImpls previewWiringDoc
-    let legacyTemplateBinderJs? := findLegacyTemplatePreviewBinderJs? st
+    let removedTemplateBinderJs? := findRemovedTemplatePreviewBinderJs? st
     let inlineJs? := findInlinePreviewJs? st
     let mathJs? := findMathPreludeJs? st
     pure (
@@ -43,7 +43,7 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
         ".bp_summary_preview_panel_body"
         ".bp_summary_preview_panel_close"
         (allowHtmlCache := true) &&
-      legacyTemplateBinderJs?.isNone &&
+      removedTemplateBinderJs?.isNone &&
       match inlineJs?, mathJs? with
       | some inlineJs, some mathJs =>
         hasSubstr mathJs "\\\\newcommand{\\\\previewmacro}{\\\\mathsf{Preview}}" &&

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -623,7 +623,7 @@ class TestPreviewRuntimeRegressions:
                         hasDiagnostics: typeof api.diagnostics !== "undefined",
                         hasReadHtml: typeof api.readHtml === "function"
                     },
-                    legacyGlobals: {
+                    removedGlobals: {
                         hasPreviewUtils: "bpPreviewUtils" in window,
                         hasPreviewHydrators: "bpPreviewHydrators" in window,
                         hasPreviewTrace: "bpPreviewTrace" in window,
@@ -662,7 +662,7 @@ class TestPreviewRuntimeRegressions:
             "hasDiagnostics": False,
             "hasReadHtml": False,
         }
-        assert rendered["legacyGlobals"] == {
+        assert rendered["removedGlobals"] == {
             "hasPreviewUtils": False,
             "hasPreviewHydrators": False,
             "hasPreviewTrace": False,

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import tempfile
 from types import SimpleNamespace
 import unittest
+from unittest.mock import patch
 
 import scripts.blueprint_harness as harness_mod
 import scripts.blueprint_reference_harness as reference_harness_mod
@@ -686,6 +687,82 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertIn("## PR Body", output)
         self.assertIn("Primary review: #11", output)
         self.assertIn("Keep review comments on #11 unless this backport diverges materially.", output)
+
+    def test_prepare_backport_pr_defaults_to_github_pr_title(self) -> None:
+        args = argparse.Namespace(
+            release="v4.28.0",
+            all_required=False,
+            main_pr=11,
+            main_title=None,
+            source_branch="feat/multi-commit-branch",
+        )
+        layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
+        out = io.StringIO()
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            load_branch_policy=lambda _checkout_root: SimpleNamespace(
+                default_dev_branch="v4.29.0",
+                required_backport_branches=("v4.28.0",),
+            ),
+            default_dev_branch=lambda _checkout_root: "v4.29.0",
+            require_checkout_role=lambda *_args, **_kwargs: None,
+            source_commit_series=lambda _repo_root, _source_branch: ["abc123", "def456"],
+            github_pr_title=lambda _repo_root, _main_pr: "feat: branch-level render API cleanup",
+            current_commit_subject=lambda _checkout_root: "fix: support release-line highlight patches",
+        ):
+            with redirect_stdout(out):
+                self.assertEqual(harness_mod.command_prepare_backport_pr(args), 0)
+
+        output = out.getvalue()
+        self.assertIn("paired_title=[backport v4.28.0] feat: branch-level render API cleanup", output)
+        self.assertIn("## PR Title\n[backport v4.28.0] feat: branch-level render API cleanup", output)
+        self.assertNotIn("fix: support release-line highlight patches", output)
+
+    def test_github_pr_title_reads_public_title(self) -> None:
+        with patch(
+            "scripts.blueprint_harness.subprocess.run",
+            return_value=SimpleNamespace(returncode=0, stdout='{"title":"doc: clarify API"}'),
+        ) as run_mock:
+            title = harness_mod.github_pr_title(Path("/tmp/worktree"), 11)
+
+        self.assertEqual(title, "doc: clarify API")
+        run_mock.assert_called_once_with(
+            ["gh", "pr", "view", "11", "--repo", "leanprover/verso-blueprint", "--json", "title"],
+            cwd=Path("/tmp/worktree"),
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_github_pr_title_returns_none_for_lookup_failure(self) -> None:
+        with patch(
+            "scripts.blueprint_harness.subprocess.run",
+            return_value=SimpleNamespace(returncode=1, stdout=""),
+        ):
+            self.assertIsNone(harness_mod.github_pr_title(Path("/tmp/worktree"), 11))
+
+    def test_prepare_backport_pr_requires_title_when_github_lookup_fails(self) -> None:
+        args = argparse.Namespace(
+            release="v4.28.0",
+            all_required=False,
+            main_pr=11,
+            main_title=None,
+            source_branch="feat/multi-commit-branch",
+        )
+        layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            load_branch_policy=lambda _checkout_root: SimpleNamespace(
+                default_dev_branch="v4.29.0",
+                required_backport_branches=("v4.28.0",),
+            ),
+            require_checkout_role=lambda *_args, **_kwargs: None,
+            github_pr_title=lambda _repo_root, _main_pr: None,
+        ):
+            with self.assertRaisesRegex(SystemExit, "pass `--main-title"):
+                harness_mod.command_prepare_backport_pr(args)
 
     def test_prepare_backport_pr_rejects_scoped_main_title(self) -> None:
         args = argparse.Namespace(

--- a/tests/harness/test_blueprint_harness_utils.py
+++ b/tests/harness/test_blueprint_harness_utils.py
@@ -6,7 +6,9 @@ from pathlib import Path
 from unittest.mock import patch
 
 from scripts.blueprint_harness_utils import (
-    EMBEDDED_ASSET_OWNER_PATHS,
+    EMBEDDED_ASSET_OWNERS,
+    EmbeddedAssetOwner,
+    discover_embedded_asset_owners,
     ensure_embedded_asset_owner_outputs,
     rebuild_embedded_asset_owners,
     refresh_embedded_asset_owner_mtimes,
@@ -18,6 +20,14 @@ def _command_arg(command: list[str], option: str) -> str:
 
 
 class TestBlueprintHarnessUtils(unittest.TestCase):
+    def test_embedded_asset_inventory_matches_browser_include_strs(self) -> None:
+        package_root = Path(__file__).resolve().parents[2]
+
+        self.assertEqual(
+            set(EMBEDDED_ASSET_OWNERS),
+            set(discover_embedded_asset_owners(package_root)),
+        )
+
     def test_common_js_assets_are_owned_by_common_module(self) -> None:
         for asset in (
             "src/VersoBlueprint/Commands/open-target-details.js",
@@ -26,12 +36,12 @@ class TestBlueprintHarnessUtils(unittest.TestCase):
             "src/VersoBlueprint/Commands/inline-preview.js",
         ):
             self.assertIn(
-                (
+                EmbeddedAssetOwner(
                     asset,
                     "src/VersoBlueprint/Commands/Common.lean",
                     "VersoBlueprint.Commands.Common",
                 ),
-                EMBEDDED_ASSET_OWNER_PATHS,
+                EMBEDDED_ASSET_OWNERS,
             )
 
     def test_preview_client_js_assets_are_owned_by_rendering_modules(self) -> None:
@@ -42,7 +52,7 @@ class TestBlueprintHarnessUtils(unittest.TestCase):
                 "VersoBlueprint.Informal.Block.Assets",
             ),
         ):
-            self.assertIn((asset, owner, target), EMBEDDED_ASSET_OWNER_PATHS)
+            self.assertIn(EmbeddedAssetOwner(asset, owner, target), EMBEDDED_ASSET_OWNERS)
 
     def test_refresh_embedded_asset_owner_mtimes_touches_owner_when_asset_is_newer(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
This PR tightens maintainer preview workflows after the standalone render-client work.

- Read paired backport PR titles from the primary GitHub PR instead of the local commit subject.
- Make embedded browser asset ownership a structured inventory covered against discovered browser include_str references.
- Refresh roadmap and maintainer docs around preview runtime boundaries and backport scaffolds.
- Rename removed-runtime-global test fixtures so absence checks do not read like compatibility code.

Backport v4.30.0: exempt: maintainer-workflow-cleanup