### PR TITLE
refactor: clarify preview runtime boundaries

### DIFF
--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -448,6 +448,34 @@ code-panel structure without changing the semantic data contract. Cached HTML
 may visibly contain relation panels, code panels, and headings, but those are a
 rendering of manifest semantics, not a second data source.
 
+### Body Fragments vs Full Node Wrappers
+
+The rendered-fragment cache should not grow into a second node-wrapper cache
+just because a browser client wants a whole Blueprint node. The current split is
+intentional:
+
+- `blueprint-html-cache.json` stores reusable rendered bodies. Those fragments
+  are small enough to use in hovers, relation panels, custom cards, Slides, and
+  generated consumers that provide their own wrapper.
+- `blueprint-manifest.json` stores the semantic entry, including the generated
+  page `href` and preview key needed to find the canonical page occurrence.
+- the generated HTML page remains the owner of the exact page-level node shell:
+  heading layout, wrapper attributes, relation-panel placement, code extras,
+  folded state, and any future page-local affordances.
+
+For `renderCanonicalPreviewInto`, the browser runtime therefore follows
+`manifestEntry.href`, loads the generated page, clones the linked node, rebases
+links, inserts the copy, and hydrates it. That JavaScript is justified because
+it delegates shell structure back to the Lean-generated page instead of
+duplicating shell semantics in browser code.
+
+Adding a richer cache would be justified only if a repeated real use case needs
+canonical node wrappers without page fetches and the cost is visible. In that
+case the new artifact should be an explicit generated-node cache, not an
+overloaded HTML-cache entry. It should still be produced by the same Lean block
+shell renderer and keyed by the same manifest preview key, so JavaScript remains
+a loader/inserter rather than the owner of Blueprint semantics.
+
 ### Phase Boundary Checklist
 
 When adding a new Blueprint surface, choose its data boundary explicitly:

--- a/src/VersoBlueprint/Commands/preview-runtime.js
+++ b/src/VersoBlueprint/Commands/preview-runtime.js
@@ -1,9 +1,11 @@
 (function () {
   if (window.VersoBlueprint && window.VersoBlueprint.render) return;
 
+  // Runtime-local registries. Keep these private and expose behavior through
+  // the render API instead of growing new window globals.
   const previewHydrators = new Map();
 
-  // Debug and local-template utilities.
+  // Runtime-local diagnostics and page-local template capture.
 
   function previewDebugEnabled() {
     try {
@@ -83,7 +85,7 @@
       .replaceAll("'", "&#39;");
   }
 
-  // Manifest and rendered-fragment cache stores.
+  // Generated-data URL helpers and graph delegation.
 
   function blueprintGraphApi() {
     return window.bpGraphApi && typeof window.bpGraphApi === "object" ? window.bpGraphApi : null;
@@ -209,6 +211,8 @@
       return loadManifestGraphs(blueprintManifestUrl(), options);
     });
   }
+
+  // Manifest/cache status, loading, and diagnostics.
 
   function missingPreviewKeyDiagnosticHtml() {
     return (
@@ -435,7 +439,12 @@
     return previewKey(label, "statement");
   }
 
-  // Preview resolution joins semantic manifest entries with opaque fragments.
+  // Preview resolution joins semantic manifest entries with opaque body fragments.
+  //
+  // The HTML cache is presentation data. Runtime code may insert and hydrate
+  // its fragments, but semantic facts must come from the manifest entry. If a
+  // future client needs another fact, add it to the manifest instead of parsing
+  // cached HTML.
 
   async function loadBlueprintStoreEntry(store, previewKey) {
     const exact = readBlueprintStoreEntry(store, previewKey);
@@ -546,6 +555,14 @@
     renderHtmlInto(target, html, opts);
     return result;
   }
+
+  // Canonical generated-node rendering.
+  //
+  // The HTML cache intentionally carries reusable body fragments, not full
+  // Blueprint node wrappers. To render the exact Lean-generated shell without
+  // duplicating wrapper semantics in JavaScript or emitting a second wrapper
+  // cache, follow the manifest href, clone the canonical node, and rebase its
+  // links for insertion into the current page.
 
   function urlWithoutHash(url) {
     const clone = new URL(url.href);
@@ -788,7 +805,12 @@
     renderAll(".bp_math.display", true);
   }
 
-  // Panel behavior helpers shared by bundled Blueprint features.
+  // Bundled preview surface and lifecycle helpers.
+  //
+  // These helpers own browser interaction state for Blueprint's bundled graph,
+  // summary, relation-panel, inline-preview, and slide clients. They are not a
+  // semantic data layer and are not part of the stable custom-client API unless
+  // explicitly re-exported through stableCustomClientApi below.
 
   function bindCloseOnce(button, onClose) {
     if (!(button instanceof Element)) return;
@@ -1619,6 +1641,8 @@
       showTrigger: showTrigger
     });
   }
+
+  // Hydration extension points and option readers.
 
   function registerPreviewHydrator(name, fn) {
     if (typeof name !== "string" || name.length === 0) return;

--- a/tests/harness/test_preview_runtime_api_docs.py
+++ b/tests/harness/test_preview_runtime_api_docs.py
@@ -17,6 +17,7 @@ from tests.preview_runtime_api import (
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 API_DOC = PACKAGE_ROOT / "doc" / "API.md"
+DESIGN_RATIONALE = PACKAGE_ROOT / "doc" / "DESIGN_RATIONALE.md"
 INTERNAL_ONLY_HELPERS = {
     "bindCloseOnce",
     "bindDismissHandlers",
@@ -147,6 +148,30 @@ class PreviewRuntimeApiDocsTests(unittest.TestCase):
         self.assertIn("const previewHydrators = new Map();", runtime)
         self.assertNotIn("window.bpPreviewHydrators", runtime)
         self.assertNotIn("window.bpPreviewTrace", runtime)
+
+    def test_preview_runtime_component_boundaries_are_named(self) -> None:
+        runtime = blueprint_js_source()
+
+        for marker in (
+            "Generated-data URL helpers and graph delegation.",
+            "Manifest/cache status, loading, and diagnostics.",
+            "Preview resolution joins semantic manifest entries with opaque body fragments.",
+            "Canonical generated-node rendering.",
+            "Bundled preview surface and lifecycle helpers.",
+            "API assembly and readiness synchronization.",
+        ):
+            self.assertIn(marker, runtime)
+
+    def test_design_rationale_explains_html_cache_boundary(self) -> None:
+        design = DESIGN_RATIONALE.read_text(encoding="utf-8")
+
+        self.assertIn("### Body Fragments vs Full Node Wrappers", design)
+        self.assertIn(
+            "The rendered-fragment cache should not grow into a second node-wrapper cache",
+            design,
+        )
+        self.assertIn("renderCanonicalPreviewInto", design)
+        self.assertIn("manifestEntry.href", design)
 
     def test_slide_runtime_uses_verso_blueprint_namespace(self) -> None:
         runtime = (BLUEPRINT_SRC / "Slides" / "blueprint-slides.js").read_text(


### PR DESCRIPTION
This PR clarifies the preview runtime's internal component boundaries and documents why the generated HTML cache remains body-fragment shaped while canonical node rendering follows manifest links back to the Lean-rendered page node.

- Name the preview runtime sections for generated-data loading, manifest/cache diagnostics, preview resolution, canonical node rendering, bundled surface helpers, and readiness.
- Document the body-fragment cache versus full-node wrapper design decision in the architecture rationale.
- Add harness guards that keep the runtime boundaries and cache-design rationale visible during future refactors.

Backport v4.30.0: exempt: comment/design-only clarification without behavior change