### PR TITLE
test: harden JavaScript API boundary checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ The browser APIs emitted under `-verso-data/api/` remain plain JavaScript ESM.
 API documentation is written in JSDoc, rendered with Docdash, and TypeScript
 checks the public API entrypoints plus their direct support modules with
 `allowJs` and `checkJs`.
+The generated-site public browser entrypoints are `api/preview.mjs`,
+`api/data.mjs`, and `api/graph.mjs`; the other emitted JavaScript modules are
+private runtime support chunks for those entrypoints and generated pages.
 This first pass intentionally focuses on the custom-client API surface; broader
 private runtime coverage and `noImplicitAny` tightening are follow-up cleanup
 items. TypeScript users consume generated declaration files from `dist/types`;

--- a/doc/API.md
+++ b/doc/API.md
@@ -510,6 +510,12 @@ The generated ESM modules expose these entrypoint groups:
 | `api/preview.mjs` | URL helpers: `dataUrl`, `manifestUrl`, `htmlCacheUrl`, `dataApiModuleUrl`, `previewApiModuleUrl`; renderer creation/default access: `createPreview`, `currentRenderApi`, `getRenderApi`, `ready`; manifest/cache helpers: `loadManifest`, `readManifestStatus`, `loadManifestEntry`, `loadHtmlCache`, `readHtmlCacheStatus`, `loadHtmlCacheEntry`; preview/render helpers: `previewKey`, `statementPreviewKey`, `resolvePreview`, `renderPreviewInto`, `resolveCanonicalPreview`, `renderCanonicalPreviewInto`, `renderNode`, `hydrate`. |
 | `api/graph.mjs` | URL helpers: `dataUrl`, `graphApiModuleUrl`; graph-data helpers: `getGraphData`, `getGraphVariants`, `loadManifestGraphs`, `loadGraphs`; graph rendering helpers: `renderGraphBlock`, `renderGraphs`. |
 
+Only the files listed in this table are public generated-site browser API
+entrypoints. Other generated JavaScript files under `-verso-data/`, including
+the `blueprint-*-core.mjs`, `blueprint-api-common.mjs`, and
+`Commands/*.mjs` support chunks, are implementation modules owned by the
+generated page runtime or by those public entrypoints.
+
 ## Browser Runtime API
 
 Browser-side custom interfaces should start from `createPreview()` in

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -477,6 +477,14 @@ The workflow implies a few constraints for renderers:
   Blueprint-owned DOM structure; otherwise they should remain bundled helpers
   until the argument shape is clearer.
 
+  The public generated-site module boundary is intentionally narrower than the
+  implementation module graph. `api/data.mjs`, `api/preview.mjs`, and
+  `api/graph.mjs` are the browser import targets for clients. The sibling
+  `blueprint-*-core.mjs`, `blueprint-api-common.mjs`, and `Commands/*.mjs`
+  modules are emitted so generated pages, Slides, and the public API wrappers
+  can share one runtime path; they are not a custom-client contract merely
+  because they are ESM modules.
+
 - **Split JavaScript by responsibility, not feature semantics.**
   The preview runtime is emitted as ESM support modules for regular Manual
   pages and public generated APIs. The current Slides path wraps those modules

--- a/doc/JS_API_DOCS.md
+++ b/doc/JS_API_DOCS.md
@@ -31,6 +31,13 @@ await preview.renderNode(document.querySelector("#target"), {
 
 ## Modules
 
+The generated-site public browser API is intentionally small: clients should
+import the preview, data, and graph modules below from `-verso-data/api/`.
+The shared types page documents generated declarations and JSDoc typedefs for
+tooling; it is not a generated browser import target. The support modules
+beside the public browser entrypoints in `-verso-data/` are private
+implementation chunks for generated pages, Slides, and those entrypoints.
+
 - [preview API](module-blueprint-preview-api.html): render Blueprint nodes,
   hydrate generated fragments, resolve canonical generated-node shells, and
   provide call-scoped external-markup fallback renderers.

--- a/scripts/check-js-api-docs.mjs
+++ b/scripts/check-js-api-docs.mjs
@@ -2,6 +2,16 @@ import { access, readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
 const docsDir = path.resolve("_out/jsdoc-api");
+const contractPath = path.resolve("tests/preview_runtime_api_contract.json");
+const publicApiContract = JSON.parse(await readFile(contractPath, "utf8"));
+const publicApiDocPages = [
+  ...Object.values(publicApiContract.modules).map((entry) => entry.jsdocPage),
+  publicApiContract.typesModule.jsdocPage
+];
+const dataPage = publicApiContract.modules.data.jsdocPage;
+const graphPage = publicApiContract.modules.graph.jsdocPage;
+const previewPage = publicApiContract.modules.preview.jsdocPage;
+const typesPage = publicApiContract.typesModule.jsdocPage;
 const failures = [];
 const textCache = new Map();
 
@@ -115,14 +125,25 @@ async function checkLocalLinks() {
   }
 }
 
+async function checkPublicModulePages() {
+  const files = await listFiles();
+  const expectedModulePages = new Set(publicApiDocPages);
+  const modulePages = files.filter((file) => file.startsWith("module-") && file.endsWith(".html"));
+  for (const modulePage of modulePages) {
+    if (!expectedModulePages.has(modulePage)) {
+      fail(`unexpected generated public module page: ${modulePage}`);
+    }
+  }
+}
+
 const pages = {
   "index.html": await requireReadableFile("index.html"),
-  "module-blueprint-api-types.html": await requireReadableFile("module-blueprint-api-types.html"),
-  "module-blueprint-data-api.html": await requireReadableFile("module-blueprint-data-api.html"),
-  "module-blueprint-graph-api.html": await requireReadableFile("module-blueprint-graph-api.html"),
-  "module-blueprint-preview-api.html": await requireReadableFile("module-blueprint-preview-api.html"),
   "jsdoc-type-links.js": await requireReadableFile("jsdoc-type-links.js")
 };
+
+for (const page of publicApiDocPages) {
+  pages[page] = await requireReadableFile(page);
+}
 
 requireIncludes(
   "index.html",
@@ -130,47 +151,38 @@ requireIncludes(
   "Verso Blueprint JavaScript API",
   "landing-page title"
 );
-requireIncludes(
-  "index.html",
-  pages["index.html"],
-  "module-blueprint-preview-api.html",
-  "preview API guide link"
-);
-requireIncludes(
-  "index.html",
-  pages["index.html"],
-  "module-blueprint-api-types.html",
-  "shared API types guide link"
-);
+for (const entry of [...Object.values(publicApiContract.modules), publicApiContract.typesModule]) {
+  requireIncludes("index.html", pages["index.html"], entry.jsdocPage, `${entry.jsdocPage} guide link`);
+}
 
 requireMatches(
-  "module-blueprint-preview-api.html",
-  pages["module-blueprint-preview-api.html"],
+  previewPage,
+  pages[previewPage],
   /id="\.createPreview"[\s\S]*?&rarr; \{BlueprintPreviewApi\}/,
   "createPreview return type"
 );
 requireMatches(
-  "module-blueprint-preview-api.html",
-  pages["module-blueprint-preview-api.html"],
+  previewPage,
+  pages[previewPage],
   /id="\.renderNode"[\s\S]*?&rarr; \{Promise\.&lt;BlueprintRenderNodeResult>\}/,
   "renderNode result type"
 );
 requireMatches(
-  "module-blueprint-preview-api.html",
-  pages["module-blueprint-preview-api.html"],
+  previewPage,
+  pages[previewPage],
   /<script src="jsdoc-type-links\.js"><\/script>/,
   "typedef-linking script"
 );
 
 requireMatches(
-  "module-blueprint-data-api.html",
-  pages["module-blueprint-data-api.html"],
+  dataPage,
+  pages[dataPage],
   /id="\.createPreviewData"[\s\S]*?&rarr; \{BlueprintDataApi\}/,
   "createPreviewData return type"
 );
 requireMatches(
-  "module-blueprint-graph-api.html",
-  pages["module-blueprint-graph-api.html"],
+  graphPage,
+  pages[graphPage],
   /id="\.loadGraphs"[\s\S]*?Load graph variants from this generated site's default manifest\./,
   "loadGraphs documentation"
 );
@@ -183,8 +195,8 @@ for (const typeName of [
   "BlueprintExternalMarkupPreference"
 ]) {
   requireIncludes(
-    "module-blueprint-api-types.html",
-    pages["module-blueprint-api-types.html"],
+    typesPage,
+    pages[typesPage],
     `id="~${typeName}"`,
     `${typeName} typedef anchor`
   );
@@ -199,11 +211,12 @@ for (const typeName of [
 requireIncludes(
   "jsdoc-type-links.js",
   pages["jsdoc-type-links.js"],
-  "module-blueprint-api-types.html#~",
+  `${typesPage}#~`,
   "typedef target prefix"
 );
 
 await checkLocalLinks();
+await checkPublicModulePages();
 
 if (failures.length > 0) {
   console.error("JavaScript API docs smoke check failed:");

--- a/scripts/check-js-api-types.mjs
+++ b/scripts/check-js-api-types.mjs
@@ -2,6 +2,8 @@ import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 
 const typesDir = path.resolve("dist/types/src/VersoBlueprint");
+const contractPath = path.resolve("tests/preview_runtime_api_contract.json");
+const publicApiContract = JSON.parse(await readFile(contractPath, "utf8"));
 const failures = [];
 
 function fail(message) {
@@ -31,6 +33,33 @@ function rejectMatches(relativePath, text, pattern, description) {
   }
 }
 
+function exportedValueNames(text) {
+  const names = new Set();
+  for (const match of text.matchAll(/^export function ([A-Za-z][A-Za-z0-9_]*)\b/gm)) {
+    names.add(match[1]);
+  }
+  for (const match of text.matchAll(/^export const ([A-Za-z][A-Za-z0-9_]*)\b/gm)) {
+    names.add(match[1]);
+  }
+  for (const match of text.matchAll(/^export \{ ([A-Za-z][A-Za-z0-9_]*) \};/gm)) {
+    names.add(match[1]);
+  }
+  return names;
+}
+
+function requireExactExports(relativePath, text, expectedNames) {
+  const actualNames = exportedValueNames(text);
+  const expected = new Set(expectedNames);
+  const missing = [...expected].filter((name) => !actualNames.has(name)).sort();
+  const extra = [...actualNames].filter((name) => !expected.has(name)).sort();
+  if (missing.length > 0 || extra.length > 0) {
+    fail(
+      `${relativePath}: public declaration exports mismatch` +
+      `; missing=[${missing.join(", ")}] extra=[${extra.join(", ")}]`
+    );
+  }
+}
+
 function requireTypeBlock(relativePath, text, typeName) {
   const pattern = new RegExp(`export type ${typeName} = \\{[\\s\\S]*?\\n\\};`);
   const match = text.match(pattern);
@@ -41,71 +70,100 @@ function requireTypeBlock(relativePath, text, typeName) {
   return match[0];
 }
 
-const declarations = {
-  "blueprint-api-types.d.mts": await requireDeclaration("blueprint-api-types.d.mts"),
-  "blueprint-data-api.d.mts": await requireDeclaration("blueprint-data-api.d.mts"),
-  "blueprint-graph-api.d.mts": await requireDeclaration("blueprint-graph-api.d.mts"),
-  "blueprint-preview-api.d.mts": await requireDeclaration("blueprint-preview-api.d.mts")
-};
+function declarationFilename(entry) {
+  return path.basename(entry.declaration);
+}
+
+const declarationEntries = [
+  publicApiContract.typesModule,
+  publicApiContract.modules.data,
+  publicApiContract.modules.graph,
+  publicApiContract.modules.preview
+];
+const declarations = Object.fromEntries(await Promise.all(
+  declarationEntries.map(async (entry) => {
+    const filename = declarationFilename(entry);
+    return [filename, await requireDeclaration(filename)];
+  })
+));
+
+const apiTypesDeclaration = declarationFilename(publicApiContract.typesModule);
+const dataDeclaration = declarationFilename(publicApiContract.modules.data);
+const graphDeclaration = declarationFilename(publicApiContract.modules.graph);
+const previewDeclaration = declarationFilename(publicApiContract.modules.preview);
 
 for (const [relativePath, text] of Object.entries(declarations)) {
   rejectMatches(relativePath, text, /module:blueprint-api-types~/, "JSDoc longname leak");
   rejectMatches(relativePath, text, /(:|=>|<|,)\s*any\b/, "public API any type");
 }
 
+requireExactExports(
+  dataDeclaration,
+  declarations[dataDeclaration],
+  publicApiContract.exports.data
+);
+requireExactExports(
+  graphDeclaration,
+  declarations[graphDeclaration],
+  publicApiContract.exports.graph
+);
+requireExactExports(
+  previewDeclaration,
+  declarations[previewDeclaration],
+  publicApiContract.exports.preview
+);
+
 requireMatches(
-  "blueprint-preview-api.d.mts",
-  declarations["blueprint-preview-api.d.mts"],
+  previewDeclaration,
+  declarations[previewDeclaration],
   /export function createPreview\(options\?: BlueprintPreviewOptions\): BlueprintPreviewApi;/,
   "typed createPreview export"
 );
 requireMatches(
-  "blueprint-preview-api.d.mts",
-  declarations["blueprint-preview-api.d.mts"],
+  previewDeclaration,
+  declarations[previewDeclaration],
   /export function renderNode\(element: Element, request: string \| BlueprintRenderNodeRequest, options\?: BlueprintPreviewOptions\): Promise<BlueprintRenderNodeResult>;/,
   "typed module-level renderNode export"
 );
 requireMatches(
-  "blueprint-preview-api.d.mts",
-  declarations["blueprint-preview-api.d.mts"],
+  previewDeclaration,
+  declarations[previewDeclaration],
   /export function hydrate\(element: Element, options\?: BlueprintPreviewOptions\): Promise<boolean>;/,
   "async module-level hydrate export"
 );
 
 requireMatches(
-  "blueprint-data-api.d.mts",
-  declarations["blueprint-data-api.d.mts"],
+  dataDeclaration,
+  declarations[dataDeclaration],
   /export function createPreviewData\(options\?: BlueprintDataApiOptions\): BlueprintDataApi;/,
   "typed createPreviewData export"
 );
 requireMatches(
-  "blueprint-data-api.d.mts",
-  declarations["blueprint-data-api.d.mts"],
+  dataDeclaration,
+  declarations[dataDeclaration],
   /export function loadHtmlCacheEntry\(key: string, options\?: BlueprintDataApiOptions\): Promise<BlueprintHtmlCacheEntry \| null>;/,
   "typed data loadHtmlCacheEntry export"
 );
 
 requireMatches(
-  "blueprint-graph-api.d.mts",
-  declarations["blueprint-graph-api.d.mts"],
+  graphDeclaration,
+  declarations[graphDeclaration],
   /export function loadGraphs\(options\?: BlueprintDataApiOptions\): Promise<BlueprintGraphData\[]>;/,
   "typed graph loadGraphs export"
 );
 requireMatches(
-  "blueprint-graph-api.d.mts",
-  declarations["blueprint-graph-api.d.mts"],
+  graphDeclaration,
+  declarations[graphDeclaration],
   /export function renderGraphBlock\(graphBlock: Element, options\?: BlueprintGraphRenderOptions\): Promise<BlueprintGraphController \| null>;/,
   "typed graph renderGraphBlock export"
 );
 
 const graphApiNames = [
-  "graphApiModuleUrl",
   "graphsFromManifest",
-  "getGraphData",
-  "getGraphVariants",
-  "loadManifestGraphs",
-  "loadGraphs",
-  "normalizeGraphData"
+  "normalizeGraphData",
+  ...publicApiContract.exports.graph.filter(
+    (name) => !["dataUrl", "renderGraphBlock", "renderGraphs", "version"].includes(name)
+  )
 ];
 const graphInternalApiNames = [
   "ensureGraphRuntimeLibraries",
@@ -122,66 +180,66 @@ const graphInternalApiNames = [
 
 for (const apiName of graphApiNames) {
   rejectMatches(
-    "blueprint-data-api.d.mts",
-    declarations["blueprint-data-api.d.mts"],
+    dataDeclaration,
+    declarations[dataDeclaration],
     new RegExp(`export (?:function|const) ${apiName}\\b`),
     `${apiName} data API export`
   );
   rejectMatches(
-    "blueprint-preview-api.d.mts",
-    declarations["blueprint-preview-api.d.mts"],
+    previewDeclaration,
+    declarations[previewDeclaration],
     new RegExp(`export (?:function|const) ${apiName}\\b`),
     `${apiName} preview API export`
   );
 }
 for (const apiName of graphInternalApiNames) {
   rejectMatches(
-    "blueprint-graph-api.d.mts",
-    declarations["blueprint-graph-api.d.mts"],
+    graphDeclaration,
+    declarations[graphDeclaration],
     new RegExp(`export (?:function|const) ${apiName}\\b`),
     `${apiName} graph API export`
   );
 }
 
-const apiTypes = declarations["blueprint-api-types.d.mts"];
+const apiTypes = declarations[apiTypesDeclaration];
 const dataApiType = requireTypeBlock(
-  "blueprint-api-types.d.mts",
+  apiTypesDeclaration,
   apiTypes,
   "BlueprintDataApi"
 );
 const previewApiType = requireTypeBlock(
-  "blueprint-api-types.d.mts",
+  apiTypesDeclaration,
   apiTypes,
   "BlueprintPreviewApi"
 );
 requireMatches(
-  "blueprint-api-types.d.mts",
+  apiTypesDeclaration,
   dataApiType,
   /dataUrl: \(arg0: string\) => string;[\s\S]*?loadManifest: \(arg0: BlueprintDataApiOptions \| undefined\) => Promise<Map<string, BlueprintManifestEntry>>;[\s\S]*?loadHtmlCacheEntry: \(arg0: string, arg1: BlueprintDataApiOptions \| undefined\) => Promise<\(?BlueprintHtmlCacheEntry \| null\)?>;/,
   "BlueprintDataApi manifest/cache object shape"
 );
 requireMatches(
-  "blueprint-api-types.d.mts",
+  apiTypesDeclaration,
   previewApiType,
   /dataUrl: \(arg0: string\) => string;[\s\S]*?resolvePreview: \(arg0: string, arg1: BlueprintDataApiOptions \| undefined\) => Promise<BlueprintPreviewResult>;[\s\S]*?renderNode: \(arg0: Element, arg1: \(string \| BlueprintRenderNodeRequest\), arg2: BlueprintPreviewOptions \| undefined\) => Promise<BlueprintRenderNodeResult>;[\s\S]*?hydrate: \(arg0: Element, arg1: BlueprintPreviewOptions \| undefined\) => boolean;/,
   "BlueprintPreviewApi render object shape"
 );
 for (const apiName of graphApiNames) {
   rejectMatches(
-    "blueprint-api-types.d.mts",
+    apiTypesDeclaration,
     dataApiType,
     new RegExp(`\\b${apiName}:`),
     `${apiName} on BlueprintDataApi`
   );
   rejectMatches(
-    "blueprint-api-types.d.mts",
+    apiTypesDeclaration,
     previewApiType,
     new RegExp(`\\b${apiName}:`),
     `${apiName} on BlueprintPreviewApi`
   );
 }
 requireMatches(
-  "blueprint-api-types.d.mts",
+  apiTypesDeclaration,
   apiTypes,
   /export type BlueprintExternalMarkupRenderer = \(payload: BlueprintExternalMarkupPayload, target: Element\) => void \| string \| Node \| Promise<void \| string \| Node>;/,
   "external-markup renderer callback"

--- a/tests/harness/test_preview_runtime_api_docs.py
+++ b/tests/harness/test_preview_runtime_api_docs.py
@@ -1,10 +1,20 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
+import re
 import unittest
 
 from tests.preview_runtime_api import (
     BLUEPRINT_SRC,
+    PACKAGE_ROOT,
+    PUBLIC_API_JSDOC_SOURCES,
+    PUBLIC_API_MODULES,
+    PUBLIC_API_PACKAGE_EXPORTS,
+    PUBLIC_DATA_API_EXPORTS,
+    PUBLIC_GENERATED_API_MODULES,
+    PUBLIC_GRAPH_API_EXPORTS,
+    PUBLIC_PREVIEW_API_EXPORTS,
     RUNTIME_BOOTSTRAP_JS,
     blueprint_js_files,
     blueprint_js_source,
@@ -15,9 +25,10 @@ from tests.preview_runtime_api import (
     js_object_methods,
 )
 
-PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 API_DOC = PACKAGE_ROOT / "doc" / "API.md"
 DESIGN_RATIONALE = PACKAGE_ROOT / "doc" / "DESIGN_RATIONALE.md"
+JSDOC_CONFIG = PACKAGE_ROOT / "jsdoc.json"
+PACKAGE_JSON = PACKAGE_ROOT / "package.json"
 INTERNAL_ONLY_HELPERS = {
     "bindCloseOnce",
     "bindDismissHandlers",
@@ -35,44 +46,6 @@ INTERNAL_ONLY_HELPERS = {
     "renderHtmlInto",
     "resetPanelPosition",
     "shouldKeepOpen",
-}
-PREVIEW_ESM_EXTRA_EXPORTS = {
-    "createPreview",
-    "currentRenderApi",
-    "getRenderApi",
-    "ready",
-    "version",
-}
-DATA_ESM_EXPORTS = {
-    "createPreviewData",
-    "currentDataApi",
-    "dataApiModuleUrl",
-    "dataUrl",
-    "getDataApi",
-    "htmlCacheUrl",
-    "loadHtmlCache",
-    "loadHtmlCacheEntry",
-    "loadManifest",
-    "loadManifestEntry",
-    "manifestUrl",
-    "previewApiModuleUrl",
-    "previewKey",
-    "readHtmlCacheStatus",
-    "readManifestStatus",
-    "ready",
-    "statementPreviewKey",
-    "version",
-}
-GRAPH_ESM_EXPORTS = {
-    "dataUrl",
-    "getGraphData",
-    "getGraphVariants",
-    "graphApiModuleUrl",
-    "loadGraphs",
-    "loadManifestGraphs",
-    "renderGraphBlock",
-    "renderGraphs",
-    "version",
 }
 GRAPH_CORE_HELPERS = {
     "dataUrl",
@@ -128,6 +101,47 @@ GRAPH_RUNTIME_CORE_HELPERS = {
 
 
 class PreviewRuntimeApiDocsTests(unittest.TestCase):
+    def test_package_json_exports_only_public_js_api_modules(self) -> None:
+        package = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
+
+        preview_entry = PUBLIC_API_MODULES["preview"]
+        self.assertEqual(package["type"], "module")
+        self.assertEqual(package["main"], f"./{preview_entry['source']}")
+        self.assertEqual(package["module"], f"./{preview_entry['source']}")
+        self.assertEqual(package["types"], f"./{preview_entry['declaration']}")
+        self.assertEqual(set(package["exports"]), set(PUBLIC_API_PACKAGE_EXPORTS))
+        for export_name, entry in PUBLIC_API_PACKAGE_EXPORTS.items():
+            self.assertEqual(
+                package["exports"][export_name],
+                {
+                    "types": f"./{entry['declaration']}",
+                    "import": f"./{entry['source']}",
+                },
+            )
+
+    def test_jsdoc_documents_only_public_js_api_modules(self) -> None:
+        jsdoc_config = json.loads(JSDOC_CONFIG.read_text(encoding="utf-8"))
+        source_includes = set(jsdoc_config["source"]["include"])
+
+        self.assertEqual(source_includes, PUBLIC_API_JSDOC_SOURCES)
+        self.assertFalse(any("/Commands/" in source for source in source_includes))
+        self.assertFalse(any(source.endswith("-core.mjs") for source in source_includes))
+        self.assertFalse(any(source.endswith("-common.mjs") for source in source_includes))
+
+    def test_api_doc_module_table_matches_public_generated_modules(self) -> None:
+        api_doc = API_DOC.read_text(encoding="utf-8")
+        js_api_docs = (PACKAGE_ROOT / "doc" / "JS_API_DOCS.md").read_text(
+            encoding="utf-8"
+        )
+
+        documented_modules = set(
+            re.findall(r"\| `(api/[A-Za-z][A-Za-z0-9_-]*\.mjs)` \|", api_doc)
+        )
+        self.assertEqual(documented_modules, PUBLIC_GENERATED_API_MODULES)
+        self.assertIn("Only the files listed in this table are public", api_doc)
+        for entry in PUBLIC_API_MODULES.values():
+            self.assertIn(entry["jsdoc_page"], js_api_docs)
+
     def test_api_stable_api_table_matches_runtime_source(self) -> None:
         runtime = blueprint_js_source()
         api_doc = API_DOC.read_text(encoding="utf-8")
@@ -174,10 +188,9 @@ class PreviewRuntimeApiDocsTests(unittest.TestCase):
         default_methods = js_object_keys(source, "previewApi")
         helper_methods = js_object_methods(runtime, "bundledFeatureRenderHelpers")
 
-        self.assertLessEqual(stable_methods, named_exports)
-        self.assertLessEqual(stable_methods, default_methods)
-        self.assertEqual(named_exports, stable_methods | PREVIEW_ESM_EXTRA_EXPORTS)
-        self.assertEqual(default_methods, stable_methods | PREVIEW_ESM_EXTRA_EXPORTS)
+        self.assertLessEqual(stable_methods, PUBLIC_PREVIEW_API_EXPORTS)
+        self.assertEqual(named_exports, PUBLIC_PREVIEW_API_EXPORTS)
+        self.assertEqual(default_methods, PUBLIC_PREVIEW_API_EXPORTS)
         self.assertFalse(named_exports & helper_methods)
         self.assertFalse(default_methods & helper_methods)
 
@@ -187,8 +200,8 @@ class PreviewRuntimeApiDocsTests(unittest.TestCase):
         named_exports = esm_named_exports(source)
         default_methods = js_object_keys(source, "dataApi")
 
-        self.assertEqual(named_exports, DATA_ESM_EXPORTS)
-        self.assertEqual(default_methods, DATA_ESM_EXPORTS)
+        self.assertEqual(named_exports, PUBLIC_DATA_API_EXPORTS)
+        self.assertEqual(default_methods, PUBLIC_DATA_API_EXPORTS)
         for render_name in (
             "renderPreviewInto",
             "renderCanonicalPreviewInto",
@@ -449,7 +462,7 @@ class PreviewRuntimeApiDocsTests(unittest.TestCase):
 
         self.assertIn('from "./blueprint-graph-core.mjs";', graph_esm)
         self.assertIn('from "../blueprint-graph-core.mjs";', graph_runtime)
-        self.assertEqual(esm_named_exports(graph_esm), GRAPH_ESM_EXPORTS)
+        self.assertEqual(esm_named_exports(graph_esm), PUBLIC_GRAPH_API_EXPORTS)
         self.assertIn(
             'throw new Error("Blueprint graph rendering requires options.previewUtils from createPreview().");',
             graph_esm,

--- a/tests/preview_runtime_api.py
+++ b/tests/preview_runtime_api.py
@@ -1,11 +1,51 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 import re
 
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
 BLUEPRINT_SRC = PACKAGE_ROOT / "src" / "VersoBlueprint"
+PUBLIC_API_CONTRACT = json.loads(
+    (PACKAGE_ROOT / "tests" / "preview_runtime_api_contract.json").read_text(
+        encoding="utf-8"
+    )
+)
+
+
+def normalize_public_api_entry(entry: dict[str, str]) -> dict[str, str]:
+    normalized = dict(entry)
+    normalized["package_export"] = normalized.pop("packageExport")
+    normalized["jsdoc_page"] = normalized.pop("jsdocPage")
+    return normalized
+
+
+PUBLIC_API_MODULES = {
+    name: normalize_public_api_entry(entry)
+    for name, entry in PUBLIC_API_CONTRACT["modules"].items()
+}
+PUBLIC_API_TYPES_MODULE = normalize_public_api_entry(
+    PUBLIC_API_CONTRACT["typesModule"]
+)
+PUBLIC_API_PACKAGE_EXPORTS = {
+    entry["package_export"]: {
+        "source": entry["source"],
+        "declaration": entry["declaration"],
+    }
+    for entry in [*PUBLIC_API_MODULES.values(), PUBLIC_API_TYPES_MODULE]
+}
+PUBLIC_API_JSDOC_SOURCES = {
+    entry["source"]
+    for entry in [*PUBLIC_API_MODULES.values(), PUBLIC_API_TYPES_MODULE]
+}
+PUBLIC_GENERATED_API_MODULES = {
+    entry["generated"]
+    for entry in PUBLIC_API_MODULES.values()
+}
+PUBLIC_DATA_API_EXPORTS = set(PUBLIC_API_CONTRACT["exports"]["data"])
+PUBLIC_PREVIEW_API_EXPORTS = set(PUBLIC_API_CONTRACT["exports"]["preview"])
+PUBLIC_GRAPH_API_EXPORTS = set(PUBLIC_API_CONTRACT["exports"]["graph"])
 RUNTIME_BOOTSTRAP_JS = {
     Path("Commands/preview-runtime-base.mjs"),
     Path("Commands/preview-runtime-data.mjs"),

--- a/tests/preview_runtime_api_contract.json
+++ b/tests/preview_runtime_api_contract.json
@@ -1,0 +1,90 @@
+{
+  "modules": {
+    "data": {
+      "source": "src/VersoBlueprint/blueprint-data-api.mjs",
+      "declaration": "dist/types/src/VersoBlueprint/blueprint-data-api.d.mts",
+      "generated": "api/data.mjs",
+      "packageExport": "./data",
+      "jsdocPage": "module-blueprint-data-api.html"
+    },
+    "preview": {
+      "source": "src/VersoBlueprint/blueprint-preview-api.mjs",
+      "declaration": "dist/types/src/VersoBlueprint/blueprint-preview-api.d.mts",
+      "generated": "api/preview.mjs",
+      "packageExport": ".",
+      "jsdocPage": "module-blueprint-preview-api.html"
+    },
+    "graph": {
+      "source": "src/VersoBlueprint/blueprint-graph-api.mjs",
+      "declaration": "dist/types/src/VersoBlueprint/blueprint-graph-api.d.mts",
+      "generated": "api/graph.mjs",
+      "packageExport": "./graph",
+      "jsdocPage": "module-blueprint-graph-api.html"
+    }
+  },
+  "typesModule": {
+    "source": "src/VersoBlueprint/blueprint-api-types.mjs",
+    "declaration": "dist/types/src/VersoBlueprint/blueprint-api-types.d.mts",
+    "packageExport": "./types",
+    "jsdocPage": "module-blueprint-api-types.html"
+  },
+  "exports": {
+    "data": [
+      "createPreviewData",
+      "currentDataApi",
+      "dataApiModuleUrl",
+      "dataUrl",
+      "getDataApi",
+      "htmlCacheUrl",
+      "loadHtmlCache",
+      "loadHtmlCacheEntry",
+      "loadManifest",
+      "loadManifestEntry",
+      "manifestUrl",
+      "previewApiModuleUrl",
+      "previewKey",
+      "readHtmlCacheStatus",
+      "readManifestStatus",
+      "ready",
+      "statementPreviewKey",
+      "version"
+    ],
+    "preview": [
+      "createPreview",
+      "currentRenderApi",
+      "dataApiModuleUrl",
+      "dataUrl",
+      "getRenderApi",
+      "htmlCacheUrl",
+      "hydrate",
+      "loadHtmlCache",
+      "loadHtmlCacheEntry",
+      "loadManifest",
+      "loadManifestEntry",
+      "manifestUrl",
+      "previewApiModuleUrl",
+      "previewKey",
+      "readHtmlCacheStatus",
+      "readManifestStatus",
+      "ready",
+      "renderCanonicalPreviewInto",
+      "renderNode",
+      "renderPreviewInto",
+      "resolveCanonicalPreview",
+      "resolvePreview",
+      "statementPreviewKey",
+      "version"
+    ],
+    "graph": [
+      "dataUrl",
+      "getGraphData",
+      "getGraphVariants",
+      "graphApiModuleUrl",
+      "loadGraphs",
+      "loadManifestGraphs",
+      "renderGraphBlock",
+      "renderGraphs",
+      "version"
+    ]
+  }
+}


### PR DESCRIPTION
This PR hardens the JavaScript API boundary checks so package exports, generated docs, and generated declaration files share one explicit public API contract.

- Add a shared test contract for the public JavaScript data, preview, graph, and type modules.
- Make Python, JSDoc, and declaration smoke checks read that contract instead of duplicating expected API surfaces.
- Clarify that generated public browser entrypoints are limited to api/data.mjs, api/preview.mjs, and api/graph.mjs; support chunks remain private runtime implementation modules.

Backport v4.30.0: #197