### PR TITLE
refactor: tidy summary sorting helpers

### DIFF
--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -146,7 +146,7 @@ flowchart TD
   elab["Lean / Verso elaboration<br/>directive parsing and local semantic registration"]
   env["Environment.State<br/>persistent semantic data in oleans"]
   traverse["Verso traversal<br/>numbering, hrefs, anchors, local preview blocks"]
-  indexes["TraversalIndex domains<br/>Nodes, InlineCode, TraversalPreviews,<br/>LeanCodePreviews, citations, external-decl anchors"]
+  indexes["TraversalIndex domains<br/>Nodes, InlineCode, RustInlineCode,<br/>TraversalPreviews, LeanCodePreviews,<br/>citations, external-decl anchors"]
   render["HTML page rendering<br/>manual pages, graph, summary, bibliography"]
   manifest["PreviewManifest extra step<br/>semantic manifest and rendered-fragment cache"]
   artifacts["Generated artifacts<br/>HTML pages, assets, -verso-docs.json,<br/>blueprint-manifest.json, blueprint-html-cache.json"]
@@ -220,7 +220,7 @@ that owner.
 | --- | --- | --- | --- |
 | Blueprint labels, node kind, declared dependencies, parent/group, owner, tags, priority, effort, PR URL | Elaboration | `Environment.State.data` and related environment maps | traversal, graph, summary, manifest construction |
 | Group and author declarations | Elaboration | `Environment.State.groups` and `Environment.State.authors` | block rendering, summary, graph/group panels |
-| Inline Lean and Rust attachments | Elaboration plus traversal | semantic code refs in environment; render-time code-panel indexes in `TraversalIndex.InlineCode` | block renderers, code panels, manifest entries |
+| Inline Lean and Rust attachments | Elaboration plus traversal | semantic code refs in environment; render-time code-panel indexes in `TraversalIndex.InlineCode` and `TraversalIndex.RustInlineCode` | block renderers, code panels, manifest entries |
 | External Lean declaration snapshots | Elaboration / declaration snapshot registration | `ExternalRef` records on semantic nodes, enriched with presence/status/source/render data | block renderers, code-summary badges, summary, graph, manifest |
 | Numbering, hrefs, anchors, preview keys | Traversal | `TraverseState` and `TraversalIndex` domains | page rendering, preview manifest, browser triggers |
 | Statement/proof preview source blocks | Traversal | `TraversalIndex.TraversalPreviews` | manifest/cache emission, same-document manual grafts |

--- a/src/VersoBlueprint/Commands/Summary.lean
+++ b/src/VersoBlueprint/Commands/Summary.lean
@@ -110,87 +110,76 @@ private def explicitPriorityRank (priority? : Option String) : Nat :=
   | some "low" => 2
   | _ => 3
 
+private def byNatAsc (left right : Nat) (tie : Bool) : Bool :=
+  left < right || (left == right && tie)
+
+private def byNatDesc (left right : Nat) (tie : Bool) : Bool :=
+  left > right || (left == right && tie)
+
+private def byStringAsc (left right : String) : Bool :=
+  left < right
+
+private def byNameStringAsc (left right : Name) : Bool :=
+  left.toString < right.toString
+
 private def sortPriorityItems (items : Array PriorityItem) : Array PriorityItem :=
   items.qsort fun a b =>
-    explicitPriorityRank a.priority < explicitPriorityRank b.priority ||
-      (explicitPriorityRank a.priority == explicitPriorityRank b.priority &&
-        (a.downstreamUses > b.downstreamUses ||
-      (a.downstreamUses == b.downstreamUses &&
-        (a.directUses > b.directUses ||
-          (a.directUses == b.directUses &&
-            (priorityStageRank a.stage < priorityStageRank b.stage ||
-              (priorityStageRank a.stage == priorityStageRank b.stage &&
-                a.label.toString < b.label.toString)))))))
+    byNatAsc (explicitPriorityRank a.priority) (explicitPriorityRank b.priority) <|
+      byNatDesc a.downstreamUses b.downstreamUses <|
+        byNatDesc a.directUses b.directUses <|
+          byNatAsc (priorityStageRank a.stage) (priorityStageRank b.stage) <|
+            byNameStringAsc a.label b.label
 
 private def sortUsageItems (items : Array UsageItem) : Array UsageItem :=
   items.qsort fun a b =>
-    a.directUses > b.directUses ||
-      (a.directUses == b.directUses &&
-        (a.downstreamUses > b.downstreamUses ||
-          (a.downstreamUses == b.downstreamUses &&
-            a.label.toString < b.label.toString)))
+    byNatDesc a.directUses b.directUses <|
+      byNatDesc a.downstreamUses b.downstreamUses <|
+        byNameStringAsc a.label b.label
 
 private def sortUsageItemsByAxis (items : Array UsageItem) (axisUses : UsageItem → Nat) : Array UsageItem :=
   items.qsort fun a b =>
-    axisUses a > axisUses b ||
-      (axisUses a == axisUses b &&
-        (a.downstreamUses > b.downstreamUses ||
-          (a.downstreamUses == b.downstreamUses &&
-            (a.directUses > b.directUses ||
-              (a.directUses == b.directUses &&
-                a.label.toString < b.label.toString)))))
+    byNatDesc (axisUses a) (axisUses b) <|
+      byNatDesc a.downstreamUses b.downstreamUses <|
+        byNatDesc a.directUses b.directUses <|
+          byNameStringAsc a.label b.label
 
 private def sortDependencyLoadItems (items : Array DependencyLoadItem) : Array DependencyLoadItem :=
   items.qsort fun a b =>
-    a.totalDeps > b.totalDeps ||
-      (a.totalDeps == b.totalDeps &&
-        (a.proofDeps > b.proofDeps ||
-          (a.proofDeps == b.proofDeps &&
-            (a.statementDeps > b.statementDeps ||
-              (a.statementDeps == b.statementDeps &&
-                a.label.toString < b.label.toString)))))
+    byNatDesc a.totalDeps b.totalDeps <|
+      byNatDesc a.proofDeps b.proofDeps <|
+        byNatDesc a.statementDeps b.statementDeps <|
+          byNameStringAsc a.label b.label
 
 private def sortDebtHotspotItems (items : Array DebtHotspotItem) : Array DebtHotspotItem :=
   items.qsort fun a b =>
-    a.totalDebt > b.totalDebt ||
-      (a.totalDebt == b.totalDebt &&
-        (a.affectedEntries > b.affectedEntries ||
-          (a.affectedEntries == b.affectedEntries &&
-            a.header < b.header)))
+    byNatDesc a.totalDebt b.totalDebt <|
+      byNatDesc a.affectedEntries b.affectedEntries <|
+        byStringAsc a.header b.header
 
 private def sortGroupHealthItems (items : Array GroupHealthItem) : Array GroupHealthItem :=
   items.qsort fun a b =>
-    a.readyEntries > b.readyEntries ||
-      (a.readyEntries == b.readyEntries &&
-        (a.unlockScore > b.unlockScore ||
-          (a.unlockScore == b.unlockScore &&
-            (a.totalEntries > b.totalEntries ||
-              (a.totalEntries == b.totalEntries &&
-                a.header < b.header)))))
+    byNatDesc a.readyEntries b.readyEntries <|
+      byNatDesc a.unlockScore b.unlockScore <|
+        byNatDesc a.totalEntries b.totalEntries <|
+          byStringAsc a.header b.header
 
 private def sortOwnerRollupItems (items : Array OwnerRollupItem) : Array OwnerRollupItem :=
   items.qsort fun a b =>
-    a.actionableEntries > b.actionableEntries ||
-      (a.actionableEntries == b.actionableEntries &&
-        (a.quickWins > b.quickWins ||
-          (a.quickWins == b.quickWins &&
-            (a.totalEntries > b.totalEntries ||
-              (a.totalEntries == b.totalEntries &&
-                a.displayName < b.displayName)))))
+    byNatDesc a.actionableEntries b.actionableEntries <|
+      byNatDesc a.quickWins b.quickWins <|
+        byNatDesc a.totalEntries b.totalEntries <|
+          byStringAsc a.displayName b.displayName
 
 private def sortTagRollupItems (items : Array TagRollupItem) : Array TagRollupItem :=
   items.qsort fun a b =>
-    a.actionableEntries > b.actionableEntries ||
-      (a.actionableEntries == b.actionableEntries &&
-        (a.quickWins > b.quickWins ||
-          (a.quickWins == b.quickWins &&
-            (a.totalEntries > b.totalEntries ||
-              (a.totalEntries == b.totalEntries &&
-                a.tag < b.tag)))))
+    byNatDesc a.actionableEntries b.actionableEntries <|
+      byNatDesc a.quickWins b.quickWins <|
+        byNatDesc a.totalEntries b.totalEntries <|
+          byStringAsc a.tag b.tag
 
 private def sortMetadataEntryItems (items : Array MetadataEntryItem) : Array MetadataEntryItem :=
   items.qsort fun a b =>
-    a.label.toString < b.label.toString
+    byNameStringAsc a.label b.label
 
 private def triageVisibleLimit : Nat := 10
 


### PR DESCRIPTION
This PR simplifies Blueprint summary sorting by sharing small tie-breaker helpers across the summary item orderings, and updates the design rationale so the traversal workflow names both Lean and Rust inline-code indexes.

Backport v4.30.0: #170
