### PR TITLE
doc: clarify browser rendering paths

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -27,6 +27,7 @@ first. The short version is:
 
 - [Stability Policy](#stability-policy)
 - [Choosing an API](#choosing-an-api)
+- [Rendering Path Map](#rendering-path-map)
 - [Generated Data Files](#generated-data-files)
 - [Graph Data APIs](#graph-data-apis)
 - [Lean Graft and Render APIs](#lean-graft-and-render-apis)
@@ -88,6 +89,28 @@ Two rules keep most integrations simple:
    records, dependency data, preview keys, hrefs, and display metadata.
 2. Treat `blueprint-html-cache.json` as rendered HTML: insert it and hydrate it,
    but do not parse it to recover semantic facts.
+
+## Rendering Path Map
+
+Most integrations fit one of the paths below. The main choice is whether the
+client owns a custom interface, is part of Blueprint's generated page runtime,
+or is still going through the classic Slides bridge.
+
+| Context | Entry point | What it owns | What callers should use |
+| --- | --- | --- | --- |
+| Regular generated Manual page | `-verso-data/blueprint-page-runtime.mjs` | Creates one renderer with `createPreview()`, starts inline previews, relation panels, graphs, and descriptor-bound template previews. | Nothing extra; `withBlueprintAssets` installs this module. |
+| Custom browser page, dashboard, audit view, or slide adapter | `-verso-data/api/preview.mjs` | Manifest/cache loading, preview lookup, rendered-fragment insertion, canonical node loading, math rendering, and hydration. | `createPreview()`, then `resolvePreview`, `renderPreviewInto`, `renderCanonicalPreviewInto`, `renderNode`, or `hydrate`. |
+| Data-only browser or Node-like client | `-verso-data/api/data.mjs` | Manifest/cache URL helpers, loading, status readers, and graph-data loading without DOM rendering. | `createPreviewData()`, `loadManifest`, `loadHtmlCache`, `loadGraphs`, or single-entry readers. |
+| Graph data or graph-block rendering | `-verso-data/api/graph.mjs` | Graph JSON discovery, manifest graph loading, lazy graph runtime loading, and graph block initialization. | `loadGraphs`, `getGraphData`, `getGraphVariants`, or `renderGraphs(root, { previewUtils })`. |
+| Blueprint-owned panels in generated pages | Renderer bundled helpers | Panel slots, content updates, trigger lifetime, dismissal, repositioning, diagnostics, and shared preview lookup. | Feature scripts use `createPreviewSurface`, `renderPreviewIntoSurface`, or `resolvePreviewHtml`; custom clients should not import these helpers directly. |
+| Summary and code-summary previews | Lean-emitted template descriptors plus `preview-runtime-template.mjs` | Selector configuration and binding for preview templates. | Emit descriptor attributes from Lean; no feature-specific startup script is needed. |
+| Current classic-script Slides output | `Slides/ClassicPreviewAdapter.lean` and `window.VersoBlueprint.onRenderReady` | Classic-script compatibility for the same renderer shape used elsewhere. | Treat this as an internal bridge until the Slides path moves to the generated ESM entrypoints. |
+
+The stable data boundary is the generated manifest/cache pair. The stable
+browser module boundary is `api/data.mjs`, `api/preview.mjs`, and
+`api/graph.mjs`. Files under `src/VersoBlueprint/Commands/` are implementation
+chunks for Blueprint's own runtime unless this document lists a generated
+module that re-exports a stable API.
 
 ## Generated Data Files
 
@@ -515,6 +538,10 @@ entrypoints. Other generated JavaScript files under `-verso-data/`, including
 the `blueprint-*-core.mjs`, `blueprint-api-common.mjs`, and
 `Commands/*.mjs` support chunks, are implementation modules owned by the
 generated page runtime or by those public entrypoints.
+
+The exact JavaScript signatures, typedefs, and module-level examples are
+generated from JSDoc. In CI they are published as the `js-api-docs` artifact;
+locally, run `npm run docs` and open `_out/jsdoc-api/index.html`.
 
 ## Browser Runtime API
 

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -361,6 +361,30 @@ which is deliberately narrower than the graft manifest/cache context: it only
 packages the live traversal state and stored informal blocks needed to compute
 group, uses, and used-by panel rows.
 
+### Browser Rendering Path Inventory
+
+The browser rendering paths intentionally converge on one renderer shape, but
+they do not all start the same way. Use this inventory before adding a new
+runtime hook or moving code between feature modules.
+
+| Path | Startup owner | Semantic source | Rendering and interaction owner |
+| --- | --- | --- | --- |
+| Regular generated Manual pages | `blueprint-page-runtime.mjs` imported from `extraHead` | `blueprint-manifest.json`, `blueprint-html-cache.json`, graph JSON embedded in graph blocks | One `createPreview()` renderer starts inline previews, relation panels, graph blocks, and template-preview descriptor binding. |
+| Custom ESM preview clients | `api/preview.mjs` and caller-created `createPreview()` renderer | Manifest/cache plus optional canonical generated pages | The stable preview API loads data, inserts rendered fragments or canonical nodes, runs math, and hydrates nested Blueprint widgets. |
+| Data-only clients | `api/data.mjs` and caller-created `createPreviewData()` data API | Manifest/cache and manifest graph records | No DOM rendering; callers own all UI and use the data API for URL construction, loading, status, and single-entry lookup. |
+| Graph clients | `api/graph.mjs` | Finalized graph records from the manifest or graph data embedded beside a graph block | Data helpers stay graph-only; render helpers lazy-load `Commands/graph.mjs` and require an explicit preview renderer for graph preview panels. |
+| Blueprint-owned panel features | `blueprint-page-runtime.mjs` or the Slides adapter passes a renderer into feature startup | Manifest/cache entries and feature-owned Lean-emitted attributes | Feature scripts adapt `createPreviewSurface`, `renderPreviewIntoSurface`, `resolvePreviewHtml`, and lifecycle helpers to concrete panel UIs. |
+| Summary and code-summary previews | Lean emits descriptor attributes; `preview-runtime-template.mjs` binds them at page load and after hydration | Descriptor attributes plus local templates or manifest/cache lookup keys | The shared template binder creates surfaces and triggers; no feature-specific startup module owns this path. |
+| Current classic-script Slides output | `Slides/ClassicPreviewAdapter.lean` installs the private `window.VersoBlueprint.onRenderReady` bridge | Same manifest/cache and generated node markup as other consumers | Classic-script compatibility wraps the ESM runtime chunks and should stay isolated until Slides move to an ESM entrypoint. |
+
+Two invariants keep these paths from drifting apart:
+
+1. A custom client starts from a generated public ESM module, not from
+   `Commands/*.mjs` implementation chunks or `window.VersoBlueprint`.
+2. A bundled panel feature may configure a preview surface, but it should not
+   reimplement manifest/cache loading, panel slot updates, trigger lifetime,
+   dismissal, repositioning, or preview diagnostics.
+
 ### Node Component Ownership
 
 A rendered Blueprint node is intentionally assembled from a small set of owned

--- a/doc/JS_API_DOCS.md
+++ b/doc/JS_API_DOCS.md
@@ -4,11 +4,24 @@ Verso Blueprint emits browser-facing ESM modules under `-verso-data/api/` in
 generated sites. These modules are plain JavaScript, documented with JSDoc, and
 checked with TypeScript's `allowJs` and `checkJs` workflow.
 
-Use the preview API for most custom clients:
+Start from the kind of client you are writing:
+
+| Client | Import | Main entry point |
+| --- | --- | --- |
+| Render Blueprint previews or generated nodes in the browser | `./-verso-data/api/preview.mjs` | `createPreview()` |
+| Read manifest/cache data without DOM rendering | `./-verso-data/api/data.mjs` | `createPreviewData()` |
+| Read graph data or initialize existing graph blocks | `./-verso-data/api/graph.mjs` | `loadGraphs()` or `renderGraphs()` |
+
+Use the preview API for most custom browser clients. It owns manifest/cache
+loading, rendered-fragment insertion, canonical generated-node loading, math
+rendering, and hydration:
 
 ```js
+// Import the render-capable API from the generated site.
 import { createPreview } from "./-verso-data/api/preview.mjs";
 
+// Create one renderer for this custom client and register any client widgets
+// that need to run after Blueprint content is inserted.
 const preview = createPreview({
   hydrators: {
     audit(root) {
@@ -17,6 +30,8 @@ const preview = createPreview({
   }
 });
 
+// Render by Blueprint label. Native generated content is preferred; external
+// markup fallbacks are used only when the native preview is unavailable.
 await preview.renderNode(document.querySelector("#target"), {
   label: "Chapter2:Problem2.11.6",
   externalMarkup: {
@@ -27,6 +42,42 @@ await preview.renderNode(document.querySelector("#target"), {
     ]
   }
 });
+```
+
+Use the data API when your code owns all UI and only needs structured generated
+data:
+
+```js
+// Import the data-only API when no DOM rendering is needed.
+import { createPreviewData } from "./-verso-data/api/data.mjs";
+
+// Create an isolated data loader for this client.
+const data = createPreviewData();
+
+// Load semantic manifest data and build the same preview key Blueprint uses.
+const manifest = await data.loadManifest();
+const entry = manifest.get(data.statementPreviewKey("Chapter2:Problem2.11.6"));
+
+if (entry) {
+  console.log(entry.href, entry.label, entry.facet);
+}
+```
+
+Use the graph API when you need finalized graph records, or when you already
+have graph-block markup and want the same interactive graph renderer used by
+generated Blueprint pages:
+
+```js
+// Graph rendering still needs the preview renderer for popovers and hydration.
+import { createPreview } from "./-verso-data/api/preview.mjs";
+import { loadGraphs, renderGraphs } from "./-verso-data/api/graph.mjs";
+
+// Read graph records from the manifest without rendering them.
+const graphs = await loadGraphs();
+
+// Initialize generated graph-block markup with the interactive graph runtime.
+const previewUtils = createPreview();
+await renderGraphs(document.querySelector("#graph-host"), { previewUtils, refresh: true });
 ```
 
 ## Modules
@@ -49,6 +100,24 @@ implementation chunks for generated pages, Slides, and those entrypoints.
   generated graph blocks with an explicit preview renderer.
 - [shared API types](module-blueprint-api-types.html): request, result, option,
   manifest, cache, graph, external-markup, and hydrator shapes.
+
+## Rendering Paths
+
+These generated docs describe the public JavaScript modules. They do not
+document Blueprint's private runtime chunks directly.
+
+| Path | Use | Avoid |
+| --- | --- | --- |
+| `api/preview.mjs` | Custom browser views that render previews, canonical nodes, external-markup fallbacks, or already-inserted fragments. | Reading `window.VersoBlueprint` or importing `Commands/*.mjs`. |
+| `api/data.mjs` | Audit tools, dashboards, migration checks, and Node-like clients that only need generated JSON data. | Parsing rendered HTML to rediscover labels, graph topology, status, or dependencies. |
+| `api/graph.mjs` | Graph dashboards and custom pages that render generated graph blocks. | Calling graph render helpers without an explicit `previewUtils` renderer. |
+| `blueprint-page-runtime.mjs` | Regular generated Manual pages; it starts Blueprint's bundled feature scripts for you. | Custom clients that need isolated loaders, custom fetchers, or independent render options. |
+
+The generated manifest is the semantic data contract. The HTML cache is
+rendered presentation. If a client needs labels, dependency metadata, graph
+records, generated links, or status metadata, read the manifest through
+`api/data.mjs` or `api/preview.mjs`. If it needs to display a preview, insert
+the cached fragment or canonical generated node through `api/preview.mjs`.
 
 ## Key Types
 
@@ -80,3 +149,6 @@ CI uses the generated docs in two places:
 - The Pages assembly workflows rebuild and check the same docs, then stage
   them under `_site/js-api/` so the deployed site exposes them at
   `https://leanprover.github.io/verso-blueprint/js-api/`.
+
+For the curated integration guide that also covers Lean APIs, generated data
+files, and stability policy, see `doc/API.md` in the source repository.

--- a/scripts/check-js-api-docs.mjs
+++ b/scripts/check-js-api-docs.mjs
@@ -154,12 +154,36 @@ requireIncludes(
 for (const entry of [...Object.values(publicApiContract.modules), publicApiContract.typesModule]) {
   requireIncludes("index.html", pages["index.html"], entry.jsdocPage, `${entry.jsdocPage} guide link`);
 }
+requireIncludes(
+  "index.html",
+  pages["index.html"],
+  "Start from the kind of client you are writing",
+  "client-selection guide"
+);
+requireIncludes(
+  "index.html",
+  pages["index.html"],
+  "Rendering Paths",
+  "rendering-path guide"
+);
 
 requireMatches(
   previewPage,
   pages[previewPage],
   /id="\.createPreview"[\s\S]*?&rarr; \{BlueprintPreviewApi\}/,
   "createPreview return type"
+);
+requireIncludes(
+  previewPage,
+  pages[previewPage],
+  "Common rendering choices",
+  "preview module rendering guidance"
+);
+requireIncludes(
+  previewPage,
+  pages[previewPage],
+  "await preview.renderCanonicalPreviewInto",
+  "createPreview example"
 );
 requireMatches(
   previewPage,
@@ -180,11 +204,23 @@ requireMatches(
   /id="\.createPreviewData"[\s\S]*?&rarr; \{BlueprintDataApi\}/,
   "createPreviewData return type"
 );
+requireIncludes(
+  dataPage,
+  pages[dataPage],
+  "The manifest is the semantic data source",
+  "data module manifest guidance"
+);
 requireMatches(
   graphPage,
   pages[graphPage],
   /id="\.loadGraphs"[\s\S]*?Load graph variants from this generated site's default manifest\./,
   "loadGraphs documentation"
+);
+requireIncludes(
+  graphPage,
+  pages[graphPage],
+  "explicit preview renderer from <code>api/preview.mjs</code>",
+  "graph module preview renderer guidance"
 );
 
 for (const typeName of [

--- a/src/VersoBlueprint/blueprint-data-api.mjs
+++ b/src/VersoBlueprint/blueprint-data-api.mjs
@@ -5,8 +5,18 @@ import { createBlueprintDataApi } from "./Commands/preview-runtime-data.mjs";
  * Generated-data API for custom Blueprint clients.
  *
  * This module is emitted as `-verso-data/api/data.mjs` in generated sites. It
- * exposes manifest, HTML cache, and URL helpers without installing any
- * page-global render hook.
+ * exposes manifest, HTML cache, preview-key, and URL helpers without importing
+ * DOM rendering code or installing any page-global render hook.
+ *
+ * Use this module for audits, dashboards, migration tools, or Node-like clients
+ * that own their UI and only need generated data. The manifest is the semantic
+ * contract: labels, facets, generated links, external markup metadata,
+ * dependency metadata, status metadata, and graph records. The HTML cache is
+ * rendered presentation data; do not parse it to recover semantics.
+ *
+ * Browser clients that need to insert Blueprint content should use
+ * `api/preview.mjs` instead. Graph dashboards may use this module for manifest
+ * data, but graph-specific helpers are collected in `api/graph.mjs`.
  *
  * @module blueprint-data-api
  */
@@ -26,6 +36,23 @@ const previewUrls = createPreviewUrlApi(moduleUrl);
  *
  * @param {BlueprintDataApiOptions} [options] Loader and generated-data base URL options.
  * @returns {BlueprintDataApi} Data API instance.
+ *
+ * @example
+ * // Import the data-only API when no DOM rendering is needed.
+ * import { createPreviewData } from "./-verso-data/api/data.mjs";
+ *
+ * // Create an isolated data loader for this client.
+ * const data = createPreviewData();
+ *
+ * // Build the same manifest/cache key Blueprint uses for statement previews.
+ * const key = data.statementPreviewKey("main_theorem");
+ *
+ * // Read one semantic manifest entry by key.
+ * const entry = await data.loadManifestEntry(key);
+ *
+ * if (entry) {
+ *   console.log(entry.href, entry.label, entry.facet);
+ * }
  */
 export function createPreviewData(options) {
   return createBlueprintDataApi(optionsWithDefaultDataBaseUrl(options, moduleUrl));
@@ -161,6 +188,10 @@ export function readHtmlCacheStatus() {
 /**
  * Load and decode the Blueprint manifest.
  *
+ * The manifest is the semantic data source for generated Blueprint sites. Use
+ * it for labels, generated links, external markup metadata, graph records, and
+ * other structured facts.
+ *
  * @param {BlueprintDataApiOptions} [options] Optional per-call load overrides.
  * @returns {Promise<Map<string, BlueprintManifestEntry>>}
  */
@@ -170,6 +201,10 @@ export function loadManifest(options) {
 
 /**
  * Load and decode the rendered HTML fragment cache.
+ *
+ * The cache contains rendered presentation fragments keyed like the manifest.
+ * Insert or display these fragments as HTML; do not parse them to rediscover
+ * semantic data that already lives in the manifest.
  *
  * @param {BlueprintDataApiOptions} [options] Optional per-call load overrides.
  * @returns {Promise<Map<string, BlueprintHtmlCacheEntry>>}

--- a/src/VersoBlueprint/blueprint-graph-api.mjs
+++ b/src/VersoBlueprint/blueprint-graph-api.mjs
@@ -15,6 +15,14 @@ import {
  * Data-only calls do not load the interactive graph renderer; render helpers
  * lazy-load it when called.
  *
+ * Use the data helpers when a dashboard needs finalized graph records from the
+ * manifest or graph JSON embedded beside a rendered graph block. Use
+ * {@link renderGraphs} or {@link renderGraphBlock} only when the page already
+ * contains generated graph-block markup. Rendering graph blocks requires an
+ * explicit preview renderer from `api/preview.mjs` so graph popovers and nested
+ * previews use the same manifest/cache loader and hydration path as the rest of
+ * the page.
+ *
  * @module blueprint-graph-api
  */
 
@@ -43,6 +51,10 @@ export const graphApiModuleUrl = (baseUrl = moduleUrl) => coreGraphApiModuleUrl(
 
 /**
  * Read embedded graph data from the current graph page or supplied root.
+ *
+ * This is for pages that already contain generated graph-block markup. Use
+ * {@link loadGraphs} when the current document does not contain the graph you
+ * want to inspect.
  *
  * @param {ParentNode | Element | Document | DocumentFragment} [root] Search root.
  * @returns {BlueprintGraphData | null}
@@ -79,8 +91,21 @@ export const loadManifestGraphs = (url, options) => {
 /**
  * Load graph variants from this generated site's default manifest.
  *
+ * This is the simplest graph-data entry point for dashboards and audits that
+ * need graph records but do not need to render graph blocks.
+ *
  * @param {BlueprintDataApiOptions} [options] Optional per-call load overrides.
  * @returns {Promise<BlueprintGraphData[]>}
+ *
+ * @example
+ * // Import graph data helpers when no graph rendering is needed.
+ * import { loadGraphs } from "./-verso-data/api/graph.mjs";
+ *
+ * // Load finalized graph records from the generated manifest.
+ * const graphs = await loadGraphs();
+ * for (const graph of graphs) {
+ *   console.log(graph.key, graph.nodes.length, graph.edges.length);
+ * }
  */
 export const loadGraphs = (options) =>
   coreLoadManifestGraphs(coreDataUrl("blueprint-manifest.json", moduleUrl), options);
@@ -126,9 +151,27 @@ function requirePreviewUtils(options) {
 /**
  * Render one standard `.bp_graph_fullwidth` graph block.
  *
+ * The block must be generated Blueprint graph markup. Pass `previewUtils` from
+ * `createPreview()` so node preview panels use the same renderer as the rest
+ * of the client.
+ *
  * @param {Element} graphBlock Standard graph block.
  * @param {BlueprintGraphRenderOptions} [options] Graph render options.
  * @returns {Promise<BlueprintGraphController | null>}
+ *
+ * @example
+ * // Graph rendering needs a preview renderer for popovers and hydration.
+ * import { createPreview } from "./-verso-data/api/preview.mjs";
+ * import { renderGraphBlock } from "./-verso-data/api/graph.mjs";
+ *
+ * // Create one preview renderer for graph node previews.
+ * const previewUtils = createPreview();
+ *
+ * // Initialize one generated graph block and force an immediate render.
+ * await renderGraphBlock(document.querySelector(".bp_graph_fullwidth"), {
+ *   previewUtils,
+ *   refresh: true
+ * });
  */
 export async function renderGraphBlock(graphBlock, options) {
   const runtime = await loadGraphRuntimeModule();
@@ -138,9 +181,26 @@ export async function renderGraphBlock(graphBlock, options) {
 /**
  * Render every standard graph block under a document, element, or fragment.
  *
+ * This initializes the same interactive graph UI used by generated Blueprint
+ * pages. It does not create graph markup from raw graph data; the root must
+ * already contain generated `.bp_graph_fullwidth` blocks.
+ *
  * @param {ParentNode | Element | Document | DocumentFragment} [root] Search root.
  * @param {BlueprintGraphRenderOptions} [options] Graph render options.
  * @returns {Promise<BlueprintGraphController[]>}
+ *
+ * @example
+ * // Graph rendering needs a preview renderer for popovers and hydration.
+ * import { createPreview } from "./-verso-data/api/preview.mjs";
+ * import { renderGraphs } from "./-verso-data/api/graph.mjs";
+ *
+ * // Create one preview renderer and initialize every graph under a custom root.
+ * const previewUtils = createPreview();
+ * await renderGraphs(document.querySelector("#slide"), {
+ *   previewUtils,
+ *   layout: "fill",
+ *   refresh: true
+ * });
  */
 export async function renderGraphs(root, options) {
   const runtime = await loadGraphRuntimeModule();

--- a/src/VersoBlueprint/blueprint-preview-api.mjs
+++ b/src/VersoBlueprint/blueprint-preview-api.mjs
@@ -5,8 +5,29 @@ import { createPreviewRuntimeApi } from "./Commands/preview-runtime-api.mjs";
  * Render-capable Blueprint preview API for custom browser clients.
  *
  * This module is emitted as `-verso-data/api/preview.mjs` in generated sites.
- * It composes the data API with DOM rendering, hydration, canonical-node
- * insertion, and call-scoped external-markup fallback renderers.
+ * Import it when your client needs to display Blueprint content in the DOM.
+ * It composes the data API with rendered-fragment insertion, canonical
+ * generated-node loading, math rendering, hydration, and call-scoped
+ * external-markup fallback renderers.
+ *
+ * The renderer returned by {@link createPreview} keeps its own manifest/cache
+ * load state. Use it instead of reading `window.VersoBlueprint` or importing
+ * private `Commands/*.mjs` chunks. Data-only clients should use
+ * `api/data.mjs`; graph-only or graph-rendering clients should use
+ * `api/graph.mjs` and pass an explicit preview renderer to graph render
+ * helpers.
+ *
+ * Common rendering choices:
+ *
+ * - {@link renderPreviewInto} inserts only the cached preview body fragment,
+ *   for clients that own their surrounding UI.
+ * - {@link renderCanonicalPreviewInto} inserts the standard generated
+ *   Blueprint node wrapper from the canonical generated page.
+ * - {@link renderNode} starts from a Blueprint label and can fall back to
+ *   call-scoped external Markdown, TeX, Verso, or source renderers when no
+ *   native preview exists.
+ * - {@link hydrate} runs Blueprint math and nested-preview behavior after a
+ *   client has inserted cached HTML itself.
  *
  * @module blueprint-preview-api
  */
@@ -21,8 +42,33 @@ const previewUrls = createPreviewUrlApi(moduleUrl);
 /**
  * Create an isolated render-capable preview API instance.
  *
+ * Prefer this entry point for custom browser clients. Pass `dataBaseUrl` or
+ * `fetchJson` when the generated data files are not next to this module, and
+ * pass `fetchText`, `loadDocument`, or `canonicalBaseUrl` when canonical node
+ * rendering needs custom page loading.
+ *
  * @param {BlueprintPreviewOptions} [options] Loader, hydration, and generated-data options.
  * @returns {BlueprintPreviewApi} Preview API instance.
+ *
+ * @example
+ * // Import the render-capable API from the generated site.
+ * import { createPreview } from "./-verso-data/api/preview.mjs";
+ *
+ * // Create one renderer for this custom client and register any client widgets
+ * // that need to run after Blueprint content is inserted.
+ * const preview = createPreview({
+ *   hydrators: {
+ *     audit(root) {
+ *       root.querySelectorAll("[data-audit-target]").forEach(bindAuditWidget);
+ *     }
+ *   }
+ * });
+ *
+ * // Render the same generated Blueprint node wrapper used by the site.
+ * await preview.renderCanonicalPreviewInto(
+ *   document.querySelector("#target"),
+ *   preview.statementPreviewKey("Chapter2:Problem2.11.6")
+ * );
  */
 export function createPreview(options) {
   return createPreviewRuntimeApi(optionsWithDefaultDataBaseUrl(options, moduleUrl));
@@ -200,6 +246,10 @@ export function loadHtmlCacheEntry(key, options) {
 /**
  * Resolve a preview key against the manifest and HTML cache.
  *
+ * This reads semantic data and rendered body HTML without writing to the DOM.
+ * Use the returned `manifestEntry` for labels, facets, generated links,
+ * external markup metadata, dependency metadata, and other semantic facts.
+ *
  * @param {string} key Preview key such as `label--statement`.
  * @param {BlueprintDataApiOptions} [options] Optional per-call load overrides.
  * @returns {Promise<BlueprintPreviewResult>}
@@ -211,10 +261,25 @@ export function resolvePreview(key, options) {
 /**
  * Render a cached preview fragment into a target element.
  *
+ * This writes the rendered body fragment from `blueprint-html-cache.json` into
+ * your existing wrapper. Use this when your application owns the surrounding
+ * card, panel, or component layout.
+ *
  * @param {Element} element Target element to replace with the resolved fragment.
  * @param {string} key Preview key such as `label--statement`.
  * @param {BlueprintPreviewOptions} [options] Optional render and load overrides.
  * @returns {Promise<BlueprintPreviewResult>}
+ *
+ * @example
+ * // Import the render-capable API from the generated site.
+ * import { createPreview } from "./-verso-data/api/preview.mjs";
+ *
+ * // Create a renderer and choose the target element owned by your UI.
+ * const preview = createPreview();
+ * const body = document.querySelector("#preview-body");
+ *
+ * // Insert only the cached preview body fragment into that target.
+ * await preview.renderPreviewInto(body, preview.statementPreviewKey("main_theorem"));
  */
 export function renderPreviewInto(element, key, options) {
   return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "renderPreviewInto", [element, key, options]);
@@ -222,6 +287,9 @@ export function renderPreviewInto(element, key, options) {
 
 /**
  * Resolve a preview key to its canonical generated-node shell.
+ *
+ * This loads the generated page referenced by the manifest entry and extracts
+ * the same Blueprint node wrapper that appears in the generated site.
  *
  * @param {string} key Preview key such as `label--statement`.
  * @param {BlueprintPreviewOptions} [options] Optional render and load overrides.
@@ -233,6 +301,9 @@ export function resolveCanonicalPreview(key, options) {
 
 /**
  * Render the canonical generated-node shell for a preview key into a target.
+ *
+ * Use this when the custom page should display normal Blueprint node visuals
+ * instead of a client-owned wrapper around a body fragment.
  *
  * @param {Element} element Target element to replace with the canonical node.
  * @param {string} key Preview key such as `label--statement`.
@@ -247,10 +318,34 @@ export function renderCanonicalPreviewInto(element, key, options) {
  * Render a Blueprint label, preferring the native rendered preview and falling
  * back to call-scoped external-markup renderers when needed.
  *
+ * This is the highest-level display helper. It is useful for standalone pages
+ * that know a Blueprint label but do not want to manually choose between native
+ * previews, canonical generated-node insertion, and external markup fallback
+ * rendering.
+ *
  * @param {Element} element Target element to replace with the rendered node.
  * @param {string | BlueprintRenderNodeRequest} request Label or detailed render request.
  * @param {BlueprintPreviewOptions} [options] Optional render and load overrides.
  * @returns {Promise<BlueprintRenderNodeResult>}
+ *
+ * @example
+ * // Import the render-capable API from the generated site.
+ * import { createPreview } from "./-verso-data/api/preview.mjs";
+ *
+ * // Create one renderer for this standalone view.
+ * const preview = createPreview();
+ *
+ * // Render by Blueprint label. Native generated content is preferred; external
+ * // markup fallbacks are used only when the native preview is unavailable.
+ * await preview.renderNode(document.querySelector("#target"), {
+ *   label: "external_markdown_statement",
+ *   externalMarkup: {
+ *     prefer: [
+ *       { language: "markdown", slot: "original", render: renderMarkdown },
+ *       { display: "source" }
+ *     ]
+ *   }
+ * });
  */
 export function renderNode(element, request, options) {
   return callDefaultApi(defaultRenderHandle.readDefaultApi, "render", "renderNode", [element, request, options]);
@@ -258,6 +353,10 @@ export function renderNode(element, request, options) {
 
 /**
  * Hydrate Blueprint-specific behavior inside an already-rendered subtree.
+ *
+ * Call this after inserting Blueprint-rendered HTML yourself. It runs math,
+ * descriptor-bound previews, registered Blueprint feature hydrators, and
+ * caller-supplied hydrators according to the render options.
  *
  * @param {Element} element Root element to hydrate.
  * @param {BlueprintPreviewOptions} [options] Hydration options.

--- a/tests/harness/test_preview_runtime_api_docs.py
+++ b/tests/harness/test_preview_runtime_api_docs.py
@@ -141,6 +141,11 @@ class PreviewRuntimeApiDocsTests(unittest.TestCase):
         self.assertIn("Only the files listed in this table are public", api_doc)
         for entry in PUBLIC_API_MODULES.values():
             self.assertIn(entry["jsdoc_page"], js_api_docs)
+        self.assertIn("Start from the kind of client you are writing", js_api_docs)
+        self.assertIn("## Rendering Paths", js_api_docs)
+        self.assertIn("api/preview.mjs", js_api_docs)
+        self.assertIn("api/data.mjs", js_api_docs)
+        self.assertIn("api/graph.mjs", js_api_docs)
 
     def test_api_stable_api_table_matches_runtime_source(self) -> None:
         runtime = blueprint_js_source()


### PR DESCRIPTION
This PR clarifies the browser rendering paths in both the curated API guide and the generated JavaScript API docs. It adds reader-facing path maps, expands the JSDoc landing page, improves the public `api/data.mjs`, `api/preview.mjs`, and `api/graph.mjs` module documentation with usage guidance and examples, and strengthens the docs smoke checks for that generated content.

Backport v4.30.0: #202