### PR TITLE
[backport v4.30.0] refactor: share extension payload decoding

### DIFF
--- a/src/VersoBlueprint/Cite.lean
+++ b/src/VersoBlueprint/Cite.lean
@@ -11,6 +11,7 @@ import VersoBlueprint.Commands.Common
 import VersoBlueprint.Data
 import VersoBlueprint.Informal.Block.Model
 import VersoBlueprint.Informal.Block.Store
+import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.Lib.HoverRender
 import VersoBlueprint.Resolve
 import VersoBlueprint.TraversalIndex
@@ -480,9 +481,9 @@ inline_extension Inline.bpCite (citations : List CiteItem) (style : CitationStyl
     (kind : Option CitePartKind := none) (index : Option String := none) where
   data := toJson ({ citations, style, kind, index } : CiteInlineData)
   traverse id data _contents := do
-    let .ok cfg := fromJson? (α := CiteInlineData) data
-      | Verso.reportError "Malformed data in Inline.bpCite.traverse"
-        return none
+    let some cfg ← Informal.ExtensionDecode.decode? (α := CiteInlineData) data
+        (fun _ => "Malformed data in Inline.bpCite.traverse")
+      | return none
     let ctxt ← read
     let path := ctxt.path
     let tagBase :=
@@ -522,9 +523,9 @@ inline_extension Inline.bpCite (citations : List CiteItem) (style : CitationStyl
   toTeX :=
     open Verso.Output.TeX in
     some <| fun go _id data content => do
-      let .ok cfg := fromJson? (α := CiteInlineData) data
-        | Verso.reportError "Malformed data in Inline.bpCite.toTeX"
-          pure .empty
+      let some cfg ← Informal.ExtensionDecode.decode? (α := CiteInlineData) data
+          (fun _ => "Malformed data in Inline.bpCite.toTeX")
+        | pure .empty
       let pieces := cfg.citations.map (fun item => pieceText cfg.style item.citation)
       let body := String.intercalate "; " pieces
       let loc? := locatorText cfg.kind cfg.index
@@ -554,9 +555,9 @@ inline_extension Inline.bpCite (citations : List CiteItem) (style : CitationStyl
     open Verso.Doc.Html in
     open Verso.Output.Html in
     some <| fun goI id data content => do
-      let .ok cfg := fromJson? (α := CiteInlineData) data
-        | Verso.reportError "Malformed data in Inline.bpCite.toHtml"
-          pure .empty
+      let some cfg ← Informal.ExtensionDecode.decode? (α := CiteInlineData) data
+          (fun _ => "Malformed data in Inline.bpCite.toHtml")
+        | pure .empty
       let st ← HtmlT.state
       let inPreviewRender ← Informal.HoverRender.inInlinePreviewRender
       let citeAnchorId? := st.externalTags[id]? |>.map (·.htmlId.toString)

--- a/src/VersoBlueprint/Commands/Bibliography.lean
+++ b/src/VersoBlueprint/Commands/Bibliography.lean
@@ -10,6 +10,7 @@ import VersoManual
 import VersoBlueprint.Compat
 import VersoBlueprint.Cite
 import VersoBlueprint.Commands.Common
+import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.PreviewCache
 import VersoBlueprint.Resolve
 import VersoBlueprint.TraversalIndex
@@ -37,9 +38,9 @@ open Verso Doc Elab Genre Manual in
 block_extension Block.bibliography (biblio : BibliographyData) where
   data := toJson biblio
   traverse id data _contents := do
-    let .ok biblio := fromJson? (α := BibliographyData) data
-      | Verso.reportError "Malformed data in Block.bibliography.traverse"
-        return none
+    let some biblio ← Informal.ExtensionDecode.decode? (α := BibliographyData) data
+        (fun _ => "Malformed data in Block.bibliography.traverse")
+      | return none
     let path ← (·.path) <$> read
     let _ ← Verso.Genre.Manual.externalTag id path s!"--bp-bibliography"
     for entry in biblio.entries do
@@ -51,9 +52,9 @@ block_extension Block.bibliography (biblio : BibliographyData) where
     open Verso.Doc.Html in
     open Verso.Output.Html in
     some <| fun goI _goB _id data _blocks => do
-      let .ok data := fromJson? (α := BibliographyData) data
-        | Verso.reportError "Malformed data in Block.bibliography.toHtml"
-          pure .empty
+      let some data ← Informal.ExtensionDecode.decode? (α := BibliographyData) data
+          (fun _ => "Malformed data in Block.bibliography.toHtml")
+        | pure .empty
       let st ← HtmlT.state
       let entries := data.entries.toArray.qsort (fun a b => a.citation.sortKey < b.citation.sortKey)
       let rows ← entries.mapM fun entry => do

--- a/src/VersoBlueprint/Commands/Graph.lean
+++ b/src/VersoBlueprint/Commands/Graph.lean
@@ -14,6 +14,7 @@ import VersoBlueprint.Graph
 import VersoBlueprint.GraphApi
 import VersoBlueprint.Lib.HoverRender
 import VersoBlueprint.Lib.HtmlId
+import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.PreviewCache
 import VersoBlueprint.Lib.PreviewSource
 import VersoBlueprint.Resolve
@@ -87,11 +88,12 @@ block_extension Block.graph (graphData : GraphBlockData) where
   -- localContentItem _ _ _ := none
   data := toJson graphData
   traverse id data _contents := do
-      match fromJson? (α := GraphBlockData) data with
-      | .ok graphData =>
+      match ← Informal.ExtensionDecode.decode? (α := GraphBlockData) data
+          (fun _ => "Malformed data in Block.graph.traverse") with
+      | some graphData =>
         modify fun state => Informal.GraphApi.saveData state id graphData.semanticGraphData
-      | .error _ =>
-        Verso.reportError "Malformed data in Block.graph.traverse"
+      | Option.none =>
+        pure ()
       return none
   toTeX := none
   toHtml :=
@@ -99,11 +101,10 @@ block_extension Block.graph (graphData : GraphBlockData) where
     open Verso.Output.Html in
     some <| fun _goI _goB id data _blocks => do
       let graphData : GraphBlockData ←
-        match fromJson? (α := GraphBlockData) data with
-        | .ok gd => pure gd
-        | .error err =>
-          Verso.reportError s!"Malformed data in Block.graph.toHtml ({err})"
-          pure { semanticGraphData := {}, options := {} }
+        match ← Informal.ExtensionDecode.decode? (α := GraphBlockData) data
+            (fun err => s!"Malformed data in Block.graph.toHtml ({err})") with
+        | some graphData => pure graphData
+        | Option.none => pure { semanticGraphData := {}, options := {} }
       let s ← HtmlT.state
       let publicGraphData := Informal.GraphApi.finalDataForBlock s id graphData.semanticGraphData
       let publicGraphDataJson : String := Lean.Json.compress (toJson publicGraphData)

--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -26,6 +26,7 @@ import VersoBlueprint.Informal.Block.Store
 import VersoBlueprint.Informal.Block.Traversal
 import VersoBlueprint.Informal.CodeSummary
 import VersoBlueprint.Informal.ExternalCode
+import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.PreviewRender
 import VersoBlueprint.Resolve
 import VersoBlueprint.TraversalIndex
@@ -61,11 +62,11 @@ block_extension Block.informal (data : BlockData) where
   data := toJson data
   traverse id data _contents := do
     -- XXX: (maybe) lift the Except into the main monad error thread
-    match fromJson? (α := BlockData) data with
-    | .error err =>
-      Verso.reportError s!"Malformed data ({err}): {data}"
+    match ← ExtensionDecode.decode? (α := BlockData) data
+        (fun err => s!"Malformed data ({err}): {data}") with
+    | none =>
       pure none
-    | .ok blockData =>
+    | some blockData =>
       let blockData := blockData.withTraversalNumberingContext (← read)
       registerTraversedBlockAssets id blockData _contents
       saveTraversedBlockData id blockData
@@ -77,11 +78,11 @@ block_extension Block.informal (data : BlockData) where
     open Verso.Doc.Html in
     open Verso.Output.Html in
     some <| fun _goI goB id data blocks => do
-      match fromJson? (α := BlockData) data with
-      | .error err =>
-        Verso.reportError s!"Malformed data ({err}): {data}"
+      match ← ExtensionDecode.decode? (α := BlockData) data
+          (fun err => s!"Malformed data ({err}): {data}") with
+      | none =>
         pure .empty
-      | .ok data =>
+      | some data =>
         let s ← HtmlT.state
         let ctxt ← HtmlT.context
         let data := data.withResolvedNumberingInContext s ctxt

--- a/src/VersoBlueprint/Informal/Code.lean
+++ b/src/VersoBlueprint/Informal/Code.lean
@@ -17,6 +17,7 @@ import VersoBlueprint.Informal.LeanCodePreview
 import VersoBlueprint.Informal.CodeSummary
 import VersoBlueprint.LabelNameParsing
 import VersoBlueprint.Lean
+import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.Profiling
 import VersoBlueprint.Resolve
 import VersoBlueprint.TraversalIndex
@@ -56,9 +57,9 @@ private partial def previewCodeBlocks
 block_extension Block.informalCode (data : InlineCodeData) where
   data := toJson data
   traverse id data _contents := do
-    let .ok cdata := fromJson? (α := InlineCodeData) data
-      | Verso.reportError s!"Malformed data: {data}"
-        pure none
+    let some cdata ← ExtensionDecode.decode? (α := InlineCodeData) data
+        (fun _ => s!"Malformed data: {data}")
+      | pure none
     let label := cdata.label
     if let .some _d := Informal.TraversalIndex.InlineCode.object? (← get) label then
       pure none
@@ -95,9 +96,10 @@ block_extension Block.informalCode (data : InlineCodeData) where
     open Verso.Doc.Html in
     open Verso.Output.Html in
     some <| fun _goI goB id data blocks => do
-      let .ok { label, definedDefs, definedTheorems, statementUses := _, proofUses := _, foldCodeBlock, foldProofs } := fromJson? (α := InlineCodeData) data
-        | Verso.reportError s!"Malformed data: {data}"
-          pure .empty
+      let some cdata ← ExtensionDecode.decode? (α := InlineCodeData) data
+          (fun _ => s!"Malformed data: {data}")
+        | pure .empty
+      let { label, definedDefs, definedTheorems, statementUses := _, proofUses := _, foldCodeBlock, foldProofs } := cdata
       let s ← HtmlT.state
       let ctxt ← HtmlT.context
       let attrs := s.htmlId id
@@ -272,9 +274,9 @@ private def externalMarkupSourceHtml (summary raw : String) : Verso.Output.Html 
 block_extension Block.externalMarkup (data : ExternalMarkupBlockData) where
   data := toJson data
   traverse id data _contents := do
-    let .ok cdata := fromJson? (α := ExternalMarkupBlockData) data
-      | Verso.reportError s!"Malformed external markup data: {data}"
-        pure none
+    let some cdata ← ExtensionDecode.decode? (α := ExternalMarkupBlockData) data
+        (fun _ => s!"Malformed external markup data: {data}")
+      | pure none
     let existingData := (Informal.TraversalIndex.ExternalMarkup.data? (← get) cdata.label).getD {
       label := cdata.label
     }
@@ -298,9 +300,9 @@ block_extension Block.externalMarkup (data : ExternalMarkupBlockData) where
   toHtml :=
     open Verso.Doc.Html in
     some <| fun _goI _goB _id data _blocks => do
-      let .ok cdata := fromJson? (α := ExternalMarkupBlockData) data
-        | Verso.reportError s!"Malformed external markup data: {data}"
-          pure .empty
+      let some cdata ← ExtensionDecode.decode? (α := ExternalMarkupBlockData) data
+          (fun _ => s!"Malformed external markup data: {data}")
+        | pure .empty
       let summary := externalMarkupSummary cdata.markup.language cdata.markup.slot cdata.markup.location
       pure <|
         match cdata.display with

--- a/src/VersoBlueprint/Informal/Group.lean
+++ b/src/VersoBlueprint/Informal/Group.lean
@@ -11,6 +11,7 @@ import VersoBlueprint.Data
 import VersoBlueprint.Environment
 import VersoBlueprint.Informal.GroupData
 import VersoBlueprint.LabelNameParsing
+import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.Profiling
 import VersoBlueprint.Resolve
 import VersoBlueprint.TraversalIndex
@@ -47,9 +48,9 @@ open Verso Doc Elab Genre Manual in
 block_extension Block.groupMetadata (groupData : GroupBlockData) where
   data := toJson groupData
   traverse _id data _contents := do
-    let .ok groupData := fromJson? (α := GroupBlockData) data
-      | Verso.reportError "Malformed data in Block.groupMetadata.traverse"
-        return none
+    let some groupData ← ExtensionDecode.decode? (α := GroupBlockData) data
+        (fun _ => "Malformed data in Block.groupMetadata.traverse")
+      | return none
     modify fun st =>
       Informal.TraversalIndex.Groups.saveData st groupData.label (toJson groupData)
     return none
@@ -58,9 +59,9 @@ block_extension Block.groupMetadata (groupData : GroupBlockData) where
     open Verso.Doc.Html in
     open Verso.Output.Html in
     some <| fun _ _ _ data _ => do
-      let .ok _ := fromJson? (α := GroupBlockData) data
-        | Verso.reportError "Malformed data in Block.groupMetadata.toHtml"
-          pure .empty
+      let some _ ← ExtensionDecode.decode? (α := GroupBlockData) data
+          (fun _ => "Malformed data in Block.groupMetadata.toHtml")
+        | pure .empty
       pure .empty
 
 private def collapseWhitespace (s : String) : String :=

--- a/src/VersoBlueprint/Informal/RustBlock.lean
+++ b/src/VersoBlueprint/Informal/RustBlock.lean
@@ -11,6 +11,7 @@ import VersoBlueprint.Informal.Block.Assets
 import VersoBlueprint.Informal.Block.Common
 import VersoBlueprint.Informal.Block.Store
 import VersoBlueprint.Informal.Code
+import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.Profiling
 import VersoBlueprint.Informal.RustPanel
 import VersoBlueprint.TraversalIndex
@@ -27,9 +28,9 @@ def rustBlockAssetBundle : Informal.Commands.BlueprintAssetBundle :=
 block_extension Block.informalRustCode (data : Informal.Rust.InlineCodeData) where
   data := toJson data
   traverse id data _contents := do
-    let .ok cdata := fromJson? (α := Informal.Rust.InlineCodeData) data
-      | Verso.reportError s!"Malformed Rust data: {data}"
-        pure none
+    let some cdata ← ExtensionDecode.decode? (α := Informal.Rust.InlineCodeData) data
+        (fun _ => s!"Malformed Rust data: {data}")
+      | pure none
     if let some _ := Informal.TraversalIndex.RustInlineCode.object? (← get) cdata.label then
       pure none
     else
@@ -45,9 +46,9 @@ block_extension Block.informalRustCode (data : Informal.Rust.InlineCodeData) whe
     open Verso.Doc.Html in
     open Verso.Output.Html in
     some <| fun _goI _goB id data _blocks => do
-      let .ok cdata := fromJson? (α := Informal.Rust.InlineCodeData) data
-        | Verso.reportError s!"Malformed Rust code data: {data}"
-          pure .empty
+      let some cdata ← ExtensionDecode.decode? (α := Informal.Rust.InlineCodeData) data
+          (fun _ => s!"Malformed Rust code data: {data}")
+        | pure .empty
       let s ← HtmlT.state
       let ctxt ← HtmlT.context
       let attrs := s.htmlId id

--- a/src/VersoBlueprint/Informal/Uses.lean
+++ b/src/VersoBlueprint/Informal/Uses.lean
@@ -13,6 +13,7 @@ import VersoBlueprint.Informal.Block
 import VersoBlueprint.Informal.Block.Store
 import VersoBlueprint.Informal.LabelArg
 import VersoBlueprint.Informal.UseConfig
+import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.Lib.HoverRender
 import VersoBlueprint.PreviewCache
 import VersoBlueprint.Profiling
@@ -118,9 +119,9 @@ private def wrapUseLinkPreview (node : Verso.Output.Html)
 inline_extension Inline.informal (data : InlineData) where
   data := toJson data
   traverse _id data _contents := do
-    let .ok _ := fromJson? (α := InlineData) data
-      | Verso.reportError s!"Malformed data in Inline.informal traversal: {data}"
-        pure none
+    let some _ ← ExtensionDecode.decode? (α := InlineData) data
+        (fun _ => s!"Malformed data in Inline.informal traversal: {data}")
+      | pure none
     pure none
   extraCss := usesAssetBundle.css
   extraJs := usesAssetBundle.js
@@ -128,9 +129,9 @@ inline_extension Inline.informal (data : InlineData) where
     open Verso.Doc.Html in
     open Verso.Output.Html in
     some <| fun goI _id data inlines => do
-      let .ok { label, block } := fromJson? (α := InlineData) data
-        | Verso.reportError "Malformed data in Inline.informal traversal"
-          pure .empty
+      let some { label, block } ← ExtensionDecode.decode? (α := InlineData) data
+          (fun _ => "Malformed data in Inline.informal traversal")
+        | pure .empty
       let st ← HtmlT.state
       let storedBlock? := resolveStoredBlockData? st label
       let resolvedBlock : Option BlockData :=

--- a/src/VersoBlueprint/Lib/ExtensionDecode.lean
+++ b/src/VersoBlueprint/Lib/ExtensionDecode.lean
@@ -1,0 +1,24 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import Lean
+import Verso
+import VersoBlueprint.Compat
+
+namespace Informal.ExtensionDecode
+
+open Lean
+
+def decode? {m : Type → Type} {α : Type} [Monad m] [Verso.MonadReportError m] [FromJson α]
+    (data : Json) (errorMessage : String → String) : m (Option α) := do
+  match fromJson? (α := α) data with
+  | .ok decoded =>
+      pure (some decoded)
+  | .error err =>
+      Verso.reportError (errorMessage err)
+      pure none
+
+end Informal.ExtensionDecode

--- a/src/VersoBlueprint/Math.lean
+++ b/src/VersoBlueprint/Math.lean
@@ -7,6 +7,7 @@ Author: Emilio J. Gallego Arias
 import Lean
 import VersoManual
 import VersoBlueprint.Compat
+import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.MathLint
 import VersoBlueprint.Macros
 
@@ -78,9 +79,9 @@ private def mathHtmlAssets (texPrelude : String) : HtmlAssets :=
 inline_extension Inline.bpMath (data : BpMathData) where
   data := toJson data
   traverse _id data _contents := do
-    let .ok { texPrelude, .. } := fromJson? (α := BpMathData) data
-      | Verso.reportError s!"Malformed blueprint math payload during traversal: {data}"
-        pure none
+    let some { texPrelude, .. } ← Informal.ExtensionDecode.decode? (α := BpMathData) data
+        (fun _ => s!"Malformed blueprint math payload during traversal: {data}")
+      | pure none
     modify fun st =>
       st.modifyHtmlAssets fun assets =>
         assets.combine (mathHtmlAssets texPrelude)
@@ -88,18 +89,18 @@ inline_extension Inline.bpMath (data : BpMathData) where
   toTeX :=
     open Verso.Output.TeX in
     some <| fun _go _id data _contents => do
-      let .ok { mode, source, .. } := fromJson? (α := BpMathData) data
-        | Verso.reportError s!"Malformed blueprint math payload: {data}"
-          pure .empty
+      let some { mode, source, .. } ← Informal.ExtensionDecode.decode? (α := BpMathData) data
+          (fun _ => s!"Malformed blueprint math payload: {data}")
+        | pure .empty
       pure <| match mode with
         | .inline => .raw s!"${source}$"
         | .display => .raw s!"\\[{source}\\]"
   toHtml :=
     open Verso.Doc.Html in
     some <| fun _goI _id data _contents => do
-      let .ok { mode, source, texPrelude } := fromJson? (α := BpMathData) data
-        | Verso.reportError s!"Malformed blueprint math payload: {data}"
-          pure .empty
+      let some { mode, source, texPrelude } ← Informal.ExtensionDecode.decode? (α := BpMathData) data
+          (fun _ => s!"Malformed blueprint math payload: {data}")
+        | pure .empty
       let attrs :=
         if texPrelude.isEmpty then
           #[("class", mathClasses mode)]


### PR DESCRIPTION
## Summary
Backport #169 to `v4.30.0`.

## Primary Review
- Primary review: #169
- Keep review comments on #169 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.30.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- Kept the existing `VersoBlueprint.Compat` import in `Math.lean`.
- Used the v4.30 `MonadReportError` compatibility boundary in `ExtensionDecode.lean`.