### PR TITLE
[backport v4.30.0] feat: add render node external markup fallback

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -49,6 +49,7 @@ but that namespace is not a supported client API.
 | Read data embedded in a rendered graph block | `getGraphData(element)` and `getGraphVariants(element)` |
 | Render only a preview body fragment in a custom wrapper | `renderPreviewInto(element, key)` |
 | Render the full generated Blueprint node wrapper | `renderCanonicalPreviewInto(element, key)` |
+| Render by label with external TeX or Markdown fallback source | `renderNode(element, request)` |
 | Inspect semantic manifest data before rendering | `resolvePreview(key)` or `resolveCanonicalPreview(key)` |
 | Render Blueprint nodes from a custom Lean generator | `Informal.Graft.renderNodeFromManifestCache` |
 | Join manifest/cache data manually | `PreviewManifest.File.findEntry?` and `PreviewManifest.HtmlCache.File.findHtml?` |
@@ -56,6 +57,13 @@ but that namespace is not a supported client API.
 Prefer the highest-level entry point that matches the job. Reach for direct
 manifest/cache lookup only when the client needs custom joining behavior or
 explicit diagnostics.
+
+Two rules keep most integrations simple:
+
+1. Treat `blueprint-manifest.json` as semantic data: labels, statuses, graph
+   records, dependency data, preview keys, hrefs, and display metadata.
+2. Treat `blueprint-html-cache.json` as rendered HTML: insert it and hydrate it,
+   but do not parse it to recover semantic facts.
 
 ## Generated Data Files
 
@@ -414,7 +422,7 @@ The generated ESM modules expose these entrypoint groups:
 
 | Module | Exports |
 | --- | --- |
-| `api/preview.mjs` | URL helpers: `dataUrl`, `manifestUrl`, `htmlCacheUrl`, `graphApiModuleUrl`, `previewApiModuleUrl`; runtime readiness: `onRenderReady`, `currentRenderApi`, `getRenderApi`, `ready`; manifest/cache helpers: `loadManifest`, `readManifestStatus`, `loadManifestEntry`, `loadHtmlCache`, `readHtmlCacheStatus`, `loadHtmlCacheEntry`; graph-data helpers re-exported from the graph module; preview/render helpers: `previewKey`, `statementPreviewKey`, `resolvePreview`, `renderPreviewInto`, `resolveCanonicalPreview`, `renderCanonicalPreviewInto`, `hydrate`. |
+| `api/preview.mjs` | URL helpers: `dataUrl`, `manifestUrl`, `htmlCacheUrl`, `graphApiModuleUrl`, `previewApiModuleUrl`; runtime readiness: `onRenderReady`, `currentRenderApi`, `getRenderApi`, `ready`; manifest/cache helpers: `loadManifest`, `readManifestStatus`, `loadManifestEntry`, `loadHtmlCache`, `readHtmlCacheStatus`, `loadHtmlCacheEntry`; graph-data helpers re-exported from the graph module; preview/render helpers: `previewKey`, `statementPreviewKey`, `resolvePreview`, `renderPreviewInto`, `resolveCanonicalPreview`, `renderCanonicalPreviewInto`, `renderNode`, `hydrate`. |
 | `api/graph.mjs` | URL helpers: `dataUrl`, `graphApiModuleUrl`; page-embedded graph helpers: `graphCanvasFor`, `readGraphJsonScript`, `graphFallbackVariants`, `getGraphData`, `getGraphVariants`; manifest graph helpers: `normalizeGraphData`, `graphsFromManifest`, `loadJson`, `loadManifestGraphs`, `loadGraphs`. |
 
 ## Browser Runtime API
@@ -483,6 +491,73 @@ window.VersoBlueprint.onRenderReady(async function (api) {
 });
 ```
 
+Use `renderNode` when the client starts from a Blueprint label and wants a
+generated Blueprint node. If native rendered content is available, VBP inserts
+the regular generated node shell. If only external markup is available, VBP
+still owns that shell: heading, relation chips, metadata, anchors, and
+hydration. The call-scoped renderer receives only the node's content slot as
+its target. The renderer is not registered globally.
+
+The ownership boundary is strict:
+
+- `renderNode` owns the outer Blueprint node shell.
+- The supplied external-markup renderer owns only the body target passed as its
+  second argument, which is the generated node's `.bp_content` slot.
+- The renderer should replace or append children inside that body target; it
+  should not replace the surrounding node, heading, relation chips, metadata
+  panel, anchors, or hydrated preview controls.
+- If external markup exists but VBP cannot find a generated node shell for the
+  label, `renderNode` reports `external-markup-node-shell-missing` rather than
+  inventing a different wrapper.
+
+```javascript
+window.VersoBlueprint.onRenderReady(async function (api) {
+  const target = document.querySelector("#comparison-preview");
+  if (!target) return;
+
+  const result = await api.renderNode(target, {
+    label: "Chapter2:Problem2.11.6",
+    facet: "statement",
+    externalMarkup: {
+      prefer: [
+        { language: "markdown", slot: "original", render: renderMarkdown },
+        { language: "tex", slot: "original", render: renderTexSource },
+        { display: "source" }
+      ]
+    }
+  });
+
+  if (!result.ok) {
+    console.warn(result.reason);
+  }
+});
+
+async function renderMarkdown(markup, target) {
+  const node = await markdownToDom(markup.raw);
+  target.replaceChildren(node);
+}
+
+async function renderTexSource(markup, target) {
+  const pre = document.createElement("pre");
+  pre.textContent = markup.raw;
+  target.replaceChildren(pre);
+}
+```
+
+The renderer receives
+`{ raw, language, slot, location, node, manifestEntry, label, facet, nativePreview, externalMarkup }`
+plus the node-body target element as its second argument. `node` and
+`manifestEntry` are the manifest entry that owns the external markup; `location`
+is the optional project-relative source range recorded by the `tex` or `md`
+block. If the manifest has external markup but no generated Blueprint node shell
+for the label, `renderNode` returns a typed diagnostic instead of inventing a
+different wrapper shape.
+
+A complete standalone version of this pattern is available in
+[`standalone-render-node-markdown.js`](../tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/standalone-render-node-markdown.js).
+It does not use the showcase card UI: it binds one target element, calls
+`renderNode`, and renders Markdown into the body slot supplied by VBP.
+
 ### Runtime Readiness
 
 After readiness, the same API is available as `window.VersoBlueprint.render`.
@@ -516,6 +591,7 @@ views, and browser-only examples.
 | `api.renderPreviewInto(element, key, options)` | Write the rendered body fragment or diagnostic HTML into `element`, then hydrate nested previews and math. |
 | `api.resolveCanonicalPreview(key)` | Resolve the same data as `resolvePreview`, then load the generated page named by `manifestEntry.href` and return `canonicalHtml` plus `canonicalSourceHref` for the real Blueprint node wrapper. |
 | `api.renderCanonicalPreviewInto(element, key, options)` | Write the canonical Blueprint node wrapper or diagnostic HTML into `element`, then hydrate nested previews and math. |
+| `api.renderNode(element, request, options)` | Render by label as a generated Blueprint node: native content uses the canonical generated shell, and external markup uses the same shell with a call-scoped TeX/Markdown body renderer from `request.externalMarkup` or `request.preferredExternalMarkup`. |
 | `api.hydrate(element, options)` | Hydrate custom wrappers that inserted cached rendered fragments themselves. |
 
 ## Preview Result Shapes
@@ -531,6 +607,7 @@ the rendered HTML used by the operation. Failed results include a `reason` and
 | `renderPreviewInto(element, key, options)` | The `resolvePreview` success shape after writing `html` into `element` and hydrating it. | The `resolvePreview` failure shape after writing `diagnosticHtml` into `element`. |
 | `resolveCanonicalPreview(key)` | `{ ok: true, key, manifestEntry, htmlCacheEntry, html, canonicalHtml, canonicalSourceHref }` | `{ ok: false, key, reason, diagnosticHtml }` |
 | `renderCanonicalPreviewInto(element, key, options)` | The `resolveCanonicalPreview` success shape after writing `canonicalHtml` into `element` and hydrating it. | The `resolveCanonicalPreview` failure shape after writing `diagnosticHtml` into `element`. |
+| `renderNode(element, request, options)` | Native-preview success shape with `renderMode: "native"` and `canonicalHtml`, or external-markup success shape with `renderMode: "external-markup"`, `externalMarkup`, and `canonicalHtml`. | `{ ok: false, key, reason, manifestEntry?, externalMarkup?, nativePreview?, diagnosticHtml }` after writing diagnostics unless `options.diagnostics === false`. |
 
 The most common failure `reason` values are:
 
@@ -540,6 +617,13 @@ The most common failure `reason` values are:
 - `canonical-href-missing`
 - `canonical-preview-node-missing`
 - `canonical-preview-load-failed`
+- `missing-label`
+- `external-markup-entry-missing`
+- `external-markup-missing`
+- `external-markup-renderer-missing`
+- `external-markup-render-failed`
+- `external-markup-node-shell-missing`
+- `external-markup-node-shell-load-failed`
 
 Treat `html` and `canonicalHtml` as opaque rendered fragments. Use
 `manifestEntry` for semantic facts such as labels, titles, dependency metadata,
@@ -570,10 +654,11 @@ dashboard client owns its component tree, selection state, filters, and wrapper
 markup, but it should treat Blueprint data as manifest/cache records loaded
 through the render API. Components should pass preview keys to
 `resolvePreview`, `renderPreviewInto`, `resolveCanonicalPreview`, or
-`renderCanonicalPreviewInto`, then render user-interface controls around the
-returned manifest entry. They should not scrape generated Blueprint DOM, call
-private bundled helpers, or couple component state to the current shape of the
-generated preview runtime.
+`renderCanonicalPreviewInto`, or pass labels plus call-scoped external-markup
+renderers to `renderNode`. They should render user-interface controls around
+the returned manifest entry, not scrape generated Blueprint DOM, call private
+bundled helpers, or couple component state to the current shape of the generated
+preview runtime.
 
 ### Private Runtime Chunks
 
@@ -679,8 +764,9 @@ as a standalone browser client on its `Custom Render Client` page. It also
 includes a graph-data card that calls `api.loadGraphs()` to read
 `blueprint-manifest.json.graphs` without embedding a rendered graph, a
 `type="module"` example that imports `renderPreviewInto` from
-`-verso-data/api/preview.mjs`, and a graph module example that imports
-`loadGraphs` from `-verso-data/api/graph.mjs`.
+`-verso-data/api/preview.mjs`, `renderNode` cards for native label rendering and
+a metadata-bearing external-markup node with a call-scoped body renderer, and a graph
+module example that imports `loadGraphs` from `-verso-data/api/graph.mjs`.
 
 The client asset lives in
 [`custom-render-client.js`](../tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/custom-render-client.js),

--- a/src/VersoBlueprint/Commands/preview-runtime-api.mjs
+++ b/src/VersoBlueprint/Commands/preview-runtime-api.mjs
@@ -27,6 +27,7 @@ export function installPreviewRuntimeApi() {
   const previewRenderApi = {
     renderPreviewInto: renderBlueprintPreviewInto,
     renderCanonicalPreviewInto: renderCanonicalBlueprintPreviewInto,
+    renderNode: renderBlueprintNodeInto,
     hydrate: hydrateRenderedPreview
   };
 
@@ -77,6 +78,7 @@ export function installPreviewRuntimeApi() {
     renderPreviewInto: previewRenderApi.renderPreviewInto,
     resolveCanonicalPreview: previewDataApi.resolveCanonicalPreview,
     renderCanonicalPreviewInto: previewRenderApi.renderCanonicalPreviewInto,
+    renderNode: previewRenderApi.renderNode,
     hydrate: previewRenderApi.hydrate
   };
 

--- a/src/VersoBlueprint/Commands/preview-runtime-render.mjs
+++ b/src/VersoBlueprint/Commands/preview-runtime-render.mjs
@@ -1,5 +1,5 @@
 import { escapeHtml, readHtml } from "./preview-runtime-base.mjs";
-import { blueprintHtmlCacheDiagnosticHtml, blueprintManifestDiagnosticHtml, loadBlueprintHtmlCacheEntry, loadBlueprintManifestEntry, missingPreviewKeyDiagnosticHtml } from "./preview-runtime-data.mjs";
+import { blueprintHtmlCacheDiagnosticHtml, blueprintManifestDiagnosticHtml, loadBlueprintHtmlCacheEntry, loadBlueprintManifestEntry, missingPreviewKeyDiagnosticHtml, previewKey } from "./preview-runtime-data.mjs";
 import { hydrateRenderedPreview } from "./preview-runtime-hydration.mjs";
 
   // Preview resolution joins semantic manifest entries with opaque body fragments.
@@ -87,6 +87,504 @@ import { hydrateRenderedPreview } from "./preview-runtime-hydration.mjs";
     return result;
   }
 
+  // Label-oriented node rendering.
+  //
+  // `renderPreviewInto` renders an exact manifest/cache key. `renderNode`
+  // starts from a Blueprint label, tries the native rendered preview first, and
+  // can fall back to call-scoped external-markup renderers for labels whose
+  // only portable body is TeX or Markdown source.
+
+  export function renderNodeDiagnosticHtml(title, detail, fields) {
+    const data = fields && typeof fields === "object" ? fields : {};
+    const parts = [
+      "<p><strong>" + escapeHtml(title) + "</strong></p>",
+      "<p>" + escapeHtml(detail) + "</p>"
+    ];
+    if (data.label) {
+      parts.push("<p>Requested label: <code>" + escapeHtml(data.label) + "</code></p>");
+    }
+    if (data.key) {
+      parts.push("<p>Requested preview: <code>" + escapeHtml(data.key) + "</code></p>");
+    }
+    if (data.language || data.slot) {
+      const language = data.language || "any";
+      const slot = data.slot || "any";
+      parts.push(
+        "<p>Requested external markup: <code>" +
+          escapeHtml(language) +
+          "</code> / <code>" +
+          escapeHtml(slot) +
+          "</code></p>"
+      );
+    }
+    return "<div class=\"bp_html_cache_preview_notice\">" + parts.join("") + "</div>";
+  }
+
+  export function normalizeRenderNodeRequest(request) {
+    if (typeof request === "string") {
+      return {
+        label: request.trim(),
+        facet: "statement",
+        externalMarkup: null
+      };
+    }
+    const opts = request && typeof request === "object" ? request : {};
+    const label = typeof opts.label === "string" ? opts.label.trim() : "";
+    const facet =
+      typeof opts.facet === "string" && opts.facet.trim()
+        ? opts.facet.trim()
+        : "statement";
+    const externalMarkup =
+      opts.externalMarkup && typeof opts.externalMarkup === "object"
+        ? opts.externalMarkup
+        : (opts.preferredExternalMarkup && typeof opts.preferredExternalMarkup === "object"
+            ? opts.preferredExternalMarkup
+            : null);
+    return {
+      label,
+      facet,
+      externalMarkup
+    };
+  }
+
+  export function renderNodePreviewResult(result, fields) {
+    return Object.assign(
+      {},
+      {
+        renderMode: "",
+        label: "",
+        facet: "",
+        externalMarkup: null,
+        nativePreview: null
+      },
+      result || {},
+      fields || {}
+    );
+  }
+
+  export function externalMarkupEntryKey(label) {
+    const trimmedLabel = typeof label === "string" ? label.trim() : "";
+    return trimmedLabel ? "externalMarkup:" + trimmedLabel : "";
+  }
+
+  export async function loadExternalMarkupNodeEntry(label) {
+    const key = externalMarkupEntryKey(label);
+    if (!key) return null;
+    return loadBlueprintManifestEntry(key);
+  }
+
+  export function normalizeExternalMarkupPreferences(externalMarkup) {
+    if (!externalMarkup || typeof externalMarkup !== "object") return [];
+    if (Array.isArray(externalMarkup)) return externalMarkup;
+    if (Array.isArray(externalMarkup.prefer)) return externalMarkup.prefer;
+    return [externalMarkup];
+  }
+
+  export function normalizeExternalMarkupToken(value) {
+    return typeof value === "string" ? value.trim().toLowerCase() : "";
+  }
+
+  export function isNativeMarkupPreference(preference) {
+    if (!preference || typeof preference !== "object") return false;
+    const language = normalizeExternalMarkupToken(preference.language);
+    return language === "verso" || language === "native";
+  }
+
+  export function externalMarkupPreferenceDisplay(preference) {
+    return normalizeExternalMarkupToken(preference && preference.display);
+  }
+
+  export function externalMarkupPreferenceCanRender(preference) {
+    return (
+      preference &&
+      typeof preference === "object" &&
+      (typeof preference.render === "function" ||
+        externalMarkupPreferenceDisplay(preference) === "source")
+    );
+  }
+
+  export function externalMarkupMatchesPreference(markup, preference) {
+    if (!markup || typeof markup !== "object") return false;
+    const language = normalizeExternalMarkupToken(preference && preference.language);
+    const slot =
+      preference && typeof preference.slot === "string" ? preference.slot.trim() : "";
+    if (language && normalizeExternalMarkupToken(markup.language) !== language) return false;
+    if (slot && String(markup.slot || "").trim() !== slot) return false;
+    return typeof markup.raw === "string" && markup.raw.length > 0;
+  }
+
+  export function firstExternalMarkupForPreference(entry, preference) {
+    const markups =
+      entry && Array.isArray(entry.externalMarkup) ? entry.externalMarkup : [];
+    return markups.find(function (markup) {
+      return externalMarkupMatchesPreference(markup, preference);
+    }) || null;
+  }
+
+  export function selectExternalMarkup(entry, preferences) {
+    let missingRenderer = null;
+    let missingMarkupPreference = null;
+    for (const preference of preferences) {
+      if (!preference || typeof preference !== "object") continue;
+      if (isNativeMarkupPreference(preference)) continue;
+      const markup = firstExternalMarkupForPreference(entry, preference);
+      if (!markup) {
+        if (!missingMarkupPreference) missingMarkupPreference = preference;
+        continue;
+      }
+      if (externalMarkupPreferenceCanRender(preference)) {
+        return {
+          ok: true,
+          markup,
+          preference
+        };
+      }
+      if (!missingRenderer) {
+        missingRenderer = {
+          ok: false,
+          reason: "external-markup-renderer-missing",
+          markup,
+          preference
+        };
+      }
+    }
+    return missingRenderer || {
+      ok: false,
+      reason: "external-markup-missing",
+      markup: null,
+      preference: missingMarkupPreference
+    };
+  }
+
+  export function renderExternalMarkupSource(target, markup) {
+    const pre = document.createElement("pre");
+    pre.className = "bp_external_markup_source";
+    const code = document.createElement("code");
+    code.textContent = markup && typeof markup.raw === "string" ? markup.raw : "";
+    pre.appendChild(code);
+    target.replaceChildren(pre);
+  }
+
+  export async function renderExternalMarkupSelectionInto(target, selection, payload) {
+    const preference = selection.preference || {};
+    if (externalMarkupPreferenceDisplay(preference) === "source") {
+      renderExternalMarkupSource(target, selection.markup);
+      return;
+    }
+    const renderer = preference.render;
+    if (typeof renderer !== "function") {
+      throw new Error("External markup renderer missing");
+    }
+    target.replaceChildren();
+    const rendered = await renderer(payload, target);
+    if (rendered instanceof Node) {
+      target.replaceChildren(rendered);
+    } else if (typeof rendered === "string") {
+      target.innerHTML = rendered;
+    }
+  }
+
+  export async function callExternalMarkupRenderer(target, selection, payload, options) {
+    await renderExternalMarkupSelectionInto(target, selection, payload);
+    hydrateRenderedPreview(target, options);
+  }
+
+  export function externalMarkupRendererPayload(request, manifestEntry, selection, nativeResult) {
+    const markup = selection.markup || {};
+    return {
+      raw: typeof markup.raw === "string" ? markup.raw : "",
+      language: typeof markup.language === "string" ? markup.language : "",
+      slot: typeof markup.slot === "string" ? markup.slot : "",
+      location: markup.location || null,
+      node: manifestEntry || null,
+      manifestEntry: manifestEntry || null,
+      label: request.label,
+      facet: request.facet,
+      nativePreview: nativeResult || null,
+      externalMarkup: markup
+    };
+  }
+
+  export function blueprintContentTargetForNode(node) {
+    if (!(node instanceof Element)) return null;
+    const direct = Array.from(node.children).find(function (child) {
+      return child instanceof Element && child.classList.contains("bp_content");
+    });
+    if (direct instanceof Element) return direct;
+    return node.querySelector(".bp_content");
+  }
+
+  export async function loadCanonicalPreviewNode(entry, result) {
+    const url = canonicalPreviewUrl(entry);
+    if (!url) {
+      return {
+        ok: false,
+        reason: "canonical-href-missing",
+        detail: "The manifest entry did not include a generated-page link for this preview.",
+        node: null,
+        canonicalHtml: "",
+        canonicalSourceHref: ""
+      };
+    }
+    try {
+      const doc = await loadCanonicalPreviewDocument(url);
+      const id = canonicalPreviewId(url, result);
+      const node = id ? doc.getElementById(id) : null;
+      if (!(node instanceof Element)) {
+        return {
+          ok: false,
+          reason: "canonical-preview-node-missing",
+          detail: "The generated page loaded, but the linked Blueprint node was not present.",
+          node: null,
+          canonicalHtml: "",
+          canonicalSourceHref: url.href
+        };
+      }
+      const clone = node.cloneNode(true);
+      rebaseCanonicalPreviewLinks(clone, canonicalPreviewDocumentBaseUrl(doc, url));
+      resetClonedPreviewBindingState(clone);
+      return {
+        ok: true,
+        reason: "",
+        detail: "",
+        node: clone,
+        canonicalHtml: clone.outerHTML,
+        canonicalSourceHref: url.href
+      };
+    } catch (err) {
+      const message = err && err.message ? err.message : String(err);
+      return {
+        ok: false,
+        reason: "canonical-preview-load-failed",
+        detail: message,
+        node: null,
+        canonicalHtml: "",
+        canonicalSourceHref: url.href
+      };
+    }
+  }
+
+  export async function renderExternalMarkupNodeInto(target, result, selection, payload, options) {
+    const loaded = await loadCanonicalPreviewNode(result.manifestEntry, result);
+    if (!loaded.ok) {
+      return {
+        ok: false,
+        reason: loaded.reason === "canonical-preview-load-failed"
+          ? "external-markup-node-shell-load-failed"
+          : "external-markup-node-shell-missing",
+        detail: loaded.detail,
+        node: null,
+        canonicalHtml: "",
+        canonicalSourceHref: loaded.canonicalSourceHref
+      };
+    }
+    const contentTarget = blueprintContentTargetForNode(loaded.node);
+    if (!(contentTarget instanceof Element)) {
+      return {
+        ok: false,
+        reason: "external-markup-node-shell-missing",
+        detail: "The generated Blueprint node shell did not include a content slot.",
+        node: null,
+        canonicalHtml: "",
+        canonicalSourceHref: loaded.canonicalSourceHref
+      };
+    }
+    await renderExternalMarkupSelectionInto(contentTarget, selection, payload);
+    target.replaceChildren(loaded.node);
+    hydrateRenderedPreview(target, options);
+    return {
+      ok: true,
+      reason: "",
+      detail: "",
+      node: loaded.node,
+      canonicalHtml: loaded.node.outerHTML,
+      canonicalSourceHref: loaded.canonicalSourceHref
+    };
+  }
+
+  export async function renderBlueprintNodeInto(target, request, options) {
+    if (!(target instanceof Element)) {
+      throw new Error("renderBlueprintNodeInto target must be a DOM Element");
+    }
+    const opts = options && typeof options === "object" ? options : {};
+    const normalized = normalizeRenderNodeRequest(request);
+    if (!normalized.label) {
+      const result = renderNodePreviewResult({
+        ok: false,
+        key: "",
+        reason: "missing-label",
+        manifestEntry: null,
+        htmlCacheEntry: null,
+        html: "",
+        diagnosticHtml: renderNodeDiagnosticHtml(
+          "Blueprint label missing.",
+          "Provide a Blueprint node label to render.",
+          {}
+        )
+      }, normalized);
+      if (opts.diagnostics !== false) renderHtmlInto(target, result.diagnosticHtml, opts);
+      else target.replaceChildren();
+      return result;
+    }
+
+    const nativeKey = previewKey(normalized.label, normalized.facet);
+    const nativeResult = await resolveBlueprintPreview(nativeKey);
+    if (nativeResult.ok) {
+      const canonicalResult = await resolveCanonicalBlueprintPreview(nativeKey);
+      const result = renderNodePreviewResult(canonicalResult, {
+        renderMode: canonicalResult.ok ? "native" : "diagnostic",
+        label: normalized.label,
+        facet: normalized.facet,
+        nativePreview: nativeResult
+      });
+      const html = result.ok
+        ? result.canonicalHtml
+        : (opts.diagnostics === false ? "" : result.diagnosticHtml);
+      renderHtmlInto(target, html, opts);
+      return result;
+    }
+
+    const preferences = normalizeExternalMarkupPreferences(normalized.externalMarkup);
+    if (preferences.length === 0) {
+      const result = renderNodePreviewResult(nativeResult, {
+        renderMode: "diagnostic",
+        label: normalized.label,
+        facet: normalized.facet,
+        nativePreview: nativeResult
+      });
+      const html = opts.diagnostics === false ? "" : result.diagnosticHtml;
+      renderHtmlInto(target, html, opts);
+      return result;
+    }
+
+    const manifestEntry =
+      nativeResult.manifestEntry || (await loadExternalMarkupNodeEntry(normalized.label));
+    if (!manifestEntry) {
+      const result = renderNodePreviewResult({
+        ok: false,
+        key: nativeKey,
+        reason: "external-markup-entry-missing",
+        manifestEntry: null,
+        htmlCacheEntry: nativeResult.htmlCacheEntry || null,
+        html: "",
+        diagnosticHtml: renderNodeDiagnosticHtml(
+          "External markup entry missing.",
+          "The manifest has no native preview or external-markup entry for this label.",
+          { label: normalized.label, key: nativeKey }
+        )
+      }, {
+        renderMode: "diagnostic",
+        label: normalized.label,
+        facet: normalized.facet,
+        nativePreview: nativeResult
+      });
+      const html = opts.diagnostics === false ? "" : result.diagnosticHtml;
+      renderHtmlInto(target, html, opts);
+      return result;
+    }
+
+    const selection = selectExternalMarkup(manifestEntry, preferences);
+    if (!selection.ok) {
+      const preference = selection.preference || {};
+      const result = renderNodePreviewResult({
+        ok: false,
+        key: manifestEntry.key || nativeKey,
+        reason: selection.reason,
+        manifestEntry,
+        htmlCacheEntry: nativeResult.htmlCacheEntry || null,
+        html: "",
+        diagnosticHtml: renderNodeDiagnosticHtml(
+          selection.reason === "external-markup-renderer-missing"
+            ? "External markup renderer missing."
+            : "External markup missing.",
+          selection.reason === "external-markup-renderer-missing"
+            ? "The requested external markup exists, but this render call did not provide a renderer or source display fallback."
+            : "The manifest entry did not include external markup matching this render call.",
+          {
+            label: normalized.label,
+            key: manifestEntry.key || nativeKey,
+            language: preference.language,
+            slot: preference.slot
+          }
+        )
+      }, {
+        renderMode: "diagnostic",
+        label: normalized.label,
+        facet: normalized.facet,
+        externalMarkup: selection.markup || null,
+        nativePreview: nativeResult
+      });
+      const html = opts.diagnostics === false ? "" : result.diagnosticHtml;
+      renderHtmlInto(target, html, opts);
+      return result;
+    }
+
+    const result = renderNodePreviewResult({
+      ok: true,
+      key: manifestEntry.key || nativeKey,
+      reason: "",
+      manifestEntry,
+      htmlCacheEntry: nativeResult.htmlCacheEntry || null,
+      html: "",
+      diagnosticHtml: ""
+    }, {
+      renderMode: "external-markup",
+      label: normalized.label,
+      facet: normalized.facet,
+      externalMarkup: selection.markup,
+      nativePreview: nativeResult
+    });
+    const payload = externalMarkupRendererPayload(normalized, manifestEntry, selection, nativeResult);
+    try {
+      const rendered = await renderExternalMarkupNodeInto(target, result, selection, payload, opts);
+      if (rendered.ok) {
+        return renderNodePreviewResult(result, {
+          canonicalHtml: rendered.canonicalHtml,
+          canonicalSourceHref: rendered.canonicalSourceHref
+        });
+      }
+      const failed = renderNodePreviewResult(result, {
+        ok: false,
+        reason: rendered.reason,
+        diagnosticHtml: renderNodeDiagnosticHtml(
+          rendered.reason === "external-markup-node-shell-load-failed"
+            ? "External markup node shell unavailable."
+            : "External markup node shell missing.",
+          rendered.detail,
+          {
+            label: normalized.label,
+            key: result.key,
+            language: selection.markup.language,
+            slot: selection.markup.slot
+          }
+        ),
+        canonicalSourceHref: rendered.canonicalSourceHref || ""
+      });
+      const html = opts.diagnostics === false ? "" : failed.diagnosticHtml;
+      renderHtmlInto(target, html, opts);
+      return failed;
+    } catch (err) {
+      const message = err && err.message ? err.message : String(err);
+      const failed = renderNodePreviewResult(result, {
+        ok: false,
+        reason: "external-markup-render-failed",
+        diagnosticHtml: renderNodeDiagnosticHtml(
+          "External markup renderer failed.",
+          message,
+          {
+            label: normalized.label,
+            key: result.key,
+            language: selection.markup.language,
+            slot: selection.markup.slot
+          }
+        )
+      });
+      const html = opts.diagnostics === false ? "" : failed.diagnosticHtml;
+      renderHtmlInto(target, html, opts);
+      return failed;
+    }
+  }
+
   export const canonicalPreviewDocuments = new Map();
   export const canonicalPreviewHtmlByKey = new Map();
 
@@ -102,10 +600,6 @@ import { hydrateRenderedPreview } from "./preview-runtime-hydration.mjs";
     const clone = new URL(url.href);
     clone.hash = "";
     return clone.href;
-  }
-
-  export function currentDocumentUrlWithoutHash() {
-    return urlWithoutHash(new URL(window.location.href));
   }
 
   export function canonicalPreviewUrl(entry) {
@@ -159,11 +653,10 @@ import { hydrateRenderedPreview } from "./preview-runtime-hydration.mjs";
 
   export async function loadCanonicalPreviewDocument(url) {
     const pageUrl = urlWithoutHash(url);
-    if (pageUrl === currentDocumentUrlWithoutHash()) {
-      return document;
-    }
     const existing = canonicalPreviewDocuments.get(pageUrl);
     if (existing) return existing;
+    // Do not shortcut same-page URLs to `document`: hydration mutates the live
+    // DOM by moving local panels to body and adding binding state.
     const promise = fetch(pageUrl)
       .then(function (resp) {
         if (!resp.ok) {
@@ -226,6 +719,44 @@ import { hydrateRenderedPreview } from "./preview-runtime-hydration.mjs";
     });
   }
 
+  export const clonedPreviewBindingStateAttributes = Object.freeze([
+    "data-bp-bound",
+    "data-bp-dismiss-bound",
+    "data-bp-popover-bound",
+    "data-bp-panel-reposition-bound",
+    "data-bp-preview-trigger-bound",
+    "data-bp-preview-events-bound",
+    "data-bp-preview-panel-lifetime-bound",
+    "data-bp-template-preview-bound",
+    "data-bp-inline-main-bound",
+    "data-bp-inline-child-bound",
+    "data-bp-inline-panel-reposition-bound",
+    "data-bp-relation-chip-bound",
+    "data-bp-relation-panel-lifetime-bound",
+    "data-bp-relation-dismiss-bound",
+    "data-bp-preview-bound",
+    "data-bp-variant-bound",
+    "data-bp-legend-bound",
+    "data-bp-options-bound",
+    "data-bp-group-hover-bound",
+    "data-bp-graph-panel-dismiss-bound",
+    "data-bp-graph-panel-reposition-bound"
+  ]);
+
+  export function resetClonedPreviewBindingState(root) {
+    if (!(root instanceof Element)) return;
+    const selector = clonedPreviewBindingStateAttributes.map(function (attr) {
+      return "[" + attr + "]";
+    }).join(",");
+    const reset = function (node) {
+      clonedPreviewBindingStateAttributes.forEach(function (attr) {
+        node.removeAttribute(attr);
+      });
+    };
+    reset(root);
+    root.querySelectorAll(selector).forEach(reset);
+  }
+
   export async function resolveCanonicalBlueprintPreview(previewKey) {
     const result = await resolveBlueprintPreview(previewKey);
     if (!result.ok) {
@@ -238,59 +769,34 @@ import { hydrateRenderedPreview } from "./preview-runtime-hydration.mjs";
         canonicalSourceHref: cached.href
       });
     }
-    const url = canonicalPreviewUrl(result.manifestEntry);
-    if (!url) {
+    const loaded = await loadCanonicalPreviewNode(result.manifestEntry, result);
+    if (!loaded.ok) {
+      const title =
+        loaded.reason === "canonical-href-missing"
+          ? "Canonical preview link missing."
+          : loaded.reason === "canonical-preview-node-missing"
+            ? "Canonical preview node missing."
+            : "Canonical preview page unavailable.";
       return canonicalPreviewResult(result, {
         ok: false,
-        reason: "canonical-href-missing",
+        reason: loaded.reason,
+        canonicalSourceHref: loaded.canonicalSourceHref,
         diagnosticHtml: canonicalPreviewDiagnosticHtml(
-          "Canonical preview link missing.",
-          "The manifest entry did not include a generated-page link for this preview.",
+          title,
+          loaded.detail,
           result.key
         )
       });
     }
-
-    try {
-      const doc = await loadCanonicalPreviewDocument(url);
-      const id = canonicalPreviewId(url, result);
-      const node = id ? doc.getElementById(id) : null;
-      if (!(node instanceof Element)) {
-        return canonicalPreviewResult(result, {
-          ok: false,
-          reason: "canonical-preview-node-missing",
-          canonicalSourceHref: url.href,
-          diagnosticHtml: canonicalPreviewDiagnosticHtml(
-            "Canonical preview node missing.",
-            "The generated page loaded, but the linked Blueprint node was not present.",
-            result.key
-          )
-        });
-      }
-      const clone = node.cloneNode(true);
-      rebaseCanonicalPreviewLinks(clone, canonicalPreviewDocumentBaseUrl(doc, url));
-      const canonical = {
-        html: clone.outerHTML,
-        href: url.href
-      };
-      canonicalPreviewHtmlByKey.set(result.key, canonical);
-      return canonicalPreviewResult(result, {
-        canonicalHtml: canonical.html,
-        canonicalSourceHref: canonical.href
-      });
-    } catch (err) {
-      const message = err && err.message ? err.message : String(err);
-      return canonicalPreviewResult(result, {
-        ok: false,
-        reason: "canonical-preview-load-failed",
-        canonicalSourceHref: url.href,
-        diagnosticHtml: canonicalPreviewDiagnosticHtml(
-          "Canonical preview page unavailable.",
-          message,
-          result.key
-        )
-      });
-    }
+    const canonical = {
+      html: loaded.canonicalHtml,
+      href: loaded.canonicalSourceHref
+    };
+    canonicalPreviewHtmlByKey.set(result.key, canonical);
+    return canonicalPreviewResult(result, {
+      canonicalHtml: canonical.html,
+      canonicalSourceHref: canonical.href
+    });
   }
 
   export async function renderCanonicalBlueprintPreviewInto(target, previewKey, options) {
@@ -310,10 +816,30 @@ import { hydrateRenderedPreview } from "./preview-runtime-hydration.mjs";
     resolveBlueprintPreview,
     renderHtmlInto,
     renderBlueprintPreviewInto,
+    renderNodeDiagnosticHtml,
+    normalizeRenderNodeRequest,
+    renderNodePreviewResult,
+    externalMarkupEntryKey,
+    loadExternalMarkupNodeEntry,
+    normalizeExternalMarkupPreferences,
+    normalizeExternalMarkupToken,
+    isNativeMarkupPreference,
+    externalMarkupPreferenceDisplay,
+    externalMarkupPreferenceCanRender,
+    externalMarkupMatchesPreference,
+    firstExternalMarkupForPreference,
+    selectExternalMarkup,
+    renderExternalMarkupSource,
+    renderExternalMarkupSelectionInto,
+    callExternalMarkupRenderer,
+    externalMarkupRendererPayload,
+    blueprintContentTargetForNode,
+    loadCanonicalPreviewNode,
+    renderExternalMarkupNodeInto,
+    renderBlueprintNodeInto,
     canonicalPreviewDocuments,
     canonicalPreviewHtmlByKey,
     urlWithoutHash,
-    currentDocumentUrlWithoutHash,
     canonicalPreviewUrl,
     canonicalPreviewId,
     canonicalPreviewDiagnosticHtml,
@@ -323,6 +849,8 @@ import { hydrateRenderedPreview } from "./preview-runtime-hydration.mjs";
     forEachMatchingElement,
     canonicalPreviewDocumentBaseUrl,
     rebaseCanonicalPreviewLinks,
+    clonedPreviewBindingStateAttributes,
+    resetClonedPreviewBindingState,
     resolveCanonicalBlueprintPreview,
     renderCanonicalBlueprintPreviewInto
   };

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -1423,6 +1423,7 @@ private def buildExternalMarkupEntries
     (state : TraverseState)
     (previewBackedEntries : Array Entry) : IO (Array Entry) := do
   let mut entries := #[]
+  let storedBlocks := Informal.collectStoredBlocks state
   for decoded in Informal.TraversalIndex.ExternalMarkup.entries state do
     match decoded with
     | .error err =>
@@ -1433,13 +1434,30 @@ private def buildExternalMarkupEntries
         continue
       if hasPreviewBackedBlockEntry previewBackedEntries data.label then
         continue
+      let blockData? := blockInfo? state data.label
+      let headingParts? := blockHeadingParts? state data.label .statement blockData?
       entries := entries.push {
         key := externalMarkupEntryKey data.label
         targetKind := .externalMarkup
         label := data.label
         facet := .statement
-        title := blockTitle state data.label
+        kind := blockKind? blockData?
+        title := blockTitle state data.label .statement blockData?
+        displayCaption := headingParts?.map (·.caption)
+        displayLabel := headingParts?.map (·.label)
+        href := blockHref state data.label
+        parent := blockData?.bind (·.parent)
+        parentTitle := blockParentTitle? state blockData?
+        statementUses := blockData?.map (·.statementUses) |>.getD #[]
+        proofUses := blockData?.map (·.proofUses) |>.getD #[]
         externalMarkup := data.markup.toArray
+        uses := blockData?.map (buildUsesRelations state ·) |>.getD #[]
+        usedBy := blockData?.map (buildUsedByRelations state storedBlocks ·) |>.getD #[]
+        group := blockData?.bind (buildGroupRelation? state storedBlocks)
+        ownerDisplayName := blockData?.bind (·.ownerDisplayName)
+        tags := blockData?.map (·.tags) |>.getD #[]
+        priority := blockData?.bind (·.priority)
+        effort := blockData?.bind (·.effort)
       }
   pure entries
 

--- a/src/VersoBlueprint/blueprint-preview-api.mjs
+++ b/src/VersoBlueprint/blueprint-preview-api.mjs
@@ -202,6 +202,10 @@ export function renderCanonicalPreviewInto(element, key, options) {
   return callRuntime("renderCanonicalPreviewInto", arguments);
 }
 
+export function renderNode(element, request, options) {
+  return callRuntime("renderNode", arguments);
+}
+
 export function hydrate(element, options) {
   return callRuntime("hydrate", arguments);
 }
@@ -235,6 +239,7 @@ const previewApi = {
   renderPreviewInto,
   resolveCanonicalPreview,
   renderCanonicalPreviewInto,
+  renderNode,
   hydrate
 };
 

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -416,7 +416,7 @@ class TestPreviewRuntimeRegressions:
 
         client = page.locator("#custom-render-client-example").first
         expect(client).to_have_attribute("data-bp-custom-client-status", "ready")
-        expect(client.locator("[data-bp-custom-client-example]")).to_have_count(8)
+        expect(client.locator("[data-bp-custom-client-example]")).to_have_count(10)
         preview_module_card = client.locator("[data-bp-preview-module-example]").first
         expect(preview_module_card).to_have_attribute("data-bp-preview-module-ok", "true")
         expect(preview_module_card).to_have_attribute(
@@ -441,11 +441,11 @@ class TestPreviewRuntimeRegressions:
         expect(graph_card).to_have_attribute("data-bp-graph-module-ok", "true")
         expect(graph_card).to_have_attribute("data-bp-graph-module-count", "1")
         expect(graph_card).to_have_attribute("data-bp-graph-module-key", re.compile(r"^graph:#<"))
-        expect(graph_card).to_have_attribute("data-bp-graph-node-count", "55")
-        expect(graph_card).to_have_attribute("data-bp-graph-edge-count", "13")
-        expect(graph_card).to_have_attribute("data-bp-graph-group-count", "3")
+        expect(graph_card).to_have_attribute("data-bp-graph-node-count", "58")
+        expect(graph_card).to_have_attribute("data-bp-graph-edge-count", "15")
+        expect(graph_card).to_have_attribute("data-bp-graph-group-count", "4")
         expect(graph_card.locator("[data-bp-custom-client-graph-summary]").first).to_contain_text(
-            "Nodes 55"
+            "Nodes 58"
         )
         used_target_link = graph_card.locator('[data-bp-graph-node-label="used_target"]').first
         expect(used_target_link).to_have_text(re.compile(r"Definition"))
@@ -482,6 +482,28 @@ class TestPreviewRuntimeRegressions:
         expect(fragment_body).to_contain_text("Statement facet marker")
         expect(fragment_body).not_to_contain_text("Proof facet marker")
         expect(fragment_body.locator(".bp_wrapper")).to_have_count(0)
+
+        native_node_card = client.locator(
+            '[data-bp-custom-client-body="label-native"]'
+        ).locator("xpath=ancestor::article[1]").first
+        expect(
+            native_node_card.locator("[data-bp-custom-client-title]").first
+        ).to_have_text("Label native preview")
+        expect(native_node_card).to_have_attribute("data-bp-render-ok", "true")
+        expect(native_node_card).to_have_attribute("data-bp-render-mode", "native")
+        expect(native_node_card).to_have_attribute("data-bp-canonical-preview", "true")
+        expect(native_node_card).to_have_attribute(
+            "data-bp-preview-key", "preview_facets--statement"
+        )
+        native_node_body = native_node_card.locator(
+            '[data-bp-custom-client-body="label-native"]'
+        ).first
+        expect(native_node_body.locator(".bp_wrapper").first).to_have_attribute(
+            "title", "preview_facets"
+        )
+        expect(native_node_body.locator(".bp_heading").first).to_contain_text("Theorem")
+        expect(native_node_body).to_contain_text("Statement facet marker")
+        expect(native_node_body).not_to_contain_text("Proof facet marker")
 
         canonical_statement_card = client.locator(
             '[data-bp-custom-client-body="canonical-statement"]'
@@ -569,6 +591,133 @@ class TestPreviewRuntimeRegressions:
         expect(grouped_statement_body.locator(".bp_extra_slot_used_by")).to_have_count(1)
         expect(grouped_statement_body.locator(".bp_extra_slot_code")).to_have_count(1)
 
+        external_markdown_card = client.locator(
+            '[data-bp-custom-client-body="external-markdown"]'
+        ).locator("xpath=ancestor::article[1]").first
+        expect(
+            external_markdown_card.locator("[data-bp-custom-client-title]").first
+        ).to_have_text("External Markdown fallback")
+        expect(external_markdown_card).to_have_attribute("data-bp-render-ok", "true")
+        expect(external_markdown_card).to_have_attribute("data-bp-render-mode", "external-markup")
+        expect(external_markdown_card).to_have_attribute("data-bp-canonical-preview", "true")
+        expect(external_markdown_card).to_have_attribute(
+            "data-bp-preview-key", "externalMarkup:custom_client_external_markdown_metadata"
+        )
+        expect(external_markdown_card).to_have_attribute(
+            "data-bp-manifest-label", "custom_client_external_markdown_metadata"
+        )
+        expect(external_markdown_card).to_have_attribute("data-bp-manifest-facet", "statement")
+        expect(external_markdown_card).to_have_attribute(
+            "data-bp-external-markup-language", "markdown"
+        )
+        expect(external_markdown_card).to_have_attribute(
+            "data-bp-external-markup-slot", "original"
+        )
+        external_markdown_body = external_markdown_card.locator(
+            '[data-bp-custom-client-body="external-markdown"]'
+        ).first
+        external_wrapper = external_markdown_body.locator(".bp_wrapper").first
+        expect(external_wrapper).to_have_attribute("title", "custom_client_external_markdown_metadata")
+        expect(external_wrapper.locator(".bp_heading").first).to_contain_text("Theorem")
+        expect(external_wrapper.locator(".bp_heading").first).to_contain_text("3.1")
+        expect(external_wrapper.locator(".bp_extra_slot_uses .bp_relation_chip").first).to_have_text(
+            "uses 1"
+        )
+        expect(
+            external_wrapper.locator(".bp_extra_slot_used_by .bp_relation_chip").first
+        ).to_have_text("used by 1")
+        external_uses_trigger = external_wrapper.locator(
+            ".bp_extra_slot_uses .bp_inline_preview_ref"
+        ).first
+        external_uses_trigger.hover()
+        inline_panel = page.locator("#bp-inline-preview-panel")
+        expect(inline_panel).to_be_visible()
+        inline_body = inline_panel.locator(".bp_inline_preview_panel_body")
+        page.wait_for_function(
+            "(el) => !!el && el.textContent.includes('Target statement with associated Lean code.')",
+            arg=inline_body.element_handle(),
+        )
+        expect(inline_panel.locator(".bp_inline_preview_panel_label")).to_contain_text(
+            "used_target"
+        )
+
+        page.mouse.move(0, 0)
+        expect(inline_panel).to_be_hidden(timeout=1000)
+
+        external_used_by_trigger = external_wrapper.locator(
+            ".bp_extra_slot_used_by .bp_inline_preview_ref"
+        ).first
+        external_used_by_trigger.hover()
+        expect(inline_panel).to_be_visible()
+        page.wait_for_function(
+            "(el) => !!el && el.textContent.includes('Consumer node that gives the Markdown fallback target a used-by relation.')",
+            arg=inline_body.element_handle(),
+        )
+        expect(inline_panel.locator(".bp_inline_preview_panel_label")).to_contain_text(
+            "custom_client_external_metadata_consumer"
+        )
+
+        page.mouse.move(0, 0)
+        expect(inline_panel).to_be_hidden(timeout=1000)
+
+        external_code_trigger = external_wrapper.locator(
+            ".bp_extra_slot_code .bp_code_summary_preview_wrap_active"
+        ).first
+        external_code_trigger.hover()
+        code_panel = page.locator(".bp_code_summary_preview_panel:not([hidden])").first
+        expect(code_panel).to_be_visible()
+        expect(code_panel.locator(".bp_code_summary_preview_title")).to_have_text(
+            "custom_client_external_markdown_metadata"
+        )
+        expect(code_panel.locator(".bp_code_summary_preview_body")).to_contain_text(
+            "No associated Lean code or declarations."
+        )
+
+        page.mouse.move(0, 0)
+        expect(code_panel).to_be_hidden(timeout=1000)
+
+        expect(external_wrapper.locator(".bp_extra_slot_code")).to_have_count(1)
+        metadata_panel = external_wrapper.locator(".bp_metadata_panel").first
+        expect(metadata_panel).to_contain_text("Effort")
+        expect(metadata_panel).to_contain_text("small")
+        expect(metadata_panel).to_contain_text("Priority")
+        expect(metadata_panel).to_contain_text("medium")
+        expect(metadata_panel).to_contain_text("Tags")
+        expect(metadata_panel).to_contain_text("external")
+        expect(metadata_panel).to_contain_text("markdown")
+        external_content = external_wrapper.locator(".bp_content").first
+        expect(external_content).to_contain_text("Markdown fallback")
+        expect(external_content.locator("h4").first).to_have_text(
+            "External Markdown with metadata"
+        )
+        expect(external_content).to_contain_text("manifest metadata")
+        expect(external_content).to_contain_text("Source markdown/original")
+
+        standalone = page.locator("#standalone-render-node-markdown-example").first
+        expect(standalone).to_have_attribute("data-bp-render-ok", "true")
+        expect(standalone).to_have_attribute("data-bp-render-mode", "external-markup")
+        expect(standalone).to_have_attribute("data-bp-canonical-preview", "true")
+        expect(standalone).to_have_attribute(
+            "data-bp-preview-key", "externalMarkup:custom_client_external_markdown_metadata"
+        )
+        expect(standalone).to_have_attribute(
+            "data-bp-manifest-label", "custom_client_external_markdown_metadata"
+        )
+        expect(standalone).to_have_attribute("data-bp-external-markup-language", "markdown")
+        standalone_target = standalone.locator("[data-bp-standalone-render-node-target]").first
+        standalone_wrapper = standalone_target.locator(".bp_wrapper").first
+        expect(standalone_wrapper).to_have_attribute(
+            "title", "custom_client_external_markdown_metadata"
+        )
+        expect(standalone_wrapper.locator(".bp_heading").first).to_contain_text("Theorem")
+        expect(standalone_wrapper.locator(".bp_extra_slot_uses .bp_relation_chip").first).to_have_text(
+            "uses 1"
+        )
+        expect(standalone_wrapper.locator(".bp_content h4").first).to_have_text(
+            "External Markdown with metadata"
+        )
+        expect(standalone_wrapper.locator(".bp_content")).to_contain_text("manifest metadata")
+
         broken_custom_links = page.evaluate(
             """
             async () => {
@@ -617,6 +766,174 @@ class TestPreviewRuntimeRegressions:
         missing_body = missing_card.locator('[data-bp-custom-client-body="missing"]').first
         expect(missing_body).to_contain_text("Preview entry missing from manifest")
         expect(missing_body).to_contain_text("missing_custom_client_target--statement")
+
+        assert_no_runtime_errors(errors)
+
+    def test_render_node_external_markup_diagnostics(self, server: str, page: Page):
+        errors = record_runtime_errors(page)
+        page.goto(f"{server}/Custom-Render-Client/")
+
+        diagnostics = page.evaluate(
+            blueprint_render_api_script(
+                """
+                const host = document.createElement("section");
+                document.body.appendChild(host);
+
+                async function run(request) {
+                    host.replaceChildren();
+                    const result = await api.renderNode(host, request);
+                    return {
+                        ok: result.ok,
+                        key: result.key || "",
+                        reason: result.reason || "",
+                        renderMode: result.renderMode || "",
+                        label: result.label || "",
+                        facet: result.facet || "",
+                        manifestLabel:
+                            result.manifestEntry && result.manifestEntry.label
+                                ? result.manifestEntry.label
+                                : "",
+                        externalMarkupLanguage:
+                            result.externalMarkup && result.externalMarkup.language
+                                ? result.externalMarkup.language
+                                : "",
+                        externalMarkupSlot:
+                            result.externalMarkup && result.externalMarkup.slot
+                                ? result.externalMarkup.slot
+                                : "",
+                        text: host.textContent || "",
+                        html: host.innerHTML || ""
+                    };
+                }
+
+                const missingEntry = await run({
+                    label: "missing_custom_client_target",
+                    externalMarkup: {
+                        prefer: [{ display: "source" }]
+                    }
+                });
+
+                const missingMarkup = await run({
+                    label: "custom_client_external_markdown",
+                    externalMarkup: {
+                        prefer: [
+                            {
+                                language: "tex",
+                                slot: "original",
+                                render: function (_payload, target) {
+                                    target.textContent = "unexpected TeX render";
+                                }
+                            }
+                        ]
+                    }
+                });
+
+                const missingRenderer = await run({
+                    label: "custom_client_external_markdown",
+                    externalMarkup: {
+                        prefer: [
+                            {
+                                language: "markdown",
+                                slot: "original"
+                            }
+                        ]
+                    }
+                });
+
+                const rendererFailed = await run({
+                    label: "custom_client_external_markdown_metadata",
+                    externalMarkup: {
+                        prefer: [
+                            {
+                                language: "markdown",
+                                slot: "original",
+                                render: function () {
+                                    throw new Error("markdown renderer exploded");
+                                }
+                            }
+                        ]
+                    }
+                });
+
+                const sourceFallback = await run({
+                    label: "custom_client_external_markdown_metadata",
+                    externalMarkup: {
+                        prefer: [
+                            {
+                                language: "tex",
+                                slot: "original",
+                                render: function (_payload, target) {
+                                    target.textContent = "unexpected TeX render";
+                                }
+                            },
+                            { display: "source" }
+                        ]
+                    }
+                });
+
+                const missingShell = await run({
+                    label: "custom_client_external_markdown",
+                    externalMarkup: {
+                        prefer: [{ display: "source" }]
+                    }
+                });
+
+                return {
+                    missingEntry,
+                    missingMarkup,
+                    missingRenderer,
+                    rendererFailed,
+                    sourceFallback,
+                    missingShell
+                };
+                """
+            )
+        )
+
+        assert diagnostics["missingEntry"]["ok"] is False
+        assert diagnostics["missingEntry"]["reason"] == "external-markup-entry-missing"
+        assert diagnostics["missingEntry"]["renderMode"] == "diagnostic"
+        assert diagnostics["missingEntry"]["label"] == "missing_custom_client_target"
+        assert "External markup entry missing" in diagnostics["missingEntry"]["text"]
+        assert "missing_custom_client_target--statement" in diagnostics["missingEntry"]["text"]
+
+        assert diagnostics["missingMarkup"]["ok"] is False
+        assert diagnostics["missingMarkup"]["reason"] == "external-markup-missing"
+        assert diagnostics["missingMarkup"]["key"] == "externalMarkup:custom_client_external_markdown"
+        assert diagnostics["missingMarkup"]["manifestLabel"] == "custom_client_external_markdown"
+        assert diagnostics["missingMarkup"]["externalMarkupLanguage"] == ""
+        assert "External markup missing" in diagnostics["missingMarkup"]["text"]
+        assert "tex / original" in diagnostics["missingMarkup"]["text"]
+
+        assert diagnostics["missingRenderer"]["ok"] is False
+        assert diagnostics["missingRenderer"]["reason"] == "external-markup-renderer-missing"
+        assert diagnostics["missingRenderer"]["externalMarkupLanguage"] == "markdown"
+        assert diagnostics["missingRenderer"]["externalMarkupSlot"] == "original"
+        assert "External markup renderer missing" in diagnostics["missingRenderer"]["text"]
+
+        assert diagnostics["rendererFailed"]["ok"] is False
+        assert diagnostics["rendererFailed"]["reason"] == "external-markup-render-failed"
+        assert diagnostics["rendererFailed"]["externalMarkupLanguage"] == "markdown"
+        assert diagnostics["rendererFailed"]["externalMarkupSlot"] == "original"
+        assert "External markup renderer failed" in diagnostics["rendererFailed"]["text"]
+        assert "markdown renderer exploded" in diagnostics["rendererFailed"]["text"]
+
+        assert diagnostics["sourceFallback"]["ok"] is True
+        assert diagnostics["sourceFallback"]["reason"] == ""
+        assert diagnostics["sourceFallback"]["renderMode"] == "external-markup"
+        assert diagnostics["sourceFallback"]["externalMarkupLanguage"] == "markdown"
+        assert diagnostics["sourceFallback"]["externalMarkupSlot"] == "original"
+        assert "Theorem" in diagnostics["sourceFallback"]["text"]
+        assert "uses 1" in diagnostics["sourceFallback"]["text"]
+        assert "# External Markdown with metadata" in diagnostics["sourceFallback"]["text"]
+        assert "unexpected TeX render" not in diagnostics["sourceFallback"]["text"]
+
+        assert diagnostics["missingShell"]["ok"] is False
+        assert diagnostics["missingShell"]["reason"] == "external-markup-node-shell-missing"
+        assert diagnostics["missingShell"]["renderMode"] == "external-markup"
+        assert diagnostics["missingShell"]["externalMarkupLanguage"] == "markdown"
+        assert "External markup node shell missing" in diagnostics["missingShell"]["text"]
+        assert "generated-page link" in diagnostics["missingShell"]["text"]
 
         assert_no_runtime_errors(errors)
 

--- a/tests/harness/test_preview_runtime_api_docs.py
+++ b/tests/harness/test_preview_runtime_api_docs.py
@@ -261,6 +261,8 @@ class PreviewRuntimeApiDocsTests(unittest.TestCase):
         self.assertIn("async function renderPreviewIntoSurface(surface, previewKey, options)", surface)
         self.assertIn("function previewMessageHtml(options)", surface)
         self.assertIn("export const previewRuntimeSurface = {", surface)
+        self.assertIn("async function renderBlueprintNodeInto(target, request, options)", render)
+        self.assertIn("function externalMarkupRendererPayload", render)
         self.assertIn("function bindTemplatePreview(options)", template)
         self.assertIn("function bindTemplatePreviewDescriptor(root)", template)
         self.assertIn("export const previewRuntimeTemplate = {", template)
@@ -271,6 +273,7 @@ class PreviewRuntimeApiDocsTests(unittest.TestCase):
         self.assertIn("const stableCustomClientApi = {", api)
         self.assertIn("export function installPreviewRuntimeApi()", api)
         self.assertIn("function onRenderReady(fn)", api)
+        self.assertIn("renderNode: previewRenderApi.renderNode", api)
         for helper in (
             "function loadBlueprintStore(store)",
             "function previewKey(label, facet)",

--- a/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/CustomRenderClient.lean
+++ b/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/CustomRenderClient.lean
@@ -58,6 +58,7 @@ def customRenderClientCss : String := r##"
 }
 
 .bp_custom_render_client_example[data-bp-custom-client-example="render-preview-into"],
+.bp_custom_render_client_example[data-bp-custom-client-example="render-node"],
 .bp_custom_render_client_example[data-bp-render-ok="false"] {
   background: var(--bp-color-surface);
   border: 1px solid var(--bp-color-border-soft);
@@ -172,11 +173,39 @@ def customRenderClientCss : String := r##"
 .bp_custom_render_client_body .bp_extra_slot {
   justify-content: flex-start;
 }
+
+.bp_custom_render_client_external {
+  background: var(--bp-color-background);
+  border: 1px solid var(--bp-color-border-soft);
+  border-radius: var(--bp-radius-sm);
+  padding: 0.75rem;
+}
+
+.bp_custom_render_client_external h4 {
+  font-size: 0.95rem;
+  margin: 0 0 0.45rem;
+}
+
+.bp_custom_render_client_external p {
+  margin: 0.35rem 0;
+}
+
+.bp_custom_render_client_external_kicker {
+  color: var(--bp-color-text-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  margin-bottom: 0.35rem;
+  text-transform: uppercase;
+}
 "##
 
 -- Keep this module rebuilt when the standalone custom-client asset changes.
 def customRenderClientJs : String :=
   Informal.Commands.withPreviewClientReadyJs (include_str "custom-render-client.js")
+
+-- Keep this module rebuilt when the standalone render-node Markdown example changes.
+def standaloneRenderNodeMarkdownJs : String :=
+  Informal.Commands.withPreviewClientReadyJs (include_str "standalone-render-node-markdown.js")
 
 private def clientText (text : String) : Verso.Output.Html :=
   VersoBlueprint.Html.text text
@@ -339,6 +368,14 @@ if (card) {
 }
 "##
 
+private def standaloneRenderNodeMarkdownHtml : Verso.Output.Html :=
+  clientTag "section"
+    #[ ("id", "standalone-render-node-markdown-example"),
+       ("data-bp-standalone-render-node-markdown", "true"),
+       ("data-bp-label", "custom_client_external_markdown_metadata"),
+       ("data-bp-facet", "statement") ]
+    (clientTag "div" #[("data-bp-standalone-render-node-target", "true")] .empty)
+
 def customRenderClientHtml : Verso.Output.Html :=
   let heading := clientTag "h2" #[] (clientText "Standalone Render Client")
   let status :=
@@ -356,6 +393,9 @@ def customRenderClientHtml : Verso.Output.Html :=
         clientExample "render-preview-into" "preview_facets" "statement" "Body fragment"
           "statement"
           "Direct insertion with renderPreviewInto: useful for custom UIs, but intentionally body-only.",
+        clientExample "render-node" "preview_facets" "statement" "Label native preview"
+          "label-native"
+          "Label-oriented renderNode call: native content uses the generated Blueprint node shell.",
         clientExample "render-canonical-preview-into" "preview_facets" "statement" "Canonical statement"
           "canonical-statement"
           "Canonical insertion with renderCanonicalPreviewInto; this reuses the generated Blueprint node wrapper.",
@@ -374,6 +414,9 @@ def customRenderClientHtml : Verso.Output.Html :=
         clientExample "render-canonical-preview-into" "used_grouped_proof_panel" "proof" "Proof dependencies"
           "grouped-proof"
           "The proof facet for the same theorem, showing proof-side uses and relation metadata.",
+        clientExample "render-node" "custom_client_external_markdown_metadata" "statement" "External Markdown fallback"
+          "external-markdown"
+          "Label-oriented renderNode call: the generated Blueprint shell stays standard while Markdown fills the content slot.",
         clientExample "render-canonical-preview-into" "missing_custom_client_target" "statement" "Missing preview diagnostic"
           "missing"
           "An expected miss that demonstrates the runtime diagnostic branch for custom clients."
@@ -388,11 +431,19 @@ def customRenderClientHtml : Verso.Output.Html :=
          ("data-bp-custom-render-client", "true"),
          ("data-bp-custom-client-status", "idle") ]
       (Verso.Output.Html.seq #[header, examples])
-  Verso.Output.Html.seq #[sectionBlock, previewModuleExampleScript, graphModuleExampleScript]
+  Verso.Output.Html.seq #[
+    sectionBlock,
+    standaloneRenderNodeMarkdownHtml,
+    previewModuleExampleScript,
+    graphModuleExampleScript
+  ]
 
 def customRenderClientAssetBundle : Informal.Commands.BlueprintAssetBundle :=
   (Informal.Commands.blueprintCssAssetBundle [customRenderClientCss]).append
-    (Informal.Commands.previewRuntimeJsAssetBundle.withJs [] [customRenderClientJs])
+    (Informal.Commands.previewRuntimeJsAssetBundle.withJs [] [
+      customRenderClientJs,
+      standaloneRenderNodeMarkdownJs
+    ])
 
 open Verso Doc Elab Genre Manual in
 block_extension Block.customRenderClientExample where
@@ -419,3 +470,24 @@ open PreviewRuntimeShowcase.Chapters.CustomRenderClient
 This page carries a standalone browser client for the Blueprint render API.
 
 {custom_render_client_example}
+
+:::Informal.group "custom_client_external_metadata_group"
+Custom render external metadata group.
+:::
+
+:::Informal.theorem "custom_client_external_markdown_metadata" (parent := "custom_client_external_metadata_group") (uses := "used_target") (tags := "external, markdown") (effort := "small") (priority := "medium")
+:::
+
+:::Informal.lemma_ "custom_client_external_metadata_consumer" (uses := "custom_client_external_markdown_metadata")
+Consumer node that gives the Markdown fallback target a used-by relation.
+:::
+
+```Informal.md "custom_client_external_markdown_metadata" (slot := original)
+# External Markdown with metadata
+This fallback keeps **manifest metadata** such as uses, used-by, group, tags, priority, and effort.
+```
+
+```Informal.md "custom_client_external_markdown" (slot := original)
+# External Markdown source
+This witness has **only Markdown** attached and no generated Blueprint node shell, so diagnostics can exercise source-only external markup.
+```

--- a/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/custom-render-client.js
+++ b/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/custom-render-client.js
@@ -37,8 +37,14 @@
     example.dataset.bpRenderOk = result.ok ? "true" : "false";
     example.dataset.bpExpectedOk = expectedOk(example) ? "true" : "false";
     example.dataset.bpRenderReason = result.reason || "";
+    example.dataset.bpRenderMode = result.renderMode || "";
     example.dataset.bpCanonicalPreview = result.canonicalHtml ? "true" : "false";
     example.dataset.bpCanonicalSourceHref = result.canonicalSourceHref || "";
+    if (result.externalMarkup) {
+      example.dataset.bpExternalMarkupLanguage = result.externalMarkup.language || "";
+      example.dataset.bpExternalMarkupSlot = result.externalMarkup.slot || "";
+      example.dataset.bpExternalMarkupHasLocation = result.externalMarkup.location ? "true" : "false";
+    }
     if (result.manifestEntry) {
       example.dataset.bpManifestLabel = result.manifestEntry.label || "";
       example.dataset.bpManifestFacet = result.manifestEntry.facet || "";
@@ -110,6 +116,42 @@
     appendFact(facts, "Proof uses", Array.isArray(entry.proofUses) ? entry.proofUses.length : 0);
     appendFact(facts, "Used by", Array.isArray(entry.usedBy) ? entry.usedBy.length : 0);
     appendFact(facts, "Code previews", Array.isArray(entry.leanCodePreviewKeys) ? entry.leanCodePreviewKeys.length : 0);
+    appendFact(facts, "External markup", Array.isArray(entry.externalMarkup) ? entry.externalMarkup.length : 0);
+  }
+
+  function appendMarkdownInline(parent, text) {
+    String(text || "").split(/(\*\*[^*]+\*\*)/g).forEach(function (part) {
+      if (!part) return;
+      if (part.startsWith("**") && part.endsWith("**") && part.length > 4) {
+        appendTextNode(parent, "strong", "", part.slice(2, -2));
+      } else {
+        parent.appendChild(document.createTextNode(part));
+      }
+    });
+  }
+
+  async function renderMarkdownFallback(payload, target) {
+    const article = document.createElement("article");
+    article.className = "bp_custom_render_client_external";
+    appendTextNode(article, "div", "bp_custom_render_client_external_kicker", "Markdown fallback");
+    const lines = String(payload.raw || "").split(/\n+/).map(function (line) {
+      return line.trim();
+    }).filter(Boolean);
+    lines.forEach(function (line) {
+      if (line.startsWith("# ")) {
+        appendTextNode(article, "h4", "", line.slice(2).trim());
+      } else {
+        const paragraph = document.createElement("p");
+        appendMarkdownInline(paragraph, line);
+        article.appendChild(paragraph);
+      }
+    });
+    appendFact(
+      article,
+      "Source",
+      (payload.language || "markup") + "/" + (payload.slot || "default")
+    );
+    target.replaceChildren(article);
   }
 
   function graphSampleNodes(graph) {
@@ -185,6 +227,17 @@
       result = await api.renderPreviewInto(body, key);
     } else if (exampleName === "render-canonical-preview-into") {
       result = await api.renderCanonicalPreviewInto(body, key);
+    } else if (exampleName === "render-node") {
+      result = await api.renderNode(body, {
+        label: example.dataset.bpPreviewLabel,
+        facet: example.dataset.bpPreviewFacet,
+        externalMarkup: {
+          prefer: [
+            { language: "markdown", slot: "original", render: renderMarkdownFallback },
+            { display: "source" }
+          ]
+        }
+      });
     } else {
       throw new Error("Unknown custom render client example: " + exampleName);
     }

--- a/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/standalone-render-node-markdown.js
+++ b/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/standalone-render-node-markdown.js
@@ -1,0 +1,79 @@
+(function () {
+  function appendTextNode(parent, tagName, className, text) {
+    const node = document.createElement(tagName);
+    if (className) node.className = className;
+    node.textContent = text;
+    parent.appendChild(node);
+    return node;
+  }
+
+  function appendMarkdownInline(parent, text) {
+    String(text || "").split(/(\*\*[^*]+\*\*)/g).forEach(function (part) {
+      if (!part) return;
+      if (part.startsWith("**") && part.endsWith("**") && part.length > 4) {
+        appendTextNode(parent, "strong", "", part.slice(2, -2));
+      } else {
+        parent.appendChild(document.createTextNode(part));
+      }
+    });
+  }
+
+  async function renderMarkdown(payload, target) {
+    const fragment = document.createDocumentFragment();
+    String(payload.raw || "").split(/\n+/).map(function (line) {
+      return line.trim();
+    }).filter(Boolean).forEach(function (line) {
+      if (line.startsWith("# ")) {
+        appendTextNode(fragment, "h4", "", line.slice(2).trim());
+      } else {
+        const paragraph = document.createElement("p");
+        appendMarkdownInline(paragraph, line);
+        fragment.appendChild(paragraph);
+      }
+    });
+    target.replaceChildren(fragment);
+  }
+
+  async function renderStandaloneNode(api, root) {
+    if (!(root instanceof HTMLElement)) return;
+    if (root.dataset.bpStandaloneRenderNodeBound === "true") return;
+    root.dataset.bpStandaloneRenderNodeBound = "true";
+    const target = root.querySelector("[data-bp-standalone-render-node-target]");
+    if (!(target instanceof Element)) return;
+    const result = await api.renderNode(target, {
+      label: root.dataset.bpLabel || "",
+      facet: root.dataset.bpFacet || "statement",
+      externalMarkup: {
+        prefer: [
+          { language: "markdown", slot: "original", render: renderMarkdown },
+          { display: "source" }
+        ]
+      }
+    });
+    root.dataset.bpRenderOk = result.ok ? "true" : "false";
+    root.dataset.bpRenderMode = result.renderMode || "";
+    root.dataset.bpRenderReason = result.reason || "";
+    root.dataset.bpPreviewKey = result.key || "";
+    root.dataset.bpCanonicalPreview = result.canonicalHtml ? "true" : "false";
+    root.dataset.bpManifestLabel =
+      result.manifestEntry && result.manifestEntry.label ? result.manifestEntry.label : "";
+    root.dataset.bpExternalMarkupLanguage =
+      result.externalMarkup && result.externalMarkup.language ? result.externalMarkup.language : "";
+  }
+
+  function bindAll(api) {
+    document.querySelectorAll("[data-bp-standalone-render-node-markdown]").forEach(function (root) {
+      renderStandaloneNode(api, root);
+    });
+  }
+
+  window.VersoBlueprint.onRenderReady(function (api) {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", function () {
+        bindAll(api);
+      });
+    } else {
+      bindAll(api);
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
Backport #184 to `v4.30.0`.

## Primary Review
- Primary review: #184
- Keep review comments on #184 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.30.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- Conflict resolution kept the v4.30 API document's compact "Choosing an API" table while adding the new `renderNode` entry and semantic/cache guidance.