### PR TITLE
[backport v4.30.0] refactor: centralize Blueprint render presentation

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -518,7 +518,7 @@ callbacks, or generated preview code still need them directly.
 | Helper family | Helpers | Bundled consumers |
 | --- | --- | --- |
 | Template lifecycle | `collectPreviewTemplates` | Graph-local preview stores; summary and code-summary previews use Lean-emitted DOM descriptors that the runtime auto-binds |
-| Surface, shell, and content | `createPreviewSurface`, `createPreviewPanel`, `previewMessageHtml`, `escapeHtml` | Graph preview panels, inline preview panels, relation panels, and runtime diagnostics |
+| Surface, shell, and content | `createPreviewSurface`, `createPreviewPanel`, `renderPreviewIntoSurface`, `previewMessageHtml`, `escapeHtml` | Graph preview panels, inline preview panels, relation panels, and runtime diagnostics |
 | Behavior, positioning, and dismissal | `bindAnchoredPopover`, `hidePreviewSurfaces` | Graph popovers, slide-change cleanup, and feature-specific positioning callbacks |
 | Hydration and debug hooks | `registerPreviewHydrator`, `previewDebug`, `previewDebugLabel` | Bundled previews that need feature-specific post-render binding or local runtime diagnostics |
 
@@ -531,10 +531,13 @@ not need feature-specific startup scripts.
 preview panels. It groups a panel's slots, current behavior, content/header
 updates, close-button wiring, trigger binding, dismissal binding, reposition
 binding, pointer checks, and keep-open checks into one controller object.
-Bundled feature scripts should prefer `surface.bindTriggers`,
-`surface.bindDismissal`, `surface.bindRepositioner`, `surface.position`,
-`surface.pointerWithin`, and `surface.shouldKeepOpen` over direct lifecycle
-helpers. External clients should stay on the stable custom-client API above.
+`renderPreviewIntoSurface` layers shared preview lookup, diagnostics, loading
+content, stale-request checks, and rendered-fragment insertion on top of that
+surface controller. Bundled feature scripts should prefer
+`surface.bindTriggers`, `surface.bindDismissal`, `surface.bindRepositioner`,
+`surface.position`, `surface.pointerWithin`, `surface.shouldKeepOpen`, and
+`renderPreviewIntoSurface` over direct lifecycle and cache-resolution helpers.
+External clients should stay on the stable custom-client API above.
 
 For new custom interfaces, prefer the highest-level entry point that fits the
 job; see [Choosing an API](#choosing-an-api).

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -106,6 +106,14 @@ Per-command CSS overlays stay with their commands:
 - `Commands/summary.css`
 - `Commands/bibliography.css`
 
+Browser asset composition is intentionally separate from physical emission.
+`Informal.Commands.BlueprintAssetBundle` in `Commands/Common.lean` records the
+ordered CSS and JavaScript fragments needed by a Blueprint feature. Manual pages
+consume those bundles as inline Verso `HtmlAssets`; Slides consume the same
+logical bundles when building their standalone composite slide files. The Python
+`EMBEDDED_ASSET_OWNERS` inventory remains rebuild metadata for `include_str`
+owner modules, not the semantic source of asset ordering.
+
 ## Rendering Clients
 
 The same Blueprint object data is consumed in three broad ways:
@@ -317,7 +325,8 @@ hydration.
 | Relation panel/chip markup and relation-row badges | `Informal.RelatedPanel.renderPanel` | normal Manual nodes and manifest/cache-backed nodes through `PreviewManifest.BlockRender` | single Lean owner |
 | Relation panel browser activation, loading/error replacement, and cache lookup | `Informal/Block/relation-panel.js` configured with `Commands/preview-runtime.js` `createPreviewSurface` trigger and dismissal binding | relation panels emitted by normal, grafted, Slides, and custom generated nodes | single JS owner for feature behavior; panel slots plus trigger/dismiss lifetime are shared through the surface, and relation-panel JS reuses the Lean-rendered loading body and only owns runtime error diagnostics |
 | Code-summary trigger, template, and preview panel shell | `Informal.HoverRender.templatePreviewRoot`, configured by `Informal.CodeSummary.renderCodeSummaryPreview` | heading code badges and code-panel indicators | shared wrapper helper, code-summary-specific selectors |
-| Code-summary semantics, declaration rows, status marks, and indicators | `Informal.CodeSummary` | node heading code extra and code-panel summary indicator | single semantic owner |
+| Declaration-level Lean status labels, classes, and symbols | `Informal.Data.ProvedStatus.presentation` | code-summary declaration rows, summary detail rows, heading status marks, heading code-entry icons, external-code rows/footers, rendered external declaration header badges | single presentation owner for declaration status; renderers still own their surrounding HTML |
+| Code-summary semantics, declaration rows, status marks, and indicators | `Informal.CodeSummary` using `ProvedStatus.presentation` for declaration-status vocabulary | node heading code extra and code-panel summary indicator | single code-summary owner; declaration status presentation is delegated to `ProvedStatus` |
 | Companion Lean/external-code panel shell | `Informal.mkCodePanel` | inline Lean panels, external declaration panels, Rust panels, manifest/cache-backed code panels | single panel-shell owner |
 | External declaration rows and rendered declaration body strategy | `Informal.ExternalCode.renderExternalDeclRowsWith` | external-code panels and HTML-cache-backed Lean-code previews | shared row/status/footer owner with page-hover and self-contained body strategies |
 | Manifest/cache-backed block shell assembly | `Informal.PreviewManifest.BlockRender.renderWithRenderedContent` | Slides, grafts, and custom generated consumers | single manifest-backed assembly owner; callers only supply config and content |
@@ -608,6 +617,8 @@ pre-emit boundary as the asset normalization.
 The current policy is:
 
 - semantic completion remains driven by `ProvedStatus`
+- declaration-level status labels, classes, and symbols come from
+  `ProvedStatus.presentation`
 - external render failures surface as local UI warnings
 - optional summary diagnostics can expose those failures for maintainers
 - coverage buckets and completion counts remain semantic rather than
@@ -874,8 +885,9 @@ the node fill.
 
 These are the current architectural fault lines that still deserve care:
 
-1. status semantics can still drift between local block rendering and global
-   outputs
+1. aggregate graph/summary status buckets still need care when new completion
+   states are added, even though declaration-level labels/classes now share
+   `ProvedStatus.presentation`
 2. preview retrieval still has multiple internal representations and adapters
 3. external hover and panel rendering still share concepts that are not fully
    unified in one view model

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -163,7 +163,9 @@ generated HTML or browser tests:
 The tracked owner inventory lives in `EMBEDDED_ASSET_OWNER_PATHS` in
 `scripts/blueprint_harness_utils.py`. When adding a new `include_str` browser
 asset, add it to that inventory and cover the mapping in the harness tests so
-artifact generation rebuilds the right Lean owner.
+artifact generation rebuilds the right Lean owner. Keep semantic asset ordering
+in the Lean `BlueprintAssetBundle` definitions; the Python inventory is only
+rebuild metadata.
 
 ### Generate Review Artifacts
 

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -75,9 +75,11 @@ Work:
    traversal indexes as rendered-site projections; consolidate only if the
    replacement keeps numbering, hrefs, preview ids, and HTML-cache keys
    phase-safe
-3. define a shared status record derived from `Data.Node` plus external
-   declaration checks, and route graph, summary, and local block badges through
-   it
+3. extend the centralized declaration-level presentation in
+   `ProvedStatus.presentation` into a broader node-health record derived from
+   `Data.Node` plus external declaration checks; declaration rows, summary
+   detail rows, heading marks, code-entry icons, and external-code rows already
+   share the declaration-status vocabulary
 4. encode the intended ownership rules for `CodeRef.external`, especially the
    difference between Blueprint-owned labels and Lean-owned declaration names
 5. decide whether richer group metadata belongs in the core data model, then

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -30,6 +30,7 @@ lean_lib VersoBlueprintTests where
   srcDir := "tests"
   roots := #[
     `VersoBlueprintTests.Blueprint.Support,
+    `VersoBlueprintTests.BlueprintAssets,
     `VersoBlueprintTests.BlueprintAutoDeps,
     `VersoBlueprintTests.BlueprintAttribute,
     `VersoBlueprintTests.BlueprintCodeRenderMatrix,

--- a/src/VersoBlueprint/Cite.lean
+++ b/src/VersoBlueprint/Cite.lean
@@ -24,6 +24,9 @@ namespace Informal.Cite
 
 open Verso.Genre.Manual.Bibliography
 
+def citeAssetBundle : Informal.Commands.BlueprintAssetBundle :=
+  Informal.Commands.inlinePreviewAssetBundle
+
 syntax (name := bib) "bib" ppSpace str : attr
 
 private def parseNameOrSimple (s : String) : Name :=
@@ -514,8 +517,8 @@ inline_extension Inline.bpCite (citations : List CiteItem) (style : CitationStyl
             })
         | Option.none => st
     pure none
-  extraCss := Informal.Commands.withInlinePreviewCssAssets
-  extraJs := Informal.Commands.withInlinePreviewJsAssets [] []
+  extraCss := citeAssetBundle.css
+  extraJs := citeAssetBundle.js
   toTeX :=
     open Verso.Output.TeX in
     some <| fun go _id data content => do

--- a/src/VersoBlueprint/Commands/Bibliography.lean
+++ b/src/VersoBlueprint/Commands/Bibliography.lean
@@ -30,6 +30,9 @@ deriving FromJson, ToJson
 
 def bibliographyCss := include_str "bibliography.css"
 
+def bibliographyAssetBundle : BlueprintAssetBundle :=
+  inlinePreviewAssetBundle (cssExtras := [bibliographyCss]) (jsBefore := [openTargetDetailsJs])
+
 open Verso Doc Elab Genre Manual in
 block_extension Block.bibliography (biblio : BibliographyData) where
   data := toJson biblio
@@ -134,8 +137,8 @@ block_extension Block.bibliography (biblio : BibliographyData) where
           </details>
         </div>
       }}
-  extraCss := Informal.Commands.withInlinePreviewCssAssets [bibliographyCss]
-  extraJs := Informal.Commands.withInlinePreviewJsAssets [openTargetDetailsJs] []
+  extraCss := bibliographyAssetBundle.css
+  extraJs := bibliographyAssetBundle.js
 
 open Verso Doc Elab Syntax in
 def mkBibliographyPart (stx : Syntax) (endPos : String.Pos.Raw) : PartElabM FinishedPart := do

--- a/src/VersoBlueprint/Commands/Common.lean
+++ b/src/VersoBlueprint/Commands/Common.lean
@@ -375,28 +375,69 @@ def withPreviewClientReadyJs (js : String) : String :=
 -- Keep this module rebuilt when the embedded inline preview runtime changes.
 def inlineLinkPreviewJs : String := withPreviewClientReadyJs (include_str "inline-preview.js")
 
-def withBlueprintCssAssets (extras : List String := []) : List String :=
-  [blueprintTokensCss] ++ extras
+/--
+Logical Blueprint browser assets before choosing a physical output mode.
 
-def withPreviewPanelCssAssets (extras : List String := []) : List String :=
-  withBlueprintCssAssets ([previewPanelCss] ++ extras)
+Manual renderers currently inline these lists through Verso `HtmlAssets`; Slides
+turn selected bundles into named files. Keeping composition here lets both paths
+share ordering and dependencies while preserving their existing emitters.
+-/
+structure BlueprintAssetBundle where
+  css : List String := []
+  js : List String := []
+deriving Inhabited
 
-def withInlinePreviewCssAssets (extras : List String := []) : List String :=
-  withBlueprintCssAssets (extras ++ [previewHeaderCss, inlinePreviewCss])
+namespace BlueprintAssetBundle
 
-def withPreviewPanelInlinePreviewCssAssets (extras : List String := []) : List String :=
-  withPreviewPanelCssAssets (extras ++ [previewHeaderCss, inlinePreviewCss])
+def append (left right : BlueprintAssetBundle) : BlueprintAssetBundle :=
+  { css := left.css ++ right.css
+    js := left.js ++ right.js }
 
-def previewRuntimeJsAssets : List String :=
-  [previewHoverUtilsJs]
+def withCss (assets : BlueprintAssetBundle) (extras : List String) : BlueprintAssetBundle :=
+  { assets with css := assets.css ++ extras }
 
-def inlinePreviewJsAssets : List String :=
-  previewRuntimeJsAssets ++ [inlineLinkPreviewJs]
+def withJs (assets : BlueprintAssetBundle) (before after : List String) : BlueprintAssetBundle :=
+  { assets with js := before ++ assets.js ++ after }
 
-def withPreviewRuntimeJsAssets (before : List String) (after : List String) : List String :=
-  before ++ previewRuntimeJsAssets ++ after
+end BlueprintAssetBundle
 
-def withInlinePreviewJsAssets (before : List String) (after : List String) : List String :=
-  before ++ inlinePreviewJsAssets ++ after
+def blueprintCssAssetBundle (extras : List String := []) : BlueprintAssetBundle :=
+  ({ css := [blueprintTokensCss] } : BlueprintAssetBundle).withCss extras
+
+def previewPanelCssAssetBundle (extras : List String := []) : BlueprintAssetBundle :=
+  (blueprintCssAssetBundle [previewPanelCss]).withCss extras
+
+def inlinePreviewCssAssetBundle (extras : List String := []) : BlueprintAssetBundle :=
+  (blueprintCssAssetBundle extras).withCss [previewHeaderCss, inlinePreviewCss]
+
+def previewPanelInlinePreviewCssAssetBundle (extras : List String := []) : BlueprintAssetBundle :=
+  (previewPanelCssAssetBundle extras).withCss [previewHeaderCss, inlinePreviewCss]
+
+def previewRuntimeJsAssetBundle : BlueprintAssetBundle :=
+  { js := [previewHoverUtilsJs] }
+
+def inlinePreviewJsAssetBundle : BlueprintAssetBundle :=
+  { js := previewRuntimeJsAssetBundle.js ++ [inlineLinkPreviewJs] }
+
+def previewPanelAssetBundle
+    (cssExtras : List String := [])
+    (jsBefore : List String := [])
+    (jsAfter : List String := []) : BlueprintAssetBundle :=
+  (previewPanelCssAssetBundle cssExtras).append
+    (previewRuntimeJsAssetBundle.withJs jsBefore jsAfter)
+
+def inlinePreviewAssetBundle
+    (cssExtras : List String := [])
+    (jsBefore : List String := [])
+    (jsAfter : List String := []) : BlueprintAssetBundle :=
+  (inlinePreviewCssAssetBundle cssExtras).append
+    (inlinePreviewJsAssetBundle.withJs jsBefore jsAfter)
+
+def previewPanelInlinePreviewAssetBundle
+    (cssExtras : List String := [])
+    (jsBefore : List String := [])
+    (jsAfter : List String := []) : BlueprintAssetBundle :=
+  (previewPanelInlinePreviewCssAssetBundle cssExtras).append
+    (inlinePreviewJsAssetBundle.withJs jsBefore jsAfter)
 
 end Informal.Commands

--- a/src/VersoBlueprint/Commands/Graph.lean
+++ b/src/VersoBlueprint/Commands/Graph.lean
@@ -78,7 +78,9 @@ def fallbackGraphControlId (id : Verso.Multi.InternalId) (suffix : String) : Str
 -- plus user-controlled resize persistence and cheap height resets.
 def loadD3Dot := withPreviewClientReadyJs (include_str "graph.js")
 
--- block_extension Block.dependency_graph (label : String) where
+def graphAssetBundle : BlueprintAssetBundle :=
+  previewPanelAssetBundle (cssExtras := [graphCss]) (jsAfter := [loadD3Dot])
+
 open Verso Doc Elab Genre Manual in
 block_extension Block.graph (graphData : GraphBlockData) where
   -- for TOC
@@ -336,8 +338,8 @@ block_extension Block.graph (graphData : GraphBlockData) where
           {{groupHoverPanel}}
         </div>
       }}
-  extraCss := withPreviewPanelCssAssets [graphCss]
-  extraJs := withPreviewRuntimeJsAssets [] [loadD3Dot]
+  extraCss := graphAssetBundle.css
+  extraJs := graphAssetBundle.js
 
 def buildAll : CoreM Informal.Graph.GraphData := do
   reportImportedConflicts

--- a/src/VersoBlueprint/Commands/Summary.lean
+++ b/src/VersoBlueprint/Commands/Summary.lean
@@ -798,6 +798,9 @@ private def Summary.previewLabels (data : Summary) : Array Name :=
 -- Keep this binding in Lean so summary CSS edits ride along with command module rebuilds.
 def summaryCss := include_str "summary.css"
 
+def summaryAssetBundle : BlueprintAssetBundle :=
+  previewPanelInlinePreviewAssetBundle (cssExtras := [summaryCss]) (jsBefore := [openTargetDetailsJs])
+
 open Verso Doc Html Genre Manual
 open Verso.Output.Html
 open Verso.Multi (AllRemotes)
@@ -862,8 +865,30 @@ private def SummaryHtmlContext.declItems (ctx : SummaryHtmlContext) (label : Nam
     let declNode := summaryRenderLeanDeclLink decl {{<code>s!"{decl}"</code>}} (ctx.declHref? label decl)
     {{ <li>{{declNode}}</li> }}
 
-private def summaryBadge (text : String) (className : String := "bp_summary_badge") : Output.Html :=
+private def summaryBadgeClass : String := "bp_summary_badge"
+
+private def summaryBadgeWarnClass : String :=
+  s!"{summaryBadgeClass} bp_summary_badge_warn"
+
+private def summaryBadgeErrorClass : String :=
+  s!"{summaryBadgeClass} bp_summary_badge_error"
+
+private def summaryBadge (text : String) (className : String := summaryBadgeClass) : Output.Html :=
   {{ <span class={{className}}>s!"{text}"</span> }}
+
+private def summaryWarnBadge (text : String) : Output.Html :=
+  summaryBadge text summaryBadgeWarnClass
+
+private def summaryErrorBadge (text : String) : Output.Html :=
+  summaryBadge text summaryBadgeErrorClass
+
+private def summaryBadgeClassForStatus (status : Data.ProvedStatus) : String :=
+  if status.isMissing then
+    summaryBadgeErrorClass
+  else if status.isIncomplete then
+    summaryBadgeWarnClass
+  else
+    summaryBadgeClass
 
 private def summaryBadgeRow (badges : Array Output.Html) : Output.Html :=
   if badges.isEmpty then
@@ -873,11 +898,10 @@ private def summaryBadgeRow (badges : Array Output.Html) : Output.Html :=
 
 private def summaryMetadataBadges (metadata : MetadataPresentation) : Array Output.Html :=
   metadata.summaryBadgeSpecs.map fun badge =>
-    summaryBadge badge.text <|
-      if badge.warning then
-        "bp_summary_badge bp_summary_badge_warn"
-      else
-        "bp_summary_badge"
+    if badge.warning then
+      summaryWarnBadge badge.text
+    else
+      summaryBadge badge.text
 
 private def summaryMetadataActionLinks (metadata : MetadataPresentation) : Array Output.Html :=
   metadata.summaryActionLinks.map fun action =>
@@ -889,8 +913,13 @@ private def summaryActionLinksRow (actionLinks : Array Output.Html) : Output.Htm
   else
     {{<div class="bp_summary_item_actions">"Links: " {{(actionLinks.toList.intersperse {{<span class="bp_summary_sep">" | "</span>}}).toArray}}</div>}}
 
+private def summaryCardClass : String := "bp_summary_card"
+
+private def summaryCardWarnClass : String :=
+  s!"{summaryCardClass} bp_summary_card_warn"
+
 private def summaryCard (label value : String) (status? : Option String := Option.none)
-    (className : String := "bp_summary_card") : Output.Html :=
+    (className : String := summaryCardClass) : Output.Html :=
   let statusNode : Output.Html :=
     match status? with
     | Option.some status => {{<span class="bp_summary_status">{{.text true status}}</span>}}
@@ -902,7 +931,7 @@ private def summaryCard (label value : String) (status? : Option String := Optio
     </div> }}
 
 private def summaryOptionalCard (visible : Bool) (label value : String)
-    (status? : Option String := Option.none) (className : String := "bp_summary_card") :
+    (status? : Option String := Option.none) (className : String := summaryCardClass) :
     Output.Html :=
   if visible then
     summaryCard label value status? className
@@ -911,7 +940,7 @@ private def summaryOptionalCard (visible : Bool) (label value : String)
 
 private def summaryWarnCard (label value : String) (status? : Option String := Option.none) :
     Output.Html :=
-  summaryCard label value status? "bp_summary_card bp_summary_card_warn"
+  summaryCard label value status? summaryCardWarnClass
 
 private def summaryOptionalWarnCard (visible : Bool) (label value : String)
     (status? : Option String := Option.none) : Output.Html :=
@@ -949,6 +978,18 @@ private def summaryDetailsList (title : String) (rows : Array Output.Html)
       <ul class="bp_summary_list">
         {{rows}}
       </ul>
+    </details> }}
+
+private def summarySection (title : String) (content : Output.Html)
+    (open? : Bool := false) : Output.Html :=
+  let attrs :=
+    if open? then
+      #[("class", "bp_summary_section"), ("open", "open")]
+    else
+      #[("class", "bp_summary_section")]
+  {{ <details {{attrs}}>
+      <summary>{{.text true title}}</summary>
+      {{content}}
     </details> }}
 
 private def summaryOptionalDetailsList (visible : Bool) (title : String) (rows : Array Output.Html)
@@ -1018,24 +1059,34 @@ private def SummaryHtmlContext.sorryRow (ctx : SummaryHtmlContext) (item : Sorry
   let entryRef := ctx.entryRef item.label
   let declLink :=
     summaryRenderLeanDeclLink item.decl {{<code>s!"{item.decl}"</code>}} (ctx.declHref? item.label item.decl)
-  let statusInfo ←
+  let view := item.status.presentation
+  let declPrefix ←
     match item.status with
-    | .missing =>
-      pure ("missing", "Missing declaration: ", "bp_summary_badge bp_summary_badge_error",
-        item.status.sorryLocationText, "n/a")
-    | .axiomLike =>
-      pure ("axiom-like", "Axiom-like declaration: ", "bp_summary_badge bp_summary_badge_warn",
-        item.status.sorryLocationText, "n/a")
+    | .missing => pure "Missing declaration: "
+    | .axiomLike => pure "Axiom-like declaration: "
+    | .containsSorry _ => pure "Declaration with sorry: "
+    | .proved =>
+      Verso.reportError s!"Unexpected proved status in summary sorry details for {item.decl}"
+      pure "Declaration: "
+  let refsTxt :=
+    match item.status with
     | .containsSorry _ =>
       let (typeSorryRefs, proofSorryRefs) := item.status.sorryRefCounts
       let sorryRefs := typeSorryRefs + proofSorryRefs
-      let refsTxt := if sorryRefs > 0 then toString sorryRefs else "unknown"
-      pure ("contains sorry", "Declaration with sorry: ", "bp_summary_badge bp_summary_badge_warn",
-        item.status.sorryLocationText, refsTxt)
-    | .proved =>
-      Verso.reportError s!"Unexpected proved status in summary sorry details for {item.decl}"
-      pure ("proved", "Declaration: ", "bp_summary_badge", "proved", "0")
-  let (statusLabel, declPrefix, badgeClass, whereTxt, refsTxt) := statusInfo
+      if sorryRefs > 0 then toString sorryRefs else "unknown"
+    | .proved => "0"
+    | _ => "n/a"
+  let statusLabel :=
+    if item.status.isProved then
+      item.status.statusLabel
+    else
+      view.externalHeaderText
+  let whereTxt :=
+    if item.status.isProved then
+      item.status.statusLabel
+    else
+      item.status.sorryLocationText
+  let badgeClass := summaryBadgeClassForStatus item.status
   let body := {{
     <div class="bp_summary_item_body">
       {{.text true declPrefix}} {{declLink}} " "
@@ -1059,14 +1110,14 @@ private def SummaryHtmlContext.externalDeclNode (ctx : SummaryHtmlContext) (labe
     {{ <span> <code>s!"{written}"</code> " (resolved as " {{canonicalNode}} ")" </span> }}
 
 private def SummaryHtmlContext.externalDeclIssueRow (ctx : SummaryHtmlContext) (label : Name)
-    (kind : String) (written canonical : Name) (bodyPrefix badgeText badgeClass : String)
+    (kind : String) (written canonical : Name) (bodyPrefix : String) (badge : Output.Html)
     (actions : Output.Html := .empty) : Output.Html :=
   let entryRef := ctx.entryRef label
   let declNode := ctx.externalDeclNode label written canonical
   let body := {{
     <div class="bp_summary_item_body">
         {{.text true bodyPrefix}} {{declNode}} " "
-        <span class={{badgeClass}}>{{.text true badgeText}}</span>
+        {{badge}}
     </div>
   }}
   summaryItemShell entryRef (some (.text true s!"({kind})")) body .empty #[actions]
@@ -1074,12 +1125,12 @@ private def SummaryHtmlContext.externalDeclIssueRow (ctx : SummaryHtmlContext) (
 private def SummaryHtmlContext.missingRow (ctx : SummaryHtmlContext) (item : MissingLeanDeclItem) :
     Output.Html :=
   ctx.externalDeclIssueRow item.label item.kind item.written item.canonical
-    "Missing external Lean declaration: " "[missing declaration]" "bp_summary_badge bp_summary_badge_error"
+    "Missing external Lean declaration: " (summaryErrorBadge "[missing declaration]")
 
 private def SummaryHtmlContext.renderFailureRow (ctx : SummaryHtmlContext) (item : RenderFailureItem) :
     Output.Html :=
   ctx.externalDeclIssueRow item.label item.kind item.written item.canonical
-    "External render failed for " "[render failure]" "bp_summary_badge bp_summary_badge_warn"
+    "External render failed for " (summaryWarnBadge "[render failure]")
     (summaryItemActions {{<code>{{.text true item.message}}</code>}})
 
 private def SummaryHtmlContext.priorityRow (ctx : SummaryHtmlContext) (item : PriorityItem) :
@@ -1110,7 +1161,7 @@ private def SummaryHtmlContext.usageRow (ctx : SummaryHtmlContext) (item : Usage
   let entryRef := ctx.entryRef item.label
   let badges :=
     #[
-      summaryBadge s!"{primaryLabel}: {primaryCount}" "bp_summary_badge bp_summary_badge_warn",
+      summaryWarnBadge s!"{primaryLabel}: {primaryCount}",
       summaryBadge s!"{secondaryLabel}: {secondaryCount}",
       summaryBadge s!"direct uses: {item.directUses}",
       summaryBadge s!"downstream unlocks: {item.downstreamUses}"
@@ -1125,7 +1176,7 @@ private def SummaryHtmlContext.dependencyLoadRow (ctx : SummaryHtmlContext)
   let entryRef := ctx.entryRef item.label
   let badges :=
     #[
-      summaryBadge s!"total deps: {item.totalDeps}" "bp_summary_badge bp_summary_badge_warn",
+      summaryWarnBadge s!"total deps: {item.totalDeps}",
       summaryBadge s!"statement deps: {item.statementDeps}",
       summaryBadge s!"proof deps: {item.proofDeps}",
       summaryBadge s!"direct uses: {item.directUses}",
@@ -1139,7 +1190,7 @@ private def SummaryHtmlContext.dependencyLoadRow (ctx : SummaryHtmlContext)
 private def summaryProofDebtHotspotRow (item : DebtHotspotItem) : Output.Html :=
   let badges :=
     #[
-      summaryBadge s!"affected entries: {item.affectedEntries}" "bp_summary_badge bp_summary_badge_warn",
+      summaryWarnBadge s!"affected entries: {item.affectedEntries}",
       summaryBadge s!"incomplete decls: {item.incompleteDecls}",
       summaryBadge s!"missing decls: {item.missingDecls}",
       summaryBadge s!"total debt: {item.totalDebt}"
@@ -1155,7 +1206,7 @@ private def summaryRollupBadges (totalEntries actionableEntries quickWins linked
     Array Output.Html :=
   #[
     summaryBadge s!"entries: {totalEntries}",
-    summaryBadge s!"actionable: {actionableEntries}" "bp_summary_badge bp_summary_badge_warn",
+    summaryWarnBadge s!"actionable: {actionableEntries}",
     summaryBadge s!"quick wins: {quickWins}",
     summaryBadge s!"linked PRs: {linkedPrs}"
   ]
@@ -1174,7 +1225,7 @@ private def summaryTagRollupRow (item : TagRollupItem) : Output.Html :=
   let badges :=
     summaryRollupBadges item.totalEntries item.actionableEntries item.quickWins item.linkedPrs
   summaryItemShell
-    (summaryBadge s!"tag: {item.tag}" "bp_summary_badge bp_summary_badge_warn")
+    (summaryWarnBadge s!"tag: {item.tag}")
     Option.none
     .empty
     (summaryBadgeRow badges)
@@ -1202,7 +1253,7 @@ private def SummaryHtmlContext.groupHealthRow (ctx : SummaryHtmlContext) (item :
       summaryBadge s!"total: {item.totalEntries}",
       summaryBadge s!"closed: {item.closedEntries}",
       summaryBadge s!"local-only: {item.localOnlyEntries}",
-      summaryBadge s!"ready: {item.readyEntries}" "bp_summary_badge bp_summary_badge_warn",
+      summaryWarnBadge s!"ready: {item.readyEntries}",
       summaryBadge s!"blocked: {item.blockedEntries}",
       summaryBadge s!"incomplete Lean: {item.incompleteLeanEntries}",
       summaryBadge s!"unlock score: {item.unlockScore}"
@@ -1219,7 +1270,7 @@ private def SummaryHtmlContext.groupHealthRow (ctx : SummaryHtmlContext) (item :
     let nextRef := ctx.entryRef next.label
     let priorityBadges : Array Output.Html :=
       match next.priority with
-      | Option.some priority => #[summaryBadge s!"priority: {priority}" "bp_summary_badge bp_summary_badge_warn"]
+      | Option.some priority => #[summaryWarnBadge s!"priority: {priority}"]
       | Option.none => #[]
     summaryItemShell
       (.text true item.header)
@@ -1328,8 +1379,7 @@ private def summaryOverviewSection (data : Summary) (rows : SummaryRows) : Outpu
   let showBlockers := rows.blockerCount > 0
   let showPendingInformal := !rows.pendingInformalRows.isEmpty
   let showQuickWins := !rows.quickWinRows.isEmpty
-  {{ <details class="bp_summary_section" open>
-      <summary>"Overview"</summary>
+  summarySection "Overview" {{
       <div class="bp_summary_grid">
         {{summaryCard "Total entries" (toString data.totalEntries) (Option.some (statusCountsText data.totalStatus))}}
         {{summaryCard
@@ -1380,7 +1430,7 @@ private def summaryOverviewSection (data : Summary) (rows : SummaryRows) : Outpu
           showPendingInformal
           s!"Missing informal coverage ({data.pendingInformalEntries.length})"
           rows.pendingInformalRows}}
-    </details> }}
+    }} true
 
 private def summaryEntryIndexSection (data : Summary) (rows : SummaryRows) : Output.Html :=
   let showDefinitionCard := data.definitions > 0
@@ -1398,8 +1448,7 @@ private def summaryEntryIndexSection (data : Summary) (rows : SummaryRows) : Out
   if !(showDefinitionIndex || showTheoremLikeIndex || showAxiomIndex) then
     .empty
   else
-    {{ <details class="bp_summary_section">
-        <summary>s!"Entry index ({data.totalEntries})"</summary>
+    summarySection s!"Entry index ({data.totalEntries})" {{
         <div class="bp_summary_grid">
           {{summaryOptionalCard
               showDefinitionCard
@@ -1446,14 +1495,13 @@ private def summaryEntryIndexSection (data : Summary) (rows : SummaryRows) : Out
             s!"Axiom-like Index ({data.axiomIndex.length})"
             rows.axiomRows
             "bp_summary_subsection bp_summary_subsection_warn"}}
-      </details> }}
+      }}
 
 private def summaryDependencyInsightsSection (rows : SummaryRows) : Output.Html :=
   if rows.statementUsedRows.isEmpty && rows.proofUsedRows.isEmpty && rows.groupHealthRows.isEmpty then
     .empty
   else
-    {{ <details class="bp_summary_section">
-        <summary>"Dependency insights"</summary>
+    summarySection "Dependency insights" {{
         <div class="bp_summary_grid">
           {{summaryOptionalCard
               (!rows.statementUsedRows.isEmpty)
@@ -1486,7 +1534,7 @@ private def summaryDependencyInsightsSection (rows : SummaryRows) : Output.Html 
             s!"Group health ({rows.groupHealthRows.size})"
             rows.groupHealthRows
             "groups"}}
-      </details> }}
+      }}
 
 private def summaryMetadataSection (data : Summary) (rows : SummaryRows) : Output.Html :=
   let showQuickWins := !rows.quickWinRows.isEmpty
@@ -1499,8 +1547,7 @@ private def summaryMetadataSection (data : Summary) (rows : SummaryRows) : Outpu
   if !(showMetadataCards || showMetadataAudit) then
     .empty
   else
-    {{ <details class="bp_summary_section">
-        <summary>"Metadata"</summary>
+    summarySection "Metadata" {{
         {{if showMetadataCards then
             {{<div class="bp_summary_grid">
               {{summaryOptionalCard
@@ -1582,14 +1629,13 @@ private def summaryMetadataSection (data : Summary) (rows : SummaryRows) : Outpu
                   "bp_summary_nested"}}
             </details>}}
           else .empty}}
-      </details> }}
+      }}
 
 private def summaryDiagnosticsSection (data : Summary) (rows : SummaryRows) : Output.Html :=
   if !(data.showDebugDiagnostics && !rows.renderFailureRows.isEmpty) then
     .empty
   else
-    {{ <details class="bp_summary_section">
-        <summary>"Maintainer diagnostics"</summary>
+    summarySection "Maintainer diagnostics" {{
         <div class="bp_summary_grid">
           {{summaryWarnCard
               "Render failures"
@@ -1601,7 +1647,7 @@ private def summaryDiagnosticsSection (data : Summary) (rows : SummaryRows) : Ou
             rows.renderFailureRows
             "render-failure entries"
             "bp_summary_subsection bp_summary_subsection_warn"}}
-      </details> }}
+      }}
 
 private def summaryStructureSection (data : Summary) (rows : SummaryRows) : Output.Html :=
   let showHeaviestPrerequisites := !rows.heaviestPrerequisiteRows.isEmpty
@@ -1618,8 +1664,7 @@ private def summaryStructureSection (data : Summary) (rows : SummaryRows) : Outp
       showNoDependents || showProofDebtHotspots) then
     .empty
   else
-    {{ <details class="bp_summary_section">
-        <summary>"Structure and coverage"</summary>
+    summarySection "Structure and coverage" {{
         <div class="bp_summary_grid">
           {{summaryOptionalCard
               (data.coverageSplit.informalOnly > 0)
@@ -1668,7 +1713,7 @@ private def summaryStructureSection (data : Summary) (rows : SummaryRows) : Outp
             rows.proofDebtHotspotRows
             "proof-debt hotspots"
             "bp_summary_subsection bp_summary_subsection_warn"}}
-      </details> }}
+      }}
 
 private def summaryBlockToHtml : BlockToHtml Manual (ReaderT AllRemotes (ReaderT ExtensionImpls IO)) :=
   fun _goI _goB _id json _blocks => do
@@ -1717,8 +1762,8 @@ block_extension Block.summary (summary : Summary) where
     return none
   toTeX := none
   toHtml := some summaryBlockToHtml
-  extraCss := withPreviewPanelInlinePreviewCssAssets [summaryCss]
-  extraJs := withInlinePreviewJsAssets [openTargetDetailsJs] []
+  extraCss := summaryAssetBundle.css
+  extraJs := summaryAssetBundle.js
 
 open Verso Doc Elab Syntax in
 def mkSummaryPart (stx : Syntax) (endPos : String.Pos.Raw) : PartElabM FinishedPart := do

--- a/src/VersoBlueprint/Commands/graph.js
+++ b/src/VersoBlueprint/Commands/graph.js
@@ -131,18 +131,31 @@
     );
   }
 
-  function collectGraphData(previewUtils, root) {
-    if (!previewUtils || typeof previewUtils.getGraphData !== "function") return null;
-    return previewUtils.getGraphData(root);
+  function readPublicGraphData(previewUtils, root) {
+    if (previewUtils && typeof previewUtils.getGraphData === "function") {
+      return previewUtils.getGraphData(root);
+    }
+    const api = window.bpGraphApi;
+    if (api && typeof api.getGraphData === "function") {
+      return api.getGraphData(root);
+    }
+    return null;
   }
 
-  function collectGraphVariants(previewUtils, graphContainer) {
-    if (!previewUtils || typeof previewUtils.getGraphVariants !== "function") return [];
-    const root =
-      graphContainer && typeof graphContainer.node === "function"
-        ? graphContainer.node()
-        : graphContainer;
-    return previewUtils.getGraphVariants(root);
+  function readPublicGraphVariants(previewUtils, root) {
+    let variants = [];
+    if (previewUtils && typeof previewUtils.getGraphVariants === "function") {
+      variants = previewUtils.getGraphVariants(root);
+    } else {
+      const api = window.bpGraphApi;
+      if (api && typeof api.getGraphVariants === "function") {
+        variants = api.getGraphVariants(root);
+      }
+    }
+    if (Array.isArray(variants) && variants.length > 0) {
+      return variants;
+    }
+    return [];
   }
 
   function dotWithGraphAttribute(dot, name, value) {
@@ -551,7 +564,7 @@
         const graphContainer = d3.select(graphRoot);
         if (graphContainer.empty()) return;
         const graphState = ensureGraphBlockState(graphBlock);
-        const graphApiData = collectGraphData(previewUtils, graphBlock);
+        const graphApiData = readPublicGraphData(previewUtils, graphBlock);
         if (graphApiData) {
           graphState.graphData = graphApiData;
           graphBlock.__bpGraphData = graphApiData;
@@ -621,7 +634,7 @@
           { keepOpen: true }
         );
 
-        const rawVariants = collectGraphVariants(previewUtils, graphContainer);
+        const rawVariants = readPublicGraphVariants(previewUtils, graphBlock);
         if (!Array.isArray(rawVariants) || rawVariants.length === 0) return;
         const variantsByKey = new Map();
         rawVariants.forEach(function (variant) {

--- a/src/VersoBlueprint/Commands/preview-runtime.js
+++ b/src/VersoBlueprint/Commands/preview-runtime.js
@@ -1371,6 +1371,76 @@
     return surface;
   }
 
+  async function renderPreviewIntoSurface(surface, previewKey, options) {
+    if (!surface || typeof surface.replaceBody !== "function") {
+      throw new Error("renderPreviewIntoSurface surface must be a preview surface");
+    }
+    const opts = options && typeof options === "object" ? options : {};
+    const heading = readStringOption(
+      opts,
+      "heading",
+      surface.title instanceof Element ? (surface.title.textContent || "") : ""
+    );
+    const loadingHtml = readStringOption(opts, "loadingHtml", "");
+    const renderOptions = readObjectOption(opts, "renderOptions", {});
+    const loadingRenderOptions =
+      readObjectOption(opts, "loadingRenderOptions", { hydrate: false, renderMath: false });
+    const diagnosticRenderOptions =
+      readObjectOption(opts, "diagnosticRenderOptions", { hydrate: false, renderMath: false });
+    const shouldRender = readFunctionOption(opts, "shouldRender", null);
+    const mayRender = function () {
+      return !shouldRender || shouldRender();
+    };
+    const replaceBody = function (html, bodyRenderOptions) {
+      if (!mayRender()) return false;
+      surface.replaceBody({
+        heading: heading,
+        html: html,
+        allowEmpty: true,
+        renderOptions: bodyRenderOptions
+      });
+      return true;
+    };
+    const fallbackDiagnostic = function (optionName, fallbackDetail) {
+      const messageOptions = readObjectOption(opts, optionName, {});
+      return previewMessageHtml(Object.assign({
+        kind: "error",
+        title: "Preview unavailable",
+        detail: fallbackDetail
+      }, messageOptions));
+    };
+
+    if (loadingHtml.length > 0) {
+      replaceBody(loadingHtml, loadingRenderOptions);
+    }
+    try {
+      const result = await resolveBlueprintPreview(previewKey);
+      if (!mayRender()) return result;
+      if (!result || !result.ok) {
+        const diagnosticHtml = result && typeof result.diagnosticHtml === "string"
+          ? result.diagnosticHtml
+          : "";
+        replaceBody(
+          diagnosticHtml ||
+            fallbackDiagnostic("fallbackDiagnostic", "The preview cache content could not be loaded."),
+          diagnosticRenderOptions
+        );
+        return result;
+      }
+      replaceBody(result.html, renderOptions);
+      return result;
+    } catch (_err) {
+      replaceBody(
+        fallbackDiagnostic(
+          "exceptionDiagnostic",
+          "The preview cache content could not be loaded. Refresh the page, or rebuild the site if this persists."
+        ),
+        diagnosticRenderOptions
+      );
+      return null;
+    }
+  }
+
   function bindPreviewTriggers(options) {
     const opts = options && typeof options === "object" ? options : {};
     const triggerRoot = readRootOption(opts, "triggerRoot", document);
@@ -2008,7 +2078,8 @@
     escapeHtml: escapeHtml,
     previewMessageHtml: previewMessageHtml,
     createPreviewPanel: createPreviewPanel,
-    createPreviewSurface: createPreviewSurface
+    createPreviewSurface: createPreviewSurface,
+    renderPreviewIntoSurface: renderPreviewIntoSurface
   };
 
   const previewLifecycleHelpers = {
@@ -2057,6 +2128,7 @@
     previewDebugLabel: previewHydrationHelpers.previewDebugLabel,
     previewMessageHtml: previewContentHelpers.previewMessageHtml,
     createPreviewPanel: previewContentHelpers.createPreviewPanel,
+    renderPreviewIntoSurface: previewContentHelpers.renderPreviewIntoSurface,
     bindAnchoredPopover: previewLifecycleHelpers.bindAnchoredPopover,
     hidePreviewSurfaces: previewLifecycleHelpers.hidePreviewSurfaces
   };

--- a/src/VersoBlueprint/ExternalRefSnapshot.lean
+++ b/src/VersoBlueprint/ExternalRefSnapshot.lean
@@ -235,15 +235,8 @@ private def mkProvenance (workspaceRoot : System.FilePath)
       .outWorkspace moduleName none
 
 private def externalDeclStatusBadge (status : Data.ProvedStatus) : ExternalDeclHeaderBadge :=
-  match status with
-  | .proved =>
-    { className := "bp_external_decl_ok", text := "complete" }
-  | .missing =>
-    { className := "bp_external_decl_missing", text := "missing" }
-  | .axiomLike =>
-    { className := "bp_external_decl_sorry", text := "axiom-like" }
-  | .containsSorry _ =>
-    { className := "bp_external_decl_sorry", text := "contains sorry" }
+  let view := status.presentation
+  { className := view.externalDeclClass, text := view.externalHeaderText }
 
 /--
 Build a full snapshot for one external declaration reference using the environment

--- a/src/VersoBlueprint/Graft.lean
+++ b/src/VersoBlueprint/Graft.lean
@@ -27,6 +27,9 @@ open Verso.Genre Manual
 open Verso.Output
 open Verso.Output.Html
 
+def manualGraftAssetBundle : Informal.Commands.BlueprintAssetBundle :=
+  Informal.Block.Assets.blockAssetBundle.withCss Informal.Graft.cssAssets
+
 private def manualNodeClass (node : Informal.Graft.BlueprintNode) : String :=
   if node.compact then
     "bp_graft_node bp_graft_manifest_node bp_graft_node_compact"
@@ -147,8 +150,8 @@ block_extension Block.blueprintGraftNode (cfg : Informal.Graft.BlueprintNodeConf
   data := toJson cfg
   traverse _ _ _ := pure none
   toTeX := none
-  extraCss := Informal.Block.Assets.blockCssAssets ++ Informal.Graft.cssAssets
-  extraJs := Informal.Block.Assets.blockJsAssets
+  extraCss := manualGraftAssetBundle.css
+  extraJs := manualGraftAssetBundle.js
   toHtml :=
     open Verso.Doc.Html in
     open Verso.Output.Html in
@@ -164,8 +167,8 @@ block_extension Block.blueprintGraftSideBySide (cfg : Informal.Graft.SideBySideC
   data := toJson cfg
   traverse _ _ _ := pure none
   toTeX := none
-  extraCss := Informal.Block.Assets.blockCssAssets ++ Informal.Graft.cssAssets
-  extraJs := Informal.Block.Assets.blockJsAssets
+  extraCss := manualGraftAssetBundle.css
+  extraJs := manualGraftAssetBundle.js
   toHtml :=
     open Verso.Doc.Html in
     open Verso.Output.Html in

--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -85,7 +85,7 @@ block_extension Block.informal (data : BlockData) where
         let s ← HtmlT.state
         let ctxt ← HtmlT.context
         let data := data.withResolvedNumberingInContext s ctxt
-        let relatedPanelContext := RelatedPanel.Context.ofState s
+        let relatedPanelContext := RelatedPanel.RenderContext.ofState s
         let attrs := s.htmlId id
         let codeHref : Option String :=
           match Informal.TraversalIndex.InlineCode.object? s data.label with

--- a/src/VersoBlueprint/Informal/Block/Assets.lean
+++ b/src/VersoBlueprint/Informal/Block/Assets.lean
@@ -1481,20 +1481,25 @@ div.proof_content {
 }
 "##
 
-def codeCssAssets : List String :=
-  Informal.Commands.withBlueprintCssAssets [css, Verso.Genre.Manual.docstringStyle]
-
-def blockCssAssets : List String :=
-  Informal.Commands.withPreviewPanelInlinePreviewCssAssets
-    [css, Informal.StyleSwitcher.css, Verso.Genre.Manual.docstringStyle]
-
 -- Keep this module rebuilt when relation panel runtime changes.
 def relationPanelJs : String :=
   Informal.Commands.withPreviewClientReadyJs (include_str "relation-panel.js")
 
+def codeAssetBundle : Informal.Commands.BlueprintAssetBundle :=
+  Informal.Commands.blueprintCssAssetBundle [css, Verso.Genre.Manual.docstringStyle]
+
+def blockAssetBundle : Informal.Commands.BlueprintAssetBundle :=
+  Informal.Commands.previewPanelInlinePreviewAssetBundle
+    (cssExtras := [css, Informal.StyleSwitcher.css, Verso.Genre.Manual.docstringStyle])
+    (jsAfter := [relationPanelJs, Informal.StyleSwitcher.jsInteractive])
+
+def codeCssAssets : List String :=
+  codeAssetBundle.css
+
+def blockCssAssets : List String :=
+  blockAssetBundle.css
+
 def blockJsAssets : List String :=
-  Informal.Commands.withInlinePreviewJsAssets
-    []
-    [relationPanelJs, Informal.StyleSwitcher.jsInteractive]
+  blockAssetBundle.js
 
 end Informal.Block.Assets

--- a/src/VersoBlueprint/Informal/Block/Common.lean
+++ b/src/VersoBlueprint/Informal/Block/Common.lean
@@ -59,12 +59,7 @@ deriving Repr, Inhabited
 def BlockStatusMark.text (s : BlockStatusMark) : String :=
   match s.symbolOverride? with
   | some txt => txt
-  | none =>
-    match s.status with
-    | .proved => "✓"
-    | .missing => "✗"
-    | .axiomLike => "⚠"
-    | .containsSorry _ => "✗"
+  | none => s.status.presentation.statusMarkSymbol
 
 def BlockStatusMark.toHtml (s : BlockStatusMark) : Output.Html :=
   open Verso.Output.Html in
@@ -139,24 +134,8 @@ register_option verso.blueprint.foldCodeBlocks : Bool := {
   descr := "Render VersoBlueprint Lean, Rust, and external code panels as collapsed details blocks"
 }
 
-def provedStatusHasSorry (status : Data.ProvedStatus) : Bool :=
-  status.isIncomplete
-
-def provedStatusLocationText (status : Data.ProvedStatus) : String :=
-  status.sorryLocationText
-
-def provedStatusContainsSorry (status : Data.ProvedStatus) : Bool :=
-  status.containsExplicitSorry
-
-def provedStatusSummaryText (status : Data.ProvedStatus) : String :=
-  match status with
-  | .missing => "missing declaration"
-  | .axiomLike => "axiom-like (no body)"
-  | .containsSorry _ => s!"sorry {provedStatusLocationText status}"
-  | .proved => "unknown"
-
 def externalDeclHasGap (decl : Data.ExternalRef) : Bool :=
-  decl.present && provedStatusHasSorry decl.provedStatus
+  decl.present && decl.provedStatus.isIncomplete
 
 def externalCodeEntryTitle (found total missing withGaps : Nat) : String :=
   if missing > 0 then

--- a/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
+++ b/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
@@ -37,25 +37,25 @@ private structure GroupRenderInfo where
   title : String
   declared : Bool := false
 
-/-- Render-time context shared by group and dependency header panels. -/
-structure Context where
+/-- Traversal-backed render context shared by group and dependency header panels. -/
+structure RenderContext where
   state : Verso.Genre.Manual.TraverseState
   storedBlocks : Array BlockData
 
 /-- Collect the traversal data needed to render related-block panels. -/
-def Context.ofState (state : Verso.Genre.Manual.TraverseState) : Context := {
+def RenderContext.ofState (state : Verso.Genre.Manual.TraverseState) : RenderContext := {
   state
   storedBlocks := collectStoredBlocks state
 }
 
-private def blockSummaryTitle (ctx : Context) (data : BlockData) : String :=
+private def blockSummaryTitle (ctx : RenderContext) (data : BlockData) : String :=
   data.displayTitle ctx.state
 
-private def storedBlockByLabel? (ctx : Context) (label : Data.Label) : Option BlockData :=
+private def storedBlockByLabel? (ctx : RenderContext) (label : Data.Label) : Option BlockData :=
   ctx.storedBlocks.find? (·.label == label)
 
 private def groupRenderInfo?
-    (ctx : Context) (data : BlockData) : Option GroupRenderInfo := do
+    (ctx : RenderContext) (data : BlockData) : Option GroupRenderInfo := do
   let parent ← data.parent
   match resolveStoredGroupData? ctx.state parent with
   | some groupData => some { label := parent, title := groupData.header, declared := true }
@@ -259,7 +259,7 @@ private def addUsedByEntry
     acc.push <| mergeUsedByEntry { source } useRef isProof
 
 private def collectUsedByEntries
-    (ctx : Context) (target : Data.Label) : Array UsedByEntry :=
+    (ctx : RenderContext) (target : Data.Label) : Array UsedByEntry :=
   sortUsedByEntries <| ctx.storedBlocks.foldl (init := #[]) fun acc source =>
     if source.label == target then
       acc
@@ -281,7 +281,7 @@ private def mergeUsesEntry (existing : UsesEntry) (useRef : Data.UseRef) (isProo
   }
 
 private def addUsesEntry
-    (ctx : Context) (acc : Array UsesEntry) (useRef : Data.UseRef) (isProof : Bool) :
+    (ctx : RenderContext) (acc : Array UsesEntry) (useRef : Data.UseRef) (isProof : Bool) :
     Array UsesEntry :=
   if acc.any (·.label == useRef.label) then
     acc.map fun entry =>
@@ -303,7 +303,7 @@ private def usesEntryLess (a b : UsesEntry) : Bool :=
   | none, none => a.label.toString < b.label.toString
 
 private def collectUsesEntries
-    (ctx : Context) (data : BlockData) : Array UsesEntry :=
+    (ctx : RenderContext) (data : BlockData) : Array UsesEntry :=
   let source := (storedBlockByLabel? ctx data.label).getD data
   let isProof :=
     match data.kind with
@@ -316,7 +316,7 @@ private def collectUsesEntries
   |>.qsort usesEntryLess
 
 private def collectGroupEntries
-    (ctx : Context) (target : BlockData) (group : GroupRenderInfo) :
+    (ctx : RenderContext) (target : BlockData) (group : GroupRenderInfo) :
     Array BlockData :=
   ctx.storedBlocks.foldl (init := #[]) fun acc source =>
     if source.label == target.label then
@@ -345,25 +345,29 @@ private def relationBadge (className title text : String) : Output.Html :=
   open Verso.Output.Html in
   {{<span class={{className}} title={{title}}>{{.text true text}}</span>}}
 
+private def relationBadgeBaseClass : String :=
+  "bp_relation_axis_badge"
+
+private def relationScopedBadgeClass (scope variant : String) : String :=
+  s!"{relationBadgeBaseClass} bp_relation_badge_{scope} bp_relation_badge_{scope}_{variant}"
+
+private def relationAxisBadgeClass (axis : String) : String :=
+  s!"{relationBadgeBaseClass} bp_relation_badge_axis bp_relation_badge_{axis}"
+
 private def useOriginBadgeClass : Data.UseOrigin → String
-  | .manual =>
-    "bp_relation_axis_badge bp_relation_badge_origin bp_relation_badge_origin_manual"
-  | .automatic =>
-    "bp_relation_axis_badge bp_relation_badge_origin bp_relation_badge_origin_automatic"
+  | .manual => relationScopedBadgeClass "origin" "manual"
+  | .automatic => relationScopedBadgeClass "origin" "automatic"
 
 private def useIntentBadgeClass : Data.UseIntent → String
-  | .regular =>
-    "bp_relation_axis_badge bp_relation_badge_intent bp_relation_badge_intent_regular"
-  | .auxiliary =>
-    "bp_relation_axis_badge bp_relation_badge_intent bp_relation_badge_intent_auxiliary"
-  | .technical =>
-    "bp_relation_axis_badge bp_relation_badge_intent bp_relation_badge_intent_technical"
+  | .regular => relationScopedBadgeClass "intent" "regular"
+  | .auxiliary => relationScopedBadgeClass "intent" "auxiliary"
+  | .technical => relationScopedBadgeClass "intent" "technical"
 
 private def renderAxisBadges (inStatement inProof : Bool) : Output.Html :=
   let statementBadge : Array Output.Html :=
     if inStatement then
       #[relationBadge
-          "bp_relation_axis_badge bp_relation_badge_axis bp_relation_badge_statement"
+          (relationAxisBadgeClass "statement")
           "Declared in the statement"
           "statement"]
     else
@@ -371,7 +375,7 @@ private def renderAxisBadges (inStatement inProof : Bool) : Output.Html :=
   let proofBadge : Array Output.Html :=
     if inProof then
       #[relationBadge
-          "bp_relation_axis_badge bp_relation_badge_axis bp_relation_badge_proof"
+          (relationAxisBadgeClass "proof")
           "Declared in the proof"
           "proof"]
     else
@@ -398,7 +402,7 @@ private def renderUseMetadataBadges
 
 private def mkBlockEntry {m}
     [Monad m]
-    (ctx : Context)
+    (ctx : RenderContext)
     (source : BlockData) (previewId : String)
     (badgesHtml : Output.Html := .empty) :
     Verso.Doc.Html.HtmlT Verso.Genre.Manual m PanelEntry := do
@@ -416,7 +420,7 @@ private def mkBlockEntry {m}
 
 private def mkLabelEntry {m}
     [Monad m]
-    (ctx : Context)
+    (ctx : RenderContext)
     (label : Data.Label) (previewId : String)
     (badgesHtml : Output.Html := .empty) :
     Verso.Doc.Html.HtmlT Verso.Genre.Manual m PanelEntry := do
@@ -555,7 +559,7 @@ def renderPanel (cfg : PanelConfig) (entries : Array PanelEntry) : Output.Html :
 /-- Render the reverse-dependency header extra for a statement block. -/
 def renderUsedByExtra {m}
     [Monad m]
-    (ctx : Context)
+    (ctx : RenderContext)
     (data : BlockData) :
     Verso.Doc.Html.HtmlT Verso.Genre.Manual m Output.Html := do
   match data.kind with
@@ -574,7 +578,7 @@ def renderUsedByExtra {m}
 /-- Render the forward-dependency header extra for a statement or proof block. -/
 def renderUsesExtra {m}
     [Monad m]
-    (ctx : Context)
+    (ctx : RenderContext)
     (data : BlockData) :
     Verso.Doc.Html.HtmlT Verso.Genre.Manual m Output.Html := do
   let entries := collectUsesEntries ctx data
@@ -597,7 +601,7 @@ def renderUsesExtra {m}
 /-- Render the group-membership header extra, if the block belongs to a group. -/
 def renderGroupExtra {m}
     [Monad m]
-    (ctx : Context)
+    (ctx : RenderContext)
     (data : BlockData) :
     Verso.Doc.Html.HtmlT Verso.Genre.Manual m (Option Output.Html) := do
   match data.kind, groupRenderInfo? ctx data with

--- a/src/VersoBlueprint/Informal/Block/relation-panel.js
+++ b/src/VersoBlueprint/Informal/Block/relation-panel.js
@@ -1,22 +1,13 @@
 (function () {
-  function previewExceptionHtml(previewUtils, fallbackDetail) {
-    return previewUtils.previewMessageHtml({
+  function relationPreviewDiagnosticOptions(detail) {
+    return {
       rootClass: "bp_relation_preview_message",
       titleClass: "bp_relation_preview_message_title",
       detailClass: "bp_relation_preview_message_detail",
       kind: "error",
       title: "Preview unavailable",
-      detail: fallbackDetail || "The preview cache content could not be loaded."
-    });
-  }
-
-  function setRelationBodyHtml(surface, html, renderOptions) {
-    surface.replaceBody({
-      heading: surface.title ? (surface.title.textContent || "") : "",
-      html: html,
-      allowEmpty: true,
-      renderOptions: renderOptions || { hydrate: false, renderMath: false }
-    });
+      detail: detail || "The preview cache content could not be loaded."
+    };
   }
 
   function bindRelationPanel(previewUtils, panel) {
@@ -111,31 +102,24 @@
       const previewKey = (item.getAttribute("data-bp-relation-preview-key") || "").trim();
       const requestToken = ++activateRequestToken;
       selectItem(item);
-      setRelationBodyHtml(surface, initialLoadingHtml);
       if (opts.openWrap !== false) {
         openWrap({ loadPreview: false });
       }
-      try {
-        const result = await previewUtils.resolvePreview(previewKey);
-        if (requestToken !== activateRequestToken) return;
-        if (!result || !result.ok) {
-          const diagnosticHtml = result && typeof result.diagnosticHtml === "string"
-            ? result.diagnosticHtml
-            : "";
-          setRelationBodyHtml(
-            surface,
-            diagnosticHtml || previewExceptionHtml(previewUtils, "The preview cache content could not be loaded.")
-          );
-          return;
-        }
-        setRelationBodyHtml(surface, result.html, {});
-      } catch (_err) {
-        if (requestToken !== activateRequestToken) return;
-        setRelationBodyHtml(surface, previewExceptionHtml(
-          previewUtils,
+      await previewUtils.renderPreviewIntoSurface(surface, previewKey, {
+        loadingHtml: initialLoadingHtml,
+        renderOptions: {},
+        loadingRenderOptions: { hydrate: false, renderMath: false },
+        diagnosticRenderOptions: { hydrate: false, renderMath: false },
+        shouldRender: function () {
+          return requestToken === activateRequestToken;
+        },
+        fallbackDiagnostic: relationPreviewDiagnosticOptions(
+          "The preview cache content could not be loaded."
+        ),
+        exceptionDiagnostic: relationPreviewDiagnosticOptions(
           "The preview cache content could not be loaded. Refresh the page, or rebuild the site if this persists."
-        ));
-      }
+        )
+      });
     }
 
     items.forEach(function (item) {

--- a/src/VersoBlueprint/Informal/CodeSummary.lean
+++ b/src/VersoBlueprint/Informal/CodeSummary.lean
@@ -98,22 +98,10 @@ private structure SummaryTooltipSection where
   emptyText : String := "No associated Lean declarations."
 
 private def declSummaryStatusText (item : DeclSummaryItem) : String :=
-  if !item.present then
-    "missing declaration"
-  else if item.status.isIncomplete then
-    provedStatusSummaryText item.status
-  else
-    "complete"
+  (item.status.presentation (present := item.present)).summaryText
 
 private def declSummaryStatusClass (item : DeclSummaryItem) : String :=
-  if !item.present || item.status.isMissing then
-    "bp_code_decl_status_missing"
-  else if item.status.isAxiomLike then
-    "bp_code_decl_status_axiom"
-  else if item.status.isIncomplete then
-    "bp_code_decl_status_warning"
-  else
-    "bp_code_decl_status_ok"
+  (item.status.presentation (present := item.present)).codeDeclClass
 
 private def renderDeclSummaryItems (items : Array DeclSummaryItem) : Array Output.Html :=
   open Verso.Output.Html in
@@ -272,37 +260,18 @@ private def renderSummaryPreview (_label : Data.Label) (cdata : ComputedData)
       </div>
     }}
 
-private inductive CodeEntryVisual where
-  | absent
-  | proved
-  | warning
-  | missing
-  | axiom
-deriving BEq
-
-private def CodeEntryVisual.symbol : CodeEntryVisual → String
-  | .absent => "X"
-  | .proved => "✓"
-  | .warning => "⚠"
-  | .missing => "!"
-  | .axiom => "A"
-
-private def CodeEntryVisual.classSuffix : CodeEntryVisual → String
-  | .absent => "absent"
-  | .proved => "proved"
-  | .warning => "warning"
-  | .missing => "missing"
-  | .axiom => "axiom"
+private structure CodeEntryVisual where
+  classSuffix : String
+  symbol : String
+  absent : Bool := false
+deriving Inhabited
 
 private def codeEntryVisual (hasSource : Bool) (statusMark : BlockStatusMark) : CodeEntryVisual :=
   if !hasSource then
-    .absent
+    { classSuffix := "absent", symbol := "X", absent := true }
   else
-    match statusMark.status with
-    | .proved => .proved
-    | .containsSorry _ => .warning
-    | .missing => .missing
-    | .axiomLike => .axiom
+    let view := statusMark.status.presentation
+    { classSuffix := view.codeEntryClassSuffix, symbol := view.codeEntrySymbol }
 
 private structure ExternalRenderHealth where
   failureCount : Nat := 0
@@ -331,7 +300,7 @@ private def renderCodeEntryNode (href : Option String) (title : String) (visual 
     (renderHealth : ExternalRenderHealth := {}) : Output.Html :=
   open Verso.Output.Html in
   let linkClass := s!"bp_code_link bp_code_link_status bp_code_link_status_{visual.classSuffix}" ++
-    (if visual == .absent then " bp_code_link_empty" else "")
+    (if visual.absent then " bp_code_link_empty" else "")
   let body : Output.Html := {{
     {{renderCodeHeadingRenderHealthBadge renderHealth}}
     <span class="bp_code_status_symbol">{{.text true visual.symbol}}</span>
@@ -518,15 +487,16 @@ private def renderInlinePanelIndicator (label : Data.Label) (codeData : InlineCo
       .empty
     else
       let segments := orderedDecls.map fun decl =>
-        let hasSorry := provedStatusHasSorry decl.provedStatus
+        let hasSorry := decl.provedStatus.isIncomplete
+        let statusView := decl.provedStatus.presentation
         let cls := progressSegmentClass false hasSorry
         let weight := max decl.weight 1
         let title :=
           if hasSorry then
-            if provedStatusContainsSorry decl.provedStatus then
-              s!"{decl.name}: contains sorry {provedStatusLocationText decl.provedStatus}"
+            if decl.provedStatus.containsExplicitSorry then
+              s!"{decl.name}: {statusView.externalPanelText}"
             else
-              s!"{decl.name}: {provedStatusLocationText decl.provedStatus}"
+              s!"{decl.name}: {statusView.summaryText}"
           else
             s!"{decl.name}: complete"
         {{
@@ -586,14 +556,35 @@ private def externalIndicatorText
   else
     declText
 
-private def externalIndicatorStatus
-    (health : Informal.Graph.CodeHealth) : String × String × String :=
+private structure ExternalIndicatorPresentation where
+  className : String
+  iconText : String := "●"
+  title : String
+  badgeText : String
+deriving Inhabited
+
+private def externalIndicatorPresentation
+    (decls : Array Data.ExternalRef) (health : Informal.Graph.CodeHealth) :
+    ExternalIndicatorPresentation :=
+  let badgeText := externalIndicatorText decls health
   if health.missingDecls > 0 then
-    ("bp_external_status_missing", "●", s!"Lean declarations: {health.presentDecls}/{health.totalDecls} present ({health.missingDecls} missing)")
+    {
+      className := "bp_external_status_missing"
+      title := s!"Lean declarations: {health.presentDecls}/{health.totalDecls} present ({health.missingDecls} missing)"
+      badgeText
+    }
   else if health.anyGapCount > 0 then
-    ("bp_external_status_sorry", "●", s!"Lean declarations: all present, {health.anyGapCount} incomplete")
+    {
+      className := "bp_external_status_sorry"
+      title := s!"Lean declarations: all present, {health.anyGapCount} incomplete"
+      badgeText
+    }
   else
-    ("bp_external_status_ok", "●", s!"Lean declarations: all {health.totalDecls} present")
+    {
+      className := "bp_external_status_ok"
+      title := s!"Lean declarations: all {health.totalDecls} present"
+      badgeText
+    }
 
 private def renderExternalPanelIndicator (decls : Array Data.ExternalRef)
     (label : Data.Label) (hrefOf : Name → Option String) : PanelIndicatorParts :=
@@ -601,18 +592,17 @@ private def renderExternalPanelIndicator (decls : Array Data.ExternalRef)
   let health := Informal.Graph.codeHealthOfBlockSource .definition {} (some (.external decls))
   let renderHealth := externalRenderHealth decls
   let previewBody := renderSummaryPreview label { source := some (.external decls) } hrefOf
-  let (iconClass, iconText, iconTitle) := externalIndicatorStatus health
-  let badgeText := externalIndicatorText decls health
+  let presentation := externalIndicatorPresentation decls health
   let summaryTitle :=
     s!"Lean code for {label}: " ++ appendRenderHealthSummary
       (externalCodeEntryTitle health.presentDecls health.totalDecls health.missingDecls health.anyGapCount)
       renderHealth
   let badgeTitle :=
-    appendRenderHealthSummary iconTitle renderHealth
+    appendRenderHealthSummary presentation.title renderHealth
   let badge : Output.Html := {{
-    <span class={{s!"bp_external_status_badge bp_external_status_badge_summary {iconClass}"}} title={{badgeTitle}}>
-      <span class={{s!"bp_external_status_icon {iconClass}"}}>{{.text true iconText}}</span>
-      <span class="bp_external_status_badge_text">{{.text true badgeText}}</span>
+    <span class={{s!"bp_external_status_badge bp_external_status_badge_summary {presentation.className}"}} title={{badgeTitle}}>
+      <span class={{s!"bp_external_status_icon {presentation.className}"}}>{{.text true presentation.iconText}}</span>
+      <span class="bp_external_status_badge_text">{{.text true presentation.badgeText}}</span>
     </span>
   }}
   {

--- a/src/VersoBlueprint/Informal/ExternalCode.lean
+++ b/src/VersoBlueprint/Informal/ExternalCode.lean
@@ -162,21 +162,6 @@ private def linkedExternalDecl
     anchorAttrs := getDeclAnchorAttrs decl
   }
 
-private def externalDeclSorryLocation (decl : LinkedExternalDecl) : String :=
-  if decl.decl.present then
-    provedStatusLocationText decl.decl.provedStatus
-  else
-    "location unknown"
-
-private def externalDeclGapStatusText? (item : LinkedExternalDecl) : Option String :=
-  if externalDeclHasGap item.decl then
-    if provedStatusContainsSorry item.decl.provedStatus then
-      some s!"contains sorry {externalDeclSorryLocation item}"
-    else
-      some (externalDeclSorryLocation item)
-  else
-    none
-
 /--
 Status-derived rendering data for one linked external declaration.
 
@@ -189,22 +174,12 @@ private structure ExternalDeclStatusView where
   renderedMetaText : String
 
 private def externalDeclStatusView (item : LinkedExternalDecl) : ExternalDeclStatusView :=
-  let className :=
-    if !item.decl.present then
-      "bp_external_decl_missing"
-    else if (externalRenderFailure? item.decl).isSome then
-      "bp_external_decl_error"
-    else if externalDeclHasGap item.decl then
-      "bp_external_decl_sorry"
+  let statusView := item.decl.provedStatus.presentation (present := item.decl.present)
+  let (className, panelText) :=
+    if item.decl.present && (externalRenderFailure? item.decl).isSome then
+      ("bp_external_decl_error", "render failed")
     else
-      "bp_external_decl_ok"
-  let panelText :=
-    if !item.decl.present then
-      "missing declaration"
-    else if (externalRenderFailure? item.decl).isSome then
-      "render failed"
-    else
-      (externalDeclGapStatusText? item).getD "complete"
+      (statusView.externalDeclClass, statusView.externalPanelText)
   { className, panelText, renderedMetaText := panelText }
 
 private def externalDeclNode (item : LinkedExternalDecl) : Output.Html :=

--- a/src/VersoBlueprint/Informal/RustBlock.lean
+++ b/src/VersoBlueprint/Informal/RustBlock.lean
@@ -21,6 +21,9 @@ open Lean Lean.Elab
 
 namespace Informal
 
+def rustBlockAssetBundle : Informal.Commands.BlueprintAssetBundle :=
+  Informal.Block.Assets.codeAssetBundle.withCss [Informal.Rust.css]
+
 block_extension Block.informalRustCode (data : Informal.Rust.InlineCodeData) where
   data := toJson data
   traverse id data _contents := do
@@ -36,8 +39,8 @@ block_extension Block.informalRustCode (data : Informal.Rust.InlineCodeData) whe
       modify fun s => s.saveDomainObjectData Informal.Rust.informalRustCodeDomain cdata.label.toString (toJson cdata)
       pure none
   toTeX := none
-  extraCss := Informal.Block.Assets.codeCssAssets ++ [Informal.Rust.css]
-  extraJs := ([] : List String)
+  extraCss := rustBlockAssetBundle.css
+  extraJs := rustBlockAssetBundle.js
   toHtml :=
     open Verso.Doc.Html in
     open Verso.Output.Html in

--- a/src/VersoBlueprint/Informal/Uses.lean
+++ b/src/VersoBlueprint/Informal/Uses.lean
@@ -26,6 +26,9 @@ open Lean.Doc.Syntax
 
 namespace Informal
 
+def usesAssetBundle : Informal.Commands.BlueprintAssetBundle :=
+  Informal.Commands.inlinePreviewAssetBundle
+
 /--
 Arguments accepted by the inline `{uses ...}` role.
 
@@ -119,8 +122,8 @@ inline_extension Inline.informal (data : InlineData) where
       | Verso.reportError s!"Malformed data in Inline.informal traversal: {data}"
         pure none
     pure none
-  extraCss := Informal.Commands.withInlinePreviewCssAssets
-  extraJs := Informal.Commands.withInlinePreviewJsAssets [] []
+  extraCss := usesAssetBundle.css
+  extraJs := usesAssetBundle.js
   toHtml :=
     open Verso.Doc.Html in
     open Verso.Output.Html in

--- a/src/VersoBlueprint/Math.lean
+++ b/src/VersoBlueprint/Math.lean
@@ -67,6 +67,14 @@ private def lintBpMathTerm [Monad m] [MonadLiftT IO m] [MonadOptions m]
     logWarningAt (warningRef.getD ref) failure.toMessageData
   | none => pure ()
 
+private def mathHtmlAssets (texPrelude : String) : HtmlAssets :=
+  {
+    extraJs := [
+      Informal.Macros.texPreludeTableJs texPrelude,
+      Informal.Macros.blueprintMathJs
+    ]
+  }
+
 inline_extension Inline.bpMath (data : BpMathData) where
   data := toJson data
   traverse _id data _contents := do
@@ -75,12 +83,7 @@ inline_extension Inline.bpMath (data : BpMathData) where
         pure none
     modify fun st =>
       st.modifyHtmlAssets fun assets =>
-        assets.combine {
-          extraJs := [
-            Informal.Macros.texPreludeTableJs texPrelude,
-            Informal.Macros.blueprintMathJs
-          ]
-        }
+        assets.combine (mathHtmlAssets texPrelude)
     pure none
   toTeX :=
     open Verso.Output.TeX in

--- a/src/VersoBlueprint/ProvedStatus.lean
+++ b/src/VersoBlueprint/ProvedStatus.lean
@@ -17,7 +17,8 @@ The API is organized into:
 - state predicates (`isProved`, `isMissing`, `isIncomplete`, ...),
 - axis predicates (`hasTypeGap`, `hasProofGap`),
 - completion policy (`blocksStatementCompletion`, `blocksProofCompletion`),
-- rendering helpers (`statusLabel`, `sorryLocationText`, `sorryRefCounts`),
+- rendering helpers (`statusLabel`, `sorryLocationText`, `sorryRefCounts`,
+  `presentation`),
 - collection helpers (`any*`),
 - constructors/merging (`of*`, `mergeConservative`),
 - Lean environment bridge (`ConstantInfo.blueprint*`).
@@ -99,6 +100,89 @@ def ProvedStatus.statusLabel : ProvedStatus → String
   | .axiomLike => "axiom-like"
   | .containsSorry _ => "contains sorry"
   | .proved => "proved"
+
+/--
+Presentation data shared by the renderers that show declaration-level Lean
+status. The semantic source remains `ProvedStatus`; this structure keeps the
+small visual vocabulary from being reconstructed independently by each renderer.
+-/
+structure ProvedStatusPresentation where
+  /-- Bracketed status text used in compact declaration-summary rows. -/
+  summaryText : String
+  /-- Status text used in expanded external-code panel rows. -/
+  externalPanelText : String
+  /-- Short status text used in rendered external declaration headers. -/
+  externalHeaderText : String
+  /-- CSS class used by compact declaration-summary rows. -/
+  codeDeclClass : String
+  /-- CSS class used by external declaration badges. -/
+  externalDeclClass : String
+  /-- CSS class suffix used by heading-level code-entry icons. -/
+  codeEntryClassSuffix : String
+  /-- Symbol used by heading-level code-entry icons. -/
+  codeEntrySymbol : String
+  /-- Default symbol used by statement-heading status marks. -/
+  statusMarkSymbol : String
+deriving Repr, Inhabited
+
+/--
+Declaration-level status presentation.
+
+`present := false` handles unresolved external references even when their
+stored semantic status has not already been normalized to `.missing`.
+-/
+def ProvedStatus.presentation (status : ProvedStatus) (present : Bool := true) :
+    ProvedStatusPresentation :=
+  let missingView : ProvedStatusPresentation := {
+    summaryText := "missing declaration"
+    externalPanelText := "missing declaration"
+    externalHeaderText := "missing"
+    codeDeclClass := "bp_code_decl_status_missing"
+    externalDeclClass := "bp_external_decl_missing"
+    codeEntryClassSuffix := "missing"
+    codeEntrySymbol := "!"
+    statusMarkSymbol := "✗"
+  }
+  if !present || status.isMissing then
+    missingView
+  else
+    match status with
+    | .proved =>
+      {
+        summaryText := "complete"
+        externalPanelText := "complete"
+        externalHeaderText := "complete"
+        codeDeclClass := "bp_code_decl_status_ok"
+        externalDeclClass := "bp_external_decl_ok"
+        codeEntryClassSuffix := "proved"
+        codeEntrySymbol := "✓"
+        statusMarkSymbol := "✓"
+      }
+    | .missing =>
+      missingView
+    | .axiomLike =>
+      {
+        summaryText := "axiom-like (no body)"
+        externalPanelText := "axiom-like (no body)"
+        externalHeaderText := "axiom-like"
+        codeDeclClass := "bp_code_decl_status_axiom"
+        externalDeclClass := "bp_external_decl_sorry"
+        codeEntryClassSuffix := "axiom"
+        codeEntrySymbol := "A"
+        statusMarkSymbol := "⚠"
+      }
+    | .containsSorry _ =>
+      let locationText := status.sorryLocationText
+      {
+        summaryText := s!"sorry {locationText}"
+        externalPanelText := s!"contains sorry {locationText}"
+        externalHeaderText := "contains sorry"
+        codeDeclClass := "bp_code_decl_status_warning"
+        externalDeclClass := "bp_external_decl_sorry"
+        codeEntryClassSuffix := "warning"
+        codeEntrySymbol := "⚠"
+        statusMarkSymbol := "✗"
+      }
 
 /-- Aggregate per-axis sorry reference counts `(statementRefs, proofRefs)`. -/
 def ProvedStatus.sorryRefCounts : ProvedStatus → Nat × Nat

--- a/src/VersoBlueprint/Slides/Assets.lean
+++ b/src/VersoBlueprint/Slides/Assets.lean
@@ -19,27 +19,29 @@ def blueprintSlidesJsFilename : String := "blueprint-slides.js"
 
 private def slideNodeCss : String := include_str "blueprint-slides.css"
 
-def blueprintSlidesCss : String :=
-  String.intercalate "\n\n" <|
-    Informal.Commands.withPreviewPanelInlinePreviewCssAssets
-      [Informal.Block.Assets.css, Informal.Graft.css, Verso.Genre.Manual.docstringStyle, slideNodeCss]
-
-def blueprintSlidesCssFile : VersoSlides.CssFile where
-  filename := blueprintSlidesCssFilename
-  contents := ⟨blueprintSlidesCss⟩
-
 /--
 Hydrate interactions around Blueprint slide nodes whose HTML shell was rendered
 while generating the slide deck.
 -/
 private def slideNodeHydrationJs : String := include_str "blueprint-slides.js"
 
+def blueprintSlidesAssetBundle : Informal.Commands.BlueprintAssetBundle :=
+  { css :=
+      (Informal.Commands.previewPanelInlinePreviewCssAssetBundle
+        [Informal.Block.Assets.css, Informal.Graft.css, Verso.Genre.Manual.docstringStyle, slideNodeCss]).css
+    js :=
+      (Informal.Commands.inlinePreviewJsAssetBundle.withJs []
+        [Informal.Block.Assets.relationPanelJs, slideNodeHydrationJs]).js }
+
+def blueprintSlidesCss : String :=
+  String.intercalate "\n\n" blueprintSlidesAssetBundle.css
+
+def blueprintSlidesCssFile : VersoSlides.CssFile where
+  filename := blueprintSlidesCssFilename
+  contents := ⟨blueprintSlidesCss⟩
+
 def blueprintSlidesJs : String :=
-  String.intercalate "\n\n" <|
-    Informal.Commands.inlinePreviewJsAssets ++
-      [ Informal.Block.Assets.relationPanelJs
-      , slideNodeHydrationJs
-      ]
+  String.intercalate "\n\n" blueprintSlidesAssetBundle.js
 
 public def blueprintSlidesExtraJs : Array String :=
   #[blueprintSlidesJsFilename]

--- a/tests/VersoBlueprintTests/Blueprint.lean
+++ b/tests/VersoBlueprintTests/Blueprint.lean
@@ -5,6 +5,7 @@ Author: Emilio J. Gallego Arias
 -/
 
 import VersoBlueprintTests.BlueprintAttribute
+import VersoBlueprintTests.BlueprintAssets
 import VersoBlueprintTests.BlueprintAutoDeps
 import VersoBlueprintTests.BlueprintBlockFolding
 import VersoBlueprintTests.BlueprintCodeRenderMatrix

--- a/tests/VersoBlueprintTests/BlueprintAssets.lean
+++ b/tests/VersoBlueprintTests/BlueprintAssets.lean
@@ -1,0 +1,131 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoBlueprint.Commands.Bibliography
+import VersoBlueprint.Commands.Graph
+import VersoBlueprint.Commands.Summary
+import VersoBlueprint.Cite
+import VersoBlueprint.Graft
+import VersoBlueprint.Informal.RustBlock
+import VersoBlueprint.Informal.Uses
+import VersoBlueprint.Slides
+
+namespace Verso.VersoBlueprintTests.BlueprintAssets
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  let bundle :=
+    Informal.Commands.previewPanelAssetBundle
+      (cssExtras := ["graph-css"])
+      (jsAfter := ["graph-js"])
+  bundle.css ==
+      [Informal.Commands.blueprintTokensCss, Informal.Commands.previewPanelCss, "graph-css"] &&
+    bundle.js == [Informal.Commands.previewHoverUtilsJs, "graph-js"]
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  let bundle :=
+    Informal.Commands.inlinePreviewAssetBundle
+      (cssExtras := ["bibliography-css"])
+      (jsBefore := ["open-target"])
+  bundle.css ==
+      [Informal.Commands.blueprintTokensCss, "bibliography-css",
+        Informal.Commands.previewHeaderCss, Informal.Commands.inlinePreviewCss] &&
+    bundle.js ==
+      ["open-target", Informal.Commands.previewHoverUtilsJs, Informal.Commands.inlineLinkPreviewJs]
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  Informal.Commands.graphAssetBundle.css ==
+      [Informal.Commands.blueprintTokensCss, Informal.Commands.previewPanelCss,
+        Informal.Commands.graphCss] &&
+    Informal.Commands.graphAssetBundle.js ==
+      [Informal.Commands.previewHoverUtilsJs, Informal.Commands.loadD3Dot]
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  Informal.Commands.summaryAssetBundle.css ==
+      [Informal.Commands.blueprintTokensCss, Informal.Commands.previewPanelCss,
+        Informal.Commands.summaryCss, Informal.Commands.previewHeaderCss,
+        Informal.Commands.inlinePreviewCss] &&
+    Informal.Commands.summaryAssetBundle.js ==
+      [Informal.Commands.openTargetDetailsJs, Informal.Commands.previewHoverUtilsJs,
+        Informal.Commands.inlineLinkPreviewJs]
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  Informal.Commands.bibliographyAssetBundle.css ==
+      [Informal.Commands.blueprintTokensCss, Informal.Commands.bibliographyCss,
+        Informal.Commands.previewHeaderCss, Informal.Commands.inlinePreviewCss] &&
+    Informal.Commands.bibliographyAssetBundle.js ==
+      [Informal.Commands.openTargetDetailsJs, Informal.Commands.previewHoverUtilsJs,
+        Informal.Commands.inlineLinkPreviewJs]
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  Informal.Block.Assets.codeAssetBundle.css ==
+      [Informal.Commands.blueprintTokensCss, Informal.Block.Assets.css,
+        Verso.Genre.Manual.docstringStyle] &&
+    Informal.Block.Assets.codeAssetBundle.js == []
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  Informal.Block.Assets.blockAssetBundle.css ==
+      [Informal.Commands.blueprintTokensCss, Informal.Commands.previewPanelCss,
+        Informal.Block.Assets.css, Informal.StyleSwitcher.css, Verso.Genre.Manual.docstringStyle,
+        Informal.Commands.previewHeaderCss, Informal.Commands.inlinePreviewCss] &&
+    Informal.Block.Assets.blockAssetBundle.js ==
+      [Informal.Commands.previewHoverUtilsJs, Informal.Commands.inlineLinkPreviewJs,
+        Informal.Block.Assets.relationPanelJs, Informal.StyleSwitcher.jsInteractive]
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  Informal.Graft.manualGraftAssetBundle.css ==
+      Informal.Block.Assets.blockCssAssets ++ Informal.Graft.cssAssets &&
+    Informal.Graft.manualGraftAssetBundle.js == Informal.Block.Assets.blockJsAssets
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  Informal.Cite.citeAssetBundle.css ==
+      [Informal.Commands.blueprintTokensCss, Informal.Commands.previewHeaderCss,
+        Informal.Commands.inlinePreviewCss] &&
+    Informal.Cite.citeAssetBundle.js ==
+      [Informal.Commands.previewHoverUtilsJs, Informal.Commands.inlineLinkPreviewJs]
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  Informal.usesAssetBundle.css ==
+      [Informal.Commands.blueprintTokensCss, Informal.Commands.previewHeaderCss,
+        Informal.Commands.inlinePreviewCss] &&
+    Informal.usesAssetBundle.js ==
+      [Informal.Commands.previewHoverUtilsJs, Informal.Commands.inlineLinkPreviewJs]
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  Informal.rustBlockAssetBundle.css ==
+      Informal.Block.Assets.codeCssAssets ++ [Informal.Rust.css] &&
+    Informal.rustBlockAssetBundle.js == []
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  Informal.Slides.blueprintSlidesCss ==
+      String.intercalate "\n\n" Informal.Slides.blueprintSlidesAssetBundle.css &&
+    Informal.Slides.blueprintSlidesJs ==
+      String.intercalate "\n\n" Informal.Slides.blueprintSlidesAssetBundle.js
+
+end Verso.VersoBlueprintTests.BlueprintAssets

--- a/tests/VersoBlueprintTests/BlueprintGraph/Basics.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraph/Basics.lean
@@ -43,6 +43,27 @@ open Verso.VersoBlueprintTests.BlueprintGraph.Shared
   status.statusLabel = "contains sorry" &&
   status.sorryRefCounts = (2, 3)
 
+/-- info: true -/
+#guard_msgs in
+#eval
+  let sorryStatus : Data.ProvedStatus :=
+    .containsSorry #[{ location := .proof, refs? := some 1 }]
+  let sorryView := sorryStatus.presentation
+  let missingView := Data.ProvedStatus.proved.presentation (present := false)
+  let axiomView := Data.ProvedStatus.axiomLike.presentation
+  sorryView.summaryText == "sorry in proof" &&
+    sorryView.externalPanelText == "contains sorry in proof" &&
+    sorryView.externalHeaderText == "contains sorry" &&
+    sorryView.codeDeclClass == "bp_code_decl_status_warning" &&
+    sorryView.externalDeclClass == "bp_external_decl_sorry" &&
+    sorryView.codeEntryClassSuffix == "warning" &&
+    missingView.summaryText == "missing declaration" &&
+    missingView.externalHeaderText == "missing" &&
+    missingView.codeEntryClassSuffix == "missing" &&
+    axiomView.summaryText == "axiom-like (no body)" &&
+    axiomView.codeEntryClassSuffix == "axiom" &&
+    axiomView.statusMarkSymbol == "⚠"
+
 def nestedPopState : Environment.State :=
   {
     data := (mkState [(`outer, { kind := .definition, statement := some (mkInformal #[]) })]).data

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
@@ -83,7 +83,9 @@ private def samplePanelEntry : Informal.RelatedPanel.PanelEntry := {
         !hasSubstr relationJs "function blueprintRender()" &&
         hasAllSubstr relationJs [
           "previewUtils.registerPreviewHydrator(\"relationPanel\", function (root) {",
-          "previewUtils.previewMessageHtml({",
+          "previewUtils.renderPreviewIntoSurface(surface, previewKey, {",
+          "relationPreviewDiagnosticOptions(",
+          "shouldRender: function () {",
           "previewUtils.createPreviewSurface({",
           "surface.bindTriggers({",
           "surface.bindDismissal({",
@@ -92,6 +94,7 @@ private def samplePanelEntry : Informal.RelatedPanel.PanelEntry := {
         ] &&
         lacksAllSubstr relationJs [
           "previewUtils.renderPreviewInto(body, previewKey, { diagnostics: false })",
+          "previewUtils.resolvePreview(previewKey)",
           "previewUtils.readHtmlCacheStatus()",
           "previewUtils.bindDismissHandlers({",
           "previewUtils.shouldKeepOpen(",
@@ -170,7 +173,7 @@ private def samplePanelEntry : Informal.RelatedPanel.PanelEntry := {
       match relationJs? with
       | some relationJs =>
         hasRenderReadyCallback relationJs "previewUtils" &&
-        hasSubstr relationJs "previewUtils.resolvePreview(previewKey)" &&
+        hasSubstr relationJs "previewUtils.renderPreviewIntoSurface(surface, previewKey, {" &&
         hasSubstr relationJs "previewUtils.createPreviewSurface({" &&
         !hasSubstr relationJs "previewUtils.setPreviewHeaderLink(headerLabel, item)"
       | none => false
@@ -202,7 +205,7 @@ private def samplePanelEntry : Informal.RelatedPanel.PanelEntry := {
       match relationJs? with
       | some relationJs =>
         hasRenderReadyCallback relationJs "previewUtils" &&
-        hasSubstr relationJs "previewUtils.resolvePreview(previewKey)" &&
+        hasSubstr relationJs "previewUtils.renderPreviewIntoSurface(surface, previewKey, {" &&
         !hasSubstr relationJs "activate(initialItem, { openWrap: false })"
       | none => false
     )

--- a/tests/harness/test_preview_runtime_api_docs.py
+++ b/tests/harness/test_preview_runtime_api_docs.py
@@ -158,6 +158,15 @@ class PreviewRuntimeApiDocsTests(unittest.TestCase):
         self.assertNotIn("window.bpSlideNodeRuntime", runtime)
         self.assertNotIn("window.bpSlideNodeRuntimeConfig", runtime)
 
+    def test_graph_runtime_uses_structured_variants_only(self) -> None:
+        runtime = (BLUEPRINT_SRC / "Commands" / "graph.js").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("readPublicGraphVariants(previewUtils, graphBlock)", runtime)
+        self.assertIn("previewUtils.getGraphVariants(root)", runtime)
+        self.assertNotIn("legacyGraphVariants", runtime)
+
     def test_feature_js_uses_render_ready_instead_of_direct_runtime_reads(self) -> None:
         direct_runtime_reads: list[str] = []
         missing_ready_callbacks: list[str] = []

--- a/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/CustomRenderClient.lean
+++ b/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/CustomRenderClient.lean
@@ -390,13 +390,17 @@ def customRenderClientHtml : Verso.Output.Html :=
       (Verso.Output.Html.seq #[header, examples])
   Verso.Output.Html.seq #[sectionBlock, previewModuleExampleScript, graphModuleExampleScript]
 
+def customRenderClientAssetBundle : Informal.Commands.BlueprintAssetBundle :=
+  (Informal.Commands.blueprintCssAssetBundle [customRenderClientCss]).append
+    (Informal.Commands.previewRuntimeJsAssetBundle.withJs [] [customRenderClientJs])
+
 open Verso Doc Elab Genre Manual in
 block_extension Block.customRenderClientExample where
   data := Lean.Json.null
   traverse _id _data _contents := pure none
   toTeX := none
-  extraCss := Informal.Commands.withBlueprintCssAssets [customRenderClientCss]
-  extraJs := Informal.Commands.withPreviewRuntimeJsAssets [] [customRenderClientJs]
+  extraCss := customRenderClientAssetBundle.css
+  extraJs := customRenderClientAssetBundle.js
   toHtml :=
     some <| fun _goI _goB _id _data _blocks => do
       pure customRenderClientHtml


### PR DESCRIPTION
## Summary
Backport #155 to `v4.30.0`.

## Primary Review
- Primary review: #155
- Keep review comments on #155 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.30.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.