### PR TITLE
[backport v4.30.0] chore: add JavaScript API type tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,30 @@ jobs:
       - name: Check Python harness syntax
         run: python3 -m compileall -q scripts
 
+  js-api-tooling:
+    name: JavaScript API Tooling
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: npm
+      - name: Install JavaScript dependencies
+        run: npm ci
+      - name: Typecheck JavaScript API
+        run: npm run typecheck
+      - name: Build JavaScript API declarations
+        run: npm run build:types
+      - name: Generate JavaScript API docs
+        run: npm run docs
+      - name: Upload JavaScript API docs artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: js-api-docs
+          path: _out/jsdoc-api
+
   project-template-fresh-repo:
     name: Project Template Fresh Repo
     if: github.event_name == 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ _out/
 _site/
 tests/browser/.venv/
 tests/browser/uv.lock
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -206,8 +206,9 @@ passed to the generator binary, such as
 ### JavaScript API tooling
 
 The browser APIs emitted under `-verso-data/api/` remain plain JavaScript ESM.
-API documentation is written in JSDoc, and TypeScript checks the public API
-entrypoints plus their direct support modules with `allowJs` and `checkJs`.
+API documentation is written in JSDoc, rendered with Docdash, and TypeScript
+checks the public API entrypoints plus their direct support modules with
+`allowJs` and `checkJs`.
 This first pass intentionally focuses on the custom-client API surface; broader
 private runtime coverage and `noImplicitAny` tightening are follow-up cleanup
 items. TypeScript users consume generated declaration files from `dist/types`;

--- a/README.md
+++ b/README.md
@@ -203,6 +203,50 @@ passed to the generator binary, such as
 `--dump-manifest`, `--dump-html-cache`, and `--dump-schema`. See
 [doc/API.md](./doc/API.md) for the stable generated-data contract.
 
+### JavaScript API tooling
+
+The browser APIs emitted under `-verso-data/api/` remain plain JavaScript ESM.
+API documentation is written in JSDoc, and TypeScript checks the public API
+entrypoints plus their direct support modules with `allowJs` and `checkJs`.
+This first pass intentionally focuses on the custom-client API surface; broader
+private runtime coverage and `noImplicitAny` tightening are follow-up cleanup
+items. TypeScript users consume generated declaration files from `dist/types`;
+those files are build artifacts and are not tracked in source.
+
+Useful maintainer commands:
+
+- `npm run typecheck`
+- `npm run build:types`
+- `npm run docs`
+
+Custom clients can import the generated preview module directly from a rendered
+site:
+
+```js
+import { createPreview } from "./-verso-data/api/preview.mjs";
+
+const preview = createPreview();
+const container = document.querySelector("#target");
+if (!container) throw new Error("Missing preview target");
+
+await preview.renderNode(container, {
+  label: "Chapter2:Problem2.11.6",
+  externalMarkup: {
+    prefer: [
+      { language: "verso", slot: "statement" },
+      {
+        language: "markdown",
+        slot: "original",
+        render: async ({ raw }, target) => {
+          target.replaceChildren(renderMarkdown(raw));
+        }
+      },
+      { display: "source" }
+    ]
+  }
+});
+```
+
 ### Widget
 
 The widget surface is experimental. Import `VersoBlueprint.Widget` explicitly if

--- a/doc/JS_API_DOCS.md
+++ b/doc/JS_API_DOCS.md
@@ -1,0 +1,62 @@
+# Verso Blueprint JavaScript API
+
+Verso Blueprint emits browser-facing ESM modules under `-verso-data/api/` in
+generated sites. These modules are plain JavaScript, documented with JSDoc, and
+checked with TypeScript's `allowJs` and `checkJs` workflow.
+
+Use the preview API for most custom clients:
+
+```js
+import { createPreview } from "./-verso-data/api/preview.mjs";
+
+const preview = createPreview({
+  hydrators: {
+    audit(root) {
+      root.querySelectorAll("[data-audit-target]").forEach(bindAuditWidget);
+    }
+  }
+});
+
+await preview.renderNode(document.querySelector("#target"), {
+  label: "Chapter2:Problem2.11.6",
+  externalMarkup: {
+    prefer: [
+      { language: "verso", slot: "statement" },
+      { language: "markdown", slot: "original", render: renderMarkdown },
+      { display: "source" }
+    ]
+  }
+});
+```
+
+## Modules
+
+- [preview API](module-blueprint-preview-api.html): render Blueprint nodes,
+  hydrate generated fragments, resolve canonical generated-node shells, and
+  provide call-scoped external-markup fallback renderers.
+- [data API](module-blueprint-data-api.html): load generated manifests,
+  rendered-fragment caches, graph payloads, and generated-data URLs without
+  installing browser-global render hooks.
+- [graph API](module-blueprint-graph-api.html): read graph data embedded in
+  generated graph pages or load graph variants from a manifest.
+- [shared API types](module-blueprint-api-types.html): request, result, option,
+  manifest, cache, graph, external-markup, and hydrator shapes.
+
+## Key Types
+
+- `BlueprintPreviewOptions`: loader, hydration, math-rendering, canonical-page,
+  and cache options accepted by render-capable APIs.
+- `BlueprintRenderNodeRequest`: label-oriented request accepted by
+  `renderNode`.
+- `BlueprintExternalMarkupPreference`: ordered fallback entry for Markdown,
+  TeX, Verso source, or raw-source display when a native rendered preview is
+  unavailable.
+- `BlueprintRenderNodeResult`: typed success or diagnostic result returned by
+  `renderNode`.
+
+## Generated Artifacts
+
+The declarations produced by `npm run build:types` are build artifacts under
+`dist/types`; they are not tracked in source. The HTML docs produced by
+`npm run docs` are written to `_out/jsdoc-api`; CI validates them and uploads
+that directory as the `js-api-docs` artifact.

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -97,6 +97,11 @@ Work:
    - graph rendering orchestration, variant selection, and graph UI event
      binding
      (landed as `Commands/graph.mjs`, imported by the Manual page runtime)
+8. deduplicate the public JSDoc API object typedefs once the JS API surface
+   settles; today `BlueprintPreviewApi` deliberately repeats the data API
+   methods from `BlueprintDataApi` because classic JSDoc composition is brittle
+   for generated declaration output, but the long-term source of truth should be
+   a single shared API shape plus preview-specific extensions
 
 ### Data Model and Status Semantics
 

--- a/doc/jsdoc-static/jsdoc-type-links.js
+++ b/doc/jsdoc-static/jsdoc-type-links.js
@@ -1,0 +1,102 @@
+(function () {
+  "use strict";
+
+  var typeNames = [
+    "BlueprintCanonicalPreviewResult",
+    "BlueprintDataApi",
+    "BlueprintDataApiOptions",
+    "BlueprintExternalMarkup",
+    "BlueprintExternalMarkupPayload",
+    "BlueprintExternalMarkupPreference",
+    "BlueprintExternalMarkupPreferences",
+    "BlueprintExternalMarkupRenderer",
+    "BlueprintFetchJson",
+    "BlueprintFetchText",
+    "BlueprintGraphData",
+    "BlueprintGraphVariant",
+    "BlueprintHtmlCacheEntry",
+    "BlueprintHydrator",
+    "BlueprintHydratorContext",
+    "BlueprintHydratorEntry",
+    "BlueprintHydrators",
+    "BlueprintLoadDocument",
+    "BlueprintLoadDocumentPayload",
+    "BlueprintManifestEntry",
+    "BlueprintPreviewApi",
+    "BlueprintPreviewOptions",
+    "BlueprintPreviewResult",
+    "BlueprintRenderNodeRequest",
+    "BlueprintRenderNodeResult",
+    "BlueprintStoreStatus",
+    "BlueprintTemplateBinder"
+  ];
+
+  typeNames.sort(function (left, right) {
+    return right.length - left.length;
+  });
+
+  var links = Object.create(null);
+  typeNames.forEach(function (name) {
+    links[name] = "module-blueprint-api-types.html#~" + name;
+  });
+
+  var typePattern = new RegExp("\\b(" + typeNames.join("|") + ")\\b", "g");
+
+  function hasTypeName(text) {
+    typePattern.lastIndex = 0;
+    return typePattern.test(text);
+  }
+
+  function linkTextNode(node) {
+    var text = node.nodeValue || "";
+    if (!hasTypeName(text)) return;
+
+    var fragment = document.createDocumentFragment();
+    var lastIndex = 0;
+    typePattern.lastIndex = 0;
+
+    text.replace(typePattern, function (match, typeName, offset) {
+      if (offset > lastIndex) {
+        fragment.appendChild(document.createTextNode(text.slice(lastIndex, offset)));
+      }
+
+      var link = document.createElement("a");
+      link.href = links[typeName];
+      link.textContent = match;
+      fragment.appendChild(link);
+      lastIndex = offset + match.length;
+      return match;
+    });
+
+    if (lastIndex < text.length) {
+      fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
+    }
+
+    node.parentNode.replaceChild(fragment, node);
+  }
+
+  function linkTypeNames() {
+    var roots = document.querySelectorAll(".type-signature, .param-type, td.type");
+    roots.forEach(function (root) {
+      var nodes = [];
+      var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+        acceptNode: function (node) {
+          if (!hasTypeName(node.nodeValue || "")) return NodeFilter.FILTER_REJECT;
+          if (node.parentElement && node.parentElement.closest("a")) {
+            return NodeFilter.FILTER_REJECT;
+          }
+          return NodeFilter.FILTER_ACCEPT;
+        }
+      });
+
+      while (walker.nextNode()) nodes.push(walker.currentNode);
+      nodes.forEach(linkTextNode);
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", linkTypeNames);
+  } else {
+    linkTypeNames();
+  }
+})();

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,0 +1,22 @@
+{
+  "source": {
+    "include": [
+      "src/VersoBlueprint/blueprint-data-api.mjs",
+      "src/VersoBlueprint/blueprint-api-types.mjs",
+      "src/VersoBlueprint/blueprint-preview-api.mjs",
+      "src/VersoBlueprint/blueprint-graph-api.mjs"
+    ],
+    "includePattern": ".+\\.mjs$",
+    "excludePattern": "(^|/)(node_modules|dist|\\.lake|_out)/"
+  },
+  "opts": {
+    "destination": "_out/jsdoc-api",
+    "readme": "doc/JS_API_DOCS.md",
+    "recurse": false
+  },
+  "templates": {
+    "default": {
+      "outputSourceFiles": false
+    }
+  }
+}

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -9,14 +9,39 @@
     "includePattern": ".+\\.mjs$",
     "excludePattern": "(^|/)(node_modules|dist|\\.lake|_out)/"
   },
+  "plugins": ["plugins/markdown"],
   "opts": {
     "destination": "_out/jsdoc-api",
     "readme": "doc/JS_API_DOCS.md",
-    "recurse": false
+    "recurse": false,
+    "template": "node_modules/docdash"
   },
   "templates": {
     "default": {
-      "outputSourceFiles": false
-    }
+      "includeDate": false,
+      "outputSourceFiles": false,
+      "staticFiles": {
+        "include": ["doc/jsdoc-static"]
+      }
+    },
+    "cleverLinks": false,
+    "monospaceLinks": false
+  },
+  "docdash": {
+    "collapse": "top",
+    "meta": {
+      "description": "Verso Blueprint JavaScript API reference",
+      "title": "Verso Blueprint JavaScript API"
+    },
+    "nameInOutputPath": false,
+    "private": false,
+    "scopeInOutputPath": false,
+    "scripts": ["jsdoc-type-links.js"],
+    "search": true,
+    "sort": true,
+    "static": true,
+    "typedefs": true,
+    "versionInOutputPath": false,
+    "wrap": true
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "verso-blueprint",
       "version": "0.0.0-private",
       "devDependencies": {
+        "docdash": "^2.0.2",
         "jsdoc": "^4.0.5",
         "typescript": "^6.0.3"
       }
@@ -125,6 +126,16 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/docdash": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/docdash/-/docdash-2.0.2.tgz",
+      "integrity": "sha512-3SDDheh9ddrwjzf6dPFe1a16M6ftstqTNjik2+1fx46l24H9dD2osT2q9y+nBEC1wWz4GIqA48JmicOLQ0R8xA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsdoc/salty": "^0.2.1"
       }
     },
     "node_modules/entities": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,378 @@
+{
+  "name": "verso-blueprint",
+  "version": "0.0.0-private",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "verso-blueprint",
+      "version": "0.0.0-private",
+      "devDependencies": {
+        "jsdoc": "^4.0.5",
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@jsdoc/salty": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.12.tgz",
+      "integrity": "sha512-TuB0x50EoAvEX/UEWITd8Mkn3WhiTjSvbTMCLj0BhsQEl5iUzjXdA0bETEVpTk+5TGTLR6QktI9H4hLviVeaAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "^4.18.1"
+      },
+      "engines": {
+        "node": ">=v12.0.0"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/catharsis": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js2xmlparser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+      "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xmlcreate": "^2.0.4"
+      }
+    },
+    "node_modules/jsdoc": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.5.tgz",
+      "integrity": "sha512-P4C6MWP9yIlMiK8nwoZvxN84vb6MsnXcHuy7XzVOvQoCizWX5JFCBsWIIWKXBltpoRZXddUOVQmCTOZt9yDj9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/parser": "^7.20.15",
+        "@jsdoc/salty": "^0.2.1",
+        "@types/markdown-it": "^14.1.1",
+        "bluebird": "^3.7.2",
+        "catharsis": "^0.9.0",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.2",
+        "klaw": "^3.0.0",
+        "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "^8.6.7",
+        "marked": "^4.0.10",
+        "mkdirp": "^1.0.4",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.1.0",
+        "underscore": "~1.13.2"
+      },
+      "bin": {
+        "jsdoc": "jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/klaw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-anchor": {
+      "version": "8.6.7",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
+      "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
+      "dev": true,
+      "license": "Unlicense",
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/requizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+      "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/xmlcreate": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "verso-blueprint",
+  "version": "0.0.0-private",
+  "private": true,
+  "type": "module",
+  "main": "./src/VersoBlueprint/blueprint-preview-api.mjs",
+  "module": "./src/VersoBlueprint/blueprint-preview-api.mjs",
+  "types": "./dist/types/src/VersoBlueprint/blueprint-preview-api.d.mts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/src/VersoBlueprint/blueprint-preview-api.d.mts",
+      "import": "./src/VersoBlueprint/blueprint-preview-api.mjs"
+    },
+    "./data": {
+      "types": "./dist/types/src/VersoBlueprint/blueprint-data-api.d.mts",
+      "import": "./src/VersoBlueprint/blueprint-data-api.mjs"
+    },
+    "./graph": {
+      "types": "./dist/types/src/VersoBlueprint/blueprint-graph-api.d.mts",
+      "import": "./src/VersoBlueprint/blueprint-graph-api.mjs"
+    },
+    "./types": {
+      "types": "./dist/types/src/VersoBlueprint/blueprint-api-types.d.mts",
+      "import": "./src/VersoBlueprint/blueprint-api-types.mjs"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json",
+    "build:types": "tsc -p tsconfig.types.json",
+    "docs": "rm -rf _out/jsdoc-api && jsdoc -c jsdoc.json"
+  },
+  "devDependencies": {
+    "jsdoc": "^4.0.5",
+    "typescript": "^6.0.3"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "docs": "rm -rf _out/jsdoc-api && jsdoc -c jsdoc.json"
   },
   "devDependencies": {
+    "docdash": "^2.0.2",
     "jsdoc": "^4.0.5",
     "typescript": "^6.0.3"
   }

--- a/src/VersoBlueprint/Commands/Summary.lean
+++ b/src/VersoBlueprint/Commands/Summary.lean
@@ -896,7 +896,7 @@ private def Summary.previewLabels (data : Summary) : Array Name :=
 def summaryCss := include_str "summary.css"
 
 def summaryAssetBundle : BlueprintAssetBundle :=
-  previewPanelInlinePreviewAssetBundle (cssExtras := [summaryCss]) (jsBefore := [openTargetDetailsJs])
+  previewPanelInlinePreviewAssetBundle (cssExtras := [summaryCss])
 
 open Verso Doc Html Genre Manual
 open Verso.Output.Html

--- a/src/VersoBlueprint/Commands/preview-runtime-lifecycle.mjs
+++ b/src/VersoBlueprint/Commands/preview-runtime-lifecycle.mjs
@@ -32,7 +32,7 @@ import { normalizePanelBehavior, readElementOption, readFunctionOption, readNumb
     const open = readFunctionOption(opts, "open", function () {});
     const close = readFunctionOption(opts, "close", function () {});
     const isOpen = readFunctionOption(opts, "isOpen", function () {
-      return panel instanceof Element ? !panel.hidden : true;
+      return panel instanceof HTMLElement ? !panel.hidden : true;
     });
     const toggle = readFunctionOption(opts, "toggle", function () {
       if (isOpen()) {
@@ -115,40 +115,44 @@ import { normalizePanelBehavior, readElementOption, readFunctionOption, readNumb
     const closeButton = readElementOption(opts, "close", null);
     const boundAttr = readStringOption(opts, "boundAttr", "data-bp-popover-bound");
     const offset = readNumberOption(opts, "offset", 8);
-    const positionPopover = readFunctionOption(opts, "position", function () {
-      const rootRect = root.getBoundingClientRect();
-      const triggerRect = trigger.getBoundingClientRect();
+    const positionPopover = readFunctionOption(opts, "position", function (_controller, rootNode, triggerNode, panelNode) {
+      if (!(rootNode instanceof Element)) return;
+      if (!(triggerNode instanceof Element)) return;
+      if (!(panelNode instanceof HTMLElement)) return;
+      const rootRect = rootNode.getBoundingClientRect();
+      const triggerRect = triggerNode.getBoundingClientRect();
       const top = Math.max(0, Math.round(triggerRect.bottom - rootRect.top + offset));
       const right = Math.max(0, Math.round(rootRect.right - triggerRect.right));
-      panel.style.top = top + "px";
-      panel.style.right = right + "px";
+      panelNode.style.top = top + "px";
+      panelNode.style.right = right + "px";
     });
 
-    if (!(root instanceof Element) || !(trigger instanceof Element) || !(panel instanceof Element)) {
+    if (!(root instanceof Element) || !(trigger instanceof Element) || !(panel instanceof HTMLElement)) {
       return null;
     }
+    const panelElement = panel;
 
     const controller = {
       root: root,
       trigger: trigger,
-      panel: panel,
+      panel: panelElement,
       closeButton: closeButton,
-      isOpen: function () { return !panel.hidden; },
+      isOpen: function () { return !panelElement.hidden; },
       open: function () { setOpen(true); },
       close: function () { setOpen(false); },
-      toggle: function () { setOpen(panel.hidden); },
+      toggle: function () { setOpen(panelElement.hidden); },
       position: position,
       setOpen: setOpen
     };
 
     function position() {
-      positionPopover(controller, root, trigger, panel);
+      positionPopover(controller, root, trigger, panelElement);
     }
 
     function setOpen(isOpen) {
       const open = !!isOpen;
       if (open) position();
-      panel.hidden = !open;
+      panelElement.hidden = !open;
       trigger.setAttribute("aria-expanded", open ? "true" : "false");
     }
 
@@ -157,7 +161,7 @@ import { normalizePanelBehavior, readElementOption, readFunctionOption, readNumb
       owner: trigger,
       root: root,
       trigger: trigger,
-      panel: panel,
+      panel: panelElement,
       close: controller.close,
       closeButton: closeButton,
       isOpen: controller.isOpen,
@@ -187,7 +191,7 @@ import { normalizePanelBehavior, readElementOption, readFunctionOption, readNumb
   }
 
   export function positionAnchoredPanel(panel, anchor, margin, offset) {
-    if (!(panel instanceof Element)) return;
+    if (!(panel instanceof HTMLElement)) return;
     const rect = readAnchorRect(anchor);
     if (!rect) return;
     const safeMargin = Number.isFinite(margin) ? margin : 12;
@@ -240,6 +244,12 @@ import { normalizePanelBehavior, readElementOption, readFunctionOption, readNumb
     const inlinePanel = document.getElementById("bp-inline-preview-panel");
     if (inlinePanel instanceof Element && inlinePanel.contains(nextTarget)) return true;
     return false;
+  }
+
+  function eventKey(ev) {
+    if (!ev || typeof ev !== "object" || !("key" in ev)) return "";
+    const key = ev.key;
+    return typeof key === "string" ? key : "";
   }
 
   export function bindPreviewTriggers(options) {
@@ -326,15 +336,21 @@ import { normalizePanelBehavior, readElementOption, readFunctionOption, readNumb
       behavior: behavior
     };
 
+    /**
+     * @param {unknown} target
+     * @param {unknown} ev
+     * @returns {Element | null}
+     */
     function resolveTrigger(target, ev) {
       if (resolveTriggerOption) {
         const resolved = resolveTriggerOption(target, ev);
         return resolved instanceof Element ? resolved : null;
       }
-      if (!(target instanceof Element)) return null;
-      if (!triggerSelector) return target;
-      if (target.matches(triggerSelector)) return target;
-      const closest = target.closest(triggerSelector);
+      const element = target instanceof Element ? target : null;
+      if (!element) return null;
+      if (!triggerSelector) return element;
+      if (element.matches(triggerSelector)) return element;
+      const closest = Element.prototype.closest.call(element, triggerSelector);
       return closest instanceof Element ? closest : null;
     }
 
@@ -394,7 +410,8 @@ import { normalizePanelBehavior, readElementOption, readFunctionOption, readNumb
       }
       if (activateOnKeydown) {
         trigger.addEventListener("keydown", function (ev) {
-          if (ev.key !== "Enter" && ev.key !== " ") return;
+          const key = eventKey(ev);
+          if (key !== "Enter" && key !== " ") return;
           activateTrigger(trigger, ev);
         });
       }
@@ -425,7 +442,8 @@ import { normalizePanelBehavior, readElementOption, readFunctionOption, readNumb
       }
       if (activateOnKeydown) {
         root.addEventListener("keydown", function (ev) {
-          if (ev.key !== "Enter" && ev.key !== " ") return;
+          const key = eventKey(ev);
+          if (key !== "Enter" && key !== " ") return;
           activateTrigger(resolveTrigger(ev.target, ev), ev);
         });
       }
@@ -478,7 +496,7 @@ import { normalizePanelBehavior, readElementOption, readFunctionOption, readNumb
         reposition: function () {
           const current = behavior();
           const activeAnchor = getActiveAnchor();
-          if (current.isAnchored && activeAnchor && panel instanceof Element && !panel.hidden) {
+          if (current.isAnchored && activeAnchor && panel instanceof HTMLElement && !panel.hidden) {
             position(activeAnchor);
           }
         }

--- a/src/VersoBlueprint/Commands/preview-runtime-render.mjs
+++ b/src/VersoBlueprint/Commands/preview-runtime-render.mjs
@@ -9,6 +9,12 @@ import { hydrateRenderedPreview } from "./preview-runtime-hydration.mjs";
   // future client needs another fact, add it to the manifest instead of parsing
   // cached HTML.
 
+  function errorMessage(err) {
+    return err instanceof Error && typeof err.message === "string" && err.message.length > 0
+      ? err.message
+      : String(err);
+  }
+
   function blueprintDataApi(options) {
     const opts = options && typeof options === "object" ? options : {};
     return opts.dataApi && typeof opts.dataApi === "object" ? opts.dataApi : null;
@@ -372,6 +378,16 @@ import { hydrateRenderedPreview } from "./preview-runtime-hydration.mjs";
         };
       }
       const clone = node.cloneNode(true);
+      if (!(clone instanceof Element)) {
+        return {
+          ok: false,
+          reason: "canonical-preview-node-missing",
+          detail: "The generated page loaded, but the linked Blueprint node clone was not an element.",
+          node: null,
+          canonicalHtml: "",
+          canonicalSourceHref: url.href
+        };
+      }
       rebaseCanonicalPreviewLinks(clone, canonicalPreviewDocumentBaseUrl(doc, url));
       resetClonedPreviewBindingState(clone);
       return {
@@ -383,7 +399,7 @@ import { hydrateRenderedPreview } from "./preview-runtime-hydration.mjs";
         canonicalSourceHref: url.href
       };
     } catch (err) {
-      const message = err && err.message ? err.message : String(err);
+      const message = errorMessage(err);
       return {
         ok: false,
         reason: "canonical-preview-load-failed",
@@ -409,7 +425,18 @@ import { hydrateRenderedPreview } from "./preview-runtime-hydration.mjs";
         canonicalSourceHref: loaded.canonicalSourceHref
       };
     }
-    const contentTarget = blueprintContentTargetForNode(loaded.node);
+    const loadedNode = loaded.node;
+    if (!(loadedNode instanceof Element)) {
+      return {
+        ok: false,
+        reason: "external-markup-node-shell-missing",
+        detail: "The generated Blueprint node shell was not an element.",
+        node: null,
+        canonicalHtml: "",
+        canonicalSourceHref: loaded.canonicalSourceHref
+      };
+    }
+    const contentTarget = blueprintContentTargetForNode(loadedNode);
     if (!(contentTarget instanceof Element)) {
       return {
         ok: false,
@@ -421,14 +448,14 @@ import { hydrateRenderedPreview } from "./preview-runtime-hydration.mjs";
       };
     }
     await renderExternalMarkupSelectionInto(contentTarget, selection, payload);
-    target.replaceChildren(loaded.node);
+    target.replaceChildren(loadedNode);
     hydrateRenderedPreview(target, options);
     return {
       ok: true,
       reason: "",
       detail: "",
-      node: loaded.node,
-      canonicalHtml: loaded.node.outerHTML,
+      node: loadedNode,
+      canonicalHtml: loadedNode.outerHTML,
       canonicalSourceHref: loaded.canonicalSourceHref
     };
   }
@@ -595,7 +622,7 @@ import { hydrateRenderedPreview } from "./preview-runtime-hydration.mjs";
       renderHtmlInto(target, html, opts);
       return failed;
     } catch (err) {
-      const message = err && err.message ? err.message : String(err);
+      const message = errorMessage(err);
       const failed = renderNodePreviewResult(result, {
         ok: false,
         reason: "external-markup-render-failed",

--- a/src/VersoBlueprint/Commands/preview-runtime-surface.mjs
+++ b/src/VersoBlueprint/Commands/preview-runtime-surface.mjs
@@ -2,13 +2,70 @@ import { escapeHtml, normalizePanelBehavior, normalizePreviewMode, normalizePrev
 import { renderHtmlInto, resolveBlueprintPreview } from "./preview-runtime-render.mjs";
 import { bindCloseOnce, bindDismissHandlers, bindPanelRepositioner, bindPreviewTriggers, positionAnchoredPanel, readAnchorRect, shouldKeepOpen } from "./preview-runtime-lifecycle.mjs";
 
+  /**
+   * @typedef {Object} PreviewTriggerLifecycle
+   * @property {() => void} cancelHide
+   * @property {() => void} scheduleHide
+   * @property {() => void} hide
+   * @property {() => object} behavior
+   * @property {(root?: unknown) => void} refresh
+   * @property {(trigger: unknown, ev?: unknown, force?: unknown) => void} showTrigger
+   */
+
+  /**
+   * @typedef {Object} PreviewRepositionLifecycle
+   * @property {() => void} reposition
+   */
+
+  /**
+   * @typedef {Object} PreviewDismissLifecycle
+   * @property {unknown} root
+   * @property {unknown} trigger
+   * @property {unknown} panel
+   * @property {unknown} closeButton
+   * @property {() => boolean} isOpen
+   * @property {(...args: unknown[]) => void} open
+   * @property {(...args: unknown[]) => void} close
+   * @property {(...args: unknown[]) => void} toggle
+   */
+
+  /**
+   * @typedef {Object} PreviewSurface
+   * @property {HTMLElement} panel
+   * @property {Element} title
+   * @property {HTMLElement | null} headerLabel
+   * @property {Element} body
+   * @property {HTMLElement | null} footer
+   * @property {HTMLElement | null} closeButton
+   * @property {object} behavior
+   * @property {PreviewTriggerLifecycle | null} triggerLifecycle
+   * @property {PreviewRepositionLifecycle | null} repositionLifecycle
+   * @property {PreviewDismissLifecycle | null} dismissLifecycle
+   * @property {() => boolean} isOpen
+   * @property {(nextBehavior: unknown) => object} setBehavior
+   * @property {(sourceNode: unknown) => void} setSource
+   * @property {(sourceNode: unknown) => void} setFooterSource
+   * @property {() => void} clearChrome
+   * @property {() => void} hideContent
+   * @property {(content: unknown) => boolean} showContent
+   * @property {(content: unknown) => void} replaceBody
+   * @property {(anchor?: unknown, nextBehavior?: unknown) => void} position
+   * @property {() => void} hide
+   * @property {(ev: unknown) => boolean} pointerWithin
+   * @property {(nextTarget: unknown, trigger: unknown) => boolean} shouldKeepOpen
+   * @property {(heading: string, payload: unknown, anchor?: unknown) => boolean} show
+   * @property {(triggerOptions: unknown) => PreviewTriggerLifecycle} bindTriggers
+   * @property {(repositionOptions: unknown) => PreviewRepositionLifecycle | null} bindRepositioner
+   * @property {(dismissOptions: unknown) => PreviewDismissLifecycle} bindDismissal
+   */
+
   // Bundled preview surface, panel, and content helpers.
   //
   // These helpers own panel slots, behavior state, content updates,
   // and runtime diagnostic markup for bundled clients.
 
   export function resetPanelPosition(panel) {
-    if (!(panel instanceof Element)) return;
+    if (!(panel instanceof HTMLElement)) return;
     panel.style.left = "";
     panel.style.top = "";
   }
@@ -28,7 +85,7 @@ import { bindCloseOnce, bindDismissHandlers, bindPanelRepositioner, bindPreviewT
   }
 
   export function configureCloseButton(closeButton, onClose, behavior) {
-    if (!(closeButton instanceof Element)) return;
+    if (!(closeButton instanceof HTMLElement)) return;
     const pinned = !!(behavior && behavior.isPinned);
     closeButton.hidden = !pinned;
     closeButton.style.display = pinned ? "" : "none";
@@ -72,9 +129,14 @@ import { bindCloseOnce, bindDismissHandlers, bindPanelRepositioner, bindPreviewT
   export function createPreviewSurface(options) {
     const opts = options && typeof options === "object" ? options : {};
     const panel = readElementOption(opts, "panel", null);
-    if (!(panel instanceof Element)) return null;
+    if (!(panel instanceof HTMLElement)) return null;
     const slots = readPreviewSurfaceSlots(panel, opts);
-    if (!(slots.title instanceof Element) || !(slots.body instanceof Element)) return null;
+    const titleSlot = slots.title;
+    const bodySlot = slots.body;
+    if (!(titleSlot instanceof Element) || !(bodySlot instanceof Element)) return null;
+    const headerLabelSlot = slots.headerLabel instanceof HTMLElement ? slots.headerLabel : null;
+    const footerSlot = slots.footer instanceof HTMLElement ? slots.footer : null;
+    const closeButtonSlot = slots.closeButton instanceof HTMLElement ? slots.closeButton : null;
 
     const defaults = readObjectOption(opts, "defaults", {});
     const margin = readNumberOption(opts, "margin", 12);
@@ -88,36 +150,42 @@ import { bindCloseOnce, bindDismissHandlers, bindPanelRepositioner, bindPreviewT
     const renderBody = readFunctionOption(opts, "renderBody", null);
     const positionPanel = readFunctionOption(opts, "positionPanel", null);
     const onHide = readFunctionOption(opts, "onHide", null);
+    /** @type {PreviewTriggerLifecycle | null} */
     let triggerLifecycle = null;
+    /** @type {PreviewRepositionLifecycle | null} */
     let repositionLifecycle = null;
+    /** @type {PreviewDismissLifecycle | null} */
     let dismissLifecycle = null;
 
     function renderSurfaceBody(content) {
-      const payload = content && typeof content === "object" ? content : {};
+      const payload = /** @type {Record<string, unknown>} */ (
+        content && typeof content === "object" ? content : {}
+      );
       if (renderBody) {
         const bodyPayload = Object.prototype.hasOwnProperty.call(payload, "payload")
           ? payload.payload
           : payload.html;
-        renderBody(slots.body, bodyPayload, surface, payload);
+        renderBody(bodySlot, bodyPayload, surface, payload);
         return true;
       }
       const html = typeof payload.html === "string" ? payload.html : "";
       if (html.length === 0 && payload.allowEmpty !== true) return false;
-      renderHtmlInto(slots.body, html, readObjectOption(payload, "renderOptions", undefined));
+      renderHtmlInto(bodySlot, html, readObjectOption(payload, "renderOptions", undefined));
       return true;
     }
 
+    /** @type {PreviewSurface} */
     const surface = {
       panel: panel,
-      title: slots.title,
-      headerLabel: slots.headerLabel,
-      body: slots.body,
-      footer: slots.footer,
-      closeButton: slots.closeButton,
+      title: titleSlot,
+      headerLabel: headerLabelSlot,
+      body: bodySlot,
+      footer: footerSlot,
+      closeButton: closeButtonSlot,
       behavior: normalizePanelBehavior(panel, defaults, null),
-      triggerLifecycle: null,
-      repositionLifecycle: null,
-      dismissLifecycle: null,
+      triggerLifecycle: /** @type {typeof triggerLifecycle} */ (null),
+      repositionLifecycle: /** @type {typeof repositionLifecycle} */ (null),
+      dismissLifecycle: /** @type {typeof dismissLifecycle} */ (null),
       isOpen: function () {
         return !panel.hidden;
       },
@@ -140,9 +208,10 @@ import { bindCloseOnce, bindDismissHandlers, bindPanelRepositioner, bindPreviewT
         surface.setFooterSource(sourceNode);
       },
       setFooterSource: function (sourceNode) {
-        if (!(slots.footer instanceof Element)) return;
+        if (!(slots.footer instanceof HTMLElement)) return;
+        const footerSlot = slots.footer;
         if (renderFooter) {
-          renderFooter(slots.footer, sourceNode, surface);
+          renderFooter(footerSlot, sourceNode, surface);
           return;
         }
         if (!footerHtmlAttr) return;
@@ -151,11 +220,11 @@ import { bindCloseOnce, bindDismissHandlers, bindPanelRepositioner, bindPreviewT
             ? (sourceNode.getAttribute(footerHtmlAttr) || "").trim()
             : "";
         if (footerHtml.length > 0) {
-          renderHtmlInto(slots.footer, footerHtml);
-          slots.footer.hidden = false;
+          renderHtmlInto(footerSlot, footerHtml);
+          footerSlot.hidden = false;
         } else {
-          slots.footer.replaceChildren();
-          slots.footer.hidden = true;
+          footerSlot.replaceChildren();
+          footerSlot.hidden = true;
         }
       },
       clearChrome: function () {
@@ -164,13 +233,15 @@ import { bindCloseOnce, bindDismissHandlers, bindPanelRepositioner, bindPreviewT
       },
       hideContent: function () {
         panel.hidden = true;
-        slots.title.textContent = "";
-        clearBody(slots.body);
+        titleSlot.textContent = "";
+        clearBody(bodySlot);
         surface.clearChrome();
         if (onHide) onHide(surface);
       },
       showContent: function (content) {
-        const payload = content && typeof content === "object" ? content : {};
+        const payload = /** @type {Record<string, unknown>} */ (
+          content && typeof content === "object" ? content : {}
+        );
         const behavior =
           payload.behavior && typeof payload.behavior === "object"
             ? surface.setBehavior(payload.behavior)
@@ -180,11 +251,12 @@ import { bindCloseOnce, bindDismissHandlers, bindPanelRepositioner, bindPreviewT
           surface.hideContent();
           return false;
         }
-        if (!renderBody && payload.html.length === 0 && payload.allowEmpty !== true) {
+        const html = typeof payload.html === "string" ? payload.html : "";
+        if (!renderBody && html.length === 0 && payload.allowEmpty !== true) {
           surface.hideContent();
           return false;
         }
-        slots.title.textContent = typeof payload.heading === "string" ? payload.heading : "";
+        titleSlot.textContent = typeof payload.heading === "string" ? payload.heading : "";
         surface.setSource(source);
         if (!renderSurfaceBody(payload)) {
           surface.hideContent();
@@ -195,11 +267,13 @@ import { bindCloseOnce, bindDismissHandlers, bindPanelRepositioner, bindPreviewT
         return true;
       },
       replaceBody: function (content) {
-        const payload = content && typeof content === "object" ? content : {};
+        const payload = /** @type {Record<string, unknown>} */ (
+          content && typeof content === "object" ? content : {}
+        );
         if (payload.behavior && typeof payload.behavior === "object") {
           surface.setBehavior(payload.behavior);
         }
-        slots.title.textContent = typeof payload.heading === "string" ? payload.heading : "";
+        titleSlot.textContent = typeof payload.heading === "string" ? payload.heading : "";
         if (
           Object.prototype.hasOwnProperty.call(payload, "source") ||
           Object.prototype.hasOwnProperty.call(payload, "anchor")
@@ -246,8 +320,9 @@ import { bindCloseOnce, bindDismissHandlers, bindPanelRepositioner, bindPreviewT
         return surface.showContent(content);
       },
       bindTriggers: function (triggerOptions) {
-        const triggerOpts =
-          triggerOptions && typeof triggerOptions === "object" ? Object.assign({}, triggerOptions) : {};
+        const triggerOpts = /** @type {Record<string, unknown>} */ (
+          triggerOptions && typeof triggerOptions === "object" ? Object.assign({}, triggerOptions) : {}
+        );
         if (!(triggerOpts.panel instanceof Element)) triggerOpts.panel = panel;
         if (
           typeof triggerOpts.getBehavior !== "function" &&
@@ -263,18 +338,20 @@ import { bindCloseOnce, bindDismissHandlers, bindPanelRepositioner, bindPreviewT
         return triggerLifecycle;
       },
       bindRepositioner: function (repositionOptions) {
-        const repositionOpts =
+        const repositionOpts = /** @type {Record<string, unknown>} */ (
           repositionOptions && typeof repositionOptions === "object"
             ? Object.assign({}, repositionOptions)
-            : {};
+            : {}
+        );
         if (!(repositionOpts.owner instanceof Element)) repositionOpts.owner = panel;
         repositionLifecycle = bindPanelRepositioner(repositionOpts);
         surface.repositionLifecycle = repositionLifecycle;
         return repositionLifecycle;
       },
       bindDismissal: function (dismissOptions) {
-        const dismissOpts =
-          dismissOptions && typeof dismissOptions === "object" ? Object.assign({}, dismissOptions) : {};
+        const dismissOpts = /** @type {Record<string, unknown>} */ (
+          dismissOptions && typeof dismissOptions === "object" ? Object.assign({}, dismissOptions) : {}
+        );
         if (!(dismissOpts.panel instanceof Element)) dismissOpts.panel = panel;
         if (
           !Object.prototype.hasOwnProperty.call(dismissOpts, "closeButton") &&
@@ -485,7 +562,7 @@ import { bindCloseOnce, bindDismissHandlers, bindPanelRepositioner, bindPreviewT
   }
 
   export function setPreviewHeaderLink(labelNode, sourceNode) {
-    if (!(labelNode instanceof Element)) return;
+    if (!(labelNode instanceof HTMLElement)) return;
     const label =
       sourceNode instanceof Element
         ? (sourceNode.getAttribute("data-bp-preview-header-label") || "").trim()

--- a/src/VersoBlueprint/Commands/preview-runtime-template.mjs
+++ b/src/VersoBlueprint/Commands/preview-runtime-template.mjs
@@ -52,11 +52,12 @@ import { createPreviewSurface } from "./preview-runtime-surface.mjs";
       onClose: function () { hidePanel(); }
     });
     if (!surface || (!allowHtmlCache && previewMap.size === 0)) {
-      if (panel instanceof Element) panel.hidden = true;
+      if (panel instanceof HTMLElement) panel.hidden = true;
       return null;
     }
+    const previewSurface = surface;
     if (triggers.length === 0) {
-      surface.hide();
+      previewSurface.hide();
       return null;
     }
     let activeTrigger = null;
@@ -66,7 +67,7 @@ import { createPreviewSurface } from "./preview-runtime-surface.mjs";
     function hidePanel() {
       if (triggerLifecycle) triggerLifecycle.cancelHide();
       showRequestToken += 1;
-      surface.hide();
+      previewSurface.hide();
       activeTrigger = null;
     }
 
@@ -100,14 +101,14 @@ import { createPreviewSurface } from "./preview-runtime-surface.mjs";
       }
       activeTrigger = trigger;
       const heading = readTitle(trigger, key);
-      surface.showContent({
+      previewSurface.showContent({
         heading: heading,
         html: html,
         anchor: trigger
       });
     }
 
-    triggerLifecycle = surface.bindTriggers({
+    triggerLifecycle = previewSurface.bindTriggers({
       triggerRoot: triggerRoot,
       triggerSelector: triggerSelector,
       triggerBoundAttr: triggerBoundAttr,
@@ -118,8 +119,8 @@ import { createPreviewSurface } from "./preview-runtime-surface.mjs";
 
     return {
       previewMap: previewMap,
-      surface: surface,
-      behavior: surface.behavior,
+      surface: previewSurface,
+      behavior: previewSurface.behavior,
       hidePanel: hidePanel,
       showFromTrigger: showFromTrigger
     };

--- a/src/VersoBlueprint/blueprint-api-types.mjs
+++ b/src/VersoBlueprint/blueprint-api-types.mjs
@@ -1,0 +1,336 @@
+/**
+ * Shared JSDoc typedefs for the browser-facing Blueprint ESM APIs.
+ *
+ * The runtime remains JavaScript. These declarations document the generated
+ * data contract that custom clients consume from `-verso-data/api/*.mjs`.
+ *
+ * @module blueprint-api-types
+ */
+
+/**
+ * Custom JSON loader used by standalone clients that cannot or do not want to
+ * use the page's global `fetch`.
+ *
+ * @callback BlueprintFetchJson
+ * @param {string} url URL to load.
+ * @param {Record<string, unknown>} [options] The resolved load options.
+ * @returns {unknown | Promise<unknown>} Parsed JSON data or a promise for it.
+ */
+
+/**
+ * Common options accepted by the generated-data loaders.
+ *
+ * @typedef {Object} BlueprintDataApiOptions
+ * @property {string} [dataBaseUrl] Base URL used to resolve files under `-verso-data/`.
+ * @property {BlueprintFetchJson} [fetchJson] Per-API JSON loader override.
+ * @property {RequestInit} [fetchOptions] Options forwarded to `fetch` when no custom loader is supplied.
+ */
+
+/**
+ * Context passed to preview hydrators.
+ *
+ * @typedef {Object} BlueprintHydratorContext
+ * @property {string} name Hydrator name when known.
+ * @property {"registered" | "options" | string} source Where the hydrator came from.
+ */
+
+/**
+ * Custom post-render hook for nested preview bindings, math, or client widgets.
+ *
+ * @callback BlueprintHydrator
+ * @param {Element | Document} root Rendered root to hydrate.
+ * @param {BlueprintHydratorContext} context Hydrator provenance.
+ * @returns {void}
+ */
+
+/**
+ * Named hydrator object accepted in preview options.
+ *
+ * @typedef {Object} BlueprintHydratorEntry
+ * @property {string} [name] Optional hydrator name.
+ * @property {BlueprintHydrator} [fn] Hydrator function.
+ * @property {BlueprintHydrator} [hydrate] Hydrator method.
+ */
+
+/**
+ * Hydrator collection accepted by preview render calls.
+ *
+ * @typedef {BlueprintHydrator | BlueprintHydratorEntry | Array<BlueprintHydrator | BlueprintHydratorEntry> | Map<string, BlueprintHydrator | BlueprintHydratorEntry> | Record<string, BlueprintHydrator | BlueprintHydratorEntry>} BlueprintHydrators
+ */
+
+/**
+ * Custom binder for Lean-emitted preview templates in rendered fragments.
+ *
+ * @callback BlueprintTemplateBinder
+ * @param {ParentNode | Element | Document | DocumentFragment} root Rendered root.
+ * @param {BlueprintPreviewOptions} [options] Render options for this call.
+ * @returns {unknown}
+ */
+
+/**
+ * Custom text loader used by canonical generated-node rendering.
+ *
+ * @callback BlueprintFetchText
+ * @param {string} url URL to load.
+ * @param {BlueprintPreviewOptions} [options] Render options for this call.
+ * @returns {string | Promise<string>} Loaded HTML text.
+ */
+
+/**
+ * Payload passed to a custom canonical document loader.
+ *
+ * @typedef {Object} BlueprintLoadDocumentPayload
+ * @property {string} url Canonical page URL without the hash.
+ * @property {string} sourceUrl Canonical source URL including the requested hash.
+ * @property {BlueprintPreviewOptions} options Render options for this call.
+ */
+
+/**
+ * Custom canonical document loader.
+ *
+ * @callback BlueprintLoadDocument
+ * @param {BlueprintLoadDocumentPayload} payload Canonical document load request.
+ * @returns {Document | string | Promise<Document | string>} Loaded document or HTML source.
+ */
+
+/**
+ * Options accepted by render-capable preview APIs.
+ *
+ * @typedef {Object} BlueprintPreviewOptions
+ * @property {string} [dataBaseUrl] Base URL used to resolve files under `-verso-data/`.
+ * @property {BlueprintFetchJson} [fetchJson] Per-API JSON loader override.
+ * @property {RequestInit} [fetchOptions] Options forwarded to `fetch` when no custom loader is supplied.
+ * @property {boolean} [hydrate] Set to `false` to skip preview-template and hydrator hooks.
+ * @property {boolean} [renderMath] Set to `false` to skip KaTeX rendering.
+ * @property {BlueprintHydrators} [hydrators] Per-render or per-preview hydrators.
+ * @property {boolean} [inheritPageHydrators] Set to `false` to ignore registered page hydrators.
+ * @property {BlueprintTemplateBinder} [templateBinder] Custom preview-template binder.
+ * @property {BlueprintFetchText} [fetchText] Custom text loader for canonical generated pages.
+ * @property {BlueprintLoadDocument} [loadDocument] Custom document loader for canonical generated pages.
+ * @property {string} [canonicalBaseUrl] Base URL used to resolve canonical generated-page links.
+ * @property {Map<string, Document | Promise<Document>>} [canonicalPreviewDocuments] Canonical page document cache.
+ * @property {Map<string, string>} [canonicalPreviewHtmlByKey] Canonical generated-node HTML cache.
+ */
+
+/**
+ * Loading status for a generated JSON store such as the manifest or HTML cache.
+ *
+ * @typedef {Object} BlueprintStoreStatus
+ * @property {"idle" | "loading" | "ready" | "error" | string} state Current loader state.
+ * @property {number} attempts Number of load attempts.
+ * @property {string} url URL most recently used for the store.
+ * @property {string} lastError Last error message, or an empty string.
+ * @property {number} entryCount Number of decoded entries when ready.
+ */
+
+/**
+ * External source markup attached to a Blueprint label.
+ *
+ * @typedef {Object} BlueprintExternalMarkup
+ * @property {string} language Source language, for example `markdown`, `tex`, or `verso`.
+ * @property {string} slot Logical source slot, for example `statement` or `proof`.
+ * @property {string} raw Raw source text.
+ * @property {unknown} [location] Optional source provenance supplied by the generator.
+ */
+
+/**
+ * Semantic manifest entry emitted for a rendered Blueprint preview or an
+ * external-markup-only node.
+ *
+ * @typedef {Object} BlueprintManifestEntry
+ * @property {string} key Stable manifest key.
+ * @property {string} [label] Blueprint node label when available.
+ * @property {string} [facet] Rendered facet such as `statement` or `proof`.
+ * @property {string} [href] Link to the canonical generated node.
+ * @property {BlueprintExternalMarkup[]} [externalMarkup] Attached external source snippets.
+ */
+
+/**
+ * Rendered-fragment cache entry.
+ *
+ * @typedef {Object} BlueprintHtmlCacheEntry
+ * @property {string} key Stable cache key.
+ * @property {string} html Rendered HTML fragment.
+ */
+
+/**
+ * Graph data exported by the Blueprint manifest or embedded in a graph page.
+ *
+ * @typedef {Object} BlueprintGraphData
+ * @property {number} schemaVersion Graph payload schema version.
+ * @property {string} key Variant key.
+ * @property {unknown[]} nodes Graph node payloads.
+ * @property {unknown[]} edges Graph edge payloads.
+ * @property {unknown[]} groups Optional graph grouping payloads.
+ */
+
+/**
+ * DOT fallback graph variant embedded by graph pages.
+ *
+ * @typedef {Object} BlueprintGraphVariant
+ * @property {string} key Variant key.
+ * @property {string} label Human-readable variant label.
+ * @property {string} dot DOT source.
+ * @property {Record<string, unknown>} [options] Rendering options emitted with the fallback.
+ * @property {unknown[]} [selectOnNodeId] Node IDs to select when the variant is active.
+ * @property {unknown[]} [hoverOnNodeId] Node IDs to highlight on hover.
+ */
+
+/**
+ * Result of resolving a preview key against the manifest and HTML cache.
+ *
+ * @typedef {Object} BlueprintPreviewResult
+ * @property {boolean} ok Whether the rendered preview is available.
+ * @property {string} key Requested preview key.
+ * @property {string} reason Empty on success; diagnostic reason otherwise.
+ * @property {BlueprintManifestEntry | null} manifestEntry Matching manifest entry.
+ * @property {BlueprintHtmlCacheEntry | null} htmlCacheEntry Matching HTML cache entry.
+ * @property {string} html Rendered fragment HTML on success.
+ * @property {string} diagnosticHtml Diagnostic HTML when unavailable.
+ */
+
+/**
+ * Result of resolving a canonical generated node for insertion into another
+ * document.
+ *
+ * @typedef {Object} BlueprintCanonicalPreviewResult
+ * @property {boolean} ok Whether the canonical node is available.
+ * @property {string} key Requested preview key.
+ * @property {string} reason Empty on success; diagnostic reason otherwise.
+ * @property {BlueprintManifestEntry | null} manifestEntry Matching manifest entry.
+ * @property {BlueprintHtmlCacheEntry | null} htmlCacheEntry Matching HTML cache entry.
+ * @property {string} html Rendered fragment HTML on success.
+ * @property {string} diagnosticHtml Diagnostic HTML when unavailable.
+ * @property {string} [canonicalHtml] Full canonical generated-node HTML.
+ * @property {string} [canonicalSourceHref] Source document URL for the canonical node.
+ */
+
+/**
+ * Payload supplied to a call-scoped external markup renderer.
+ *
+ * @typedef {Object} BlueprintExternalMarkupPayload
+ * @property {string} raw Raw external source.
+ * @property {string} language Selected source language.
+ * @property {string} slot Selected source slot.
+ * @property {unknown} location Source provenance when available.
+ * @property {BlueprintManifestEntry | null} node Manifest node data.
+ * @property {BlueprintManifestEntry | null} manifestEntry Manifest node data.
+ * @property {string} label Requested Blueprint label.
+ * @property {string} facet Requested rendered facet.
+ * @property {BlueprintPreviewResult | null} nativePreview Native preview resolution result.
+ * @property {BlueprintExternalMarkup} externalMarkup Selected external source entry.
+ */
+
+/**
+ * Renders selected external markup into a target element.
+ *
+ * @callback BlueprintExternalMarkupRenderer
+ * @param {BlueprintExternalMarkupPayload} payload VBP-owned source and provenance data.
+ * @param {Element} target Element whose contents should be replaced or updated.
+ * @returns {void | string | Node | Promise<void | string | Node>}
+ */
+
+/**
+ * Preference used by `renderNode` when a native rendered preview is absent.
+ *
+ * @typedef {Object} BlueprintExternalMarkupPreference
+ * @property {string} [language] Preferred language such as `markdown`, `tex`, or `verso`.
+ * @property {string} [slot] Preferred source slot.
+ * @property {"source" | string} [display] Use `source` to render the raw source without a custom renderer.
+ * @property {BlueprintExternalMarkupRenderer} [render] Per-call renderer for this preference.
+ */
+
+/**
+ * Ordered external-markup fallback preferences.
+ *
+ * @typedef {Object} BlueprintExternalMarkupPreferences
+ * @property {BlueprintExternalMarkupPreference[]} prefer Ordered external-markup preferences.
+ */
+
+/**
+ * Label-oriented render request.
+ *
+ * @typedef {Object} BlueprintRenderNodeRequest
+ * @property {string} label Blueprint label to render.
+ * @property {string} [facet="statement"] Rendered facet to prefer for native previews.
+ * @property {BlueprintExternalMarkupPreference | BlueprintExternalMarkupPreference[] | BlueprintExternalMarkupPreferences} [externalMarkup] External-markup fallback preferences.
+ * @property {BlueprintExternalMarkupPreference} [preferredExternalMarkup] Shorthand for a single external-markup preference.
+ */
+
+/**
+ * Result returned by `renderNode`.
+ *
+ * @typedef {Object} BlueprintRenderNodeResult
+ * @property {boolean} ok Whether rendering succeeded.
+ * @property {string} key Requested preview key.
+ * @property {string} reason Empty on success; diagnostic reason otherwise.
+ * @property {BlueprintManifestEntry | null} manifestEntry Matching manifest entry.
+ * @property {BlueprintHtmlCacheEntry | null} htmlCacheEntry Matching HTML cache entry.
+ * @property {string} html Rendered fragment HTML when available.
+ * @property {string} diagnosticHtml Diagnostic HTML when unavailable.
+ * @property {"native" | "external-markup" | "diagnostic" | string} [renderMode] Rendering path used.
+ * @property {string} [label] Requested Blueprint label.
+ * @property {string} [facet] Requested rendered facet.
+ * @property {BlueprintExternalMarkup | null} [externalMarkup] Selected external markup, if any.
+ * @property {BlueprintPreviewResult | null} [nativePreview] Native preview lookup result.
+ * @property {string} [canonicalHtml] Full canonical generated-node HTML.
+ * @property {string} [canonicalSourceHref] Source document URL for the canonical node.
+ */
+
+/**
+ * Data API returned by `createPreviewData`.
+ *
+ * @typedef {Object} BlueprintDataApi
+ * @property {function(string): string} dataUrl
+ * @property {function(): string} manifestUrl
+ * @property {function(): string} htmlCacheUrl
+ * @property {function(): string} graphApiModuleUrl
+ * @property {function(): string} dataApiModuleUrl
+ * @property {function(): string} previewApiModuleUrl
+ * @property {function(string, string=): string} previewKey
+ * @property {function(string): string} statementPreviewKey
+ * @property {function(): BlueprintStoreStatus} readManifestStatus
+ * @property {function(): BlueprintStoreStatus} readHtmlCacheStatus
+ * @property {function(BlueprintDataApiOptions=): Promise<Map.<string, BlueprintManifestEntry>>} loadManifest
+ * @property {function(BlueprintDataApiOptions=): Promise<Map.<string, BlueprintHtmlCacheEntry>>} loadHtmlCache
+ * @property {function(string, BlueprintDataApiOptions=): Promise<(BlueprintManifestEntry | null)>} loadManifestEntry
+ * @property {function(string, BlueprintDataApiOptions=): Promise<(BlueprintHtmlCacheEntry | null)>} loadHtmlCacheEntry
+ * @property {function(unknown): BlueprintGraphData[]} graphsFromManifest
+ * @property {function((ParentNode | Element | Document | DocumentFragment | null)=): (BlueprintGraphData | null)} getGraphData
+ * @property {function((ParentNode | Element | Document | DocumentFragment | null)=): BlueprintGraphVariant[]} getGraphVariants
+ * @property {function(string=, BlueprintDataApiOptions=): Promise<BlueprintGraphData[]>} loadManifestGraphs
+ * @property {function(BlueprintDataApiOptions=): Promise<BlueprintGraphData[]>} loadGraphs
+ */
+
+/**
+ * Preview API returned by `createPreview`.
+ *
+ * @typedef {Object} BlueprintPreviewApi
+ * @property {function(string): string} dataUrl
+ * @property {function(): string} manifestUrl
+ * @property {function(): string} htmlCacheUrl
+ * @property {function(): string} graphApiModuleUrl
+ * @property {function(): string} dataApiModuleUrl
+ * @property {function(): string} previewApiModuleUrl
+ * @property {function(string, string=): string} previewKey
+ * @property {function(string): string} statementPreviewKey
+ * @property {function(): BlueprintStoreStatus} readManifestStatus
+ * @property {function(): BlueprintStoreStatus} readHtmlCacheStatus
+ * @property {function(BlueprintDataApiOptions=): Promise<Map.<string, BlueprintManifestEntry>>} loadManifest
+ * @property {function(BlueprintDataApiOptions=): Promise<Map.<string, BlueprintHtmlCacheEntry>>} loadHtmlCache
+ * @property {function(string, BlueprintDataApiOptions=): Promise<(BlueprintManifestEntry | null)>} loadManifestEntry
+ * @property {function(string, BlueprintDataApiOptions=): Promise<(BlueprintHtmlCacheEntry | null)>} loadHtmlCacheEntry
+ * @property {function(unknown): BlueprintGraphData[]} graphsFromManifest
+ * @property {function((ParentNode | Element | Document | DocumentFragment | null)=): (BlueprintGraphData | null)} getGraphData
+ * @property {function((ParentNode | Element | Document | DocumentFragment | null)=): BlueprintGraphVariant[]} getGraphVariants
+ * @property {function(string=, BlueprintDataApiOptions=): Promise<BlueprintGraphData[]>} loadManifestGraphs
+ * @property {function(BlueprintDataApiOptions=): Promise<BlueprintGraphData[]>} loadGraphs
+ * @property {function(string, BlueprintDataApiOptions=): Promise<BlueprintPreviewResult>} resolvePreview
+ * @property {function(Element, string, BlueprintPreviewOptions=): Promise<BlueprintPreviewResult>} renderPreviewInto
+ * @property {function(string, BlueprintPreviewOptions=): Promise<BlueprintCanonicalPreviewResult>} resolveCanonicalPreview
+ * @property {function(Element, string, BlueprintPreviewOptions=): Promise<BlueprintCanonicalPreviewResult>} renderCanonicalPreviewInto
+ * @property {function(Element, (string | BlueprintRenderNodeRequest), BlueprintPreviewOptions=): Promise<BlueprintRenderNodeResult>} renderNode
+ * @property {function(Element, BlueprintPreviewOptions=): boolean} hydrate
+ */
+
+export {};

--- a/src/VersoBlueprint/blueprint-data-api.mjs
+++ b/src/VersoBlueprint/blueprint-data-api.mjs
@@ -1,86 +1,262 @@
 import { callDefaultApi, callDefaultApiSync, createDefaultApiHandle, createPreviewUrlApi, fallbackStoreStatus, optionsWithDefaultDataBaseUrl, version } from "./blueprint-api-common.mjs";
 import { createBlueprintDataApi } from "./Commands/preview-runtime-data.mjs";
 
+/**
+ * Generated-data API for custom Blueprint clients.
+ *
+ * This module is emitted as `-verso-data/api/data.mjs` in generated sites. It
+ * exposes manifest, HTML cache, graph, and URL helpers without installing any
+ * page-global render hook.
+ *
+ * @module blueprint-data-api
+ */
+
+/** @import { BlueprintDataApiOptions, BlueprintDataApi, BlueprintStoreStatus, BlueprintManifestEntry, BlueprintHtmlCacheEntry, BlueprintGraphData, BlueprintGraphVariant } from "./blueprint-api-types.mjs" */
+
 export { version };
 
 const moduleUrl = import.meta.url;
 const previewUrls = createPreviewUrlApi(moduleUrl);
 
+/**
+ * Create an isolated data API instance.
+ *
+ * Use this when a custom client wants explicit loaders and cache state instead
+ * of the module-level default singleton.
+ *
+ * @param {BlueprintDataApiOptions} [options] Loader and generated-data base URL options.
+ * @returns {BlueprintDataApi} Data API instance.
+ */
 export function createPreviewData(options) {
   return createBlueprintDataApi(optionsWithDefaultDataBaseUrl(options, moduleUrl));
 }
 
 const defaultDataHandle = createDefaultApiHandle(createPreviewData);
 
+/**
+ * Return the module-level data API if it has already been created.
+ *
+ * @returns {BlueprintDataApi | null}
+ */
 export function currentDataApi() {
   return defaultDataHandle.currentApi();
 }
 
+/**
+ * Return the module-level data API, creating it on first use.
+ *
+ * @returns {Promise<BlueprintDataApi>}
+ */
 export function getDataApi() {
   return defaultDataHandle.getApi();
 }
 
+/**
+ * Promise for the default data API instance.
+ *
+ * @type {Promise<BlueprintDataApi>}
+ */
 export const ready = defaultDataHandle.ready;
 
-export const dataUrl = previewUrls.dataUrl;
-export const manifestUrl = previewUrls.manifestUrl;
-export const htmlCacheUrl = previewUrls.htmlCacheUrl;
-export const graphApiModuleUrl = previewUrls.graphApiModuleUrl;
-export const dataApiModuleUrl = previewUrls.dataApiModuleUrl;
-export const previewApiModuleUrl = previewUrls.previewApiModuleUrl;
-export const previewKey = previewUrls.previewKey;
-export const statementPreviewKey = previewUrls.statementPreviewKey;
+/**
+ * Resolve a generated data filename under `-verso-data/`.
+ *
+ * @param {string} filename Generated data filename.
+ * @param {string} [baseUrl] Base URL. Defaults to this module URL.
+ * @returns {string}
+ */
+export function dataUrl(filename, baseUrl) {
+  return previewUrls.dataUrl(filename, baseUrl);
+}
 
+/**
+ * Resolve `blueprint-manifest.json`.
+ *
+ * @param {string} [baseUrl] Base URL. Defaults to this module URL.
+ * @returns {string}
+ */
+export function manifestUrl(baseUrl) {
+  return previewUrls.manifestUrl(baseUrl);
+}
+
+/**
+ * Resolve `blueprint-html-cache.json`.
+ *
+ * @param {string} [baseUrl] Base URL. Defaults to this module URL.
+ * @returns {string}
+ */
+export function htmlCacheUrl(baseUrl) {
+  return previewUrls.htmlCacheUrl(baseUrl);
+}
+
+/**
+ * Resolve the generated graph API module URL.
+ *
+ * @param {string} [baseUrl] Base URL. Defaults to this module URL.
+ * @returns {string}
+ */
+export function graphApiModuleUrl(baseUrl) {
+  return previewUrls.graphApiModuleUrl(baseUrl);
+}
+
+/**
+ * Resolve the generated data API module URL.
+ *
+ * @param {string} [baseUrl] Base URL. Defaults to this module URL.
+ * @returns {string}
+ */
+export function dataApiModuleUrl(baseUrl) {
+  return previewUrls.dataApiModuleUrl(baseUrl);
+}
+
+/**
+ * Resolve the generated preview API module URL.
+ *
+ * @param {string} [baseUrl] Base URL. Defaults to this module URL.
+ * @returns {string}
+ */
+export function previewApiModuleUrl(baseUrl) {
+  return previewUrls.previewApiModuleUrl(baseUrl);
+}
+
+/**
+ * Build the preview key for a Blueprint label and facet.
+ *
+ * @param {string} label Blueprint label.
+ * @param {string} [facet] Preview facet. Defaults to `statement`.
+ * @returns {string}
+ */
+export function previewKey(label, facet) {
+  return previewUrls.previewKey(label, facet);
+}
+
+/**
+ * Build the statement preview key for a Blueprint label.
+ *
+ * @param {string} label Blueprint label.
+ * @returns {string}
+ */
+export function statementPreviewKey(label) {
+  return previewUrls.statementPreviewKey(label);
+}
+
+/**
+ * Read cached manifest loader status without triggering a load.
+ *
+ * @returns {BlueprintStoreStatus}
+ */
 export function readManifestStatus() {
   return callDefaultApiSync(
     defaultDataHandle.readDefaultApi,
     "readManifestStatus",
     function () { return fallbackStoreStatus(manifestUrl()); },
-    arguments
+    []
   );
 }
 
+/**
+ * Read cached HTML-cache loader status without triggering a load.
+ *
+ * @returns {BlueprintStoreStatus}
+ */
 export function readHtmlCacheStatus() {
   return callDefaultApiSync(
     defaultDataHandle.readDefaultApi,
     "readHtmlCacheStatus",
     function () { return fallbackStoreStatus(htmlCacheUrl()); },
-    arguments
+    []
   );
 }
 
-export function loadManifest() {
-  return callDefaultApi(defaultDataHandle.readDefaultApi, "data", "loadManifest", arguments);
+/**
+ * Load and decode the Blueprint manifest.
+ *
+ * @param {BlueprintDataApiOptions} [options] Optional per-call load overrides.
+ * @returns {Promise<Map<string, BlueprintManifestEntry>>}
+ */
+export function loadManifest(options) {
+  return callDefaultApi(defaultDataHandle.readDefaultApi, "data", "loadManifest", [options]);
 }
 
-export function loadHtmlCache() {
-  return callDefaultApi(defaultDataHandle.readDefaultApi, "data", "loadHtmlCache", arguments);
+/**
+ * Load and decode the rendered HTML fragment cache.
+ *
+ * @param {BlueprintDataApiOptions} [options] Optional per-call load overrides.
+ * @returns {Promise<Map<string, BlueprintHtmlCacheEntry>>}
+ */
+export function loadHtmlCache(options) {
+  return callDefaultApi(defaultDataHandle.readDefaultApi, "data", "loadHtmlCache", [options]);
 }
 
-export function loadManifestEntry(key) {
-  return callDefaultApi(defaultDataHandle.readDefaultApi, "data", "loadManifestEntry", arguments);
+/**
+ * Load a single manifest entry by key.
+ *
+ * @param {string} key Manifest key.
+ * @param {BlueprintDataApiOptions} [options] Optional per-call load overrides.
+ * @returns {Promise<BlueprintManifestEntry | null>}
+ */
+export function loadManifestEntry(key, options) {
+  return callDefaultApi(defaultDataHandle.readDefaultApi, "data", "loadManifestEntry", [key, options]);
 }
 
-export function loadHtmlCacheEntry(key) {
-  return callDefaultApi(defaultDataHandle.readDefaultApi, "data", "loadHtmlCacheEntry", arguments);
+/**
+ * Load a single HTML-cache entry by key.
+ *
+ * @param {string} key HTML cache key.
+ * @param {BlueprintDataApiOptions} [options] Optional per-call load overrides.
+ * @returns {Promise<BlueprintHtmlCacheEntry | null>}
+ */
+export function loadHtmlCacheEntry(key, options) {
+  return callDefaultApi(defaultDataHandle.readDefaultApi, "data", "loadHtmlCacheEntry", [key, options]);
 }
 
+/**
+ * Extract graph variants from an already-loaded manifest object.
+ *
+ * @param {unknown} manifest Parsed manifest JSON.
+ * @returns {BlueprintGraphData[]}
+ */
 export function graphsFromManifest(manifest) {
   return defaultDataHandle.readDefaultApi().graphsFromManifest(manifest);
 }
 
+/**
+ * Read embedded graph data from a generated graph page.
+ *
+ * @param {ParentNode | Element | Document | DocumentFragment | null} [root] Search root. Defaults to `document`.
+ * @returns {BlueprintGraphData | null}
+ */
 export function getGraphData(root) {
   return defaultDataHandle.readDefaultApi().getGraphData(root);
 }
 
+/**
+ * Read graph variants embedded in a generated graph page.
+ *
+ * @param {ParentNode | Element | Document | DocumentFragment | null} [root] Search root. Defaults to `document`.
+ * @returns {BlueprintGraphVariant[]}
+ */
 export function getGraphVariants(root) {
   return defaultDataHandle.readDefaultApi().getGraphVariants(root);
 }
 
+/**
+ * Load graph variants from a manifest URL.
+ *
+ * @param {string} [url] Manifest URL. Defaults to this module's generated-data manifest.
+ * @param {BlueprintDataApiOptions} [options] Optional per-call load overrides.
+ * @returns {Promise<BlueprintGraphData[]>}
+ */
 export function loadManifestGraphs(url, options) {
   return defaultDataHandle.readDefaultApi().loadManifestGraphs(url, options);
 }
 
+/**
+ * Load graph variants from this generated site's default manifest.
+ *
+ * @param {BlueprintDataApiOptions} [options] Optional per-call load overrides.
+ * @returns {Promise<BlueprintGraphData[]>}
+ */
 export function loadGraphs(options) {
   return defaultDataHandle.readDefaultApi().loadGraphs(options);
 }

--- a/src/VersoBlueprint/blueprint-graph-api.mjs
+++ b/src/VersoBlueprint/blueprint-graph-api.mjs
@@ -13,18 +13,62 @@ import {
   version as coreVersion
 } from "./blueprint-graph-core.mjs";
 
+/**
+ * Graph-only Blueprint browser API.
+ *
+ * This module is emitted as `-verso-data/api/graph.mjs` in generated sites. It
+ * exposes URL helpers and graph data readers without loading the preview
+ * runtime.
+ *
+ * @module blueprint-graph-api
+ */
+
+/** @import { BlueprintDataApiOptions, BlueprintGraphData, BlueprintGraphVariant } from "./blueprint-api-types.mjs" */
+
+/** Graph API schema/runtime version. */
 export const version = coreVersion;
 const moduleUrl = import.meta.url;
+
+/**
+ * Resolve a generated data filename under `-verso-data/`.
+ *
+ * @param {string} filename Generated data filename.
+ * @param {string} [baseUrl] Base URL. Defaults to this module URL.
+ * @returns {string}
+ */
 export const dataUrl = (filename, baseUrl = moduleUrl) => coreDataUrl(filename, baseUrl);
+
+/**
+ * Resolve the generated graph API module URL.
+ *
+ * @param {string} [baseUrl] Base URL. Defaults to this module URL.
+ * @returns {string}
+ */
 export const graphApiModuleUrl = (baseUrl = moduleUrl) => coreGraphApiModuleUrl(baseUrl);
+/** Find the graph canvas associated with a root node. */
 export const graphCanvasFor = coreGraphCanvasFor;
+/** Read and parse an embedded graph JSON script from a graph page. */
 export const readGraphJsonScript = coreReadGraphJsonScript;
+/** Read the DOT fallback graph variants embedded in a graph page. */
 export const graphFallbackVariants = coreGraphFallbackVariants;
+/** Normalize raw graph JSON into the stable graph payload shape. */
 export const normalizeGraphData = coreNormalizeGraphData;
+/** Extract graph variants from a parsed Blueprint manifest. */
 export const graphsFromManifest = coreGraphsFromManifest;
+/** Read embedded graph data from the current graph page or supplied root. */
 export const getGraphData = coreGetGraphData;
+/** Read embedded graph variants from the current graph page or supplied root. */
 export const getGraphVariants = coreGetGraphVariants;
+/** Load and parse JSON using `fetch` or `options.fetchJson`. */
 export const loadJson = coreLoadJson;
+
+/**
+ * Load graph variants from a manifest URL.
+ *
+ * @param {string} [url] Manifest URL. Defaults to this module's generated-data manifest.
+ * @param {BlueprintDataApiOptions} [options] Optional per-call load overrides.
+ * @returns {Promise<BlueprintGraphData[]>}
+ */
 export const loadManifestGraphs = (url, options) => {
   const manifestUrl =
     typeof url === "string" && url.trim()
@@ -32,6 +76,13 @@ export const loadManifestGraphs = (url, options) => {
       : coreDataUrl("blueprint-manifest.json", moduleUrl);
   return coreLoadManifestGraphs(manifestUrl, options);
 };
+
+/**
+ * Load graph variants from this generated site's default manifest.
+ *
+ * @param {BlueprintDataApiOptions} [options] Optional per-call load overrides.
+ * @returns {Promise<BlueprintGraphData[]>}
+ */
 export const loadGraphs = (options) =>
   coreLoadManifestGraphs(coreDataUrl("blueprint-manifest.json", moduleUrl), options);
 

--- a/src/VersoBlueprint/blueprint-graph-core.mjs
+++ b/src/VersoBlueprint/blueprint-graph-core.mjs
@@ -1,5 +1,7 @@
 const version = 1;
 
+/** @import { BlueprintDataApiOptions, BlueprintGraphData, BlueprintGraphVariant } from "./blueprint-api-types.mjs" */
+
 function defaultGlobalScope() {
   return typeof globalThis !== "undefined" ? globalThis : {};
 }
@@ -27,24 +29,54 @@ function currentDocument(globalScope = defaultGlobalScope()) {
   return globalScope && globalScope.document ? globalScope.document : null;
 }
 
+/**
+ * @param {unknown} node
+ * @param {Record<string, unknown>} [globalScope]
+ * @returns {boolean}
+ */
 function isElement(node, globalScope = defaultGlobalScope()) {
-  const ElementCtor = globalScope && globalScope.Element;
+  const ElementCtor = /** @type {Function | undefined} */ (
+    globalScope && globalScope.Element
+  );
   return typeof ElementCtor !== "undefined" && node instanceof ElementCtor;
 }
 
+/**
+ * @param {unknown} node
+ * @param {Record<string, unknown>} [globalScope]
+ * @returns {boolean}
+ */
 function isDocumentLike(node, globalScope = defaultGlobalScope()) {
-  const DocumentCtor = globalScope && globalScope.Document;
-  const DocumentFragmentCtor = globalScope && globalScope.DocumentFragment;
+  const DocumentCtor = /** @type {Function | undefined} */ (
+    globalScope && globalScope.Document
+  );
+  const DocumentFragmentCtor = /** @type {Function | undefined} */ (
+    globalScope && globalScope.DocumentFragment
+  );
   return (
     (typeof DocumentCtor !== "undefined" && node instanceof DocumentCtor) ||
     (typeof DocumentFragmentCtor !== "undefined" && node instanceof DocumentFragmentCtor)
   );
 }
 
+/**
+ * @param {unknown} node
+ * @returns {boolean}
+ */
 function isScriptElement(node) {
-  return !!node && typeof node.tagName === "string" && node.tagName.toLowerCase() === "script";
+  const candidate = /** @type {Object.<string, unknown>} */ (
+    node && typeof node === "object" ? node : {}
+  );
+  return typeof candidate.tagName === "string" && candidate.tagName.toLowerCase() === "script";
 }
 
+/**
+ * Resolve a generated data filename under `-verso-data/`.
+ *
+ * @param {string} filename Generated data filename.
+ * @param {string} [baseUrl] Base URL to resolve from. Defaults to the current page URL.
+ * @returns {string}
+ */
 export function dataUrl(filename, baseUrl) {
   const safeFilename = String(filename || "").trim();
   const sourceUrl =
@@ -69,10 +101,22 @@ export function dataUrl(filename, baseUrl) {
   return safeFilename ? "-verso-data/" + safeFilename : "-verso-data/";
 }
 
+/**
+ * Resolve the generated graph API module URL.
+ *
+ * @param {string} [baseUrl] Base URL to resolve from.
+ * @returns {string}
+ */
 export function graphApiModuleUrl(baseUrl) {
   return dataUrl("api/graph.mjs", baseUrl);
 }
 
+/**
+ * Find the graph canvas associated with a root node.
+ *
+ * @param {ParentNode | Element | Document | DocumentFragment | null} [root] Search root. Defaults to `document`.
+ * @returns {Element | null}
+ */
 export function graphCanvasFor(root) {
   const globalScope = defaultGlobalScope();
   const node = root || currentDocument(globalScope);
@@ -95,18 +139,32 @@ export function graphCanvasFor(root) {
   return null;
 }
 
+/**
+ * Read and parse a graph JSON script embedded in a graph canvas.
+ *
+ * @param {ParentNode | Element | Document | DocumentFragment | null} root Search root.
+ * @param {string} selector Script selector inside the graph canvas.
+ * @returns {unknown | null}
+ */
 export function readGraphJsonScript(root, selector) {
   const container = graphCanvasFor(root);
   if (!container) return null;
   const payloadNode = container.querySelector(selector);
   if (!isScriptElement(payloadNode)) return null;
+  const scriptNode = /** @type {HTMLScriptElement} */ (payloadNode);
   try {
-    return JSON.parse((payloadNode.textContent || "").trim());
+    return JSON.parse((scriptNode.textContent || "").trim());
   } catch (_err) {
     return null;
   }
 }
 
+/**
+ * Read DOT fallback graph variants embedded in a graph page.
+ *
+ * @param {ParentNode | Element | Document | DocumentFragment | null} [root] Search root. Defaults to `document`.
+ * @returns {BlueprintGraphVariant[]}
+ */
 export function graphFallbackVariants(root) {
   const graphRoot = graphCanvasFor(root);
   if (!graphRoot) return [];
@@ -126,36 +184,75 @@ export function graphFallbackVariants(root) {
   }];
 }
 
+/**
+ * Normalize raw graph JSON into the stable graph payload shape.
+ *
+ * @param {unknown} rawData Parsed graph JSON.
+ * @returns {BlueprintGraphData | null}
+ */
 export function normalizeGraphData(rawData) {
   if (!rawData || typeof rawData !== "object" || Array.isArray(rawData)) return null;
+  const data = /** @type {Record<string, unknown>} */ (rawData);
   return {
-    schemaVersion: Number.isFinite(rawData.schemaVersion) ? rawData.schemaVersion : 1,
-    key: typeof rawData.key === "string" ? rawData.key : "graph",
-    nodes: Array.isArray(rawData.nodes) ? rawData.nodes : [],
-    edges: Array.isArray(rawData.edges) ? rawData.edges : [],
-    groups: Array.isArray(rawData.groups) ? rawData.groups : []
+    schemaVersion: Number.isFinite(data.schemaVersion) ? Number(data.schemaVersion) : 1,
+    key: typeof data.key === "string" ? data.key : "graph",
+    nodes: Array.isArray(data.nodes) ? data.nodes : [],
+    edges: Array.isArray(data.edges) ? data.edges : [],
+    groups: Array.isArray(data.groups) ? data.groups : []
   };
 }
 
+/**
+ * Extract graph variants from a parsed Blueprint manifest.
+ *
+ * @param {unknown} manifest Parsed manifest JSON.
+ * @returns {BlueprintGraphData[]}
+ */
 export function graphsFromManifest(manifest) {
-  if (!manifest || typeof manifest !== "object" || !Array.isArray(manifest.graphs)) {
+  const data =
+    manifest && typeof manifest === "object"
+      ? /** @type {Record<string, unknown>} */ (manifest)
+      : null;
+  if (!data || !Array.isArray(data.graphs)) {
     return [];
   }
-  return manifest.graphs
+  return data.graphs
     .map(normalizeGraphData)
     .filter(function (graphData) { return !!graphData; });
 }
 
+/**
+ * Read embedded graph data from a generated graph page.
+ *
+ * @param {ParentNode | Element | Document | DocumentFragment | null} [root] Search root. Defaults to `document`.
+ * @returns {BlueprintGraphData | null}
+ */
 export function getGraphData(root) {
   return normalizeGraphData(readGraphJsonScript(root || currentDocument(), "script.bp-graph-data"));
 }
 
+/**
+ * Read graph variants embedded in a generated graph page.
+ *
+ * @param {ParentNode | Element | Document | DocumentFragment | null} [root] Search root. Defaults to `document`.
+ * @returns {BlueprintGraphVariant[]}
+ */
 export function getGraphVariants(root) {
   const parsed = readGraphJsonScript(root || currentDocument(), "script.bp-graph-variants");
-  if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+  if (Array.isArray(parsed) && parsed.length > 0) {
+    return /** @type {BlueprintGraphVariant[]} */ (parsed);
+  }
   return graphFallbackVariants(root || currentDocument());
 }
 
+/**
+ * Load and parse JSON using `fetch` or a custom `fetchJson`.
+ *
+ * @param {string} url URL to load.
+ * @param {BlueprintDataApiOptions} [options] Optional loader options.
+ * @param {string} [errorPrefix] Prefix used for HTTP errors.
+ * @returns {Promise<unknown>}
+ */
 export function loadJson(url, options, errorPrefix) {
   const opts = options && typeof options === "object" ? options : {};
   if (typeof opts.fetchJson === "function") {
@@ -180,6 +277,13 @@ export function loadJson(url, options, errorPrefix) {
   });
 }
 
+/**
+ * Load graph variants from a manifest URL.
+ *
+ * @param {string} [url] Manifest URL. Defaults to `blueprint-manifest.json`.
+ * @param {BlueprintDataApiOptions} [options] Optional loader options.
+ * @returns {Promise<BlueprintGraphData[]>}
+ */
 export function loadManifestGraphs(url, options) {
   const manifestUrl =
     typeof url === "string" && url.trim() ? url : dataUrl("blueprint-manifest.json");
@@ -190,6 +294,12 @@ export function loadManifestGraphs(url, options) {
   ).then(graphsFromManifest);
 }
 
+/**
+ * Load graph variants from the default generated manifest URL.
+ *
+ * @param {BlueprintDataApiOptions} [options] Optional loader options.
+ * @returns {Promise<BlueprintGraphData[]>}
+ */
 export function loadGraphs(options) {
   return loadManifestGraphs(dataUrl("blueprint-manifest.json"), options);
 }

--- a/src/VersoBlueprint/blueprint-js-globals.d.ts
+++ b/src/VersoBlueprint/blueprint-js-globals.d.ts
@@ -1,0 +1,21 @@
+export {};
+
+declare global {
+  interface Window {
+    VersoBlueprint?: {
+      render?: unknown;
+      renderReadyCallbacks?: Array<(api: unknown) => void>;
+      onRenderReady?: (fn: (api: unknown) => void) => void;
+      __private?: Record<string, unknown>;
+      slides?: Record<string, unknown>;
+    };
+    bpTexPreludeTable?: Record<string, string>;
+    Reveal?: {
+      on?: (event: string, fn: (event: { currentSlide?: Element }) => void) => void;
+    };
+  }
+
+  const katex: {
+    render: (tex: string, element: Element, options?: Record<string, unknown>) => void;
+  };
+}

--- a/src/VersoBlueprint/blueprint-preview-api.mjs
+++ b/src/VersoBlueprint/blueprint-preview-api.mjs
@@ -9,6 +9,18 @@ import {
 import { callDefaultApi, callDefaultApiSync, createDefaultApiHandle, createPreviewUrlApi, fallbackStoreStatus, optionsWithDefaultDataBaseUrl, version } from "./blueprint-api-common.mjs";
 import { createPreviewRuntimeApi } from "./Commands/preview-runtime-api.mjs";
 
+/**
+ * Render-capable Blueprint preview API for custom browser clients.
+ *
+ * This module is emitted as `-verso-data/api/preview.mjs` in generated sites.
+ * It composes the data API with DOM rendering, hydration, canonical-node
+ * insertion, and call-scoped external-markup fallback renderers.
+ *
+ * @module blueprint-preview-api
+ */
+
+/** @import { BlueprintDataApiOptions, BlueprintPreviewOptions, BlueprintPreviewApi, BlueprintStoreStatus, BlueprintManifestEntry, BlueprintHtmlCacheEntry, BlueprintGraphData, BlueprintGraphVariant, BlueprintPreviewResult, BlueprintCanonicalPreviewResult, BlueprintRenderNodeRequest, BlueprintRenderNodeResult } from "./blueprint-api-types.mjs" */
+
 export {
   getGraphData,
   getGraphVariants,
@@ -23,87 +35,263 @@ export { version };
 const moduleUrl = import.meta.url;
 const previewUrls = createPreviewUrlApi(moduleUrl);
 
+/**
+ * Create an isolated render-capable preview API instance.
+ *
+ * @param {BlueprintPreviewOptions} [options] Loader, hydration, and generated-data options.
+ * @returns {BlueprintPreviewApi} Preview API instance.
+ */
 export function createPreview(options) {
   return createPreviewRuntimeApi(optionsWithDefaultDataBaseUrl(options, moduleUrl));
 }
 
 const defaultRenderHandle = createDefaultApiHandle(createPreview);
 
+/**
+ * Return the module-level preview API if it has already been created.
+ *
+ * @returns {BlueprintPreviewApi | null}
+ */
 export function currentRenderApi() {
   return defaultRenderHandle.currentApi();
 }
 
+/**
+ * Return the module-level preview API, creating it on first use.
+ *
+ * @returns {Promise<BlueprintPreviewApi>}
+ */
 export function getRenderApi() {
   return defaultRenderHandle.getApi();
 }
 
+/**
+ * Promise for the default preview API instance.
+ *
+ * @type {Promise<BlueprintPreviewApi>}
+ */
 export const ready = defaultRenderHandle.ready;
 
-export const dataUrl = previewUrls.dataUrl;
-export const manifestUrl = previewUrls.manifestUrl;
-export const htmlCacheUrl = previewUrls.htmlCacheUrl;
-export const graphApiModuleUrl = previewUrls.graphApiModuleUrl;
-export const dataApiModuleUrl = previewUrls.dataApiModuleUrl;
-export const previewApiModuleUrl = previewUrls.previewApiModuleUrl;
-export const previewKey = previewUrls.previewKey;
-export const statementPreviewKey = previewUrls.statementPreviewKey;
+/**
+ * Resolve a generated data filename under `-verso-data/`.
+ *
+ * @param {string} filename Generated data filename.
+ * @param {string} [baseUrl] Base URL. Defaults to this module URL.
+ * @returns {string}
+ */
+export function dataUrl(filename, baseUrl) {
+  return previewUrls.dataUrl(filename, baseUrl);
+}
 
+/**
+ * Resolve `blueprint-manifest.json`.
+ *
+ * @param {string} [baseUrl] Base URL. Defaults to this module URL.
+ * @returns {string}
+ */
+export function manifestUrl(baseUrl) {
+  return previewUrls.manifestUrl(baseUrl);
+}
+
+/**
+ * Resolve `blueprint-html-cache.json`.
+ *
+ * @param {string} [baseUrl] Base URL. Defaults to this module URL.
+ * @returns {string}
+ */
+export function htmlCacheUrl(baseUrl) {
+  return previewUrls.htmlCacheUrl(baseUrl);
+}
+
+/**
+ * Resolve the generated graph API module URL.
+ *
+ * @param {string} [baseUrl] Base URL. Defaults to this module URL.
+ * @returns {string}
+ */
+export function graphApiModuleUrl(baseUrl) {
+  return previewUrls.graphApiModuleUrl(baseUrl);
+}
+
+/**
+ * Resolve the generated data API module URL.
+ *
+ * @param {string} [baseUrl] Base URL. Defaults to this module URL.
+ * @returns {string}
+ */
+export function dataApiModuleUrl(baseUrl) {
+  return previewUrls.dataApiModuleUrl(baseUrl);
+}
+
+/**
+ * Resolve the generated preview API module URL.
+ *
+ * @param {string} [baseUrl] Base URL. Defaults to this module URL.
+ * @returns {string}
+ */
+export function previewApiModuleUrl(baseUrl) {
+  return previewUrls.previewApiModuleUrl(baseUrl);
+}
+
+/**
+ * Build the preview key for a Blueprint label and facet.
+ *
+ * @param {string} label Blueprint label.
+ * @param {string} [facet] Preview facet. Defaults to `statement`.
+ * @returns {string}
+ */
+export function previewKey(label, facet) {
+  return previewUrls.previewKey(label, facet);
+}
+
+/**
+ * Build the statement preview key for a Blueprint label.
+ *
+ * @param {string} label Blueprint label.
+ * @returns {string}
+ */
+export function statementPreviewKey(label) {
+  return previewUrls.statementPreviewKey(label);
+}
+
+/**
+ * Read cached manifest loader status without triggering a load.
+ *
+ * @returns {BlueprintStoreStatus}
+ */
 export function readManifestStatus() {
   return callDefaultApiSync(
     defaultRenderHandle.readDefaultApi,
     "readManifestStatus",
     function () { return fallbackStoreStatus(manifestUrl()); },
-    arguments
+    []
   );
 }
 
+/**
+ * Read cached HTML-cache loader status without triggering a load.
+ *
+ * @returns {BlueprintStoreStatus}
+ */
 export function readHtmlCacheStatus() {
   return callDefaultApiSync(
     defaultRenderHandle.readDefaultApi,
     "readHtmlCacheStatus",
     function () { return fallbackStoreStatus(htmlCacheUrl()); },
-    arguments
+    []
   );
 }
 
-export function loadManifest() {
-  return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "loadManifest", arguments);
+/**
+ * Load and decode the Blueprint manifest.
+ *
+ * @param {BlueprintDataApiOptions} [options] Optional per-call load overrides.
+ * @returns {Promise<Map<string, BlueprintManifestEntry>>}
+ */
+export function loadManifest(options) {
+  return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "loadManifest", [options]);
 }
 
-export function loadHtmlCache() {
-  return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "loadHtmlCache", arguments);
+/**
+ * Load and decode the rendered HTML fragment cache.
+ *
+ * @param {BlueprintDataApiOptions} [options] Optional per-call load overrides.
+ * @returns {Promise<Map<string, BlueprintHtmlCacheEntry>>}
+ */
+export function loadHtmlCache(options) {
+  return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "loadHtmlCache", [options]);
 }
 
-export function loadManifestEntry(key) {
-  return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "loadManifestEntry", arguments);
+/**
+ * Load a single manifest entry by key.
+ *
+ * @param {string} key Manifest key.
+ * @param {BlueprintDataApiOptions} [options] Optional per-call load overrides.
+ * @returns {Promise<BlueprintManifestEntry | null>}
+ */
+export function loadManifestEntry(key, options) {
+  return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "loadManifestEntry", [key, options]);
 }
 
-export function loadHtmlCacheEntry(key) {
-  return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "loadHtmlCacheEntry", arguments);
+/**
+ * Load a single HTML-cache entry by key.
+ *
+ * @param {string} key HTML cache key.
+ * @param {BlueprintDataApiOptions} [options] Optional per-call load overrides.
+ * @returns {Promise<BlueprintHtmlCacheEntry | null>}
+ */
+export function loadHtmlCacheEntry(key, options) {
+  return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "loadHtmlCacheEntry", [key, options]);
 }
 
-export function resolvePreview(key) {
-  return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "resolvePreview", arguments);
+/**
+ * Resolve a preview key against the manifest and HTML cache.
+ *
+ * @param {string} key Preview key such as `label--statement`.
+ * @param {BlueprintDataApiOptions} [options] Optional per-call load overrides.
+ * @returns {Promise<BlueprintPreviewResult>}
+ */
+export function resolvePreview(key, options) {
+  return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "resolvePreview", [key, options]);
 }
 
+/**
+ * Render a cached preview fragment into a target element.
+ *
+ * @param {Element} element Target element to replace with the resolved fragment.
+ * @param {string} key Preview key such as `label--statement`.
+ * @param {BlueprintPreviewOptions} [options] Optional render and load overrides.
+ * @returns {Promise<BlueprintPreviewResult>}
+ */
 export function renderPreviewInto(element, key, options) {
-  return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "renderPreviewInto", arguments);
+  return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "renderPreviewInto", [element, key, options]);
 }
 
-export function resolveCanonicalPreview(key) {
-  return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "resolveCanonicalPreview", arguments);
+/**
+ * Resolve a preview key to its canonical generated-node shell.
+ *
+ * @param {string} key Preview key such as `label--statement`.
+ * @param {BlueprintPreviewOptions} [options] Optional render and load overrides.
+ * @returns {Promise<BlueprintCanonicalPreviewResult>}
+ */
+export function resolveCanonicalPreview(key, options) {
+  return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "resolveCanonicalPreview", [key, options]);
 }
 
+/**
+ * Render the canonical generated-node shell for a preview key into a target.
+ *
+ * @param {Element} element Target element to replace with the canonical node.
+ * @param {string} key Preview key such as `label--statement`.
+ * @param {BlueprintPreviewOptions} [options] Optional render and load overrides.
+ * @returns {Promise<BlueprintCanonicalPreviewResult>}
+ */
 export function renderCanonicalPreviewInto(element, key, options) {
-  return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "renderCanonicalPreviewInto", arguments);
+  return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "renderCanonicalPreviewInto", [element, key, options]);
 }
 
+/**
+ * Render a Blueprint label, preferring the native rendered preview and falling
+ * back to call-scoped external-markup renderers when needed.
+ *
+ * @param {Element} element Target element to replace with the rendered node.
+ * @param {string | BlueprintRenderNodeRequest} request Label or detailed render request.
+ * @param {BlueprintPreviewOptions} [options] Optional render and load overrides.
+ * @returns {Promise<BlueprintRenderNodeResult>}
+ */
 export function renderNode(element, request, options) {
-  return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "renderNode", arguments);
+  return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "renderNode", [element, request, options]);
 }
 
+/**
+ * Hydrate Blueprint-specific behavior inside an already-rendered subtree.
+ *
+ * @param {Element} element Root element to hydrate.
+ * @param {BlueprintPreviewOptions} [options] Hydration options.
+ * @returns {Promise<boolean>}
+ */
 export function hydrate(element, options) {
-  return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "hydrate", arguments);
+  return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "hydrate", [element, options]);
 }
 
 const previewApi = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+    "noImplicitAny": false,
+    "noEmit": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/VersoBlueprint/blueprint-js-globals.d.ts",
+    "src/VersoBlueprint/blueprint-api-types.mjs",
+    "src/VersoBlueprint/blueprint-api-common.mjs",
+    "src/VersoBlueprint/blueprint-data-api.mjs",
+    "src/VersoBlueprint/blueprint-graph-api.mjs",
+    "src/VersoBlueprint/blueprint-graph-core.mjs",
+    "src/VersoBlueprint/blueprint-preview-api.mjs",
+    "src/VersoBlueprint/blueprint-preview-core.mjs",
+    "src/VersoBlueprint/Commands/preview-runtime-api.mjs",
+    "src/VersoBlueprint/Commands/preview-runtime-base.mjs",
+    "src/VersoBlueprint/Commands/preview-runtime-data.mjs",
+    "src/VersoBlueprint/Commands/preview-runtime-hydration.mjs",
+    "src/VersoBlueprint/Commands/preview-runtime-lifecycle.mjs",
+    "src/VersoBlueprint/Commands/preview-runtime-render.mjs",
+    "src/VersoBlueprint/Commands/preview-runtime-surface.mjs",
+    "src/VersoBlueprint/Commands/preview-runtime-template.mjs"
+  ]
+}

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationDir": "dist/types",
+    "rootDir": "."
+  }
+}


### PR DESCRIPTION
## Summary
Backport #189 to `v4.30.0`.

## Primary Review
- Primary review: #189
- Keep review comments on #189 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.30.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- Includes the Docdash API-docs rendering update from #189.
- Removes a stale v4.30-only `openTargetDetailsJs` summary asset reference that was already absent from the default-development summary rendering path.
