### PR TITLE
refactor: tighten render data boundaries

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -585,6 +585,16 @@ labels, dependencies, group membership, Lean-code associations, or status
 metadata. The cached fragment is presentation: it may display those facts, but
 the manifest is the data contract.
 
+Custom component frameworks should keep the same split. A React, audit, or
+dashboard client owns its component tree, selection state, filters, and wrapper
+markup, but it should treat Blueprint data as manifest/cache records loaded
+through the render API. Components should pass preview keys to
+`resolvePreview`, `renderPreviewInto`, `resolveCanonicalPreview`, or
+`renderCanonicalPreviewInto`, then render user-interface controls around the
+returned manifest entry. They should not scrape generated Blueprint DOM, call
+private bundled helpers, or couple component state to the current shape of
+`preview-runtime.js`.
+
 ## Bundled Helper Boundary
 
 Bundled-feature helper APIs are intentionally narrower than the stable API.

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -420,6 +420,26 @@ The workflow implies a few constraints for renderers:
   surface's local UI state, or call hydrators; it should not infer Blueprint
   relation topology, ownership, status, or code associations from HTML markup.
 
+  The next split should preserve the current public API while moving private
+  helpers behind files that match their responsibility:
+
+  | Boundary | Current responsibility | Split target |
+  | --- | --- | --- |
+  | API readiness | Install `window.VersoBlueprint`, queue `onRenderReady` callbacks, and expose the stable render API. | small bootstrap module loaded before bundled clients |
+  | Preview data access | Resolve `-verso-data` URLs, load manifest/cache JSON, keep load status, and normalize preview keys. | data/cache module |
+  | Fragment rendering | Resolve manifest/cache pairs, produce diagnostics, insert rendered fragments, and fetch canonical node wrappers. | render module |
+  | Hydration registry | Run math rendering and feature hydrators after custom insertion. | hydration module |
+  | Template binding | Convert rendered descriptor attributes into runtime preview triggers. | descriptor module |
+  | Preview surfaces | Own panel slots, body updates, local state, and surface-level callbacks. | surface module, eventually closest to a component primitive |
+  | Lifecycle binding | Handle trigger events, dismissal, resize/scroll repositioning, pointer checks, and keep-open checks. | lifecycle module used by surfaces |
+  | Debug hooks | Expose diagnostics needed by browser tests and local inspection without becoming a public data path. | debug module compiled into the bundled runtime |
+
+  A first split should be internal-only: generated pages should still load the
+  same bundled asset and custom clients should still start from
+  `onRenderReady`. Once the internal boundaries are stable, the ESM preview API
+  can re-export selected stable functions for framework clients without exposing
+  Blueprint-owned DOM or lifecycle details.
+
 - **Keep readiness and API guards source-level.**
   Feature JavaScript must start through `window.VersoBlueprint.onRenderReady`;
   direct reads from `window.VersoBlueprint.render` are limited to the runtime

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -62,7 +62,18 @@ Work:
 7. split the large preview runtime only along the component-like boundaries now
    encoded in its API tiers: data/cache lookup, fragment rendering and
    hydration, template descriptors, preview surface state, lifecycle binding,
-   and readiness/debug hooks
+   and readiness/debug hooks. The first split should keep the same emitted
+   bundled asset and public `onRenderReady` API, then move private helpers in
+   this order:
+   - readiness/bootstrap and render API installation
+   - manifest/cache URL resolution, loading, status, and preview-key helpers
+   - fragment and canonical-node resolution plus diagnostic rendering
+   - hydration registry and math/feature hydrator dispatch
+   - template descriptor binding for Lean-emitted preview triggers
+   - preview surface state, slots, and content updates
+   - lifecycle binding for trigger events, dismissal, pointer checks,
+     repositioning, and keep-open checks
+   - debug hooks used by tests and local inspection
 
 ### Data Model and Status Semantics
 

--- a/src/VersoBlueprint/Commands/Summary.lean
+++ b/src/VersoBlueprint/Commands/Summary.lean
@@ -18,6 +18,7 @@ import VersoBlueprint.Informal.Block.Common
 import VersoBlueprint.Informal.MetadataView
 import VersoBlueprint.Informal.LeanCodeLink
 import VersoBlueprint.Informal.LeanCodePreview
+import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.Lib.HoverRender
 import VersoBlueprint.Lib.PreviewSource
 import VersoBlueprint.PreviewCache
@@ -1722,9 +1723,12 @@ private def summaryStructureSection (data : Summary) (rows : SummaryRows) : Outp
 
 private def summaryBlockToHtml : BlockToHtml Manual (ReaderT AllRemotes (ReaderT ExtensionImpls (BuildLogT IO))) :=
   fun _goI _goB _id json _blocks => do
-    let .ok data := fromJson? (α := Summary) json
-      | Verso.reportError "Malformed data in Block.summary.toHtml"
-        pure .empty
+    let some data ←
+        Informal.ExtensionDecode.decode?
+          (α := Summary)
+          json
+          (fun err => s!"Malformed data in Block.summary.toHtml ({err})")
+      | pure .empty
     let s ← HtmlT.state
     let previewLookupKeys := (data.previewLabels).foldl (init := ({} : Lean.NameMap String)) fun keys label =>
       match Informal.PreviewSource.traversalSelection? s label with

--- a/src/VersoBlueprint/Graft.lean
+++ b/src/VersoBlueprint/Graft.lean
@@ -13,6 +13,7 @@ import VersoBlueprint.Graft.Assets
 import VersoBlueprint.Graft.Node
 import VersoBlueprint.Graft.Render
 import VersoBlueprint.PreviewManifest.BlockRender
+import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.Slides.Node
 
 set_option doc.verso true
@@ -155,11 +156,13 @@ block_extension Block.blueprintGraftNode (cfg : Informal.Graft.BlueprintNodeConf
     open Verso.Doc.Html in
     open Verso.Output.Html in
     some <| fun _goI goB _id data _blocks => do
-      match fromJson? (α := Informal.Graft.BlueprintNodeConfig) data with
-      | .error err =>
-          Verso.reportError s!"Malformed Blueprint graft node data ({err}): {data}"
-          pure .empty
-      | .ok cfg => renderManualGraftNode goB cfg
+      let some cfg ←
+          Informal.ExtensionDecode.decode?
+            (α := Informal.Graft.BlueprintNodeConfig)
+            data
+            (fun err => s!"Malformed Blueprint graft node data ({err}): {data}")
+        | pure .empty
+      renderManualGraftNode goB cfg
 
 open Verso Doc Elab Genre Manual in
 block_extension Block.blueprintGraftSideBySide (cfg : Informal.Graft.SideBySideConfig) where
@@ -173,11 +176,13 @@ block_extension Block.blueprintGraftSideBySide (cfg : Informal.Graft.SideBySideC
     open Verso.Output.Html in
     some <| fun _goI goB _id data blocks => do
       let cfg ←
-        match fromJson? (α := Informal.Graft.SideBySideConfig) data with
-        | .error err =>
-            Verso.reportError s!"Malformed Blueprint graft side-by-side data ({err}): {data}"
-            pure {}
-        | .ok cfg => pure cfg
+        match ←
+            Informal.ExtensionDecode.decode?
+              (α := Informal.Graft.SideBySideConfig)
+              data
+              (fun err => s!"Malformed Blueprint graft side-by-side data ({err}): {data}") with
+        | some cfg => pure cfg
+        | Option.none => pure {}
       let content ← blocks.mapM goB
       pure <| Html.tag "div" cfg.attrs (Html.seq content)
 

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -31,6 +31,16 @@ open Lean Elab Command Term Meta
 open Verso Doc
 open Verso.Genre Manual
 
+private def readJsonFileAs [FromJson α] (path : System.FilePath) (description : String) :
+    IO α := do
+  let json ←
+    match Json.parse (← IO.FS.readFile path) with
+    | .ok json => pure json
+    | .error err => throw <| IO.userError s!"could not parse {description} {path}: {err}"
+  match fromJson? (α := α) json with
+  | .ok value => pure value
+  | .error err => throw <| IO.userError s!"could not decode {description} {path}: {err}"
+
 private def buildMetadataCss : String := r##"
 .bp_build_metadata {
   display: flex;
@@ -852,13 +862,7 @@ def File.codeHtmlBodies (file : File) (entry : _root_.Informal.PreviewManifest.E
   file.index.codeHtmlBodies entry
 
 def readFile (path : System.FilePath) : IO File := do
-  let json ←
-    match Json.parse (← IO.FS.readFile path) with
-    | .ok json => pure json
-    | .error err => throw <| IO.userError s!"could not parse Blueprint HTML cache {path}: {err}"
-  match fromJson? (α := File) json with
-  | .ok file => pure file
-  | .error err => throw <| IO.userError s!"could not decode Blueprint HTML cache {path}: {err}"
+  readJsonFileAs path "Blueprint HTML cache"
 
 end HtmlCache
 
@@ -975,13 +979,7 @@ def Index.codeEntries (index : Index) (entry : Entry) : Array Entry :=
   entry.leanCodePreviewKeys.filterMap index.findEntry?
 
 def readFile (path : System.FilePath) : IO File := do
-  let json ←
-    match Json.parse (← IO.FS.readFile path) with
-    | .ok json => pure json
-    | .error err => throw <| IO.userError s!"could not parse Blueprint manifest {path}: {err}"
-  match fromJson? (α := File) json with
-  | .ok file => pure file
-  | .error err => throw <| IO.userError s!"could not decode Blueprint manifest {path}: {err}"
+  readJsonFileAs path "Blueprint manifest"
 
 private structure SchemaState where
   seen : Std.HashSet Name := {}

--- a/src/VersoBlueprint/TraversalIndex.lean
+++ b/src/VersoBlueprint/TraversalIndex.lean
@@ -124,12 +124,8 @@ def domainName : Name := spec.name
 def object? (state : TraverseState) (label : Name) : Option Verso.Multi.Object :=
   state.getDomainObject? domainName label.toString
 
-def storedObjectData? (obj : Verso.Multi.Object) : Option Informal.StoredBlockData :=
-  (fromJson? (α := Informal.StoredBlockData) obj.data).toOption
-
-def storedData? (state : TraverseState) (label : Name) : Option Informal.StoredBlockData := do
-  let obj ← object? state label
-  storedObjectData? obj
+def storedData? (state : TraverseState) (label : Name) : Option Informal.StoredBlockData :=
+  objectData? state domainName label.toString
 
 def data? (state : TraverseState) (label : Name) : Option Informal.BlockData :=
   (storedData? state label).map (·.toBlockData)


### PR DESCRIPTION
This PR tightens render data boundaries by sharing the remaining extension payload decode and manifest/cache file-read helpers, while documenting the custom-client API boundary and the internal preview-runtime split plan.

Backport v4.30.0: #175