### PR TITLE
doc: clarify ESM API import paths

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -309,12 +309,13 @@ from `../-verso-data/api/...`. Generated clients that need to resolve the
 module URL from an arbitrary page should use `api.previewApiModuleUrl()` or
 `api.graphApiModuleUrl()`.
 
-The root files `-verso-data/blueprint-preview-api.mjs` and
-`-verso-data/blueprint-graph-api.mjs` are still emitted as compatibility
-targets. The generated data directory also contains implementation support
-files used by those modules, such as `blueprint-graph-core.js`. Those support
-files are not public import paths. New clients should use the shorter
-`-verso-data/api/` paths.
+Generated sites also emit root implementation modules,
+`-verso-data/blueprint-preview-api.mjs` and
+`-verso-data/blueprint-graph-api.mjs`. The public `api/*.mjs` modules re-export
+those implementations from stable, shorter import paths. The generated data
+directory also contains internal support files used by those modules, such as
+`blueprint-graph-core.js`; those support files are not public import paths. New
+clients should use the `-verso-data/api/` paths.
 
 URL, graph-data, and key helpers in `api/preview.mjs` are available
 immediately. Manifest/cache loading, rendering, and hydration helpers wait for


### PR DESCRIPTION
This PR clarifies that `-verso-data/api/*.mjs` are the public browser ESM import paths, while the root `blueprint-*-api.mjs` files are implementation modules re-exported by those public paths.

Backport v4.30.0: exempt: docs-only clarification