### PR TITLE
feat: expose Blueprint browser APIs as ESM

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ If you want to start a Blueprint project today, read these in order:
 1. [project_template/README.md](./project_template/README.md)
 2. [doc/GETTING_STARTED.md](./doc/GETTING_STARTED.md)
 3. [doc/MANUAL.md](./doc/MANUAL.md)
+4. [doc/API.md](./doc/API.md) when you need stable Lean, generated-data, or
+   browser integration APIs
 
 ## Current Project Shape
 
@@ -198,7 +200,8 @@ manifest, its schema, and the rendered-fragment cache
 (`blueprint-html-cache.json`) used by preview consumers. The cache includes the
 hover payloads needed by cached Lean fragments. These are command-line flags
 passed to the generator binary, such as
-`--dump-manifest`, `--dump-html-cache`, and `--dump-schema`.
+`--dump-manifest`, `--dump-html-cache`, and `--dump-schema`. See
+[doc/API.md](./doc/API.md) for the stable generated-data contract.
 
 ### Widget
 
@@ -254,19 +257,20 @@ Read these in order:
    project and file layout
 2. [doc/GETTING_STARTED.md](./doc/GETTING_STARTED.md): first Blueprint walkthrough
 3. [doc/MANUAL.md](./doc/MANUAL.md): authoring and rendering reference
+4. [doc/API.md](./doc/API.md): stable Lean, generated-data, and browser APIs
 
 ### Developer Documentation
 
-4. [doc/CONTRIBUTING.md](./doc/CONTRIBUTING.md): contribution conventions for
+5. [doc/CONTRIBUTING.md](./doc/CONTRIBUTING.md): contribution conventions for
    this repository
-5. [doc/MAINTAINER_GUIDE.md](./doc/MAINTAINER_GUIDE.md): repository-local
+6. [doc/MAINTAINER_GUIDE.md](./doc/MAINTAINER_GUIDE.md): repository-local
    generation, validation, CI publication, and worktree workflow
-6. [scripts/README.md](./scripts/README.md): lightweight guide to the
+7. [scripts/README.md](./scripts/README.md): lightweight guide to the
    repository scripts and harness entry points
-7. [doc/DESIGN_RATIONALE.md](./doc/DESIGN_RATIONALE.md): architecture and design
+8. [doc/DESIGN_RATIONALE.md](./doc/DESIGN_RATIONALE.md): architecture and design
    boundaries
-8. [doc/ROADMAP.md](./doc/ROADMAP.md): active cleanup and follow-up work
-9. [doc/UPSTREAM_BACKLOG.md](./doc/UPSTREAM_BACKLOG.md): items intended to move
+9. [doc/ROADMAP.md](./doc/ROADMAP.md): active cleanup and follow-up work
+10. [doc/UPSTREAM_BACKLOG.md](./doc/UPSTREAM_BACKLOG.md): items intended to move
    back into `verso`, Lake, or Lean
 
 ### Agent Helper Skill

--- a/doc/API.md
+++ b/doc/API.md
@@ -1,0 +1,533 @@
+# Blueprint API Reference
+
+This document records the public API surfaces for tools that read Blueprint
+data or render Blueprint fragments outside the standard generated pages.
+
+For authoring syntax and rendering behavior, see
+[`MANUAL.md`](./MANUAL.md). For the architecture boundaries behind these APIs,
+see [`DESIGN_RATIONALE.md`](./DESIGN_RATIONALE.md).
+
+## Contents
+
+- [Stability Policy](#stability-policy)
+- [Choosing an API](#choosing-an-api)
+- [Generated Data Files](#generated-data-files)
+- [Graph Data APIs](#graph-data-apis)
+- [Lean Graft and Render APIs](#lean-graft-and-render-apis)
+- [Browser ESM APIs](#browser-esm-apis)
+- [Browser Runtime API](#browser-runtime-api)
+- [Bundled Helper Boundary](#bundled-helper-boundary)
+- [Standalone Example](#standalone-example)
+
+## Stability Policy
+
+Stable APIs are the documented Lean names, generated data files, generated ESM
+modules, and browser runtime entrypoints listed here. They are intended for
+custom generators, dashboards, audit pages, slide adapters, and standalone
+browser clients.
+
+Bundled helper APIs are narrower. They exist so Blueprint's own graph, summary,
+relation-panel, inline-preview, and slide scripts can share runtime mechanics.
+They are not a custom-client contract unless they are promoted into the stable
+tables below.
+
+Compatibility globals such as `window.bpGraphApi` remain available for
+graph-specific clients, but new browser code should prefer the generated ESM
+modules or `window.VersoBlueprint.onRenderReady`.
+
+## Choosing an API
+
+| Need | Use |
+| --- | --- |
+| Build semantic graph data before traversal has finished | `Informal.Graph.buildData` |
+| Read finalized graph data after traversal has completed | `Informal.GraphApi.finalDataForBlock` or `Informal.GraphApi.cachedData` |
+| Read all generated graph records from a browser page | `loadGraphs()` from `blueprint-graph-api.mjs` or `api.loadGraphs()` |
+| Read data embedded in a rendered graph block | `getGraphData(element)` and `getGraphVariants(element)` |
+| Render only a preview body fragment in a custom wrapper | `renderPreviewInto(element, key)` |
+| Render the full generated Blueprint node wrapper | `renderCanonicalPreviewInto(element, key)` |
+| Inspect semantic manifest data before rendering | `resolvePreview(key)` or `resolveCanonicalPreview(key)` |
+| Render Blueprint nodes from a custom Lean generator | `Informal.Graft.renderNodeFromManifestCache` |
+| Join manifest/cache data manually | `PreviewManifest.File.findEntry?` and `PreviewManifest.HtmlCache.File.findHtml?` |
+
+Prefer the highest-level entry point that matches the job. Reach for direct
+manifest/cache lookup only when the client needs custom joining behavior or
+explicit diagnostics.
+
+## Generated Data Files
+
+Generated Blueprint sites write reusable data under `-verso-data/`:
+
+- `blueprint-manifest.json` contains semantic entries keyed by preview key,
+  generated-page hrefs, graph records, labels, dependency data, Lean-code
+  associations, group data, ownership, tags, priority, effort, status metadata,
+  and display metadata.
+- `blueprint-html-cache.json` contains rendered body fragments keyed by the
+  same preview keys. It is presentation data; do not parse it to rediscover
+  graph topology, labels, statuses, or dependency relationships.
+- `blueprint-graph-api.mjs` exposes graph-data helpers for ordinary browser
+  `import` usage.
+- `blueprint-preview-api.mjs` exposes the preview/render API for ordinary
+  browser `import` usage.
+
+The manifest is the semantic data contract. Cached HTML is an opaque rendered
+fragment cache that can be inserted and hydrated. The cache also carries the
+Verso hover payloads referenced by those rendered fragments; generated
+Blueprint pages merge them into `-verso-docs.json`, and Slides preloads them
+when rendering a deck.
+
+Three common workflows consume that same model:
+
+1. A Manual page can graft a node from the same document while traversal state
+   is still available.
+2. A Slides deck or generated audit page can graft nodes from a manifest/cache
+   pair emitted by a Blueprint site.
+3. Browser-side UI can use `window.VersoBlueprint.onRenderReady` or the
+   generated ESM modules to resolve and insert previews after the page loads.
+
+## Graph Data APIs
+
+Lean callers can build the semantic graph object from elaboration state with
+`Informal.Graph.buildData`. Before Verso traversal finishes, graph data is
+semantic and may not yet include rendered hrefs or display titles:
+
+```lean
+import VersoBlueprint.Graph
+
+def semanticGraph (state : Informal.Environment.State) :
+    Informal.Graph.GraphData :=
+  let roots := state.data.toArray.map (·.1)
+  Informal.Graph.buildData state roots
+```
+
+Once traversal has completed, use `Informal.GraphApi` to finalize either one
+rendered graph block or every graph cached during traversal:
+
+```lean
+import VersoBlueprint.GraphApi
+
+def graphForRenderedBlock
+    (state : Verso.Genre.Manual.TraverseState)
+    (blockId : Verso.Multi.InternalId)
+    (semantic : Informal.Graph.GraphData) : Informal.Graph.GraphData :=
+  Informal.GraphApi.finalDataForBlock state blockId semantic
+
+def allRenderedGraphs
+    (state : Verso.Genre.Manual.TraverseState) :
+    Array Informal.Graph.GraphData :=
+  Informal.GraphApi.cachedData state
+```
+
+Generated `blueprint-manifest.json` includes a `graphs` array. Each entry
+contains `schemaVersion`, `nodes`, `edges`, and `groups`, with status enums,
+dependency axes, preview keys, hrefs when traversal resolved them, and visual
+metadata for renderers that want Blueprint's default styling.
+
+The bundled graph renderer uses that finalized graph data as its block-level
+source of truth and derives DOT render variants with
+`Informal.Graph.GraphData.renderVariants`, so page rendering and custom clients
+exercise the same graph record shape.
+
+Browser callers can use the generated ESM graph module directly:
+
+```javascript
+// Import graph helpers from the generated graph API module.
+import { loadGraphs, getGraphData } from "../-verso-data/blueprint-graph-api.mjs";
+
+// Load every finalized graph record from blueprint-manifest.json.graphs.
+const graphs = await loadGraphs();
+
+// Read graph data embedded in a rendered graph block on the current page.
+const graph = getGraphData(document);
+```
+
+Browser consumers that are already using the runtime API can read page-local
+graph data from the render API:
+
+```javascript
+window.VersoBlueprint.onRenderReady((api) => {
+  const block = document.querySelector(".bp_graph_fullwidth");
+  const graph = api.getGraphData(block);
+  console.log(graph?.nodes.length ?? 0);
+});
+```
+
+Standalone clients that do not render a graph block on the current page can
+load the manifest graph records instead:
+
+```javascript
+window.VersoBlueprint.onRenderReady(async (api) => {
+  const graphs = await api.loadGraphs();
+  for (const graph of graphs) {
+    console.log(graph.key, graph.nodes.length, graph.edges.length);
+  }
+});
+```
+
+When a client must resolve the module URL relative to an arbitrary generated
+page, use `api.graphApiModuleUrl()` from the render API:
+
+```javascript
+// Wait until the generated preview runtime has installed the render API.
+window.VersoBlueprint.onRenderReady(async function (api) {
+  // Resolve and import the generated graph API module relative to this page.
+  const graphApi = await import(api.graphApiModuleUrl());
+
+  // Load every finalized graph record from the generated manifest.
+  const graphs = await graphApi.loadGraphs();
+
+  // Use the records in the custom client.
+  console.log(graphs.length);
+});
+```
+
+## Lean Graft and Render APIs
+
+Custom generators should follow the same manifest/cache path as Slides. This is
+the right layer for audit reports, dashboards, comparison pages, and other
+interfaces that create their own wrappers around Blueprint nodes.
+
+The useful data boundary is small:
+
+- `Informal.Graft.BlueprintNodeConfig` is the command-level selection shape. It
+  records the label plus options such as `facet`, `displayLabel`, `compact`,
+  `showHeader`, and `siteBase`.
+- `BlueprintNodeConfig.toNode` normalizes that selection into
+  `Informal.Graft.BlueprintNode`, including the exact preview `key`.
+- `BlueprintNode.toAttrs` and `BlueprintNode.fromAttrs?` encode and decode the
+  neutral DOM shell used by generated interfaces. The shell carries the
+  `bp_graft_manifest_node` class as a stable selector for custom consumers.
+  Slides use `Informal.Slides.blueprintNodeAttrs` and
+  `Informal.Slides.renderedBlueprintNodeAttrs` to add slide-specific classes
+  without making them part of the generic graft contract.
+- `Informal.Graft.setClassAttr`, `Informal.Graft.appendClassAttr`, and
+  `BlueprintNode.renderedAttrsWithClass` let custom renderers replace or extend
+  CSS classes without creating duplicate `class` attributes.
+- `Informal.Graft.SideBySideConfig` parses wrapper options such as `+boxed`.
+  Its `attrs` helper produces the standard wrapper classes. Slides layer
+  `Informal.Slides.sideBySideAttrs` on top for deck-specific wrappers, and
+  custom consumers can ignore both helpers and arrange nodes in their own UI.
+- Slide generators and other generated consumers should import and use the
+  `Informal.Graft` node/config names directly.
+
+`VersoBlueprint.Graft.Render` packages that lookup-and-render path for custom
+interfaces. A consumer such as an audit view can provide its own wrapper
+classes and diagnostics while reusing the same manifest/cache content:
+
+```lean
+import VersoBlueprint.Graft
+
+def renderAuditNode
+    (manifest : Informal.PreviewManifest.File)
+    (htmlCache : Informal.PreviewManifest.HtmlCache.File)
+    (label : String) : IO Verso.Output.Html := do
+  let node :=
+    ({ label := label, compact := true, showHeader := false } :
+      Informal.Graft.BlueprintNodeConfig).toNode
+  let ctx := Informal.Graft.RenderContext.ofPreviewData? (some manifest) (some htmlCache)
+  Informal.Graft.renderNodeFromManifestCache
+    {
+      blockRenderConfig := {
+        wrapperClass := "audit_blueprint_node"
+        codeBodyClass := "audit_blueprint_code"
+      }
+      nodeAttrs := fun node =>
+        node.renderedAttrsWithClass "audit_graft_node"
+    }
+    ctx
+    node
+```
+
+Use `PreviewManifest.File.findEntry?` and
+`PreviewManifest.HtmlCache.File.findHtml?` when you need direct lookup. Code
+panels can reuse `HtmlCache.File.codeHtmlBodies`.
+
+`renderNodeFromManifestCache` has three diagnostic branches that custom
+interfaces can keep or override with `ManifestRenderConfig.renderMissingNode`:
+missing manifest, missing manifest entry for the normalized node key, and
+missing rendered-fragment body for a manifest entry. The cache-miss branch also
+calls the context's `logError` callback so generators can fail or report broken
+manifest/cache pairs consistently.
+
+Consumers that already have a semantic manifest entry and rendered body content
+can call `Informal.Graft.renderNodeWithContent` directly. This keeps the graft
+node attributes, wrapper classes, and `displayLabel`/`compact`/`showHeader`
+behavior aligned with `{blueprint_node}` while letting the caller decide where
+the content came from.
+
+For still lower-level consumers, the final shared block-shell assembly point
+remains `Informal.PreviewManifest.BlockRender.renderWithRenderedContent`. Pass
+it the semantic manifest entry plus `BlockRender.RenderedContent`, using
+`BlockRender.RenderedContent.ofHtmlStrings` when the body came from
+`blueprint-html-cache.json`. The render options map directly to graft behavior:
+`displayLabelOverride?`, `compact`, and `showHeader`.
+
+## Browser ESM APIs
+
+Generated sites emit importable modules under `-verso-data/`:
+
+- `blueprint-preview-api.mjs`
+- `blueprint-graph-api.mjs`
+
+The relative path depends on the generated page location. Root generated pages
+can import from `-verso-data/...`; nested generated pages commonly import from
+`../-verso-data/...`. Generated clients that need to resolve the module URL
+from an arbitrary page should use `api.previewApiModuleUrl()` or
+`api.graphApiModuleUrl()`.
+
+URL, graph-data, and key helpers in `blueprint-preview-api.mjs` are available
+immediately. Manifest/cache loading, rendering, and hydration helpers wait for
+the page runtime before delegating to the shared render API. In the preview ESM
+module, `ready` is a Promise for the runtime API object.
+
+Render only a preview body fragment:
+
+```javascript
+// Import the key builder and body-fragment renderer from the generated module.
+import {
+  previewKey,
+  renderPreviewInto
+} from "../-verso-data/blueprint-preview-api.mjs";
+
+// Build the manifest/cache key for one rendered statement preview.
+const key = previewKey("addition_right_identity", "statement");
+
+// Choose the DOM element where the rendered fragment should be inserted.
+const target = document.querySelector("#audit-preview");
+if (target) {
+  // Render only the preview body fragment into the target element.
+  await renderPreviewInto(target, key);
+}
+```
+
+Render the full generated Blueprint node from a module path and key:
+
+```html
+<!-- Provide a target element for the rendered Blueprint node. -->
+<div id="blueprint-node"></div>
+
+<script type="module">
+  // Point at the generated ESM preview/render API module.
+  const apiModulePath = "../-verso-data/blueprint-preview-api.mjs";
+
+  // Use a full preview key: "<label>--<facet>".
+  const key = "addition_right_identity--statement";
+
+  // Import the full-node renderer from the generated module.
+  const { renderCanonicalPreviewInto } = await import(apiModulePath);
+
+  // Find the target element in this page.
+  const target = document.querySelector("#blueprint-node");
+  if (target) {
+    // Render the same Blueprint node wrapper used on the generated page.
+    const result = await renderCanonicalPreviewInto(target, key);
+
+    // Surface diagnostics when the key or generated source page is unavailable.
+    if (!result.ok) {
+      console.warn("Could not render Blueprint node:", result.reason);
+    }
+  }
+</script>
+```
+
+Resolve the generated module path from the runtime:
+
+```javascript
+// Wait for the generated runtime so it can resolve URLs for this page.
+window.VersoBlueprint.onRenderReady(async function (api) {
+  // Dynamically import the generated preview/render module.
+  const previewApi = await import(api.previewApiModuleUrl());
+
+  // Build a normalized preview key from a label and facet.
+  const key = previewApi.previewKey("addition_right_identity", "statement");
+
+  // Choose the DOM element that will receive the rendered fragment.
+  const target = document.querySelector("#audit-preview");
+  if (target) {
+    // Render the preview body fragment through the imported module.
+    await previewApi.renderPreviewInto(target, key);
+  }
+});
+```
+
+The generated ESM modules expose these entrypoint groups:
+
+| Module | Exports |
+| --- | --- |
+| `blueprint-preview-api.mjs` | URL helpers: `dataUrl`, `manifestUrl`, `htmlCacheUrl`, `graphApiModuleUrl`, `previewApiModuleUrl`; runtime readiness: `onRenderReady`, `currentRenderApi`, `getRenderApi`, `ready`; manifest/cache helpers: `loadManifest`, `readManifestStatus`, `loadManifestEntry`, `loadHtmlCache`, `readHtmlCacheStatus`, `loadHtmlCacheEntry`; graph-data helpers re-exported from the graph module; preview/render helpers: `previewKey`, `statementPreviewKey`, `resolvePreview`, `renderPreviewInto`, `resolveCanonicalPreview`, `renderCanonicalPreviewInto`, `hydrate`. |
+| `blueprint-graph-api.mjs` | URL helpers: `dataUrl`, `graphApiModuleUrl`; page-embedded graph helpers: `graphCanvasFor`, `readGraphJsonScript`, `graphFallbackVariants`, `getGraphData`, `getGraphVariants`; manifest graph helpers: `normalizeGraphData`, `graphsFromManifest`, `loadJson`, `loadManifestGraphs`, `loadGraphs`. |
+
+## Browser Runtime API
+
+Browser-side custom interfaces should start through
+`window.VersoBlueprint.onRenderReady`. The callback receives the shared render
+API installed by the standard Blueprint preview/runtime asset. It loads the
+manifest and rendered-fragment cache from the page's `-verso-data/` directory,
+keeps load status for diagnostics, and hydrates inserted fragments.
+
+Use `renderPreviewInto` when the client just needs to place a preview body
+fragment into the page:
+
+```javascript
+window.VersoBlueprint.onRenderReady(async function (api) {
+  const key = api.previewKey("addition_right_identity", "statement");
+  const target = document.querySelector("#audit-preview");
+  if (!target) return;
+
+  const result = await api.renderPreviewInto(target, key);
+  if (result.ok) {
+    console.log(result.manifestEntry.title);
+  }
+});
+```
+
+Use `renderCanonicalPreviewInto` when the client wants the same Blueprint node
+wrapper that appears on the generated page. This resolves the semantic manifest
+entry, follows its generated-page link, extracts the canonical node by id, and
+hydrates the inserted copy:
+
+```javascript
+window.VersoBlueprint.onRenderReady(async function (api) {
+  const key = api.previewKey("addition_right_identity", "statement");
+  const target = document.querySelector("#audit-preview");
+  if (!target) return;
+
+  const result = await api.renderCanonicalPreviewInto(target, key);
+  if (result.ok) {
+    console.log(result.canonicalSourceHref);
+  }
+});
+```
+
+Use `resolvePreview` when the client needs semantic data before deciding how to
+display the preview:
+
+```javascript
+window.VersoBlueprint.onRenderReady(async function (api) {
+  const key = api.previewKey("addition_right_identity", "statement");
+  const result = await api.resolvePreview(key);
+  if (!result.ok) return;
+
+  const row = document.createElement("section");
+  row.className = "audit-preview-row";
+  row.dataset.previewKey = result.key;
+  const heading = document.createElement("h3");
+  heading.textContent = result.manifestEntry.title;
+  const body = document.createElement("div");
+  body.className = "audit-preview-body";
+  row.appendChild(heading);
+  row.appendChild(body);
+  const inserted = await api.renderPreviewInto(body, result.key);
+  if (!inserted.ok) return;
+  document.querySelector("#audit-previews").appendChild(row);
+});
+```
+
+After readiness, the same API is available as `window.VersoBlueprint.render`.
+Scripts that are emitted as Blueprint inline assets should still use
+`onRenderReady`: Verso stores inline JavaScript assets as a set, so source-list
+order is not a synchronization guarantee.
+
+Blueprint's bundled preview clients get a small readiness bootstrap before
+their client code so `onRenderReady` is available even when the client asset is
+emitted before `preview-runtime.js`.
+
+Stable custom-client entrypoints:
+
+| Entry point | Use |
+| --- | --- |
+| `window.VersoBlueprint.onRenderReady(callback)` | Run startup code that needs the render API, even if the client asset executes before `preview-runtime.js`. |
+| `api.dataUrl(filename)` / `api.manifestUrl()` / `api.htmlCacheUrl()` | Resolve generated `-verso-data/` URLs relative to the current page. |
+| `api.loadManifest()` / `api.loadHtmlCache()` | Load the generated `Map` values keyed by preview key. |
+| `api.readManifestStatus()` / `api.readHtmlCacheStatus()` | Inspect diagnostics such as `idle`, `loading`, `ready`, and `error`. |
+| `api.loadManifestEntry(key)` / `api.loadHtmlCacheEntry(key)` | Read one generated entry by key. |
+| `api.getGraphData(element)` / `api.getGraphVariants(element)` | Read page-embedded graph data and render variants from a rendered graph block. |
+| `api.graphsFromManifest(manifestJson)` / `api.loadManifestGraphs(url, options)` / `api.loadGraphs()` | Decode or fetch finalized graph records from `blueprint-manifest.json.graphs`; `loadGraphs` uses the current page's generated manifest URL. |
+| `api.graphApiModuleUrl()` | Resolve the generated ESM graph API module URL for dynamic imports from custom clients. |
+| `api.previewApiModuleUrl()` | Resolve the generated ESM preview/render API module URL for dynamic imports from custom clients. |
+| `api.previewKey(label, facet)` / `api.statementPreviewKey(label)` | Build normalized preview keys for custom render targets. |
+| `api.resolvePreview(key)` | Resolve manifest data and a rendered body fragment together, returning `{ ok, key, reason, manifestEntry, htmlCacheEntry, html, diagnosticHtml }`. |
+| `api.renderPreviewInto(element, key, options)` | Write the rendered body fragment or diagnostic HTML into `element`, then hydrate nested previews and math. |
+| `api.resolveCanonicalPreview(key)` | Resolve the same data as `resolvePreview`, then load the generated page named by `manifestEntry.href` and return `canonicalHtml` plus `canonicalSourceHref` for the real Blueprint node wrapper. |
+| `api.renderCanonicalPreviewInto(element, key, options)` | Write the canonical Blueprint node wrapper or diagnostic HTML into `element`, then hydrate nested previews and math. |
+| `api.hydrate(element, options)` | Hydrate custom wrappers that inserted cached rendered fragments themselves. |
+
+Blueprint's bundled graph, summary, relation-panel, inline preview, and slide
+JavaScript also start through `onRenderReady` and receive the same render API.
+Custom clients should do the same so preview lookup, diagnostics, and hydration
+stay on one runtime path. The runtime keeps manifest/cache load state private;
+clients should inspect it through `readManifestStatus()` and
+`readHtmlCacheStatus()` rather than reading `window` globals.
+
+Slide decks keep their slide-specific rehydration bridge under the same
+namespace as `window.VersoBlueprint.slides`. That bridge is for the generated
+slide asset; custom preview clients should use the stable render API table
+above unless a slide-specific hook is explicitly documented there.
+
+For semantic queries, use the manifest entry returned by `resolvePreview` or
+`loadManifestEntry`. Do not parse inserted or cached fragments to rediscover
+labels, dependencies, group membership, Lean-code associations, or status
+metadata. The cached fragment is presentation: it may display those facts, but
+the manifest is the data contract.
+
+## Bundled Helper Boundary
+
+Bundled-feature helper APIs are intentionally narrower than the stable API.
+They are exported on `window.VersoBlueprint.render` so Blueprint's own feature
+scripts can share runtime mechanics without duplicating them. They are not a
+custom-client contract unless they are promoted into the stable table above.
+The intended path for Blueprint-owned panels is `createPreviewSurface`; it owns
+content updates plus trigger, dismissal, and reposition lifetimes. Lower-level
+helpers remain exported only where bundled graph popovers, positioning
+callbacks, or generated preview code still need them directly.
+
+| Helper family | Helpers | Bundled consumers |
+| --- | --- | --- |
+| Template lifecycle | `collectPreviewTemplates` | Graph-local preview stores; summary and code-summary previews use Lean-emitted DOM descriptors that the runtime auto-binds |
+| Surface, shell, and content | `createPreviewSurface`, `createPreviewPanel`, `previewMessageHtml`, `escapeHtml` | Graph preview panels, inline preview panels, relation panels, and runtime diagnostics |
+| Behavior, positioning, and dismissal | `bindAnchoredPopover`, `hidePreviewSurfaces` | Graph popovers, slide-change cleanup, and feature-specific positioning callbacks |
+| Hydration and debug hooks | `registerPreviewHydrator`, `previewDebug`, `previewDebugLabel` | Bundled previews that need feature-specific post-render binding or local runtime diagnostics |
+
+Template-preview roots emitted by Lean carry `data-bp-template-preview-*`
+descriptor attributes. The shared runtime binds those descriptors on page load
+and after preview-fragment hydration, so summary and code-summary previews do
+not need feature-specific startup scripts.
+
+`createPreviewSurface` is the higher-level bundled helper for Blueprint-owned
+preview panels. It groups a panel's slots, current behavior, content/header
+updates, close-button wiring, trigger binding, dismissal binding, reposition
+binding, pointer checks, and keep-open checks into one controller object.
+Bundled feature scripts should prefer `surface.bindTriggers`,
+`surface.bindDismissal`, `surface.bindRepositioner`, `surface.position`,
+`surface.pointerWithin`, and `surface.shouldKeepOpen` over direct lifecycle
+helpers. External clients should stay on the stable custom-client API above.
+
+For new custom interfaces, prefer the highest-level entry point that fits the
+job; see [Choosing an API](#choosing-an-api).
+
+Future public browser APIs should be added to the stable custom-client table
+when they are intended for external clients such as audits, dashboards, slide
+adapters, or comparison views. Bundled helpers can still exist for Blueprint's
+own JavaScript, but they should stay outside the public table until their
+argument shape and compatibility expectations are ready to support those
+clients.
+
+## Standalone Example
+
+The in-repo `preview_runtime_showcase` test blueprint includes the same pattern
+as a standalone browser client on its `Custom Render Client` page. It also
+includes a graph-data card that calls `api.loadGraphs()` to read
+`blueprint-manifest.json.graphs` without embedding a rendered graph, a
+`type="module"` example that imports `renderPreviewInto` from
+`-verso-data/blueprint-preview-api.mjs`, and a graph module example that imports
+`loadGraphs` from `-verso-data/blueprint-graph-api.mjs`.
+
+The client asset lives in
+[`custom-render-client.js`](../tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/custom-render-client.js),
+with the page shell in
+[`CustomRenderClient.lean`](../tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/CustomRenderClient.lean).
+After generating the test blueprint, inspect
+`_out/test-blueprints/preview_runtime_showcase/html-multi/Custom-Render-Client/`
+or, from a linked worktree,
+`_out/<worktree>/test-blueprints/preview_runtime_showcase/html-multi/Custom-Render-Client/`.
+That fixture is exercised by the browser regression tests, so it is a better
+starting point than copying code from a test body.

--- a/doc/API.md
+++ b/doc/API.md
@@ -16,6 +16,7 @@ see [`DESIGN_RATIONALE.md`](./DESIGN_RATIONALE.md).
 - [Lean Graft and Render APIs](#lean-graft-and-render-apis)
 - [Browser ESM APIs](#browser-esm-apis)
 - [Browser Runtime API](#browser-runtime-api)
+- [Preview Result Shapes](#preview-result-shapes)
 - [Bundled Helper Boundary](#bundled-helper-boundary)
 - [Standalone Example](#standalone-example)
 
@@ -41,7 +42,7 @@ modules or `window.VersoBlueprint.onRenderReady`.
 | --- | --- |
 | Build semantic graph data before traversal has finished | `Informal.Graph.buildData` |
 | Read finalized graph data after traversal has completed | `Informal.GraphApi.finalDataForBlock` or `Informal.GraphApi.cachedData` |
-| Read all generated graph records from a browser page | `loadGraphs()` from `blueprint-graph-api.mjs` or `api.loadGraphs()` |
+| Read all generated graph records from a browser page | `loadGraphs()` from `api/graph.mjs` or `api.loadGraphs()` |
 | Read data embedded in a rendered graph block | `getGraphData(element)` and `getGraphVariants(element)` |
 | Render only a preview body fragment in a custom wrapper | `renderPreviewInto(element, key)` |
 | Render the full generated Blueprint node wrapper | `renderCanonicalPreviewInto(element, key)` |
@@ -64,10 +65,10 @@ Generated Blueprint sites write reusable data under `-verso-data/`:
 - `blueprint-html-cache.json` contains rendered body fragments keyed by the
   same preview keys. It is presentation data; do not parse it to rediscover
   graph topology, labels, statuses, or dependency relationships.
-- `blueprint-graph-api.mjs` exposes graph-data helpers for ordinary browser
+- `api/graph.mjs` exposes graph-data helpers for ordinary browser `import`
+  usage.
+- `api/preview.mjs` exposes the preview/render API for ordinary browser
   `import` usage.
-- `blueprint-preview-api.mjs` exposes the preview/render API for ordinary
-  browser `import` usage.
 
 The manifest is the semantic data contract. Cached HTML is an opaque rendered
 fragment cache that can be inserted and hydrated. The cache also carries the
@@ -131,7 +132,7 @@ Browser callers can use the generated ESM graph module directly:
 
 ```javascript
 // Import graph helpers from the generated graph API module.
-import { loadGraphs, getGraphData } from "../-verso-data/blueprint-graph-api.mjs";
+import { loadGraphs, getGraphData } from "../-verso-data/api/graph.mjs";
 
 // Load every finalized graph record from blueprint-manifest.json.graphs.
 const graphs = await loadGraphs();
@@ -263,18 +264,22 @@ it the semantic manifest entry plus `BlockRender.RenderedContent`, using
 
 ## Browser ESM APIs
 
-Generated sites emit importable modules under `-verso-data/`:
+Generated sites emit importable modules under `-verso-data/api/`:
 
-- `blueprint-preview-api.mjs`
-- `blueprint-graph-api.mjs`
+- `preview.mjs`
+- `graph.mjs`
 
 The relative path depends on the generated page location. Root generated pages
-can import from `-verso-data/...`; nested generated pages commonly import from
-`../-verso-data/...`. Generated clients that need to resolve the module URL
-from an arbitrary page should use `api.previewApiModuleUrl()` or
+can import from `-verso-data/api/...`; nested generated pages commonly import
+from `../-verso-data/api/...`. Generated clients that need to resolve the
+module URL from an arbitrary page should use `api.previewApiModuleUrl()` or
 `api.graphApiModuleUrl()`.
 
-URL, graph-data, and key helpers in `blueprint-preview-api.mjs` are available
+The root files `-verso-data/blueprint-preview-api.mjs` and
+`-verso-data/blueprint-graph-api.mjs` are still emitted as compatibility
+targets. New clients should use the shorter `-verso-data/api/` paths.
+
+URL, graph-data, and key helpers in `api/preview.mjs` are available
 immediately. Manifest/cache loading, rendering, and hydration helpers wait for
 the page runtime before delegating to the shared render API. In the preview ESM
 module, `ready` is a Promise for the runtime API object.
@@ -286,7 +291,7 @@ Render only a preview body fragment:
 import {
   previewKey,
   renderPreviewInto
-} from "../-verso-data/blueprint-preview-api.mjs";
+} from "../-verso-data/api/preview.mjs";
 
 // Build the manifest/cache key for one rendered statement preview.
 const key = previewKey("addition_right_identity", "statement");
@@ -307,7 +312,7 @@ Render the full generated Blueprint node from a module path and key:
 
 <script type="module">
   // Point at the generated ESM preview/render API module.
-  const apiModulePath = "../-verso-data/blueprint-preview-api.mjs";
+  const apiModulePath = "../-verso-data/api/preview.mjs";
 
   // Use a full preview key: "<label>--<facet>".
   const key = "addition_right_identity--statement";
@@ -353,8 +358,8 @@ The generated ESM modules expose these entrypoint groups:
 
 | Module | Exports |
 | --- | --- |
-| `blueprint-preview-api.mjs` | URL helpers: `dataUrl`, `manifestUrl`, `htmlCacheUrl`, `graphApiModuleUrl`, `previewApiModuleUrl`; runtime readiness: `onRenderReady`, `currentRenderApi`, `getRenderApi`, `ready`; manifest/cache helpers: `loadManifest`, `readManifestStatus`, `loadManifestEntry`, `loadHtmlCache`, `readHtmlCacheStatus`, `loadHtmlCacheEntry`; graph-data helpers re-exported from the graph module; preview/render helpers: `previewKey`, `statementPreviewKey`, `resolvePreview`, `renderPreviewInto`, `resolveCanonicalPreview`, `renderCanonicalPreviewInto`, `hydrate`. |
-| `blueprint-graph-api.mjs` | URL helpers: `dataUrl`, `graphApiModuleUrl`; page-embedded graph helpers: `graphCanvasFor`, `readGraphJsonScript`, `graphFallbackVariants`, `getGraphData`, `getGraphVariants`; manifest graph helpers: `normalizeGraphData`, `graphsFromManifest`, `loadJson`, `loadManifestGraphs`, `loadGraphs`. |
+| `api/preview.mjs` | URL helpers: `dataUrl`, `manifestUrl`, `htmlCacheUrl`, `graphApiModuleUrl`, `previewApiModuleUrl`; runtime readiness: `onRenderReady`, `currentRenderApi`, `getRenderApi`, `ready`; manifest/cache helpers: `loadManifest`, `readManifestStatus`, `loadManifestEntry`, `loadHtmlCache`, `readHtmlCacheStatus`, `loadHtmlCacheEntry`; graph-data helpers re-exported from the graph module; preview/render helpers: `previewKey`, `statementPreviewKey`, `resolvePreview`, `renderPreviewInto`, `resolveCanonicalPreview`, `renderCanonicalPreviewInto`, `hydrate`. |
+| `api/graph.mjs` | URL helpers: `dataUrl`, `graphApiModuleUrl`; page-embedded graph helpers: `graphCanvasFor`, `readGraphJsonScript`, `graphFallbackVariants`, `getGraphData`, `getGraphVariants`; manifest graph helpers: `normalizeGraphData`, `graphsFromManifest`, `loadJson`, `loadManifestGraphs`, `loadGraphs`. |
 
 ## Browser Runtime API
 
@@ -451,6 +456,33 @@ Stable custom-client entrypoints:
 | `api.renderCanonicalPreviewInto(element, key, options)` | Write the canonical Blueprint node wrapper or diagnostic HTML into `element`, then hydrate nested previews and math. |
 | `api.hydrate(element, options)` | Hydrate custom wrappers that inserted cached rendered fragments themselves. |
 
+## Preview Result Shapes
+
+Preview/render helpers resolve to plain objects with an `ok` boolean and the
+normalized preview `key`. Successful results include semantic manifest data and
+the rendered HTML used by the operation. Failed results include a `reason` and
+`diagnosticHtml` suitable for insertion into the page.
+
+| Helper | Success shape | Failure shape |
+| --- | --- | --- |
+| `resolvePreview(key)` | `{ ok: true, key, manifestEntry, htmlCacheEntry, html }` | `{ ok: false, key, reason, diagnosticHtml }` |
+| `renderPreviewInto(element, key, options)` | The `resolvePreview` success shape after writing `html` into `element` and hydrating it. | The `resolvePreview` failure shape after writing `diagnosticHtml` into `element`. |
+| `resolveCanonicalPreview(key)` | `{ ok: true, key, manifestEntry, htmlCacheEntry, html, canonicalHtml, canonicalSourceHref }` | `{ ok: false, key, reason, diagnosticHtml }` |
+| `renderCanonicalPreviewInto(element, key, options)` | The `resolveCanonicalPreview` success shape after writing `canonicalHtml` into `element` and hydrating it. | The `resolveCanonicalPreview` failure shape after writing `diagnosticHtml` into `element`. |
+
+The most common failure `reason` values are:
+
+- `missing-key`
+- `manifest-entry-missing`
+- `html-cache-entry-missing`
+- `canonical-href-missing`
+- `canonical-preview-node-missing`
+- `canonical-preview-load-failed`
+
+Treat `html` and `canonicalHtml` as opaque rendered fragments. Use
+`manifestEntry` for semantic facts such as labels, titles, dependency metadata,
+group data, code associations, and generated links.
+
 Blueprint's bundled graph, summary, relation-panel, inline preview, and slide
 JavaScript also start through `onRenderReady` and receive the same render API.
 Custom clients should do the same so preview lookup, diagnostics, and hydration
@@ -518,8 +550,8 @@ as a standalone browser client on its `Custom Render Client` page. It also
 includes a graph-data card that calls `api.loadGraphs()` to read
 `blueprint-manifest.json.graphs` without embedding a rendered graph, a
 `type="module"` example that imports `renderPreviewInto` from
-`-verso-data/blueprint-preview-api.mjs`, and a graph module example that imports
-`loadGraphs` from `-verso-data/blueprint-graph-api.mjs`.
+`-verso-data/api/preview.mjs`, and a graph module example that imports
+`loadGraphs` from `-verso-data/api/graph.mjs`.
 
 The client asset lives in
 [`custom-render-client.js`](../tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/custom-render-client.js),

--- a/doc/API.md
+++ b/doc/API.md
@@ -277,7 +277,10 @@ module URL from an arbitrary page should use `api.previewApiModuleUrl()` or
 
 The root files `-verso-data/blueprint-preview-api.mjs` and
 `-verso-data/blueprint-graph-api.mjs` are still emitted as compatibility
-targets. New clients should use the shorter `-verso-data/api/` paths.
+targets. The generated data directory also contains implementation support
+files used by those modules, such as `blueprint-graph-core.js`. Those support
+files are not public import paths. New clients should use the shorter
+`-verso-data/api/` paths.
 
 URL, graph-data, and key helpers in `api/preview.mjs` are available
 immediately. Manifest/cache loading, rendering, and hydration helpers wait for

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -13,6 +13,7 @@ It is intentionally not:
 
 Those responsibilities live in
 [`MANUAL.md`](./MANUAL.md),
+[`API.md`](./API.md),
 [`MAINTAINER_GUIDE.md`](./MAINTAINER_GUIDE.md), and
 [`ROADMAP.md`](./ROADMAP.md).
 
@@ -389,7 +390,7 @@ The workflow implies a few constraints for renderers:
   custom body rendering, content updates, trigger binding, dismissal binding,
   reposition binding, pointer checks, and keep-open checks without exposing a
   stable external contract. These helpers are not a public custom-client
-  contract unless promoted into the manual's stable API table. New public
+  contract unless promoted into the API reference's stable API table. New public
   browser APIs should start as stable custom-client entries only when an
   external interface can describe its responsibility without depending on
   Blueprint-owned DOM structure; otherwise they should remain bundled helpers
@@ -408,11 +409,11 @@ The workflow implies a few constraints for renderers:
 - **Keep readiness and API guards source-level.**
   Feature JavaScript must start through `window.VersoBlueprint.onRenderReady`;
   direct reads from `window.VersoBlueprint.render` are limited to the runtime
-  bootstrap path. Stable render API additions must be reflected in the Manual's
-  custom-client table, while bundled helper additions stay out of that table
-  unless intentionally promoted. Lean rendering tests should assert emitted
-  markup, stable API wiring, and removed legacy paths; source-level guards and
-  browser tests own private JavaScript helper shape. The harness test
+  bootstrap path. Stable render API additions must be reflected in the API
+  reference's custom-client table, while bundled helper additions stay out of
+  that table unless intentionally promoted. Lean rendering tests should assert
+  emitted markup, stable API wiring, and removed legacy paths; source-level
+  guards and browser tests own private JavaScript helper shape. The harness test
   `tests/harness/test_preview_runtime_api_docs.py` owns these source-level
   guardrails so Lean rendering tests can focus on emitted markup, assets, and
   behavior instead of brittle JavaScript object-shape assertions.

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -209,5 +209,7 @@ After copying the template:
 After the first site renders:
 
 1. read [doc/MANUAL.md](./MANUAL.md) for the full authoring surface
-2. return to [project_template/README.md](../project_template/README.md) when
+2. read [doc/API.md](./API.md) when you need stable Lean, generated-data, or
+   browser integration APIs
+3. return to [project_template/README.md](../project_template/README.md) when
    you want to compare your project against the starter layout

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -18,7 +18,8 @@ It focuses on:
 
 End-user onboarding lives in
 [`../project_template/README.md`](../project_template/README.md),
-[`GETTING_STARTED.md`](./GETTING_STARTED.md), and [`MANUAL.md`](./MANUAL.md).
+[`GETTING_STARTED.md`](./GETTING_STARTED.md), [`MANUAL.md`](./MANUAL.md), and
+[`API.md`](./API.md).
 Architecture background lives in [`DESIGN_RATIONALE.md`](./DESIGN_RATIONALE.md).
 Planned cleanup and follow-up work live in [`ROADMAP.md`](./ROADMAP.md).
 
@@ -824,9 +825,10 @@ Current project-specific reference:
    [`GETTING_STARTED.md`](./GETTING_STARTED.md) for the user-facing project
    shape.
 2. Read [`MANUAL.md`](./MANUAL.md) for authoring, rendering, and options.
-3. Return here for repository-local commands, outputs, and worktree behavior.
-4. Read [`CONTRIBUTING.md`](./CONTRIBUTING.md) for branch, commit, PR, and
+3. Read [`API.md`](./API.md) for stable Lean, generated-data, and browser APIs.
+4. Return here for repository-local commands, outputs, and worktree behavior.
+5. Read [`CONTRIBUTING.md`](./CONTRIBUTING.md) for branch, commit, PR, and
    local coordination conventions.
-5. Read [`DESIGN_RATIONALE.md`](./DESIGN_RATIONALE.md) before touching
+6. Read [`DESIGN_RATIONALE.md`](./DESIGN_RATIONALE.md) before touching
    architecture boundaries.
-6. Read [`ROADMAP.md`](./ROADMAP.md) before starting structural cleanup.
+7. Read [`ROADMAP.md`](./ROADMAP.md) before starting structural cleanup.

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -688,7 +688,37 @@ Graph data is available through stable Lean, manifest, and browser APIs:
   `window.VersoBlueprint.onRenderReady` for a rendered graph block, or
   `api.loadGraphs()` for standalone clients that want the manifest `graphs`
   array without requiring a graph block on the current page. The same helpers
-  are also exposed on `window.bpGraphApi` for graph-specific clients.
+  are also exposed on `window.bpGraphApi` for graph-specific clients. Generated
+  sites also emit `-verso-data/blueprint-graph-api.mjs` for ordinary browser
+  modules:
+
+  ```javascript
+  // Import graph helpers from the generated graph API module.
+  import { loadGraphs, getGraphData } from "../-verso-data/blueprint-graph-api.mjs";
+
+  // Load every finalized graph record from blueprint-manifest.json.graphs.
+  const graphs = await loadGraphs();
+
+  // Read graph data embedded in a rendered graph block on the current page.
+  const graph = getGraphData(document);
+  ```
+
+  When a client must resolve the module URL relative to an arbitrary generated
+  page, use `api.graphApiModuleUrl()` from the render API:
+
+  ```javascript
+  // Wait until the generated preview runtime has installed the render API.
+  window.VersoBlueprint.onRenderReady(async function (api) {
+    // Resolve and import the generated graph API module relative to this page.
+    const graphApi = await import(api.graphApiModuleUrl());
+
+    // Load every finalized graph record from the generated manifest.
+    const graphs = await graphApi.loadGraphs();
+
+    // Use the records in the custom client.
+    console.log(graphs.length);
+  });
+  ```
 
 Lean-side consumers should choose the API that matches their phase. Before
 Verso traversal finishes, graph data is semantic and may not yet include
@@ -1056,6 +1086,89 @@ API installed by the standard Blueprint preview/runtime asset. It loads the
 manifest and rendered-fragment cache from the page's `-verso-data/` directory,
 keeps load status for diagnostics, and hydrates inserted fragments.
 
+Generated sites also emit the same stable custom-client surface as an ESM
+module at `-verso-data/blueprint-preview-api.mjs`. URL, graph-data, and key
+helpers are available immediately; manifest/cache loading, rendering, and
+hydration helpers wait for the page runtime before delegating to the shared
+render API:
+
+```javascript
+// Import the key builder and body-fragment renderer from the generated module.
+import {
+  previewKey,
+  renderPreviewInto
+} from "../-verso-data/blueprint-preview-api.mjs";
+
+// Build the manifest/cache key for one rendered statement preview.
+const key = previewKey("addition_right_identity", "statement");
+
+// Choose the DOM element where the rendered fragment should be inserted.
+const target = document.querySelector("#audit-preview");
+if (target) {
+  // Render only the preview body fragment into the target element.
+  await renderPreviewInto(target, key);
+}
+```
+
+When a page already has the generated module path and preview key, it can render
+the full generated Blueprint node directly:
+
+```html
+<!-- Provide a target element for the rendered Blueprint node. -->
+<div id="blueprint-node"></div>
+
+<script type="module">
+  // Point at the generated ESM preview/render API module.
+  const apiModulePath = "../-verso-data/blueprint-preview-api.mjs";
+
+  // Use a full preview key: "<label>--<facet>".
+  const key = "addition_right_identity--statement";
+
+  // Import the full-node renderer from the generated module.
+  const { renderCanonicalPreviewInto } = await import(apiModulePath);
+
+  // Find the target element in this page.
+  const target = document.querySelector("#blueprint-node");
+  if (target) {
+    // Render the same Blueprint node wrapper used on the generated page.
+    const result = await renderCanonicalPreviewInto(target, key);
+
+    // Surface diagnostics when the key or generated source page is unavailable.
+    if (!result.ok) {
+      console.warn("Could not render Blueprint node:", result.reason);
+    }
+  }
+</script>
+```
+
+For generated clients that need to resolve the module URL from an arbitrary
+page, use `api.previewApiModuleUrl()`:
+
+```javascript
+// Wait for the generated runtime so it can resolve URLs for this page.
+window.VersoBlueprint.onRenderReady(async function (api) {
+  // Dynamically import the generated preview/render module.
+  const previewApi = await import(api.previewApiModuleUrl());
+
+  // Build a normalized preview key from a label and facet.
+  const key = previewApi.previewKey("addition_right_identity", "statement");
+
+  // Choose the DOM element that will receive the rendered fragment.
+  const target = document.querySelector("#audit-preview");
+  if (target) {
+    // Render the preview body fragment through the imported module.
+    await previewApi.renderPreviewInto(target, key);
+  }
+});
+```
+
+The generated ESM modules expose these entrypoint groups:
+
+| Module | Exports |
+| --- | --- |
+| `blueprint-preview-api.mjs` | URL helpers: `dataUrl`, `manifestUrl`, `htmlCacheUrl`, `graphApiModuleUrl`, `previewApiModuleUrl`; runtime readiness: `onRenderReady`, `currentRenderApi`, `getRenderApi`, `ready`, `render`; manifest/cache helpers: `loadManifest`, `readManifestStatus`, `loadManifestEntry`, `loadHtmlCache`, `readHtmlCacheStatus`, `loadHtmlCacheEntry`; graph-data helpers re-exported from the graph module; preview/render helpers: `previewKey`, `statementPreviewKey`, `resolvePreview`, `renderPreviewInto`, `resolveCanonicalPreview`, `renderCanonicalPreviewInto`, `hydrate`. |
+| `blueprint-graph-api.mjs` | URL helpers: `dataUrl`, `graphApiModuleUrl`; page-embedded graph helpers: `graphCanvasFor`, `readGraphJsonScript`, `graphFallbackVariants`, `getGraphData`, `getGraphVariants`; manifest graph helpers: `normalizeGraphData`, `graphsFromManifest`, `loadJson`, `loadManifestGraphs`, `loadGraphs`. |
+
 Use `renderPreviewInto` when the client just needs to place a preview body
 fragment into the page:
 
@@ -1093,8 +1206,10 @@ window.VersoBlueprint.onRenderReady(async function (api) {
 The in-repo `preview_runtime_showcase` test blueprint includes the same pattern
 as a standalone browser client on its `Custom Render Client` page. It also
 includes a graph-data card that calls `api.loadGraphs()` to read
-`blueprint-manifest.json.graphs` without embedding a rendered graph. The client
-asset lives in
+`blueprint-manifest.json.graphs` without embedding a rendered graph, a
+`type="module"` example that imports `renderPreviewInto` from
+`-verso-data/blueprint-preview-api.mjs`, and a graph module example that imports
+`loadGraphs` from `-verso-data/blueprint-graph-api.mjs`. The client asset lives in
 `tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/custom-render-client.js`,
 with the page shell in
 `tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/CustomRenderClient.lean`.
@@ -1149,6 +1264,8 @@ Stable custom-client entrypoints:
 | `api.loadManifestEntry(key)` / `api.loadHtmlCacheEntry(key)` | Read one generated entry by key. |
 | `api.getGraphData(element)` / `api.getGraphVariants(element)` | Read page-embedded graph data and render variants from a rendered graph block. |
 | `api.graphsFromManifest(manifestJson)` / `api.loadManifestGraphs(url, options)` / `api.loadGraphs()` | Decode or fetch finalized graph records from `blueprint-manifest.json.graphs`; `loadGraphs` uses the current page's generated manifest URL. |
+| `api.graphApiModuleUrl()` | Resolve the generated ESM graph API module URL for dynamic imports from custom clients. |
+| `api.previewApiModuleUrl()` | Resolve the generated ESM preview/render API module URL for dynamic imports from custom clients. |
 | `api.previewKey(label, facet)` / `api.statementPreviewKey(label)` | Build normalized preview keys for custom render targets. |
 | `api.resolvePreview(key)` | Resolve manifest data and a rendered body fragment together, returning `{ ok, key, reason, manifestEntry, htmlCacheEntry, html, diagnosticHtml }`. |
 | `api.renderPreviewInto(element, key, options)` | Write the rendered body fragment or diagnostic HTML into `element`, then hydrate nested previews and math. |

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -1,6 +1,8 @@
 # Blueprint Manual
 
 This document is the current reference for Blueprint authoring and rendering.
+For stable Lean, generated-data, and browser integration APIs, see
+[`API.md`](./API.md).
 
 If you are starting a first project, read
 [project_template/README.md](../project_template/README.md) and
@@ -20,6 +22,8 @@ If you are starting a first project, read
 - [Groups, Authors, and Metadata](#groups-authors-and-metadata)
 - [Rendering Surface](#rendering-surface)
 - [Metadata Export and Preview Data](#metadata-export-and-preview-data)
+- [Reusing Blueprint Nodes and Previews](#reusing-blueprint-nodes-and-previews)
+- [Blueprint APIs](#blueprint-apis)
 - [The Generator Entry Point](#the-generator-entry-point)
 - [Blueprint Options](#blueprint-options)
 - [Experimental Widget](#experimental-widget)
@@ -669,110 +673,12 @@ The command-side options and the runtime graph controls are compatible:
 Group metadata may be used to organize the presentation, but grouping does not
 change dependency edges.
 
-Graph data is available through stable Lean, manifest, and browser APIs:
-
-- Lean callers can build the semantic graph object from elaboration state with
-  `Informal.Graph.buildData`. Once traversal has completed,
-  `Informal.GraphApi.finalDataForBlock` finalizes one rendered block from its
-  block id and semantic graph data, while `Informal.GraphApi.cachedData` reads
-  every traversal-cached graph in the same finalized public shape.
-- Generated `blueprint-manifest.json` includes a `graphs` array. Each entry
-  contains `schemaVersion`, `nodes`, `edges`, and `groups`, with status enums,
-  dependency axes, preview keys, hrefs when traversal resolved them, and visual
-  metadata for renderers that want Blueprint's default styling.
-- The bundled graph renderer uses that finalized graph data as its block-level
-  source of truth and derives DOT render variants with
-  `Informal.Graph.GraphData.renderVariants`, so page rendering and custom
-  clients exercise the same graph record shape.
-- Browser callers can use `api.getGraphData(element)` from
-  `window.VersoBlueprint.onRenderReady` for a rendered graph block, or
-  `api.loadGraphs()` for standalone clients that want the manifest `graphs`
-  array without requiring a graph block on the current page. The same helpers
-  are also exposed on `window.bpGraphApi` for graph-specific clients. Generated
-  sites also emit `-verso-data/blueprint-graph-api.mjs` for ordinary browser
-  modules:
-
-  ```javascript
-  // Import graph helpers from the generated graph API module.
-  import { loadGraphs, getGraphData } from "../-verso-data/blueprint-graph-api.mjs";
-
-  // Load every finalized graph record from blueprint-manifest.json.graphs.
-  const graphs = await loadGraphs();
-
-  // Read graph data embedded in a rendered graph block on the current page.
-  const graph = getGraphData(document);
-  ```
-
-  When a client must resolve the module URL relative to an arbitrary generated
-  page, use `api.graphApiModuleUrl()` from the render API:
-
-  ```javascript
-  // Wait until the generated preview runtime has installed the render API.
-  window.VersoBlueprint.onRenderReady(async function (api) {
-    // Resolve and import the generated graph API module relative to this page.
-    const graphApi = await import(api.graphApiModuleUrl());
-
-    // Load every finalized graph record from the generated manifest.
-    const graphs = await graphApi.loadGraphs();
-
-    // Use the records in the custom client.
-    console.log(graphs.length);
-  });
-  ```
-
-Lean-side consumers should choose the API that matches their phase. Before
-Verso traversal finishes, graph data is semantic and may not yet include
-rendered hrefs or display titles:
-
-```lean
-import VersoBlueprint.Graph
-
-def semanticGraph (state : Informal.Environment.State) :
-    Informal.Graph.GraphData :=
-  let roots := state.data.toArray.map (·.1)
-  Informal.Graph.buildData state roots
-```
-
-After traversal has completed, use `Informal.GraphApi` to finalize either one
-rendered graph block or every graph cached during traversal:
-
-```lean
-import VersoBlueprint.GraphApi
-
-def graphForRenderedBlock
-    (state : Verso.Genre.Manual.TraverseState)
-    (blockId : Verso.Multi.InternalId)
-    (semantic : Informal.Graph.GraphData) : Informal.Graph.GraphData :=
-  Informal.GraphApi.finalDataForBlock state blockId semantic
-
-def allRenderedGraphs
-    (state : Verso.Genre.Manual.TraverseState) :
-    Array Informal.Graph.GraphData :=
-  Informal.GraphApi.cachedData state
-```
-
-Browser consumers should wait for the shared runtime and read graph data from
-the render API. A page-local graph block exposes its finalized embedded record:
-
-```javascript
-window.VersoBlueprint.onRenderReady((api) => {
-  const block = document.querySelector(".bp_graph_fullwidth");
-  const graph = api.getGraphData(block);
-  console.log(graph?.nodes.length ?? 0);
-});
-```
-
-Standalone clients that do not render a graph block on the current page can
-load the manifest graph records instead:
-
-```javascript
-window.VersoBlueprint.onRenderReady(async (api) => {
-  const graphs = await api.loadGraphs();
-  for (const graph of graphs) {
-    console.log(graph.key, graph.nodes.length, graph.edges.length);
-  }
-});
-```
+Graph data is also available through stable Lean, manifest, and browser APIs.
+Lean callers can build semantic graph data before traversal or finalized graph
+records after traversal, while browser clients can read generated manifest graph
+records or data embedded in a rendered graph block. See
+[`API.md#graph-data-apis`](./API.md#graph-data-apis) for the full graph API
+contract and examples.
 
 The graph uses two orthogonal status tracks:
 
@@ -849,14 +755,10 @@ useful for:
 - metadata export for other tools
 - inspection and debugging
 
-For informal blocks, the manifest contains semantic metadata needed by generated
-consumers: direct uses, reverse uses, group-panel entries, code-preview keys,
-ownership, tags, priority, and effort. Rendered preview bodies are stored in
-the rendered-fragment cache under the same keys. The cache also carries the
-Verso hover payloads referenced by those rendered fragments; generated
-Blueprint pages merge them into `-verso-docs.json`, and Slides preloads them
-when rendering a deck. This keeps cross-toolchain consumers such as Slides from
-needing to deserialize Manual blocks or re-run the Blueprint toolchain.
+For informal blocks, these files are the same semantic manifest and opaque
+rendered-fragment cache used by generated previews, grafts, Slides, and custom
+clients. See [`API.md#generated-data-files`](./API.md#generated-data-files)
+for the stable consumer contract.
 
 After building the relevant Lean targets, useful inspection flags on a
 Blueprint generator are:
@@ -877,23 +779,12 @@ lake env lean --run <GeneratorMain>.lean --help
 
 ## Reusing Blueprint Nodes and Previews
 
-Blueprint has one reusable preview data model:
-
-- `blueprint-manifest.json` describes each preview target: label, facet, title,
-  dependencies, group data, ownership metadata, links, and associated Lean-code
-  preview keys.
-- `blueprint-html-cache.json` stores the rendered HTML bodies for those preview
-  keys. Treat these bodies as opaque HTML fragments; read semantic facts from
-  the manifest.
-
-Three common workflows consume that same model:
-
-1. A Manual page can graft a node from the same document while traversal state
-   is still available.
-2. A Slides deck or generated audit page can graft nodes from a manifest/cache
-   pair emitted by a Blueprint site.
-3. Browser-side UI can use `window.VersoBlueprint.onRenderReady` to resolve and
-   insert previews after the page loads.
+Blueprint has one reusable preview data model. Manual pages can graft from the
+current traversal state, Slides and generated audit pages can graft from the
+manifest/cache files emitted by a Blueprint site, and browser-side UI can
+resolve and insert previews after the page loads. See
+[`API.md#generated-data-files`](./API.md#generated-data-files) for the data
+contract shared by those workflows.
 
 ### Grafting a Node
 
@@ -1000,346 +891,22 @@ Custom generators should follow the same manifest/cache path as Slides. This is
 the right layer for audit reports, dashboards, comparison pages, and other
 interfaces that create their own wrappers around Blueprint nodes.
 
-The useful data boundary is small:
-
-- `Informal.Graft.BlueprintNodeConfig` is the command-level selection shape. It
-  records the label plus options such as `facet`, `displayLabel`, `compact`,
-  `showHeader`, and `siteBase`.
-- `BlueprintNodeConfig.toNode` normalizes that selection into
-  `Informal.Graft.BlueprintNode`, including the exact preview `key`.
-- `BlueprintNode.toAttrs` and `BlueprintNode.fromAttrs?` encode and decode the
-  neutral DOM shell used by generated interfaces. The shell carries the
-  `bp_graft_manifest_node` class as a stable selector for custom consumers.
-  Slides use `Informal.Slides.blueprintNodeAttrs` and
-  `Informal.Slides.renderedBlueprintNodeAttrs` to add slide-specific classes
-  without making them part of the generic graft contract.
-- `Informal.Graft.setClassAttr`, `Informal.Graft.appendClassAttr`, and
-  `BlueprintNode.renderedAttrsWithClass` let custom renderers replace or extend
-  CSS classes without creating duplicate `class` attributes.
-- `Informal.Graft.SideBySideConfig` parses wrapper options such as `+boxed`.
-  Its `attrs` helper produces the standard wrapper classes. Slides layer
-  `Informal.Slides.sideBySideAttrs` on top for deck-specific wrappers, and
-  custom consumers can ignore both helpers and arrange nodes in their own UI.
-- Slide generators and other generated consumers should import and use the
-  `Informal.Graft` node/config names directly.
-
-`VersoBlueprint.Graft.Render` packages that lookup-and-render path for custom
-interfaces. A consumer such as an audit view can provide its own wrapper
-classes and diagnostics while reusing the same manifest/cache content:
-
-```lean
-import VersoBlueprint.Graft
-
-def renderAuditNode
-    (manifest : Informal.PreviewManifest.File)
-    (htmlCache : Informal.PreviewManifest.HtmlCache.File)
-    (label : String) : IO Verso.Output.Html := do
-  let node :=
-    ({ label := label, compact := true, showHeader := false } :
-      Informal.Graft.BlueprintNodeConfig).toNode
-  let ctx := Informal.Graft.RenderContext.ofPreviewData? (some manifest) (some htmlCache)
-  Informal.Graft.renderNodeFromManifestCache
-    {
-      blockRenderConfig := {
-        wrapperClass := "audit_blueprint_node"
-        codeBodyClass := "audit_blueprint_code"
-      }
-      nodeAttrs := fun node =>
-        node.renderedAttrsWithClass "audit_graft_node"
-    }
-    ctx
-    node
-```
-
-Use `PreviewManifest.File.findEntry?` and
-`PreviewManifest.HtmlCache.File.findHtml?` when you need direct lookup. Code
-panels can reuse `HtmlCache.File.codeHtmlBodies`.
-
-`renderNodeFromManifestCache` has three diagnostic branches that custom
-interfaces can keep or override with `ManifestRenderConfig.renderMissingNode`:
-missing manifest, missing manifest entry for the normalized node key, and
-missing rendered-fragment body for a manifest entry. The cache-miss branch also
-calls the context's `logError` callback so generators can fail or report broken
-manifest/cache pairs consistently.
-
-Consumers that already have a semantic manifest entry and rendered body content
-can call `Informal.Graft.renderNodeWithContent` directly. This keeps the graft
-node attributes, wrapper classes, and `displayLabel`/`compact`/`showHeader`
-behavior aligned with `{blueprint_node}` while letting the caller decide where
-the content came from.
-
-For still lower-level consumers, the final shared block-shell assembly point
-remains `Informal.PreviewManifest.BlockRender.renderWithRenderedContent`. Pass
-it the semantic manifest entry plus `BlockRender.RenderedContent`, using
-`BlockRender.RenderedContent.ofHtmlStrings` when the body came from
-`blueprint-html-cache.json`. The render options map directly to graft behavior:
-`displayLabelOverride?`, `compact`, and `showHeader`. This lets an audit
-interface, dashboard, or slide generator use the same semantic entry and opaque
-rendered fragment while placing the rendered nodes in its own side-by-side,
-tabbed, or comparison wrapper.
+See [`API.md#lean-graft-and-render-apis`](./API.md#lean-graft-and-render-apis)
+for the reusable `Informal.Graft` data shapes, manifest/cache lookup helpers,
+and lower-level block-shell rendering APIs.
 
 ### Browser-side Consumers
 
 Browser-side custom interfaces should start through
-`window.VersoBlueprint.onRenderReady`. The callback receives the shared render
-API installed by the standard Blueprint preview/runtime asset. It loads the
-manifest and rendered-fragment cache from the page's `-verso-data/` directory,
-keeps load status for diagnostics, and hydrates inserted fragments.
+`window.VersoBlueprint.onRenderReady` or import the generated ESM modules under
+`-verso-data/`. Use `renderPreviewInto` for body fragments,
+`renderCanonicalPreviewInto` for the full generated Blueprint node wrapper, and
+`loadGraphs` for standalone graph-data clients.
 
-Generated sites also emit the same stable custom-client surface as an ESM
-module at `-verso-data/blueprint-preview-api.mjs`. URL, graph-data, and key
-helpers are available immediately; manifest/cache loading, rendering, and
-hydration helpers wait for the page runtime before delegating to the shared
-render API:
-
-```javascript
-// Import the key builder and body-fragment renderer from the generated module.
-import {
-  previewKey,
-  renderPreviewInto
-} from "../-verso-data/blueprint-preview-api.mjs";
-
-// Build the manifest/cache key for one rendered statement preview.
-const key = previewKey("addition_right_identity", "statement");
-
-// Choose the DOM element where the rendered fragment should be inserted.
-const target = document.querySelector("#audit-preview");
-if (target) {
-  // Render only the preview body fragment into the target element.
-  await renderPreviewInto(target, key);
-}
-```
-
-When a page already has the generated module path and preview key, it can render
-the full generated Blueprint node directly:
-
-```html
-<!-- Provide a target element for the rendered Blueprint node. -->
-<div id="blueprint-node"></div>
-
-<script type="module">
-  // Point at the generated ESM preview/render API module.
-  const apiModulePath = "../-verso-data/blueprint-preview-api.mjs";
-
-  // Use a full preview key: "<label>--<facet>".
-  const key = "addition_right_identity--statement";
-
-  // Import the full-node renderer from the generated module.
-  const { renderCanonicalPreviewInto } = await import(apiModulePath);
-
-  // Find the target element in this page.
-  const target = document.querySelector("#blueprint-node");
-  if (target) {
-    // Render the same Blueprint node wrapper used on the generated page.
-    const result = await renderCanonicalPreviewInto(target, key);
-
-    // Surface diagnostics when the key or generated source page is unavailable.
-    if (!result.ok) {
-      console.warn("Could not render Blueprint node:", result.reason);
-    }
-  }
-</script>
-```
-
-For generated clients that need to resolve the module URL from an arbitrary
-page, use `api.previewApiModuleUrl()`:
-
-```javascript
-// Wait for the generated runtime so it can resolve URLs for this page.
-window.VersoBlueprint.onRenderReady(async function (api) {
-  // Dynamically import the generated preview/render module.
-  const previewApi = await import(api.previewApiModuleUrl());
-
-  // Build a normalized preview key from a label and facet.
-  const key = previewApi.previewKey("addition_right_identity", "statement");
-
-  // Choose the DOM element that will receive the rendered fragment.
-  const target = document.querySelector("#audit-preview");
-  if (target) {
-    // Render the preview body fragment through the imported module.
-    await previewApi.renderPreviewInto(target, key);
-  }
-});
-```
-
-The generated ESM modules expose these entrypoint groups:
-
-| Module | Exports |
-| --- | --- |
-| `blueprint-preview-api.mjs` | URL helpers: `dataUrl`, `manifestUrl`, `htmlCacheUrl`, `graphApiModuleUrl`, `previewApiModuleUrl`; runtime readiness: `onRenderReady`, `currentRenderApi`, `getRenderApi`, `ready`, `render`; manifest/cache helpers: `loadManifest`, `readManifestStatus`, `loadManifestEntry`, `loadHtmlCache`, `readHtmlCacheStatus`, `loadHtmlCacheEntry`; graph-data helpers re-exported from the graph module; preview/render helpers: `previewKey`, `statementPreviewKey`, `resolvePreview`, `renderPreviewInto`, `resolveCanonicalPreview`, `renderCanonicalPreviewInto`, `hydrate`. |
-| `blueprint-graph-api.mjs` | URL helpers: `dataUrl`, `graphApiModuleUrl`; page-embedded graph helpers: `graphCanvasFor`, `readGraphJsonScript`, `graphFallbackVariants`, `getGraphData`, `getGraphVariants`; manifest graph helpers: `normalizeGraphData`, `graphsFromManifest`, `loadJson`, `loadManifestGraphs`, `loadGraphs`. |
-
-Use `renderPreviewInto` when the client just needs to place a preview body
-fragment into the page:
-
-```javascript
-window.VersoBlueprint.onRenderReady(async function (api) {
-  const key = api.previewKey("addition_right_identity", "statement");
-  const target = document.querySelector("#audit-preview");
-  if (!target) return;
-
-  const result = await api.renderPreviewInto(target, key);
-  if (result.ok) {
-    console.log(result.manifestEntry.title);
-  }
-});
-```
-
-Use `renderCanonicalPreviewInto` when the client wants the same Blueprint node
-wrapper that appears on the generated page. This resolves the semantic manifest
-entry, follows its generated-page link, extracts the canonical node by id, and
-hydrates the inserted copy:
-
-```javascript
-window.VersoBlueprint.onRenderReady(async function (api) {
-  const key = api.previewKey("addition_right_identity", "statement");
-  const target = document.querySelector("#audit-preview");
-  if (!target) return;
-
-  const result = await api.renderCanonicalPreviewInto(target, key);
-  if (result.ok) {
-    console.log(result.canonicalSourceHref);
-  }
-});
-```
-
-The in-repo `preview_runtime_showcase` test blueprint includes the same pattern
-as a standalone browser client on its `Custom Render Client` page. It also
-includes a graph-data card that calls `api.loadGraphs()` to read
-`blueprint-manifest.json.graphs` without embedding a rendered graph, a
-`type="module"` example that imports `renderPreviewInto` from
-`-verso-data/blueprint-preview-api.mjs`, and a graph module example that imports
-`loadGraphs` from `-verso-data/blueprint-graph-api.mjs`. The client asset lives in
-`tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/custom-render-client.js`,
-with the page shell in
-`tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/CustomRenderClient.lean`.
-After generating the test blueprint, inspect
-`_out/test-blueprints/preview_runtime_showcase/html-multi/Custom-Render-Client/`
-or, from a linked worktree,
-`_out/<worktree>/test-blueprints/preview_runtime_showcase/html-multi/Custom-Render-Client/`.
-That fixture is exercised by the browser regression tests, so it is a better
-starting point than copying code from a test body.
-
-Use `resolvePreview` when the client needs semantic data before deciding how to
-display the preview:
-
-```javascript
-window.VersoBlueprint.onRenderReady(async function (api) {
-  const key = api.previewKey("addition_right_identity", "statement");
-  const result = await api.resolvePreview(key);
-  if (!result.ok) return;
-
-  const row = document.createElement("section");
-  row.className = "audit-preview-row";
-  row.dataset.previewKey = result.key;
-  const heading = document.createElement("h3");
-  heading.textContent = result.manifestEntry.title;
-  const body = document.createElement("div");
-  body.className = "audit-preview-body";
-  row.appendChild(heading);
-  row.appendChild(body);
-  const inserted = await api.renderPreviewInto(body, result.key);
-  if (!inserted.ok) return;
-  document.querySelector("#audit-previews").appendChild(row);
-});
-```
-
-After readiness, the same API is available as `window.VersoBlueprint.render`.
-Scripts that are emitted as Blueprint inline assets should still use
-`onRenderReady`: Verso stores inline JavaScript assets as a set, so source-list
-order is not a synchronization guarantee.
-
-Blueprint's bundled preview clients get a small readiness bootstrap before
-their client code so `onRenderReady` is available even when the client asset is
-emitted before `preview-runtime.js`.
-
-Stable custom-client entrypoints:
-
-| Entry point | Use |
-| --- | --- |
-| `window.VersoBlueprint.onRenderReady(callback)` | Run startup code that needs the render API, even if the client asset executes before `preview-runtime.js`. |
-| `api.dataUrl(filename)` / `api.manifestUrl()` / `api.htmlCacheUrl()` | Resolve generated `-verso-data/` URLs relative to the current page. |
-| `api.loadManifest()` / `api.loadHtmlCache()` | Load the generated `Map` values keyed by preview key. |
-| `api.readManifestStatus()` / `api.readHtmlCacheStatus()` | Inspect diagnostics such as `idle`, `loading`, `ready`, and `error`. |
-| `api.loadManifestEntry(key)` / `api.loadHtmlCacheEntry(key)` | Read one generated entry by key. |
-| `api.getGraphData(element)` / `api.getGraphVariants(element)` | Read page-embedded graph data and render variants from a rendered graph block. |
-| `api.graphsFromManifest(manifestJson)` / `api.loadManifestGraphs(url, options)` / `api.loadGraphs()` | Decode or fetch finalized graph records from `blueprint-manifest.json.graphs`; `loadGraphs` uses the current page's generated manifest URL. |
-| `api.graphApiModuleUrl()` | Resolve the generated ESM graph API module URL for dynamic imports from custom clients. |
-| `api.previewApiModuleUrl()` | Resolve the generated ESM preview/render API module URL for dynamic imports from custom clients. |
-| `api.previewKey(label, facet)` / `api.statementPreviewKey(label)` | Build normalized preview keys for custom render targets. |
-| `api.resolvePreview(key)` | Resolve manifest data and a rendered body fragment together, returning `{ ok, key, reason, manifestEntry, htmlCacheEntry, html, diagnosticHtml }`. |
-| `api.renderPreviewInto(element, key, options)` | Write the rendered body fragment or diagnostic HTML into `element`, then hydrate nested previews and math. |
-| `api.resolveCanonicalPreview(key)` | Resolve the same data as `resolvePreview`, then load the generated page named by `manifestEntry.href` and return `canonicalHtml` plus `canonicalSourceHref` for the real Blueprint node wrapper. |
-| `api.renderCanonicalPreviewInto(element, key, options)` | Write the canonical Blueprint node wrapper or diagnostic HTML into `element`, then hydrate nested previews and math. |
-| `api.hydrate(element, options)` | Hydrate custom wrappers that inserted cached rendered fragments themselves. |
-
-Blueprint's bundled graph, summary, relation-panel, inline preview, and slide
-JavaScript also start through `onRenderReady` and receive the same render API.
-Custom clients should do the same so preview lookup, diagnostics, and hydration
-stay on one runtime path. The runtime keeps manifest/cache load state private;
-clients should inspect it through `readManifestStatus()` and
-`readHtmlCacheStatus()` rather than reading `window` globals.
-
-Slide decks keep their slide-specific rehydration bridge under the same
-namespace as `window.VersoBlueprint.slides`. That bridge is for the generated
-slide asset; custom preview clients should use the stable render API table
-above unless a slide-specific hook is explicitly documented there.
-
-For semantic queries, use the manifest entry returned by `resolvePreview` or
-`loadManifestEntry`. Do not parse inserted or cached fragments to rediscover
-labels, dependencies, group membership, Lean-code associations, or status
-metadata. The cached fragment is presentation: it may display those facts, but
-the manifest is the data contract.
-
-Bundled-feature helper APIs are intentionally narrower than the stable API.
-They are exported on `window.VersoBlueprint.render` so Blueprint's own feature
-scripts can share runtime mechanics without duplicating them. They are not a
-custom-client contract unless they are promoted into the stable table above.
-The intended path for Blueprint-owned panels is `createPreviewSurface`; it owns
-content updates plus trigger, dismissal, and reposition lifetimes. Lower-level
-helpers remain exported only where bundled graph popovers, positioning
-callbacks, or generated preview code still need them directly.
-
-| Helper family | Helpers | Bundled consumers |
-| --- | --- | --- |
-| Template lifecycle | `collectPreviewTemplates` | Graph-local preview stores; summary and code-summary previews use Lean-emitted DOM descriptors that the runtime auto-binds |
-| Surface, shell, and content | `createPreviewSurface`, `createPreviewPanel`, `previewMessageHtml`, `escapeHtml` | Graph preview panels, inline preview panels, relation panels, and runtime diagnostics |
-| Behavior, positioning, and dismissal | `bindAnchoredPopover`, `hidePreviewSurfaces` | Graph popovers, slide-change cleanup, and feature-specific positioning callbacks |
-| Hydration and debug hooks | `registerPreviewHydrator`, `previewDebug`, `previewDebugLabel` | Bundled previews that need feature-specific post-render binding or local runtime diagnostics |
-
-Template-preview roots emitted by Lean carry `data-bp-template-preview-*`
-descriptor attributes. The shared runtime binds those descriptors on page load
-and after preview-fragment hydration, so summary and code-summary previews do
-not need feature-specific startup scripts.
-
-`createPreviewSurface` is the higher-level bundled helper for Blueprint-owned
-preview panels. It groups a panel's slots, current behavior, content/header
-updates, close-button wiring, trigger binding, dismissal binding, reposition
-binding, pointer checks, and keep-open checks into one controller object.
-Bundled feature scripts should prefer `surface.bindTriggers`,
-`surface.bindDismissal`, `surface.bindRepositioner`, `surface.position`,
-`surface.pointerWithin`, and `surface.shouldKeepOpen` over direct lifecycle
-helpers. External clients should stay on the stable custom-client API above.
-
-For new custom interfaces, prefer the highest-level entry point that fits the
-job:
-
-1. Use `renderCanonicalPreviewInto` when the client wants inserted previews to
-   look like normal generated Blueprint nodes.
-2. Use `renderPreviewInto` when the client only needs a body fragment inside a
-   custom wrapper.
-3. Use `resolvePreview` or `resolveCanonicalPreview` when the client needs both
-   semantic manifest data and rendered HTML before deciding how to display it.
-4. Use `loadManifest`, `loadHtmlCache`, `loadManifestEntry`, or
-   `loadHtmlCacheEntry` only for advanced clients that need explicit cache
-   control, diagnostics, or custom joining behavior.
-
-Future public browser APIs should be added to the stable custom-client table
-when they are intended for external clients such as audits, dashboards, slide
-adapters, or comparison views. Bundled helpers can still exist for Blueprint's
-own JavaScript, but they should stay outside the public table until their
-argument shape and compatibility expectations are ready to support those
-clients.
+See [`API.md#browser-esm-apis`](./API.md#browser-esm-apis) for ordinary
+`import { ... } from ...` usage, module path rules, and the full-node rendering
+example. See [`API.md#browser-runtime-api`](./API.md#browser-runtime-api) for
+the `window.VersoBlueprint.onRenderReady` API and stable runtime table.
 
 ### Troubleshooting Grafts
 
@@ -1357,6 +924,17 @@ clients.
   current document traversal state and do not need it.
 - `-header`, `+compact`, and `+boxed` are presentation options only. They do not
   create new nodes, dependencies, groups, or manifest entries.
+
+## Blueprint APIs
+
+The detailed public API reference lives in [`API.md`](./API.md). It covers:
+
+- the generated `blueprint-manifest.json` and `blueprint-html-cache.json` files
+- finalized graph data from Lean, the manifest, and browser clients
+- `Informal.Graft` and manifest/cache rendering helpers for custom generators
+- generated ESM modules such as `blueprint-preview-api.mjs` and
+  `blueprint-graph-api.mjs`
+- the stable browser runtime API and the boundary around bundled helper APIs
 
 ## The Generator Entry Point
 

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -932,8 +932,7 @@ The detailed public API reference lives in [`API.md`](./API.md). It covers:
 - the generated `blueprint-manifest.json` and `blueprint-html-cache.json` files
 - finalized graph data from Lean, the manifest, and browser clients
 - `Informal.Graft` and manifest/cache rendering helpers for custom generators
-- generated ESM modules such as `blueprint-preview-api.mjs` and
-  `blueprint-graph-api.mjs`
+- generated ESM modules such as `api/preview.mjs` and `api/graph.mjs`
 - the stable browser runtime API and the boundary around bundled helper APIs
 
 ## The Generator Entry Point

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -9,7 +9,8 @@ in [`UPSTREAM_BACKLOG.md`](./UPSTREAM_BACKLOG.md).
 This is not the place for operational commands, option reference material, or
 architecture narrative. Those live in
 [`MAINTAINER_GUIDE.md`](./MAINTAINER_GUIDE.md),
-[`MANUAL.md`](./MANUAL.md), and
+[`MANUAL.md`](./MANUAL.md),
+[`API.md`](./API.md), and
 [`DESIGN_RATIONALE.md`](./DESIGN_RATIONALE.md).
 
 ## Working Principles

--- a/scripts/blueprint_harness_utils.py
+++ b/scripts/blueprint_harness_utils.py
@@ -19,8 +19,10 @@ class EmbeddedAssetOwner:
 EMBEDDED_ASSET_OWNERS: tuple[EmbeddedAssetOwner, ...] = (
     EmbeddedAssetOwner("src/VersoBlueprint/Commands/open-target-details.js", "src/VersoBlueprint/Commands/Common.lean", "VersoBlueprint.Commands.Common"),
     EmbeddedAssetOwner("src/VersoBlueprint/Commands/preview-ready.js", "src/VersoBlueprint/Commands/Common.lean", "VersoBlueprint.Commands.Common"),
+    EmbeddedAssetOwner("src/VersoBlueprint/blueprint-graph-core.js", "src/VersoBlueprint/Commands/Common.lean", "VersoBlueprint.Commands.Common"),
     EmbeddedAssetOwner("src/VersoBlueprint/Commands/preview-runtime.js", "src/VersoBlueprint/Commands/Common.lean", "VersoBlueprint.Commands.Common"),
     EmbeddedAssetOwner("src/VersoBlueprint/Commands/inline-preview.js", "src/VersoBlueprint/Commands/Common.lean", "VersoBlueprint.Commands.Common"),
+    EmbeddedAssetOwner("src/VersoBlueprint/blueprint-graph-core.js", "src/VersoBlueprint/PreviewManifest.lean", "VersoBlueprint.PreviewManifest"),
     EmbeddedAssetOwner("src/VersoBlueprint/Commands/graph.css", "src/VersoBlueprint/Commands/Graph.lean", "VersoBlueprint.Commands.Graph"),
     EmbeddedAssetOwner("src/VersoBlueprint/Commands/graph.js", "src/VersoBlueprint/Commands/Graph.lean", "VersoBlueprint.Commands.Graph"),
     EmbeddedAssetOwner("src/VersoBlueprint/Commands/summary.css", "src/VersoBlueprint/Commands/Summary.lean", "VersoBlueprint.Commands.Summary"),

--- a/src/VersoBlueprint/Commands/Common.lean
+++ b/src/VersoBlueprint/Commands/Common.lean
@@ -163,7 +163,10 @@ def previewPanelCss : String := r##"
 -- Keep this module rebuilt when the embedded preview runtime changes.
 -- This module owns the shared Blueprint render API boundary, so adjacent edits
 -- here should land whenever preview runtime assets are intentionally refreshed.
-def previewHoverUtilsJs : String := include_str "preview-runtime.js"
+private def previewGraphCoreJs : String := include_str "../blueprint-graph-core.js"
+
+def previewHoverUtilsJs : String :=
+  previewGraphCoreJs ++ "\n" ++ include_str "preview-runtime.js"
 
 -- Keep this module rebuilt when the preview client readiness shim changes.
 def previewClientReadyJs : String := include_str "preview-ready.js"

--- a/src/VersoBlueprint/Commands/graph.js
+++ b/src/VersoBlueprint/Commands/graph.js
@@ -131,48 +131,18 @@
     );
   }
 
-  function legacyGraphVariants(graphRoot) {
-    if (!(graphRoot instanceof Element)) return [];
-    const dotSource = graphRoot.querySelector("script.dot-source");
-    const dotTxt = dotSource ? (dotSource.textContent || "").trim() : "";
-    if (!dotTxt) return [];
-    const fallbackDirection = normalizeGraphDirection(graphRoot.getAttribute("data-bp-graph-direction"));
-    const fallbackPack = normalizeGraphPack(graphRoot.getAttribute("data-bp-graph-pack"));
-    return [{
-      key: "full",
-      label: "Full Graph",
-      dot: dotTxt,
-      options: { direction: fallbackDirection, pack: fallbackPack },
-      selectOnNodeId: [],
-      hoverOnNodeId: []
-    }];
+  function collectGraphData(previewUtils, root) {
+    if (!previewUtils || typeof previewUtils.getGraphData !== "function") return null;
+    return previewUtils.getGraphData(root);
   }
 
-  function readPublicGraphData(previewUtils, root) {
-    if (previewUtils && typeof previewUtils.getGraphData === "function") {
-      return previewUtils.getGraphData(root);
-    }
-    const api = window.bpGraphApi;
-    if (api && typeof api.getGraphData === "function") {
-      return api.getGraphData(root);
-    }
-    return null;
-  }
-
-  function readPublicGraphVariants(previewUtils, root, graphRoot) {
-    let variants = [];
-    if (previewUtils && typeof previewUtils.getGraphVariants === "function") {
-      variants = previewUtils.getGraphVariants(root);
-    } else {
-      const api = window.bpGraphApi;
-      if (api && typeof api.getGraphVariants === "function") {
-        variants = api.getGraphVariants(root);
-      }
-    }
-    if (Array.isArray(variants) && variants.length > 0) {
-      return variants;
-    }
-    return legacyGraphVariants(graphRoot);
+  function collectGraphVariants(previewUtils, graphContainer) {
+    if (!previewUtils || typeof previewUtils.getGraphVariants !== "function") return [];
+    const root =
+      graphContainer && typeof graphContainer.node === "function"
+        ? graphContainer.node()
+        : graphContainer;
+    return previewUtils.getGraphVariants(root);
   }
 
   function dotWithGraphAttribute(dot, name, value) {
@@ -581,7 +551,7 @@
         const graphContainer = d3.select(graphRoot);
         if (graphContainer.empty()) return;
         const graphState = ensureGraphBlockState(graphBlock);
-        const graphApiData = readPublicGraphData(previewUtils, graphBlock);
+        const graphApiData = collectGraphData(previewUtils, graphBlock);
         if (graphApiData) {
           graphState.graphData = graphApiData;
           graphBlock.__bpGraphData = graphApiData;
@@ -651,7 +621,7 @@
           { keepOpen: true }
         );
 
-        const rawVariants = readPublicGraphVariants(previewUtils, graphBlock, graphRoot);
+        const rawVariants = collectGraphVariants(previewUtils, graphContainer);
         if (!Array.isArray(rawVariants) || rawVariants.length === 0) return;
         const variantsByKey = new Map();
         rawVariants.forEach(function (variant) {

--- a/src/VersoBlueprint/Commands/preview-runtime.js
+++ b/src/VersoBlueprint/Commands/preview-runtime.js
@@ -171,6 +171,14 @@
     return blueprintDataUrl("blueprint-manifest.json");
   }
 
+  function graphApiModuleUrl() {
+    return blueprintDataUrl("blueprint-graph-api.mjs");
+  }
+
+  function previewApiModuleUrl() {
+    return blueprintDataUrl("blueprint-preview-api.mjs");
+  }
+
   function graphCanvasFor(root) {
     const node = root || document;
     if (node instanceof Element) {
@@ -203,6 +211,25 @@
     }
   }
 
+  function graphFallbackVariants(root) {
+    const graphRoot = graphCanvasFor(root);
+    if (!(graphRoot instanceof Element)) return [];
+    const dotSource = graphRoot.querySelector("script.dot-source");
+    const dotTxt = dotSource ? (dotSource.textContent || "").trim() : "";
+    if (!dotTxt) return [];
+    return [{
+      key: "full",
+      label: "Full Graph",
+      dot: dotTxt,
+      options: {
+        direction: graphRoot.getAttribute("data-bp-graph-direction"),
+        pack: graphRoot.getAttribute("data-bp-graph-pack")
+      },
+      selectOnNodeId: [],
+      hoverOnNodeId: []
+    }];
+  }
+
   function normalizeGraphDataPayload(rawData) {
     if (!rawData || typeof rawData !== "object" || Array.isArray(rawData)) return null;
     return {
@@ -229,7 +256,8 @@
 
   function collectGraphVariants(root) {
     const parsed = readGraphJsonScript(root, "script.bp-graph-variants");
-    return Array.isArray(parsed) ? parsed : [];
+    if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+    return graphFallbackVariants(root);
   }
 
   function loadManifestGraphs(url, options) {
@@ -242,8 +270,8 @@
     }).then(graphDataFromManifest);
   }
 
-  function loadBlueprintGraphs() {
-    return loadManifestGraphs(blueprintManifestUrl());
+  function loadBlueprintGraphs(options) {
+    return loadManifestGraphs(blueprintManifestUrl(), options);
   }
 
   function missingPreviewKeyDiagnosticHtml() {
@@ -2022,6 +2050,8 @@
     graphsFromManifest: graphDataFromManifest,
     loadManifestGraphs: loadManifestGraphs,
     loadGraphs: loadBlueprintGraphs,
+    graphApiModuleUrl: graphApiModuleUrl,
+    previewApiModuleUrl: previewApiModuleUrl,
     previewKey: previewKey,
     statementPreviewKey: statementPreviewKey,
     resolvePreview: resolveBlueprintPreview,
@@ -2071,6 +2101,8 @@
     graphsFromManifest: previewDataApi.graphsFromManifest,
     loadManifestGraphs: previewDataApi.loadManifestGraphs,
     loadGraphs: previewDataApi.loadGraphs,
+    graphApiModuleUrl: previewDataApi.graphApiModuleUrl,
+    previewApiModuleUrl: previewDataApi.previewApiModuleUrl,
     previewKey: previewDataApi.previewKey,
     statementPreviewKey: previewDataApi.statementPreviewKey,
     resolvePreview: previewDataApi.resolvePreview,
@@ -2102,11 +2134,15 @@
   const graphApi =
     window.bpGraphApi && typeof window.bpGraphApi === "object" ? window.bpGraphApi : {};
   graphApi.version = 1;
+  graphApi.graphCanvasFor = graphCanvasFor;
+  graphApi.readGraphJsonScript = readGraphJsonScript;
+  graphApi.normalizeGraphData = normalizeGraphDataPayload;
   graphApi.getGraphData = previewDataApi.getGraphData;
   graphApi.getGraphVariants = previewDataApi.getGraphVariants;
   graphApi.graphsFromManifest = previewDataApi.graphsFromManifest;
   graphApi.loadManifestGraphs = previewDataApi.loadManifestGraphs;
   graphApi.loadGraphs = previewDataApi.loadGraphs;
+  graphApi.graphApiModuleUrl = previewDataApi.graphApiModuleUrl;
   window.bpGraphApi = graphApi;
 
   function reportRenderReadyError(err) {

--- a/src/VersoBlueprint/Commands/preview-runtime.js
+++ b/src/VersoBlueprint/Commands/preview-runtime.js
@@ -85,21 +85,27 @@
 
   // Manifest and rendered-fragment cache stores.
 
+  function blueprintGraphApi() {
+    return window.bpGraphApi && typeof window.bpGraphApi === "object" ? window.bpGraphApi : null;
+  }
+
+  function callBlueprintGraphApi(name, args, fallback) {
+    const api = blueprintGraphApi();
+    const method = api && api[name];
+    if (typeof method === "function") {
+      return method.apply(api, args);
+    }
+    if (typeof fallback === "function") {
+      return fallback();
+    }
+    return fallback;
+  }
+
   function blueprintDataUrl(filename) {
-    const safeFilename = String(filename || "").trim();
-    if (!safeFilename) return "-verso-data/";
-    try {
-      const url = new URL(window.location.href);
-      const markers = ["/html-multi/", "/html-single/"];
-      for (const marker of markers) {
-        const idx = url.pathname.indexOf(marker);
-        if (idx >= 0) {
-          const rootPath = url.pathname.slice(0, idx + marker.length);
-          return rootPath + "-verso-data/" + safeFilename;
-        }
-      }
-    } catch (_err) {}
-    return "-verso-data/" + safeFilename;
+    return callBlueprintGraphApi("dataUrl", [filename], function () {
+      const safeFilename = String(filename || "").trim();
+      return safeFilename ? "-verso-data/" + safeFilename : "-verso-data/";
+    });
   }
 
   function fetchBlueprintJson(url) {
@@ -179,99 +185,29 @@
     return blueprintDataUrl("api/preview.mjs");
   }
 
-  function graphCanvasFor(root) {
-    const node = root || document;
-    if (node instanceof Element) {
-      if (node.matches(".bp_graph_canvas")) return node;
-      const ownCanvas = node.querySelector(".bp_graph_canvas");
-      if (ownCanvas instanceof Element) return ownCanvas;
-      const block = node.closest(".bp_graph_fullwidth");
-      if (block instanceof Element) {
-        const blockCanvas = block.querySelector(".bp_graph_canvas");
-        if (blockCanvas instanceof Element) return blockCanvas;
-      }
-      return null;
-    }
-    if (node instanceof Document || node instanceof DocumentFragment) {
-      const canvas = node.querySelector(".bp_graph_canvas");
-      return canvas instanceof Element ? canvas : null;
-    }
-    return null;
-  }
-
-  function readGraphJsonScript(root, selector) {
-    const container = graphCanvasFor(root);
-    if (!(container instanceof Element)) return null;
-    const payloadNode = container.querySelector(selector);
-    if (!(payloadNode instanceof HTMLScriptElement)) return null;
-    try {
-      return JSON.parse((payloadNode.textContent || "").trim());
-    } catch (_err) {
-      return null;
-    }
-  }
-
-  function graphFallbackVariants(root) {
-    const graphRoot = graphCanvasFor(root);
-    if (!(graphRoot instanceof Element)) return [];
-    const dotSource = graphRoot.querySelector("script.dot-source");
-    const dotTxt = dotSource ? (dotSource.textContent || "").trim() : "";
-    if (!dotTxt) return [];
-    return [{
-      key: "full",
-      label: "Full Graph",
-      dot: dotTxt,
-      options: {
-        direction: graphRoot.getAttribute("data-bp-graph-direction"),
-        pack: graphRoot.getAttribute("data-bp-graph-pack")
-      },
-      selectOnNodeId: [],
-      hoverOnNodeId: []
-    }];
-  }
-
-  function normalizeGraphDataPayload(rawData) {
-    if (!rawData || typeof rawData !== "object" || Array.isArray(rawData)) return null;
-    return {
-      schemaVersion: Number.isFinite(rawData.schemaVersion) ? rawData.schemaVersion : 1,
-      key: typeof rawData.key === "string" ? rawData.key : "graph",
-      nodes: Array.isArray(rawData.nodes) ? rawData.nodes : [],
-      edges: Array.isArray(rawData.edges) ? rawData.edges : [],
-      groups: Array.isArray(rawData.groups) ? rawData.groups : []
-    };
-  }
-
   function graphDataFromManifest(manifest) {
-    if (!manifest || typeof manifest !== "object" || !Array.isArray(manifest.graphs)) {
-      return [];
-    }
-    return manifest.graphs
-      .map(normalizeGraphDataPayload)
-      .filter(function (graphData) { return !!graphData; });
+    return callBlueprintGraphApi("graphsFromManifest", [manifest], []);
   }
 
   function collectGraphData(root) {
-    return normalizeGraphDataPayload(readGraphJsonScript(root, "script.bp-graph-data"));
+    return callBlueprintGraphApi("getGraphData", [root], null);
   }
 
   function collectGraphVariants(root) {
-    const parsed = readGraphJsonScript(root, "script.bp-graph-variants");
-    if (Array.isArray(parsed) && parsed.length > 0) return parsed;
-    return graphFallbackVariants(root);
+    return callBlueprintGraphApi("getGraphVariants", [root], []);
   }
 
   function loadManifestGraphs(url, options) {
     const manifestUrl = typeof url === "string" && url.trim() ? url : blueprintManifestUrl();
-    return fetch(manifestUrl, options).then(function (response) {
-      if (!response.ok) {
-        throw new Error("Could not load Blueprint graph manifest: " + response.status);
-      }
-      return response.json();
-    }).then(graphDataFromManifest);
+    return callBlueprintGraphApi("loadManifestGraphs", [manifestUrl, options], function () {
+      return Promise.reject(new Error("Blueprint graph API unavailable"));
+    });
   }
 
   function loadBlueprintGraphs(options) {
-    return loadManifestGraphs(blueprintManifestUrl(), options);
+    return callBlueprintGraphApi("loadGraphs", [options], function () {
+      return loadManifestGraphs(blueprintManifestUrl(), options);
+    });
   }
 
   function missingPreviewKeyDiagnosticHtml() {
@@ -2131,19 +2067,12 @@
     bundledFeatureRenderHelpers
   );
 
-  const graphApi =
-    window.bpGraphApi && typeof window.bpGraphApi === "object" ? window.bpGraphApi : {};
-  graphApi.version = 1;
-  graphApi.graphCanvasFor = graphCanvasFor;
-  graphApi.readGraphJsonScript = readGraphJsonScript;
-  graphApi.normalizeGraphData = normalizeGraphDataPayload;
-  graphApi.getGraphData = previewDataApi.getGraphData;
-  graphApi.getGraphVariants = previewDataApi.getGraphVariants;
-  graphApi.graphsFromManifest = previewDataApi.graphsFromManifest;
-  graphApi.loadManifestGraphs = previewDataApi.loadManifestGraphs;
-  graphApi.loadGraphs = previewDataApi.loadGraphs;
-  graphApi.graphApiModuleUrl = previewDataApi.graphApiModuleUrl;
-  window.bpGraphApi = graphApi;
+  if (!window.bpGraphApi || typeof window.bpGraphApi !== "object") {
+    window.bpGraphApi = {};
+  }
+  if (typeof window.bpGraphApi.graphApiModuleUrl !== "function") {
+    window.bpGraphApi.graphApiModuleUrl = previewDataApi.graphApiModuleUrl;
+  }
 
   function reportRenderReadyError(err) {
     window.setTimeout(function () {

--- a/src/VersoBlueprint/Commands/preview-runtime.js
+++ b/src/VersoBlueprint/Commands/preview-runtime.js
@@ -172,11 +172,11 @@
   }
 
   function graphApiModuleUrl() {
-    return blueprintDataUrl("blueprint-graph-api.mjs");
+    return blueprintDataUrl("api/graph.mjs");
   }
 
   function previewApiModuleUrl() {
-    return blueprintDataUrl("blueprint-preview-api.mjs");
+    return blueprintDataUrl("api/preview.mjs");
   }
 
   function graphCanvasFor(root) {

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -537,6 +537,15 @@ def manifestFilename : String := "blueprint-manifest.json"
 
 def htmlCacheFilename : String := "blueprint-html-cache.json"
 
+def graphApiModuleFilename : String := "blueprint-graph-api.mjs"
+
+def previewApiModuleFilename : String := "blueprint-preview-api.mjs"
+
+-- Keep this module rebuilt when the standalone browser ESM APIs change.
+private def graphApiModuleJs : String := include_str "blueprint-graph-api.mjs"
+
+private def previewApiModuleJs : String := include_str "blueprint-preview-api.mjs"
+
 inductive EntryKind where
   | block
   | leanDecl
@@ -1561,6 +1570,8 @@ def emitBlueprintPreviewData (extensionImpls : ExtensionImpls) : ExtraStep := fu
   IO.FS.createDirAll dataDir
   IO.FS.writeFile (dataDir / manifestFilename) (toJson files.manifest).compress
   IO.FS.writeFile (dataDir / htmlCacheFilename) (toJson files.htmlCache).compress
+  IO.FS.writeFile (dataDir / graphApiModuleFilename) graphApiModuleJs
+  IO.FS.writeFile (dataDir / previewApiModuleFilename) previewApiModuleJs
   mergeHtmlCacheHoverDocsIntoVersoDocs (outDir / "-verso-docs.json") files.htmlCache
   emitPublicXref mode logError cfg state
 

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -539,6 +539,8 @@ def htmlCacheFilename : String := "blueprint-html-cache.json"
 
 def graphApiModuleFilename : String := "blueprint-graph-api.mjs"
 
+def graphCoreModuleFilename : String := "blueprint-graph-core.js"
+
 def previewApiModuleFilename : String := "blueprint-preview-api.mjs"
 
 def apiModuleDirname : String := "api"
@@ -552,6 +554,8 @@ def graphApiModulePath : String := apiModuleDirname ++ "/" ++ graphApiModuleAlia
 def previewApiModulePath : String := apiModuleDirname ++ "/" ++ previewApiModuleAliasFilename
 
 -- Keep this module rebuilt when the standalone browser ESM APIs change.
+private def graphCoreModuleJs : String := include_str "blueprint-graph-core.js"
+
 private def graphApiModuleJs : String := include_str "blueprint-graph-api.mjs"
 
 private def previewApiModuleJs : String := include_str "blueprint-preview-api.mjs"
@@ -1590,6 +1594,7 @@ def emitBlueprintPreviewData (extensionImpls : ExtensionImpls) : ExtraStep := fu
   IO.FS.createDirAll apiDir
   IO.FS.writeFile (dataDir / manifestFilename) (toJson files.manifest).compress
   IO.FS.writeFile (dataDir / htmlCacheFilename) (toJson files.htmlCache).compress
+  IO.FS.writeFile (dataDir / graphCoreModuleFilename) graphCoreModuleJs
   IO.FS.writeFile (dataDir / graphApiModuleFilename) graphApiModuleJs
   IO.FS.writeFile (dataDir / previewApiModuleFilename) previewApiModuleJs
   IO.FS.writeFile (apiDir / graphApiModuleAliasFilename) graphApiModuleAliasJs

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -541,10 +541,28 @@ def graphApiModuleFilename : String := "blueprint-graph-api.mjs"
 
 def previewApiModuleFilename : String := "blueprint-preview-api.mjs"
 
+def apiModuleDirname : String := "api"
+
+def graphApiModuleAliasFilename : String := "graph.mjs"
+
+def previewApiModuleAliasFilename : String := "preview.mjs"
+
+def graphApiModulePath : String := apiModuleDirname ++ "/" ++ graphApiModuleAliasFilename
+
+def previewApiModulePath : String := apiModuleDirname ++ "/" ++ previewApiModuleAliasFilename
+
 -- Keep this module rebuilt when the standalone browser ESM APIs change.
 private def graphApiModuleJs : String := include_str "blueprint-graph-api.mjs"
 
 private def previewApiModuleJs : String := include_str "blueprint-preview-api.mjs"
+
+private def graphApiModuleAliasJs : String :=
+  "export * from \"../" ++ graphApiModuleFilename ++ "\";\n" ++
+  "export { default } from \"../" ++ graphApiModuleFilename ++ "\";\n"
+
+private def previewApiModuleAliasJs : String :=
+  "export * from \"../" ++ previewApiModuleFilename ++ "\";\n" ++
+  "export { default } from \"../" ++ previewApiModuleFilename ++ "\";\n"
 
 inductive EntryKind where
   | block
@@ -1567,11 +1585,15 @@ def emitBlueprintPreviewData (extensionImpls : ExtensionImpls) : ExtraStep := fu
   let files ← buildPreviewDataFiles extensionImpls logError state
   let outDir := outDirForMode cfg mode
   let dataDir := outDir / "-verso-data"
+  let apiDir := dataDir / apiModuleDirname
   IO.FS.createDirAll dataDir
+  IO.FS.createDirAll apiDir
   IO.FS.writeFile (dataDir / manifestFilename) (toJson files.manifest).compress
   IO.FS.writeFile (dataDir / htmlCacheFilename) (toJson files.htmlCache).compress
   IO.FS.writeFile (dataDir / graphApiModuleFilename) graphApiModuleJs
   IO.FS.writeFile (dataDir / previewApiModuleFilename) previewApiModuleJs
+  IO.FS.writeFile (apiDir / graphApiModuleAliasFilename) graphApiModuleAliasJs
+  IO.FS.writeFile (apiDir / previewApiModuleAliasFilename) previewApiModuleAliasJs
   mergeHtmlCacheHoverDocsIntoVersoDocs (outDir / "-verso-docs.json") files.htmlCache
   emitPublicXref mode logError cfg state
 

--- a/src/VersoBlueprint/blueprint-graph-api.mjs
+++ b/src/VersoBlueprint/blueprint-graph-api.mjs
@@ -1,0 +1,143 @@
+export const version = 1;
+
+export function dataUrl(filename, baseUrl = window.location.href) {
+  const safeFilename = String(filename || "").trim();
+  if (!safeFilename) return "-verso-data/";
+  try {
+    const url = new URL(baseUrl);
+    const markers = ["/html-multi/", "/html-single/"];
+    for (const marker of markers) {
+      const idx = url.pathname.indexOf(marker);
+      if (idx >= 0) {
+        const rootPath = url.pathname.slice(0, idx + marker.length);
+        return rootPath + "-verso-data/" + safeFilename;
+      }
+    }
+  } catch (_err) {}
+  return "-verso-data/" + safeFilename;
+}
+
+export function graphApiModuleUrl(baseUrl = window.location.href) {
+  return dataUrl("blueprint-graph-api.mjs", baseUrl);
+}
+
+export function graphCanvasFor(root = document) {
+  const node = root || document;
+  if (node instanceof Element) {
+    if (node.matches(".bp_graph_canvas")) return node;
+    const ownCanvas = node.querySelector(".bp_graph_canvas");
+    if (ownCanvas instanceof Element) return ownCanvas;
+    const block = node.closest(".bp_graph_fullwidth");
+    if (block instanceof Element) {
+      const blockCanvas = block.querySelector(".bp_graph_canvas");
+      if (blockCanvas instanceof Element) return blockCanvas;
+    }
+    return null;
+  }
+  if (node instanceof Document || node instanceof DocumentFragment) {
+    const canvas = node.querySelector(".bp_graph_canvas");
+    return canvas instanceof Element ? canvas : null;
+  }
+  return null;
+}
+
+export function readGraphJsonScript(root, selector) {
+  const container = graphCanvasFor(root);
+  if (!(container instanceof Element)) return null;
+  const payloadNode = container.querySelector(selector);
+  if (!(payloadNode instanceof HTMLScriptElement)) return null;
+  try {
+    return JSON.parse((payloadNode.textContent || "").trim());
+  } catch (_err) {
+    return null;
+  }
+}
+
+export function graphFallbackVariants(root = document) {
+  const graphRoot = graphCanvasFor(root);
+  if (!(graphRoot instanceof Element)) return [];
+  const dotSource = graphRoot.querySelector("script.dot-source");
+  const dotTxt = dotSource ? (dotSource.textContent || "").trim() : "";
+  if (!dotTxt) return [];
+  return [{
+    key: "full",
+    label: "Full Graph",
+    dot: dotTxt,
+    options: {
+      direction: graphRoot.getAttribute("data-bp-graph-direction"),
+      pack: graphRoot.getAttribute("data-bp-graph-pack")
+    },
+    selectOnNodeId: [],
+    hoverOnNodeId: []
+  }];
+}
+
+export function normalizeGraphData(rawData) {
+  if (!rawData || typeof rawData !== "object" || Array.isArray(rawData)) return null;
+  return {
+    schemaVersion: Number.isFinite(rawData.schemaVersion) ? rawData.schemaVersion : 1,
+    key: typeof rawData.key === "string" ? rawData.key : "graph",
+    nodes: Array.isArray(rawData.nodes) ? rawData.nodes : [],
+    edges: Array.isArray(rawData.edges) ? rawData.edges : [],
+    groups: Array.isArray(rawData.groups) ? rawData.groups : []
+  };
+}
+
+export function graphsFromManifest(manifest) {
+  if (!manifest || typeof manifest !== "object" || !Array.isArray(manifest.graphs)) {
+    return [];
+  }
+  return manifest.graphs
+    .map(normalizeGraphData)
+    .filter(function (graphData) { return !!graphData; });
+}
+
+export function getGraphData(root = document) {
+  return normalizeGraphData(readGraphJsonScript(root, "script.bp-graph-data"));
+}
+
+export function getGraphVariants(root = document) {
+  const parsed = readGraphJsonScript(root, "script.bp-graph-variants");
+  if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+  return graphFallbackVariants(root);
+}
+
+export function loadJson(url, options) {
+  return fetch(url, options).then(function (response) {
+    if (!response.ok) {
+      throw new Error("Could not load Blueprint JSON: " + response.status);
+    }
+    return response.json();
+  });
+}
+
+export function loadManifestGraphs(url = dataUrl("blueprint-manifest.json"), options) {
+  return fetch(url, options).then(function (response) {
+    if (!response.ok) {
+      throw new Error("Could not load Blueprint graph manifest: " + response.status);
+    }
+    return response.json();
+  }).then(graphsFromManifest);
+}
+
+export function loadGraphs(options) {
+  return loadManifestGraphs(dataUrl("blueprint-manifest.json"), options);
+}
+
+const graphApi = {
+  version,
+  dataUrl,
+  graphApiModuleUrl,
+  graphCanvasFor,
+  readGraphJsonScript,
+  graphFallbackVariants,
+  normalizeGraphData,
+  graphsFromManifest,
+  getGraphData,
+  getGraphVariants,
+  loadJson,
+  loadManifestGraphs,
+  loadGraphs
+};
+
+export default graphApi;

--- a/src/VersoBlueprint/blueprint-graph-api.mjs
+++ b/src/VersoBlueprint/blueprint-graph-api.mjs
@@ -1,6 +1,29 @@
 export const version = 1;
 
-export function dataUrl(filename, baseUrl = window.location.href) {
+function currentHref() {
+  return typeof window !== "undefined" && window.location ? window.location.href : "";
+}
+
+function currentDocument() {
+  return typeof document !== "undefined" ? document : null;
+}
+
+function isElement(node) {
+  return typeof Element !== "undefined" && node instanceof Element;
+}
+
+function isDocumentLike(node) {
+  return (
+    (typeof Document !== "undefined" && node instanceof Document) ||
+    (typeof DocumentFragment !== "undefined" && node instanceof DocumentFragment)
+  );
+}
+
+function isScriptElement(node) {
+  return !!node && typeof node.tagName === "string" && node.tagName.toLowerCase() === "script";
+}
+
+export function dataUrl(filename, baseUrl = currentHref()) {
   const safeFilename = String(filename || "").trim();
   if (!safeFilename) return "-verso-data/";
   try {
@@ -17,35 +40,36 @@ export function dataUrl(filename, baseUrl = window.location.href) {
   return "-verso-data/" + safeFilename;
 }
 
-export function graphApiModuleUrl(baseUrl = window.location.href) {
+export function graphApiModuleUrl(baseUrl = currentHref()) {
   return dataUrl("blueprint-graph-api.mjs", baseUrl);
 }
 
-export function graphCanvasFor(root = document) {
-  const node = root || document;
-  if (node instanceof Element) {
+export function graphCanvasFor(root = currentDocument()) {
+  const node = root || currentDocument();
+  if (!node) return null;
+  if (isElement(node)) {
     if (node.matches(".bp_graph_canvas")) return node;
     const ownCanvas = node.querySelector(".bp_graph_canvas");
-    if (ownCanvas instanceof Element) return ownCanvas;
+    if (isElement(ownCanvas)) return ownCanvas;
     const block = node.closest(".bp_graph_fullwidth");
-    if (block instanceof Element) {
+    if (isElement(block)) {
       const blockCanvas = block.querySelector(".bp_graph_canvas");
-      if (blockCanvas instanceof Element) return blockCanvas;
+      if (isElement(blockCanvas)) return blockCanvas;
     }
     return null;
   }
-  if (node instanceof Document || node instanceof DocumentFragment) {
+  if (isDocumentLike(node)) {
     const canvas = node.querySelector(".bp_graph_canvas");
-    return canvas instanceof Element ? canvas : null;
+    return isElement(canvas) ? canvas : null;
   }
   return null;
 }
 
 export function readGraphJsonScript(root, selector) {
   const container = graphCanvasFor(root);
-  if (!(container instanceof Element)) return null;
+  if (!isElement(container)) return null;
   const payloadNode = container.querySelector(selector);
-  if (!(payloadNode instanceof HTMLScriptElement)) return null;
+  if (!isScriptElement(payloadNode)) return null;
   try {
     return JSON.parse((payloadNode.textContent || "").trim());
   } catch (_err) {
@@ -53,9 +77,9 @@ export function readGraphJsonScript(root, selector) {
   }
 }
 
-export function graphFallbackVariants(root = document) {
+export function graphFallbackVariants(root = currentDocument()) {
   const graphRoot = graphCanvasFor(root);
-  if (!(graphRoot instanceof Element)) return [];
+  if (!isElement(graphRoot)) return [];
   const dotSource = graphRoot.querySelector("script.dot-source");
   const dotTxt = dotSource ? (dotSource.textContent || "").trim() : "";
   if (!dotTxt) return [];
@@ -92,11 +116,11 @@ export function graphsFromManifest(manifest) {
     .filter(function (graphData) { return !!graphData; });
 }
 
-export function getGraphData(root = document) {
+export function getGraphData(root = currentDocument()) {
   return normalizeGraphData(readGraphJsonScript(root, "script.bp-graph-data"));
 }
 
-export function getGraphVariants(root = document) {
+export function getGraphVariants(root = currentDocument()) {
   const parsed = readGraphJsonScript(root, "script.bp-graph-variants");
   if (Array.isArray(parsed) && parsed.length > 0) return parsed;
   return graphFallbackVariants(root);

--- a/src/VersoBlueprint/blueprint-graph-api.mjs
+++ b/src/VersoBlueprint/blueprint-graph-api.mjs
@@ -1,152 +1,23 @@
-export const version = 1;
+import "./blueprint-graph-core.js";
 
-function currentHref() {
-  return typeof window !== "undefined" && window.location ? window.location.href : "";
-}
+const graphCore =
+  typeof globalThis !== "undefined" && globalThis.VersoBlueprintGraphCore
+    ? globalThis.VersoBlueprintGraphCore
+    : {};
 
-function currentDocument() {
-  return typeof document !== "undefined" ? document : null;
-}
-
-function isElement(node) {
-  return typeof Element !== "undefined" && node instanceof Element;
-}
-
-function isDocumentLike(node) {
-  return (
-    (typeof Document !== "undefined" && node instanceof Document) ||
-    (typeof DocumentFragment !== "undefined" && node instanceof DocumentFragment)
-  );
-}
-
-function isScriptElement(node) {
-  return !!node && typeof node.tagName === "string" && node.tagName.toLowerCase() === "script";
-}
-
-export function dataUrl(filename, baseUrl = currentHref()) {
-  const safeFilename = String(filename || "").trim();
-  if (!safeFilename) return "-verso-data/";
-  try {
-    const url = new URL(baseUrl);
-    const markers = ["/html-multi/", "/html-single/"];
-    for (const marker of markers) {
-      const idx = url.pathname.indexOf(marker);
-      if (idx >= 0) {
-        const rootPath = url.pathname.slice(0, idx + marker.length);
-        return rootPath + "-verso-data/" + safeFilename;
-      }
-    }
-  } catch (_err) {}
-  return "-verso-data/" + safeFilename;
-}
-
-export function graphApiModuleUrl(baseUrl = currentHref()) {
-  return dataUrl("api/graph.mjs", baseUrl);
-}
-
-export function graphCanvasFor(root = currentDocument()) {
-  const node = root || currentDocument();
-  if (!node) return null;
-  if (isElement(node)) {
-    if (node.matches(".bp_graph_canvas")) return node;
-    const ownCanvas = node.querySelector(".bp_graph_canvas");
-    if (isElement(ownCanvas)) return ownCanvas;
-    const block = node.closest(".bp_graph_fullwidth");
-    if (isElement(block)) {
-      const blockCanvas = block.querySelector(".bp_graph_canvas");
-      if (isElement(blockCanvas)) return blockCanvas;
-    }
-    return null;
-  }
-  if (isDocumentLike(node)) {
-    const canvas = node.querySelector(".bp_graph_canvas");
-    return isElement(canvas) ? canvas : null;
-  }
-  return null;
-}
-
-export function readGraphJsonScript(root, selector) {
-  const container = graphCanvasFor(root);
-  if (!isElement(container)) return null;
-  const payloadNode = container.querySelector(selector);
-  if (!isScriptElement(payloadNode)) return null;
-  try {
-    return JSON.parse((payloadNode.textContent || "").trim());
-  } catch (_err) {
-    return null;
-  }
-}
-
-export function graphFallbackVariants(root = currentDocument()) {
-  const graphRoot = graphCanvasFor(root);
-  if (!isElement(graphRoot)) return [];
-  const dotSource = graphRoot.querySelector("script.dot-source");
-  const dotTxt = dotSource ? (dotSource.textContent || "").trim() : "";
-  if (!dotTxt) return [];
-  return [{
-    key: "full",
-    label: "Full Graph",
-    dot: dotTxt,
-    options: {
-      direction: graphRoot.getAttribute("data-bp-graph-direction"),
-      pack: graphRoot.getAttribute("data-bp-graph-pack")
-    },
-    selectOnNodeId: [],
-    hoverOnNodeId: []
-  }];
-}
-
-export function normalizeGraphData(rawData) {
-  if (!rawData || typeof rawData !== "object" || Array.isArray(rawData)) return null;
-  return {
-    schemaVersion: Number.isFinite(rawData.schemaVersion) ? rawData.schemaVersion : 1,
-    key: typeof rawData.key === "string" ? rawData.key : "graph",
-    nodes: Array.isArray(rawData.nodes) ? rawData.nodes : [],
-    edges: Array.isArray(rawData.edges) ? rawData.edges : [],
-    groups: Array.isArray(rawData.groups) ? rawData.groups : []
-  };
-}
-
-export function graphsFromManifest(manifest) {
-  if (!manifest || typeof manifest !== "object" || !Array.isArray(manifest.graphs)) {
-    return [];
-  }
-  return manifest.graphs
-    .map(normalizeGraphData)
-    .filter(function (graphData) { return !!graphData; });
-}
-
-export function getGraphData(root = currentDocument()) {
-  return normalizeGraphData(readGraphJsonScript(root, "script.bp-graph-data"));
-}
-
-export function getGraphVariants(root = currentDocument()) {
-  const parsed = readGraphJsonScript(root, "script.bp-graph-variants");
-  if (Array.isArray(parsed) && parsed.length > 0) return parsed;
-  return graphFallbackVariants(root);
-}
-
-export function loadJson(url, options) {
-  return fetch(url, options).then(function (response) {
-    if (!response.ok) {
-      throw new Error("Could not load Blueprint JSON: " + response.status);
-    }
-    return response.json();
-  });
-}
-
-export function loadManifestGraphs(url = dataUrl("blueprint-manifest.json"), options) {
-  return fetch(url, options).then(function (response) {
-    if (!response.ok) {
-      throw new Error("Could not load Blueprint graph manifest: " + response.status);
-    }
-    return response.json();
-  }).then(graphsFromManifest);
-}
-
-export function loadGraphs(options) {
-  return loadManifestGraphs(dataUrl("blueprint-manifest.json"), options);
-}
+export const version = graphCore.version || 1;
+export const dataUrl = graphCore.dataUrl;
+export const graphApiModuleUrl = graphCore.graphApiModuleUrl;
+export const graphCanvasFor = graphCore.graphCanvasFor;
+export const readGraphJsonScript = graphCore.readGraphJsonScript;
+export const graphFallbackVariants = graphCore.graphFallbackVariants;
+export const normalizeGraphData = graphCore.normalizeGraphData;
+export const graphsFromManifest = graphCore.graphsFromManifest;
+export const getGraphData = graphCore.getGraphData;
+export const getGraphVariants = graphCore.getGraphVariants;
+export const loadJson = graphCore.loadJson;
+export const loadManifestGraphs = graphCore.loadManifestGraphs;
+export const loadGraphs = graphCore.loadGraphs;
 
 const graphApi = {
   version,

--- a/src/VersoBlueprint/blueprint-graph-api.mjs
+++ b/src/VersoBlueprint/blueprint-graph-api.mjs
@@ -41,7 +41,7 @@ export function dataUrl(filename, baseUrl = currentHref()) {
 }
 
 export function graphApiModuleUrl(baseUrl = currentHref()) {
-  return dataUrl("blueprint-graph-api.mjs", baseUrl);
+  return dataUrl("api/graph.mjs", baseUrl);
 }
 
 export function graphCanvasFor(root = currentDocument()) {

--- a/src/VersoBlueprint/blueprint-graph-core.js
+++ b/src/VersoBlueprint/blueprint-graph-core.js
@@ -1,0 +1,203 @@
+(function (globalScope) {
+  const version = 1;
+
+  function currentHref() {
+    const windowObj = globalScope && globalScope.window;
+    return windowObj && windowObj.location ? windowObj.location.href : "";
+  }
+
+  function currentDocument() {
+    return globalScope && globalScope.document ? globalScope.document : null;
+  }
+
+  function isElement(node) {
+    const ElementCtor = globalScope && globalScope.Element;
+    return typeof ElementCtor !== "undefined" && node instanceof ElementCtor;
+  }
+
+  function isDocumentLike(node) {
+    const DocumentCtor = globalScope && globalScope.Document;
+    const DocumentFragmentCtor = globalScope && globalScope.DocumentFragment;
+    return (
+      (typeof DocumentCtor !== "undefined" && node instanceof DocumentCtor) ||
+      (typeof DocumentFragmentCtor !== "undefined" && node instanceof DocumentFragmentCtor)
+    );
+  }
+
+  function isScriptElement(node) {
+    return !!node && typeof node.tagName === "string" && node.tagName.toLowerCase() === "script";
+  }
+
+  function dataUrl(filename, baseUrl) {
+    const safeFilename = String(filename || "").trim();
+    if (!safeFilename) return "-verso-data/";
+    const sourceUrl = typeof baseUrl === "string" && baseUrl.length > 0 ? baseUrl : currentHref();
+    try {
+      const url = new URL(sourceUrl);
+      const markers = ["/html-multi/", "/html-single/"];
+      for (const marker of markers) {
+        const idx = url.pathname.indexOf(marker);
+        if (idx >= 0) {
+          const rootPath = url.pathname.slice(0, idx + marker.length);
+          return rootPath + "-verso-data/" + safeFilename;
+        }
+      }
+    } catch (_err) {}
+    return "-verso-data/" + safeFilename;
+  }
+
+  function graphApiModuleUrl(baseUrl) {
+    return dataUrl("api/graph.mjs", baseUrl);
+  }
+
+  function graphCanvasFor(root) {
+    const node = root || currentDocument();
+    if (!node) return null;
+    if (isElement(node)) {
+      if (node.matches(".bp_graph_canvas")) return node;
+      const ownCanvas = node.querySelector(".bp_graph_canvas");
+      if (isElement(ownCanvas)) return ownCanvas;
+      const block = node.closest(".bp_graph_fullwidth");
+      if (isElement(block)) {
+        const blockCanvas = block.querySelector(".bp_graph_canvas");
+        if (isElement(blockCanvas)) return blockCanvas;
+      }
+      return null;
+    }
+    if (isDocumentLike(node)) {
+      const canvas = node.querySelector(".bp_graph_canvas");
+      return isElement(canvas) ? canvas : null;
+    }
+    return null;
+  }
+
+  function readGraphJsonScript(root, selector) {
+    const container = graphCanvasFor(root);
+    if (!isElement(container)) return null;
+    const payloadNode = container.querySelector(selector);
+    if (!isScriptElement(payloadNode)) return null;
+    try {
+      return JSON.parse((payloadNode.textContent || "").trim());
+    } catch (_err) {
+      return null;
+    }
+  }
+
+  function graphFallbackVariants(root) {
+    const graphRoot = graphCanvasFor(root);
+    if (!isElement(graphRoot)) return [];
+    const dotSource = graphRoot.querySelector("script.dot-source");
+    const dotTxt = dotSource ? (dotSource.textContent || "").trim() : "";
+    if (!dotTxt) return [];
+    return [{
+      key: "full",
+      label: "Full Graph",
+      dot: dotTxt,
+      options: {
+        direction: graphRoot.getAttribute("data-bp-graph-direction"),
+        pack: graphRoot.getAttribute("data-bp-graph-pack")
+      },
+      selectOnNodeId: [],
+      hoverOnNodeId: []
+    }];
+  }
+
+  function normalizeGraphData(rawData) {
+    if (!rawData || typeof rawData !== "object" || Array.isArray(rawData)) return null;
+    return {
+      schemaVersion: Number.isFinite(rawData.schemaVersion) ? rawData.schemaVersion : 1,
+      key: typeof rawData.key === "string" ? rawData.key : "graph",
+      nodes: Array.isArray(rawData.nodes) ? rawData.nodes : [],
+      edges: Array.isArray(rawData.edges) ? rawData.edges : [],
+      groups: Array.isArray(rawData.groups) ? rawData.groups : []
+    };
+  }
+
+  function graphsFromManifest(manifest) {
+    if (!manifest || typeof manifest !== "object" || !Array.isArray(manifest.graphs)) {
+      return [];
+    }
+    return manifest.graphs
+      .map(normalizeGraphData)
+      .filter(function (graphData) { return !!graphData; });
+  }
+
+  function getGraphData(root) {
+    return normalizeGraphData(readGraphJsonScript(root || currentDocument(), "script.bp-graph-data"));
+  }
+
+  function getGraphVariants(root) {
+    const parsed = readGraphJsonScript(root || currentDocument(), "script.bp-graph-variants");
+    if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+    return graphFallbackVariants(root || currentDocument());
+  }
+
+  function loadJson(url, options, errorPrefix) {
+    const fetchFn = globalScope && globalScope.fetch;
+    if (typeof fetchFn !== "function") {
+      return Promise.reject(new Error("Blueprint graph API requires fetch"));
+    }
+    const prefix =
+      typeof errorPrefix === "string" && errorPrefix.length > 0
+        ? errorPrefix
+        : "Could not load Blueprint JSON";
+    return fetchFn.call(globalScope, url, options).then(function (response) {
+      if (!response.ok) {
+        throw new Error(prefix + ": " + response.status);
+      }
+      return response.json();
+    });
+  }
+
+  function loadManifestGraphs(url, options) {
+    const manifestUrl = typeof url === "string" && url.trim()
+      ? url
+      : dataUrl("blueprint-manifest.json");
+    return loadJson(
+      manifestUrl,
+      options,
+      "Could not load Blueprint graph manifest"
+    ).then(graphsFromManifest);
+  }
+
+  function loadGraphs(options) {
+    return loadManifestGraphs(dataUrl("blueprint-manifest.json"), options);
+  }
+
+  const graphCore = {
+    version,
+    dataUrl,
+    graphApiModuleUrl,
+    graphCanvasFor,
+    readGraphJsonScript,
+    graphFallbackVariants,
+    normalizeGraphData,
+    graphsFromManifest,
+    getGraphData,
+    getGraphVariants,
+    loadJson,
+    loadManifestGraphs,
+    loadGraphs
+  };
+
+  const existingCore =
+    globalScope.VersoBlueprintGraphCore && typeof globalScope.VersoBlueprintGraphCore === "object"
+      ? globalScope.VersoBlueprintGraphCore
+      : {};
+  Object.assign(existingCore, graphCore);
+  globalScope.VersoBlueprintGraphCore = existingCore;
+
+  const windowObj = globalScope && globalScope.window;
+  if (windowObj && typeof windowObj === "object") {
+    const existingGlobalApi =
+      windowObj.bpGraphApi && typeof windowObj.bpGraphApi === "object"
+        ? windowObj.bpGraphApi
+        : {};
+    Object.assign(existingGlobalApi, existingCore);
+    windowObj.bpGraphApi = existingGlobalApi;
+  }
+})(
+  typeof globalThis !== "undefined"
+    ? globalThis
+    : (typeof window !== "undefined" ? window : this)
+);

--- a/src/VersoBlueprint/blueprint-preview-api.mjs
+++ b/src/VersoBlueprint/blueprint-preview-api.mjs
@@ -1,0 +1,249 @@
+import {
+  getGraphData,
+  getGraphVariants,
+  graphsFromManifest,
+  loadGraphs,
+  loadManifestGraphs,
+  normalizeGraphData
+} from "./blueprint-graph-api.mjs";
+
+export {
+  getGraphData,
+  getGraphVariants,
+  graphsFromManifest,
+  loadGraphs,
+  loadManifestGraphs,
+  normalizeGraphData
+};
+
+export const version = 1;
+
+function currentHref() {
+  return typeof window !== "undefined" && window.location ? window.location.href : "";
+}
+
+function ensureNamespace() {
+  if (typeof window === "undefined") return null;
+  const namespace =
+    window.VersoBlueprint && typeof window.VersoBlueprint === "object"
+      ? window.VersoBlueprint
+      : {};
+  if (!Array.isArray(namespace.renderReadyCallbacks)) {
+    namespace.renderReadyCallbacks = [];
+  }
+  window.VersoBlueprint = namespace;
+  return namespace;
+}
+
+export function currentRenderApi() {
+  const namespace = ensureNamespace();
+  if (!namespace || !namespace.render || typeof namespace.render !== "object") return null;
+  return namespace.render;
+}
+
+export function onRenderReady(callback) {
+  if (typeof callback !== "function") return;
+  const namespace = ensureNamespace();
+  if (!namespace) return;
+  if (namespace.render && typeof namespace.render === "object") {
+    callback(namespace.render);
+    return;
+  }
+  const installed = namespace.onRenderReady;
+  if (typeof installed === "function" && installed !== onRenderReady) {
+    installed(callback);
+    return;
+  }
+  namespace.renderReadyCallbacks.push(callback);
+}
+
+const namespace = ensureNamespace();
+if (namespace && typeof namespace.onRenderReady !== "function") {
+  namespace.onRenderReady = onRenderReady;
+}
+
+export function getRenderApi() {
+  const api = currentRenderApi();
+  if (api) return Promise.resolve(api);
+  return new Promise(function (resolve) {
+    onRenderReady(resolve);
+  });
+}
+
+export const ready = getRenderApi;
+export const render = getRenderApi();
+
+export function dataUrl(filename, baseUrl = currentHref()) {
+  const api = currentRenderApi();
+  if (api && typeof api.dataUrl === "function" && baseUrl === currentHref()) {
+    return api.dataUrl(filename);
+  }
+  const safeFilename = String(filename || "").trim();
+  if (!safeFilename) return "-verso-data/";
+  try {
+    const url = new URL(baseUrl);
+    const markers = ["/html-multi/", "/html-single/"];
+    for (const marker of markers) {
+      const idx = url.pathname.indexOf(marker);
+      if (idx >= 0) {
+        const rootPath = url.pathname.slice(0, idx + marker.length);
+        return rootPath + "-verso-data/" + safeFilename;
+      }
+    }
+  } catch (_err) {}
+  return "-verso-data/" + safeFilename;
+}
+
+export function manifestUrl(baseUrl = currentHref()) {
+  const api = currentRenderApi();
+  if (api && typeof api.manifestUrl === "function" && baseUrl === currentHref()) {
+    return api.manifestUrl();
+  }
+  return dataUrl("blueprint-manifest.json", baseUrl);
+}
+
+export function htmlCacheUrl(baseUrl = currentHref()) {
+  const api = currentRenderApi();
+  if (api && typeof api.htmlCacheUrl === "function" && baseUrl === currentHref()) {
+    return api.htmlCacheUrl();
+  }
+  return dataUrl("blueprint-html-cache.json", baseUrl);
+}
+
+export function graphApiModuleUrl(baseUrl = currentHref()) {
+  const api = currentRenderApi();
+  if (api && typeof api.graphApiModuleUrl === "function" && baseUrl === currentHref()) {
+    return api.graphApiModuleUrl();
+  }
+  return dataUrl("blueprint-graph-api.mjs", baseUrl);
+}
+
+export function previewApiModuleUrl(baseUrl = currentHref()) {
+  const api = currentRenderApi();
+  if (api && typeof api.previewApiModuleUrl === "function" && baseUrl === currentHref()) {
+    return api.previewApiModuleUrl();
+  }
+  return dataUrl("blueprint-preview-api.mjs", baseUrl);
+}
+
+export function previewKey(label, facet) {
+  const trimmedLabel = typeof label === "string" ? label.trim() : "";
+  if (!trimmedLabel) return "";
+  const trimmedFacet = typeof facet === "string" && facet.trim() ? facet.trim() : "statement";
+  return trimmedLabel + "--" + trimmedFacet;
+}
+
+export function statementPreviewKey(label) {
+  return previewKey(label, "statement");
+}
+
+function fallbackStatus(url) {
+  return {
+    state: "idle",
+    attempts: 0,
+    url: url,
+    lastError: "",
+    entryCount: 0
+  };
+}
+
+function callRuntimeSync(name, fallback) {
+  const api = currentRenderApi();
+  const method = api && api[name];
+  if (typeof method === "function") {
+    return method.apply(api, Array.prototype.slice.call(arguments, 2));
+  }
+  return fallback();
+}
+
+async function callRuntime(name, args) {
+  const api = await getRenderApi();
+  const method = api && api[name];
+  if (typeof method !== "function") {
+    throw new Error("Blueprint render API method unavailable: " + name);
+  }
+  return method.apply(api, args);
+}
+
+export function readManifestStatus() {
+  return callRuntimeSync("readManifestStatus", function () {
+    return fallbackStatus(manifestUrl());
+  });
+}
+
+export function readHtmlCacheStatus() {
+  return callRuntimeSync("readHtmlCacheStatus", function () {
+    return fallbackStatus(htmlCacheUrl());
+  });
+}
+
+export function loadManifest() {
+  return callRuntime("loadManifest", arguments);
+}
+
+export function loadHtmlCache() {
+  return callRuntime("loadHtmlCache", arguments);
+}
+
+export function loadManifestEntry(key) {
+  return callRuntime("loadManifestEntry", arguments);
+}
+
+export function loadHtmlCacheEntry(key) {
+  return callRuntime("loadHtmlCacheEntry", arguments);
+}
+
+export function resolvePreview(key) {
+  return callRuntime("resolvePreview", arguments);
+}
+
+export function renderPreviewInto(element, key, options) {
+  return callRuntime("renderPreviewInto", arguments);
+}
+
+export function resolveCanonicalPreview(key) {
+  return callRuntime("resolveCanonicalPreview", arguments);
+}
+
+export function renderCanonicalPreviewInto(element, key, options) {
+  return callRuntime("renderCanonicalPreviewInto", arguments);
+}
+
+export function hydrate(element, options) {
+  return callRuntime("hydrate", arguments);
+}
+
+const previewApi = {
+  version,
+  dataUrl,
+  manifestUrl,
+  htmlCacheUrl,
+  graphApiModuleUrl,
+  previewApiModuleUrl,
+  currentRenderApi,
+  getRenderApi,
+  ready,
+  render,
+  onRenderReady,
+  loadManifest,
+  readManifestStatus,
+  loadManifestEntry,
+  loadHtmlCache,
+  readHtmlCacheStatus,
+  loadHtmlCacheEntry,
+  getGraphData,
+  getGraphVariants,
+  graphsFromManifest,
+  loadManifestGraphs,
+  loadGraphs,
+  normalizeGraphData,
+  previewKey,
+  statementPreviewKey,
+  resolvePreview,
+  renderPreviewInto,
+  resolveCanonicalPreview,
+  renderCanonicalPreviewInto,
+  hydrate
+};
+
+export default previewApi;

--- a/src/VersoBlueprint/blueprint-preview-api.mjs
+++ b/src/VersoBlueprint/blueprint-preview-api.mjs
@@ -1,4 +1,5 @@
 import {
+  dataUrl as graphDataUrl,
   getGraphData,
   getGraphVariants,
   graphsFromManifest,
@@ -77,20 +78,7 @@ export function dataUrl(filename, baseUrl = currentHref()) {
   if (api && typeof api.dataUrl === "function" && baseUrl === currentHref()) {
     return api.dataUrl(filename);
   }
-  const safeFilename = String(filename || "").trim();
-  if (!safeFilename) return "-verso-data/";
-  try {
-    const url = new URL(baseUrl);
-    const markers = ["/html-multi/", "/html-single/"];
-    for (const marker of markers) {
-      const idx = url.pathname.indexOf(marker);
-      if (idx >= 0) {
-        const rootPath = url.pathname.slice(0, idx + marker.length);
-        return rootPath + "-verso-data/" + safeFilename;
-      }
-    }
-  } catch (_err) {}
-  return "-verso-data/" + safeFilename;
+  return graphDataUrl(filename, baseUrl);
 }
 
 export function manifestUrl(baseUrl = currentHref()) {

--- a/src/VersoBlueprint/blueprint-preview-api.mjs
+++ b/src/VersoBlueprint/blueprint-preview-api.mjs
@@ -114,7 +114,7 @@ export function graphApiModuleUrl(baseUrl = currentHref()) {
   if (api && typeof api.graphApiModuleUrl === "function" && baseUrl === currentHref()) {
     return api.graphApiModuleUrl();
   }
-  return dataUrl("blueprint-graph-api.mjs", baseUrl);
+  return dataUrl("api/graph.mjs", baseUrl);
 }
 
 export function previewApiModuleUrl(baseUrl = currentHref()) {
@@ -122,7 +122,7 @@ export function previewApiModuleUrl(baseUrl = currentHref()) {
   if (api && typeof api.previewApiModuleUrl === "function" && baseUrl === currentHref()) {
     return api.previewApiModuleUrl();
   }
-  return dataUrl("blueprint-preview-api.mjs", baseUrl);
+  return dataUrl("api/preview.mjs", baseUrl);
 }
 
 export function previewKey(label, facet) {

--- a/src/VersoBlueprint/blueprint-preview-api.mjs
+++ b/src/VersoBlueprint/blueprint-preview-api.mjs
@@ -70,8 +70,7 @@ export function getRenderApi() {
   });
 }
 
-export const ready = getRenderApi;
-export const render = getRenderApi();
+export const ready = getRenderApi();
 
 export function dataUrl(filename, baseUrl = currentHref()) {
   const api = currentRenderApi();
@@ -223,7 +222,6 @@ const previewApi = {
   currentRenderApi,
   getRenderApi,
   ready,
-  render,
   onRenderReady,
   loadManifest,
   readManifestStatus,

--- a/tests/browser/test_graph_layout_runtime.py
+++ b/tests/browser/test_graph_layout_runtime.py
@@ -143,6 +143,11 @@ class TestGraphLayoutRuntime:
                 const manifestGraph = manifestGraphs.find((graph) => graph.key === pageGraph.key) || null;
                 const variants = api.getGraphVariants(block);
                 const globalVariants = window.bpGraphApi.getGraphVariants(block);
+                const graphModuleUrl = new URL("../-verso-data/api/graph.mjs", window.location.href).href;
+                const graphModule = await import(graphModuleUrl);
+                const esmPageGraph = graphModule.getGraphData(block);
+                const esmManifestGraphs = await graphModule.loadGraphs();
+                const esmVariants = graphModule.getGraphVariants(block);
                 const sample = pageGraph.nodes.find((node) => node.label === "used_target") || null;
                 const manifestSample = manifestGraph
                     ? manifestGraph.nodes.find((node) => node.label === "used_target") || null
@@ -150,8 +155,10 @@ class TestGraphLayoutRuntime:
                 return {
                     apiVersion: window.bpGraphApi.version,
                     sameGlobalKey: !!globalPageGraph && globalPageGraph.key === pageGraph.key,
+                    sameEsmPageKey: !!esmPageGraph && esmPageGraph.key === pageGraph.key,
                     pageKey: pageGraph.key,
                     manifestGraphs: manifestGraphs.length,
+                    esmManifestGraphs: esmManifestGraphs.length,
                     manifestKey: manifestGraph ? manifestGraph.key : "",
                     pageNodes: pageGraph.nodes.length,
                     pageEdges: pageGraph.edges.length,
@@ -161,6 +168,7 @@ class TestGraphLayoutRuntime:
                     manifestGroups: manifestGraph ? manifestGraph.groups.length : 0,
                     variantKeys: variants.map((variant) => variant.key),
                     globalVariantKeys: globalVariants.map((variant) => variant.key),
+                    esmVariantKeys: esmVariants.map((variant) => variant.key),
                     sampleTitle: sample ? sample.title : "",
                     sampleHref: sample ? sample.href : "",
                     manifestSampleTitle: manifestSample ? manifestSample.title : "",
@@ -172,8 +180,10 @@ class TestGraphLayoutRuntime:
 
         assert graph_data["apiVersion"] == 1
         assert graph_data["sameGlobalKey"]
+        assert graph_data["sameEsmPageKey"]
         assert graph_data["pageKey"].startswith("graph:#<")
         assert graph_data["manifestGraphs"] == 1
+        assert graph_data["esmManifestGraphs"] == graph_data["manifestGraphs"]
         assert graph_data["manifestKey"] == graph_data["pageKey"]
         assert graph_data["pageNodes"] == 55
         assert graph_data["pageEdges"] == 13
@@ -183,6 +193,7 @@ class TestGraphLayoutRuntime:
         assert graph_data["manifestGroups"] == graph_data["pageGroups"]
         assert {"full", "group"}.issubset(set(graph_data["variantKeys"]))
         assert set(graph_data["variantKeys"]) == set(graph_data["globalVariantKeys"])
+        assert set(graph_data["variantKeys"]) == set(graph_data["esmVariantKeys"])
         assert graph_data["sampleTitle"].startswith("Definition")
         assert graph_data["sampleHref"] == "Preview-Relationships/#--informal-preview-used_target--statement"
         assert graph_data["manifestSampleTitle"] == graph_data["sampleTitle"]

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -417,6 +417,20 @@ class TestPreviewRuntimeRegressions:
         client = page.locator("#custom-render-client-example").first
         expect(client).to_have_attribute("data-bp-custom-client-status", "ready")
         expect(client.locator("[data-bp-custom-client-example]")).to_have_count(8)
+        preview_module_card = client.locator("[data-bp-preview-module-example]").first
+        expect(preview_module_card).to_have_attribute("data-bp-preview-module-ok", "true")
+        expect(preview_module_card).to_have_attribute(
+            "data-bp-preview-module-render-api", "true"
+        )
+        expect(preview_module_card).to_have_attribute(
+            "data-bp-preview-module-key", "preview_facets--statement"
+        )
+        expect(preview_module_card).to_have_attribute(
+            "data-bp-preview-module-entry-count", re.compile(r"^[1-9][0-9]*$")
+        )
+        expect(
+            preview_module_card.locator("[data-bp-preview-module-body]").first
+        ).to_contain_text("Statement facet marker")
         graph_card = client.locator("[data-bp-custom-client-graph]").first
         expect(graph_card.locator("[data-bp-custom-client-title]").first).to_have_text(
             "Graph manifest data"
@@ -424,6 +438,9 @@ class TestPreviewRuntimeRegressions:
         expect(graph_card).to_have_attribute("data-bp-graph-ok", "true")
         expect(graph_card).to_have_attribute("data-bp-graph-count", "1")
         expect(graph_card).to_have_attribute("data-bp-graph-key", re.compile(r"^graph:#<"))
+        expect(graph_card).to_have_attribute("data-bp-graph-module-ok", "true")
+        expect(graph_card).to_have_attribute("data-bp-graph-module-count", "1")
+        expect(graph_card).to_have_attribute("data-bp-graph-module-key", re.compile(r"^graph:#<"))
         expect(graph_card).to_have_attribute("data-bp-graph-node-count", "55")
         expect(graph_card).to_have_attribute("data-bp-graph-edge-count", "13")
         expect(graph_card).to_have_attribute("data-bp-graph-group-count", "3")

--- a/tests/harness/test_blueprint_harness_utils.py
+++ b/tests/harness/test_blueprint_harness_utils.py
@@ -32,6 +32,7 @@ class TestBlueprintHarnessUtils(unittest.TestCase):
         for asset in (
             "src/VersoBlueprint/Commands/open-target-details.js",
             "src/VersoBlueprint/Commands/preview-ready.js",
+            "src/VersoBlueprint/blueprint-graph-core.js",
             "src/VersoBlueprint/Commands/preview-runtime.js",
             "src/VersoBlueprint/Commands/inline-preview.js",
         ):
@@ -43,6 +44,16 @@ class TestBlueprintHarnessUtils(unittest.TestCase):
                 ),
                 EMBEDDED_ASSET_OWNERS,
             )
+
+    def test_graph_core_js_is_owned_by_preview_manifest_module(self) -> None:
+        self.assertIn(
+            EmbeddedAssetOwner(
+                "src/VersoBlueprint/blueprint-graph-core.js",
+                "src/VersoBlueprint/PreviewManifest.lean",
+                "VersoBlueprint.PreviewManifest",
+            ),
+            EMBEDDED_ASSET_OWNERS,
+        )
 
     def test_preview_client_js_assets_are_owned_by_rendering_modules(self) -> None:
         for asset, owner, target in (

--- a/tests/harness/test_preview_runtime_api_docs.py
+++ b/tests/harness/test_preview_runtime_api_docs.py
@@ -8,14 +8,15 @@ from tests.preview_runtime_api import (
     RUNTIME_BOOTSTRAP_JS,
     blueprint_js_files,
     blueprint_js_source,
+    documented_bundled_helper_methods,
+    documented_stable_api_methods,
     esm_named_exports,
     js_object_keys,
     js_object_methods,
-    manual_bundled_helper_methods,
-    manual_stable_api_methods,
 )
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+API_DOC = PACKAGE_ROOT / "doc" / "API.md"
 INTERNAL_ONLY_HELPERS = {
     "bindCloseOnce",
     "bindDismissHandlers",
@@ -40,38 +41,37 @@ PREVIEW_ESM_EXTRA_EXPORTS = {
     "normalizeGraphData",
     "onRenderReady",
     "ready",
-    "render",
     "version",
 }
 
 
 class PreviewRuntimeApiDocsTests(unittest.TestCase):
-    def test_manual_stable_api_table_matches_runtime_source(self) -> None:
+    def test_api_stable_api_table_matches_runtime_source(self) -> None:
         runtime = blueprint_js_source()
-        manual = (PACKAGE_ROOT / "doc" / "MANUAL.md").read_text(encoding="utf-8")
+        api_doc = API_DOC.read_text(encoding="utf-8")
 
         source_methods = js_object_methods(runtime, "stableCustomClientApi")
-        documented_methods = manual_stable_api_methods(manual)
+        documented_methods = documented_stable_api_methods(api_doc)
 
         self.assertEqual(documented_methods, source_methods)
-        self.assertIn("`window.VersoBlueprint.onRenderReady(callback)`", manual)
+        self.assertIn("`window.VersoBlueprint.onRenderReady(callback)`", api_doc)
         self.assertIn("namespace.onRenderReady = onRenderReady", runtime)
 
-    def test_manual_stable_api_table_excludes_bundled_feature_helpers(self) -> None:
+    def test_api_stable_api_table_excludes_bundled_feature_helpers(self) -> None:
         runtime = blueprint_js_source()
-        manual = (PACKAGE_ROOT / "doc" / "MANUAL.md").read_text(encoding="utf-8")
+        api_doc = API_DOC.read_text(encoding="utf-8")
 
-        documented_methods = manual_stable_api_methods(manual)
+        documented_methods = documented_stable_api_methods(api_doc)
         helper_methods = js_object_methods(runtime, "bundledFeatureRenderHelpers")
 
         self.assertFalse(documented_methods & helper_methods)
 
-    def test_manual_bundled_helper_table_matches_runtime_source(self) -> None:
+    def test_api_bundled_helper_table_matches_runtime_source(self) -> None:
         runtime = blueprint_js_source()
-        manual = (PACKAGE_ROOT / "doc" / "MANUAL.md").read_text(encoding="utf-8")
+        api_doc = API_DOC.read_text(encoding="utf-8")
 
         helper_methods = js_object_methods(runtime, "bundledFeatureRenderHelpers")
-        documented_methods = manual_bundled_helper_methods(manual)
+        documented_methods = documented_bundled_helper_methods(api_doc)
 
         self.assertEqual(documented_methods, helper_methods)
 

--- a/tests/harness/test_preview_runtime_api_docs.py
+++ b/tests/harness/test_preview_runtime_api_docs.py
@@ -8,6 +8,8 @@ from tests.preview_runtime_api import (
     RUNTIME_BOOTSTRAP_JS,
     blueprint_js_files,
     blueprint_js_source,
+    esm_named_exports,
+    js_object_keys,
     js_object_methods,
     manual_bundled_helper_methods,
     manual_stable_api_methods,
@@ -31,6 +33,15 @@ INTERNAL_ONLY_HELPERS = {
     "renderHtmlInto",
     "resetPanelPosition",
     "shouldKeepOpen",
+}
+PREVIEW_ESM_EXTRA_EXPORTS = {
+    "currentRenderApi",
+    "getRenderApi",
+    "normalizeGraphData",
+    "onRenderReady",
+    "ready",
+    "render",
+    "version",
 }
 
 
@@ -71,6 +82,22 @@ class PreviewRuntimeApiDocsTests(unittest.TestCase):
         helper_methods = js_object_methods(runtime, "bundledFeatureRenderHelpers")
 
         self.assertFalse(source_methods & helper_methods)
+
+    def test_preview_esm_exports_stable_custom_client_api(self) -> None:
+        runtime = blueprint_js_source()
+        source = (BLUEPRINT_SRC / "blueprint-preview-api.mjs").read_text(encoding="utf-8")
+
+        stable_methods = js_object_methods(runtime, "stableCustomClientApi")
+        named_exports = esm_named_exports(source)
+        default_methods = js_object_keys(source, "previewApi")
+        helper_methods = js_object_methods(runtime, "bundledFeatureRenderHelpers")
+
+        self.assertLessEqual(stable_methods, named_exports)
+        self.assertLessEqual(stable_methods, default_methods)
+        self.assertEqual(named_exports, stable_methods | PREVIEW_ESM_EXTRA_EXPORTS)
+        self.assertEqual(default_methods, stable_methods | PREVIEW_ESM_EXTRA_EXPORTS)
+        self.assertFalse(named_exports & helper_methods)
+        self.assertFalse(default_methods & helper_methods)
 
     def test_internal_runtime_helpers_are_not_exported(self) -> None:
         runtime = blueprint_js_source()

--- a/tests/harness/test_preview_runtime_api_docs.py
+++ b/tests/harness/test_preview_runtime_api_docs.py
@@ -43,6 +43,30 @@ PREVIEW_ESM_EXTRA_EXPORTS = {
     "ready",
     "version",
 }
+GRAPH_CORE_HELPERS = {
+    "dataUrl",
+    "graphCanvasFor",
+    "readGraphJsonScript",
+    "graphFallbackVariants",
+    "normalizeGraphData",
+    "graphsFromManifest",
+    "getGraphData",
+    "getGraphVariants",
+    "loadJson",
+    "loadManifestGraphs",
+    "loadGraphs",
+}
+GRAPH_CORE_IMPLEMENTATION_HELPERS = {
+    "dataUrl",
+    "graphCanvasFor",
+    "readGraphJsonScript",
+    "graphFallbackVariants",
+    "normalizeGraphData",
+    "graphsFromManifest",
+    "getGraphData",
+    "getGraphVariants",
+    "loadJson",
+}
 
 
 class PreviewRuntimeApiDocsTests(unittest.TestCase):
@@ -154,6 +178,21 @@ class PreviewRuntimeApiDocsTests(unittest.TestCase):
 
         self.assertEqual([], direct_runtime_reads)
         self.assertEqual([], missing_ready_callbacks)
+
+    def test_graph_helpers_are_owned_by_graph_core(self) -> None:
+        core = (BLUEPRINT_SRC / "blueprint-graph-core.js").read_text(encoding="utf-8")
+        graph_esm = (BLUEPRINT_SRC / "blueprint-graph-api.mjs").read_text(encoding="utf-8")
+        runtime = (BLUEPRINT_SRC / "Commands" / "preview-runtime.js").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn('import "./blueprint-graph-core.js";', graph_esm)
+        self.assertIn("callBlueprintGraphApi", runtime)
+        for helper in GRAPH_CORE_HELPERS:
+            self.assertIn(f"function {helper}", core)
+            self.assertNotIn(f"function {helper}", graph_esm)
+        for helper in GRAPH_CORE_IMPLEMENTATION_HELPERS:
+            self.assertNotIn(f"function {helper}", runtime)
 
 
 if __name__ == "__main__":

--- a/tests/preview_runtime_api.py
+++ b/tests/preview_runtime_api.py
@@ -81,7 +81,7 @@ def runtime_api_methods(name: str) -> list[str]:
     return sorted(js_object_methods(blueprint_js_source(), name))
 
 
-def manual_stable_api_methods(source: str) -> set[str]:
+def documented_stable_api_methods(source: str) -> set[str]:
     start_marker = "Stable custom-client entrypoints:"
     end_marker = "Blueprint's bundled graph"
     start = source.index(start_marker) + len(start_marker)
@@ -90,7 +90,7 @@ def manual_stable_api_methods(source: str) -> set[str]:
     return set(re.findall(r"`api\.([A-Za-z][A-Za-z0-9_]*)\(", section))
 
 
-def manual_bundled_helper_methods(source: str) -> set[str]:
+def documented_bundled_helper_methods(source: str) -> set[str]:
     start_marker = "| Helper family | Helpers | Bundled consumers |"
     end_marker = "For new custom interfaces"
     start = source.index(start_marker)

--- a/tests/preview_runtime_api.py
+++ b/tests/preview_runtime_api.py
@@ -46,6 +46,37 @@ def js_object_methods(source: str, name: str) -> set[str]:
     return set(re.findall(r"^\s+([A-Za-z][A-Za-z0-9_]*):", body, flags=re.MULTILINE))
 
 
+def js_object_keys(source: str, name: str) -> set[str]:
+    body = find_balanced_js_object_body(source, name)
+    return set(
+        re.findall(
+            r"^\s+([A-Za-z][A-Za-z0-9_]*)(?=\s*(?::|,|$))",
+            body,
+            flags=re.MULTILINE,
+        )
+    )
+
+
+def esm_named_exports(source: str) -> set[str]:
+    exports = set(
+        re.findall(
+            r"^export\s+(?:async\s+)?(?:function|const|let|var|class)\s+([A-Za-z][A-Za-z0-9_]*)",
+            source,
+            flags=re.MULTILINE,
+        )
+    )
+    for body in re.findall(r"^export\s*{\s*([^}]+)\s*};", source, flags=re.MULTILINE):
+        for raw_name in body.split(","):
+            name = raw_name.strip()
+            if not name:
+                continue
+            if " as " in name:
+                name = name.rsplit(" as ", 1)[1].strip()
+            if re.fullmatch(r"[A-Za-z][A-Za-z0-9_]*", name):
+                exports.add(name)
+    return exports
+
+
 def runtime_api_methods(name: str) -> list[str]:
     return sorted(js_object_methods(blueprint_js_source(), name))
 

--- a/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/CustomRenderClient.lean
+++ b/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/CustomRenderClient.lean
@@ -238,6 +238,107 @@ private def graphDataExample : Verso.Output.Html :=
        ("data-bp-graph-ok", "false") ]
     (Verso.Output.Html.seq #[titleNode, noteNode, summaryNode, nodeList])
 
+private def previewModuleExample : Verso.Output.Html :=
+  let titleNode :=
+    clientTag "h3" #[("data-bp-custom-client-title", "true")] (clientText "Preview ESM import")
+  let noteNode :=
+    clientTag "p" #[("class", "bp_custom_render_client_note")]
+      (clientText "ESM access with renderPreviewInto from blueprint-preview-api.mjs.")
+  let summaryNode :=
+    clientTag "div"
+      #[("class", "bp_custom_render_client_summary"), ("data-bp-preview-module-summary", "true")]
+      (clientText "Waiting for preview module.")
+  let bodyNode :=
+    clientTag "div"
+      #[("class", "bp_custom_render_client_body"), ("data-bp-preview-module-body", "true")]
+      .empty
+  clientTag "article"
+    #[ ("class", "bp_custom_render_client_example"),
+       ("data-bp-preview-module-example", "true"),
+       ("data-bp-preview-module-ok", "false") ]
+    (Verso.Output.Html.seq #[titleNode, noteNode, summaryNode, bodyNode])
+
+private def previewModuleExampleScript : Verso.Output.Html :=
+  clientTag "script" #[("type", "module")] <| Verso.Output.Html.text false r##"
+// Import the generated preview/render ESM API.
+import {
+  getRenderApi,
+  loadManifest,
+  previewKey,
+  renderPreviewInto,
+  resolvePreview
+} from "../-verso-data/blueprint-preview-api.mjs";
+
+// Find the showcase card that will display this module-based result.
+const card = document.querySelector("[data-bp-preview-module-example]");
+if (card) {
+  // Locate the text summary and preview body targets inside the card.
+  const summary = card.querySelector("[data-bp-preview-module-summary]");
+  const body = card.querySelector("[data-bp-preview-module-body]");
+  try {
+    // Build the manifest/cache key for the statement facet.
+    const key = previewKey("preview_facets", "statement");
+
+    // Load the generated preview manifest through the shared runtime cache.
+    const manifest = await loadManifest();
+
+    // Resolve semantic manifest data and cached HTML for the key.
+    const resolved = await resolvePreview(key);
+
+    // Render the preview body fragment into the body target.
+    if (body) await renderPreviewInto(body, key);
+
+    // Read the shared runtime API to prove the module and runtime are connected.
+    const api = await getRenderApi();
+
+    // Store test-visible attributes that describe what the module resolved.
+    card.dataset.bpPreviewModuleOk = resolved.ok ? "true" : "false";
+    card.dataset.bpPreviewModuleKey = resolved.key || "";
+    card.dataset.bpPreviewModuleTitle =
+      resolved.manifestEntry && resolved.manifestEntry.title ? resolved.manifestEntry.title : "";
+    card.dataset.bpPreviewModuleEntryCount =
+      manifest instanceof Map ? String(manifest.size) : "0";
+    card.dataset.bpPreviewModuleRenderApi =
+      api && typeof api.renderPreviewInto === "function" ? "true" : "false";
+
+    // Update the visible status text for humans inspecting the fixture.
+    if (summary) summary.textContent = resolved.ok ? "Rendered through ESM" : resolved.reason;
+  } catch (err) {
+    // Preserve any import/load/render error for the browser regression test.
+    card.dataset.bpPreviewModuleOk = "false";
+    card.dataset.bpPreviewModuleError = err && err.message ? err.message : String(err);
+    if (summary) summary.textContent = "Preview module error";
+  }
+}
+"##
+
+private def graphModuleExampleScript : Verso.Output.Html :=
+  clientTag "script" #[("type", "module")] <| Verso.Output.Html.text false r##"
+// Import the generated graph-data ESM API.
+import { loadGraphs } from "../-verso-data/blueprint-graph-api.mjs";
+
+// Find the showcase card that already displays graph manifest data.
+const card = document.querySelector("[data-bp-custom-client-graph]");
+if (card) {
+  try {
+    // Load every finalized graph record from blueprint-manifest.json.graphs.
+    const graphs = await loadGraphs();
+
+    // Use the first graph in this small fixture.
+    const graph = graphs[0] || null;
+
+    // Store test-visible attributes that prove the ESM module loaded data.
+    card.dataset.bpGraphModuleOk = graph ? "true" : "false";
+    card.dataset.bpGraphModuleCount = String(graphs.length);
+    card.dataset.bpGraphModuleKey = graph && graph.key ? graph.key : "";
+  } catch (err) {
+    // Preserve any import/load error for the browser regression test.
+    card.dataset.bpGraphModuleOk = "false";
+    card.dataset.bpGraphModuleError = err && err.message ? err.message : String(err);
+  }
+}
+"##
+
 def customRenderClientHtml : Verso.Output.Html :=
   let heading := clientTag "h2" #[] (clientText "Standalone Render Client")
   let status :=
@@ -277,14 +378,17 @@ def customRenderClientHtml : Verso.Output.Html :=
           "missing"
           "An expected miss that demonstrates the runtime diagnostic branch for custom clients."
           false,
+        previewModuleExample,
         graphDataExample
       ])
-  clientTag "section"
-    #[ ("class", "bp_custom_render_client"),
-       ("id", "custom-render-client-example"),
-       ("data-bp-custom-render-client", "true"),
-       ("data-bp-custom-client-status", "idle") ]
-    (Verso.Output.Html.seq #[header, examples])
+  let sectionBlock :=
+    clientTag "section"
+      #[ ("class", "bp_custom_render_client"),
+         ("id", "custom-render-client-example"),
+         ("data-bp-custom-render-client", "true"),
+         ("data-bp-custom-client-status", "idle") ]
+      (Verso.Output.Html.seq #[header, examples])
+  Verso.Output.Html.seq #[sectionBlock, previewModuleExampleScript, graphModuleExampleScript]
 
 open Verso Doc Elab Genre Manual in
 block_extension Block.customRenderClientExample where

--- a/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/CustomRenderClient.lean
+++ b/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/CustomRenderClient.lean
@@ -243,7 +243,7 @@ private def previewModuleExample : Verso.Output.Html :=
     clientTag "h3" #[("data-bp-custom-client-title", "true")] (clientText "Preview ESM import")
   let noteNode :=
     clientTag "p" #[("class", "bp_custom_render_client_note")]
-      (clientText "ESM access with renderPreviewInto from blueprint-preview-api.mjs.")
+      (clientText "ESM access with renderPreviewInto from -verso-data/api/preview.mjs.")
   let summaryNode :=
     clientTag "div"
       #[("class", "bp_custom_render_client_summary"), ("data-bp-preview-module-summary", "true")]
@@ -267,7 +267,7 @@ import {
   previewKey,
   renderPreviewInto,
   resolvePreview
-} from "../-verso-data/blueprint-preview-api.mjs";
+} from "../-verso-data/api/preview.mjs";
 
 // Find the showcase card that will display this module-based result.
 const card = document.querySelector("[data-bp-preview-module-example]");
@@ -315,7 +315,7 @@ if (card) {
 private def graphModuleExampleScript : Verso.Output.Html :=
   clientTag "script" #[("type", "module")] <| Verso.Output.Html.text false r##"
 // Import the generated graph-data ESM API.
-import { loadGraphs } from "../-verso-data/blueprint-graph-api.mjs";
+import { loadGraphs } from "../-verso-data/api/graph.mjs";
 
 // Find the showcase card that already displays graph manifest data.
 const card = document.querySelector("[data-bp-custom-client-graph]");


### PR DESCRIPTION
This PR exposes generated Blueprint browser APIs as importable ESM modules under `-verso-data/api/` and documents the stable Lean, generated-data, graph, and browser integration contracts in `doc/API.md`. It keeps compatibility module files under `-verso-data/blueprint-*.mjs`, plus the existing `window.VersoBlueprint` and `window.bpGraphApi` entrypoints, while giving custom browser clients regular module imports for preview rendering and graph data helpers.

The browser graph helper implementation is now shared through generated `blueprint-graph-core.js`; both the classic runtime and ESM wrappers delegate to that core so graph canvas lookup, embedded JSON parsing, URL resolution, and manifest graph loading do not drift.

Backport PR: #157
Backport v4.30.0: exempt: paired backport #157 has v4.30-specific harness inventory conflict resolution, manually validated with no intentional behavior delta