### PR TITLE
refactor: derive summary data quotes

### DIFF
--- a/src/VersoBlueprint/Commands/Summary/Data.lean
+++ b/src/VersoBlueprint/Commands/Summary/Data.lean
@@ -18,22 +18,14 @@ structure SorryItem where
   decl : Name
   isTheorem : Bool := false
   status : Data.ProvedStatus := .proved
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote SorryItem where
-  quote s := mkCApp ``SorryItem.mk #[quote s.label, quote s.kind, quote s.decl, quote s.isTheorem, quote s.status]
+deriving Inhabited, FromJson, ToJson, Quote
 
 structure MissingLeanDeclItem where
   label : Name
   kind : String
   written : Name
   canonical : Name
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote MissingLeanDeclItem where
-  quote s := mkCApp ``MissingLeanDeclItem.mk #[quote s.label, quote s.kind, quote s.written, quote s.canonical]
+deriving Inhabited, FromJson, ToJson, Quote
 
 structure RenderFailureItem where
   label : Name
@@ -41,21 +33,13 @@ structure RenderFailureItem where
   written : Name
   canonical : Name
   message : String
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote RenderFailureItem where
-  quote s := mkCApp ``RenderFailureItem.mk #[quote s.label, quote s.kind, quote s.written, quote s.canonical, quote s.message]
+deriving Inhabited, FromJson, ToJson, Quote
 
 structure IndexItem where
   label : Name
   kind : String
   leanObjects : List Name := []
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote IndexItem where
-  quote s := mkCApp ``IndexItem.mk #[quote s.label, quote s.kind, quote s.leanObjects]
+deriving Inhabited, FromJson, ToJson, Quote
 
 abbrev PendingInformalItem := IndexItem
 
@@ -63,28 +47,14 @@ structure ParentTheoremGroup where
   parent : Name
   header : String := ""
   entries : List IndexItem := []
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote ParentTheoremGroup where
-  quote s := mkCApp ``ParentTheoremGroup.mk #[quote s.parent, quote s.header, quote s.entries]
+deriving Inhabited, FromJson, ToJson, Quote
 
 structure EntryStatusCounts where
   completed : Nat := 0
   completedDepsNo : Nat := 0
   withSorries : Nat := 0
   noProof : Nat := 0
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote EntryStatusCounts where
-  quote s := mkCApp ``EntryStatusCounts.mk
-    #[
-      quote s.completed,
-      quote s.completedDepsNo,
-      quote s.withSorries,
-      quote s.noProof
-    ]
+deriving Inhabited, FromJson, ToJson, Quote
 
 structure PriorityItem where
   label : Name
@@ -100,26 +70,7 @@ structure PriorityItem where
   directUses : Nat := 0
   downstreamUses : Nat := 0
   leanObjects : List Name := []
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote PriorityItem where
-  quote s := mkCApp ``PriorityItem.mk
-    #[
-      quote s.label,
-      quote s.kind,
-      quote s.stage,
-      quote s.priority,
-      quote s.ownerDisplayName,
-      quote s.effort,
-      quote s.prUrl,
-      quote s.tags,
-      quote s.statementStatus,
-      quote s.proofStatus,
-      quote s.directUses,
-      quote s.downstreamUses,
-      quote s.leanObjects
-    ]
+deriving Inhabited, FromJson, ToJson, Quote
 
 structure UsageItem where
   label : Name
@@ -129,20 +80,7 @@ structure UsageItem where
   directUses : Nat := 0
   downstreamUses : Nat := 0
   leanObjects : List Name := []
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote UsageItem where
-  quote s := mkCApp ``UsageItem.mk
-    #[
-      quote s.label,
-      quote s.kind,
-      quote s.statementUses,
-      quote s.proofUses,
-      quote s.directUses,
-      quote s.downstreamUses,
-      quote s.leanObjects
-    ]
+deriving Inhabited, FromJson, ToJson, Quote
 
 structure GroupHealthItem where
   parent : Name
@@ -155,23 +93,7 @@ structure GroupHealthItem where
   incompleteLeanEntries : Nat := 0
   unlockScore : Nat := 0
   nextPriority? : Option PriorityItem := none
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote GroupHealthItem where
-  quote s := mkCApp ``GroupHealthItem.mk
-    #[
-      quote s.parent,
-      quote s.header,
-      quote s.totalEntries,
-      quote s.closedEntries,
-      quote s.localOnlyEntries,
-      quote s.readyEntries,
-      quote s.blockedEntries,
-      quote s.incompleteLeanEntries,
-      quote s.unlockScore,
-      quote s.nextPriority?
-    ]
+deriving Inhabited, FromJson, ToJson, Quote
 
 structure CoverageSplit where
   informalOnly : Nat := 0
@@ -179,18 +101,7 @@ structure CoverageSplit where
   formalizedWithoutAncestors : Nat := 0
   fullyClosed : Nat := 0
   blockedOrIncomplete : Nat := 0
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote CoverageSplit where
-  quote s := mkCApp ``CoverageSplit.mk
-    #[
-      quote s.informalOnly,
-      quote s.readyToFormalize,
-      quote s.formalizedWithoutAncestors,
-      quote s.fullyClosed,
-      quote s.blockedOrIncomplete
-    ]
+deriving Inhabited, FromJson, ToJson, Quote
 
 structure DependencyLoadItem where
   label : Name
@@ -201,21 +112,7 @@ structure DependencyLoadItem where
   directUses : Nat := 0
   downstreamUses : Nat := 0
   leanObjects : List Name := []
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote DependencyLoadItem where
-  quote s := mkCApp ``DependencyLoadItem.mk
-    #[
-      quote s.label,
-      quote s.kind,
-      quote s.statementDeps,
-      quote s.proofDeps,
-      quote s.totalDeps,
-      quote s.directUses,
-      quote s.downstreamUses,
-      quote s.leanObjects
-    ]
+deriving Inhabited, FromJson, ToJson, Quote
 
 structure DebtHotspotItem where
   parent : Name
@@ -224,19 +121,7 @@ structure DebtHotspotItem where
   incompleteDecls : Nat := 0
   missingDecls : Nat := 0
   totalDebt : Nat := 0
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote DebtHotspotItem where
-  quote s := mkCApp ``DebtHotspotItem.mk
-    #[
-      quote s.parent,
-      quote s.header,
-      quote s.affectedEntries,
-      quote s.incompleteDecls,
-      quote s.missingDecls,
-      quote s.totalDebt
-    ]
+deriving Inhabited, FromJson, ToJson, Quote
 
 structure OwnerRollupItem where
   owner : Name
@@ -245,19 +130,7 @@ structure OwnerRollupItem where
   actionableEntries : Nat := 0
   quickWins : Nat := 0
   linkedPrs : Nat := 0
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote OwnerRollupItem where
-  quote s := mkCApp ``OwnerRollupItem.mk
-    #[
-      quote s.owner,
-      quote s.displayName,
-      quote s.totalEntries,
-      quote s.actionableEntries,
-      quote s.quickWins,
-      quote s.linkedPrs
-    ]
+deriving Inhabited, FromJson, ToJson, Quote
 
 structure TagRollupItem where
   tag : String
@@ -265,18 +138,7 @@ structure TagRollupItem where
   actionableEntries : Nat := 0
   quickWins : Nat := 0
   linkedPrs : Nat := 0
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote TagRollupItem where
-  quote s := mkCApp ``TagRollupItem.mk
-    #[
-      quote s.tag,
-      quote s.totalEntries,
-      quote s.actionableEntries,
-      quote s.quickWins,
-      quote s.linkedPrs
-    ]
+deriving Inhabited, FromJson, ToJson, Quote
 
 structure MetadataEntryItem where
   label : Name
@@ -287,21 +149,7 @@ structure MetadataEntryItem where
   prUrl : Option String := none
   tags : List String := []
   leanObjects : List Name := []
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote MetadataEntryItem where
-  quote s := mkCApp ``MetadataEntryItem.mk
-    #[
-      quote s.label,
-      quote s.kind,
-      quote s.ownerDisplayName,
-      quote s.effort,
-      quote s.priority,
-      quote s.prUrl,
-      quote s.tags,
-      quote s.leanObjects
-    ]
+deriving Inhabited, FromJson, ToJson, Quote
 
 structure Summary where
   showDebugDiagnostics : Bool := false
@@ -346,54 +194,6 @@ structure Summary where
   missingOwners : List MetadataEntryItem := []
   missingEffort : List MetadataEntryItem := []
   untaggedEntries : List MetadataEntryItem := []
-deriving Inhabited, FromJson, ToJson
-
-open Syntax in
-instance : Quote Summary where
-  quote s := mkCApp ``Summary.mk
-    #[
-      quote s.showDebugDiagnostics,
-      quote s.totalEntries,
-      quote s.definitions,
-      quote s.propositions,
-      quote s.lemmas,
-      quote s.theorems,
-      quote s.corollaries,
-      quote s.axioms,
-      quote s.leanOnlyEntries,
-      quote s.informalOnlyEntries,
-      quote s.totalStatus,
-      quote s.definitionStatus,
-      quote s.propositionStatus,
-      quote s.lemmaStatus,
-      quote s.theoremStatus,
-      quote s.corollaryStatus,
-      quote s.axiomStatus,
-      quote s.pendingInformalEntries,
-      quote s.leanDecls,
-      quote s.sorries,
-      quote s.sorryDetails,
-      quote s.missingLeanDecls,
-      quote s.renderFailures,
-      quote s.definitionIndex,
-      quote s.theoremLikeIndex,
-      quote s.axiomIndex,
-      quote s.theoremLikeByParent,
-      quote s.topPriorities,
-      quote s.mostUsed,
-      quote s.groupHealth,
-      quote s.coverageSplit,
-      quote s.heaviestPrerequisites,
-      quote s.noPrerequisites,
-      quote s.noDependents,
-      quote s.proofDebtHotspots,
-      quote s.quickWins,
-      quote s.ownerRollups,
-      quote s.tagRollups,
-      quote s.linkedPrs,
-      quote s.missingOwners,
-      quote s.missingEffort,
-      quote s.untaggedEntries
-    ]
+deriving Inhabited, FromJson, ToJson, Quote
 
 end Informal.Commands


### PR DESCRIPTION
This PR removes hand-written `Quote` instances from the summary data records by deriving `Quote` alongside the existing JSON instances. The data model and public imports stay unchanged, while `Summary/Data.lean` drops the large constructor-boilerplate block.

Backport v4.30.0: exempt: internal refactor only, no release-facing behavior change.