### PR TITLE
[backport v4.30.0] feat: deploy JavaScript API docs to Pages

### DIFF
--- a/.github/workflows/reference-blueprints-deploy.yml
+++ b/.github/workflows/reference-blueprints-deploy.yml
@@ -208,6 +208,17 @@ jobs:
           echo "manifest_path=${{ needs.resolve-deploy-releases.outputs.manifest_path }}"
           echo "deployable_release_count=${{ needs.resolve-deploy-releases.outputs.deployable_release_count }}"
           echo "deployable_project_count=${{ needs.resolve-deploy-releases.outputs.deployable_project_count }}"
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: npm
+      - name: Install JavaScript dependencies
+        run: npm ci
+      - name: Generate JavaScript API docs
+        run: npm run docs
+      - name: Check JavaScript API docs
+        run: npm run check:docs
       - name: Download release reference artifacts
         uses: actions/download-artifact@v7
         with:
@@ -221,7 +232,7 @@ jobs:
           name: test-blueprints
           path: _out/test-blueprints
       - name: Prepare combined Pages artifact
-        run: python3 ./scripts/prepare_reference_blueprints_pages.py
+        run: python3 ./scripts/prepare_reference_blueprints_pages.py --js-api-docs-root _out/jsdoc-api
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
         with:

--- a/.github/workflows/reference-blueprints.yml
+++ b/.github/workflows/reference-blueprints.yml
@@ -161,6 +161,17 @@ jobs:
         run: |
           echo "release_id=${{ needs.resolve-reference-release.outputs.release_id }}"
           echo "deploy_pages=${{ needs.resolve-reference-release.outputs.deploy_pages }}"
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: npm
+      - name: Install JavaScript dependencies
+        run: npm ci
+      - name: Generate JavaScript API docs
+        run: npm run docs
+      - name: Check JavaScript API docs
+        run: npm run check:docs
       - name: Download reference blueprint artifacts
         uses: actions/download-artifact@v7
         with:
@@ -173,7 +184,7 @@ jobs:
           name: test-blueprints
           path: _out/test-blueprints
       - name: Prepare site artifact
-        run: python3 ./scripts/prepare_reference_blueprints_pages.py
+        run: python3 ./scripts/prepare_reference_blueprints_pages.py --js-api-docs-root _out/jsdoc-api
       - name: Upload site artifact
         uses: actions/upload-artifact@v7
         with:

--- a/README.md
+++ b/README.md
@@ -302,20 +302,22 @@ Read these in order:
    project and file layout
 2. [doc/GETTING_STARTED.md](./doc/GETTING_STARTED.md): first Blueprint walkthrough
 3. [doc/MANUAL.md](./doc/MANUAL.md): authoring and rendering reference
-4. [doc/API.md](./doc/API.md): stable Lean, generated-data, and browser APIs
+4. [JavaScript API reference](https://leanprover.github.io/verso-blueprint/js-api/):
+   browser-facing data, preview, graph, and shared type APIs
+5. [doc/API.md](./doc/API.md): stable Lean, generated-data, and browser APIs
 
 ### Developer Documentation
 
-5. [doc/CONTRIBUTING.md](./doc/CONTRIBUTING.md): contribution conventions for
+6. [doc/CONTRIBUTING.md](./doc/CONTRIBUTING.md): contribution conventions for
    this repository
-6. [doc/MAINTAINER_GUIDE.md](./doc/MAINTAINER_GUIDE.md): repository-local
+7. [doc/MAINTAINER_GUIDE.md](./doc/MAINTAINER_GUIDE.md): repository-local
    generation, validation, CI publication, and worktree workflow
-7. [scripts/README.md](./scripts/README.md): lightweight guide to the
+8. [scripts/README.md](./scripts/README.md): lightweight guide to the
    repository scripts and harness entry points
-8. [doc/DESIGN_RATIONALE.md](./doc/DESIGN_RATIONALE.md): architecture and design
+9. [doc/DESIGN_RATIONALE.md](./doc/DESIGN_RATIONALE.md): architecture and design
    boundaries
-9. [doc/ROADMAP.md](./doc/ROADMAP.md): active cleanup and follow-up work
-10. [doc/UPSTREAM_BACKLOG.md](./doc/UPSTREAM_BACKLOG.md): items intended to move
+10. [doc/ROADMAP.md](./doc/ROADMAP.md): active cleanup and follow-up work
+11. [doc/UPSTREAM_BACKLOG.md](./doc/UPSTREAM_BACKLOG.md): items intended to move
    back into `verso`, Lake, or Lean
 
 ### Agent Helper Skill

--- a/doc/JS_API_DOCS.md
+++ b/doc/JS_API_DOCS.md
@@ -71,5 +71,12 @@ The declarations produced by `npm run build:types` are build artifacts under
 that the generated public declarations keep named API types instead of
 collapsing to broad `any` shapes. The HTML docs produced by `npm run docs` are
 written to `_out/jsdoc-api`; `npm run check:docs` validates the generated
-module pages, local links, and Blueprint typedef anchors before CI uploads that
-directory as the `js-api-docs` artifact.
+module pages, local links, and Blueprint typedef anchors.
+
+CI uses the generated docs in two places:
+
+- `ci.yml` uploads `_out/jsdoc-api` as the `js-api-docs` artifact for direct
+  inspection from pull requests and branch runs.
+- The Pages assembly workflows rebuild and check the same docs, then stage
+  them under `_site/js-api/` so the deployed site exposes them at
+  `https://leanprover.github.io/verso-blueprint/js-api/`.

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -673,6 +673,8 @@ pushes to release branches named like `v4.30.0`, and manual dispatch, it:
   `publish_reference: true`
 - builds the local `test-blueprints/` artifact set, including
   `preview_runtime_showcase`
+- builds and checks the generated JavaScript API documentation when assembling
+  a deployable site artifact
 - stages a branch-local site artifact under `_site/` only when the selected
   release target has `deploy_pages: true`
 - uploads that assembled site as a normal workflow artifact
@@ -707,6 +709,7 @@ The branch-local site artifact produced by `reference-blueprints.yml` for one
 release includes:
 
 - `_site/index.html`
+- `_site/js-api/`
 - `_site/reference-blueprints/<project-id>/` for each deployable reference
   target selected on that branch
 - `_site/test-blueprints/index.html`
@@ -717,6 +720,7 @@ The combined Pages artifact produced by `reference-blueprints-deploy.yml`
 includes:
 
 - `_site/index.html`
+- `_site/js-api/`
 - `_site/reference-blueprints/<release-id>/<project-id>/` for each selected
   reference target across all deployable release slices
 - `_site/test-blueprints/index.html`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -129,7 +129,8 @@ script map, not a second command reference.
   Local worktree-coordination helpers for ignored metadata under `.worktrees/`.
 - `prepare_reference_blueprints_pages.py`
   Helper used by the Pages publication flow to stage a combined site artifact
-  from generated reference and test blueprint output.
+  from generated reference blueprints, test blueprints, and optional generated
+  JavaScript API docs.
 - `__init__.py`
   Package marker for `python3 -m scripts ...` entry points.
 

--- a/scripts/prepare_reference_blueprints_pages.py
+++ b/scripts/prepare_reference_blueprints_pages.py
@@ -26,6 +26,11 @@ def parse_args() -> argparse.Namespace:
         default="_site",
         help="Directory to populate with the Pages artifact.",
     )
+    parser.add_argument(
+        "--js-api-docs-root",
+        default=None,
+        help="Optional generated JSDoc directory to publish under js-api/.",
+    )
     return parser.parse_args()
 
 
@@ -175,6 +180,16 @@ def copy_reference_sites(reference_root: Path, publish_reference_root: Path) -> 
     return release_projects
 
 
+def copy_js_api_docs(js_api_docs_root: Path, publish_js_api_root: Path) -> None:
+    if not js_api_docs_root.exists():
+        raise SystemExit(f"missing JavaScript API docs root: {js_api_docs_root}")
+    if not js_api_docs_root.is_dir():
+        raise SystemExit(f"JavaScript API docs root is not a directory: {js_api_docs_root}")
+    if not (js_api_docs_root / "index.html").exists():
+        raise SystemExit(f"JavaScript API docs root is missing index.html: {js_api_docs_root}")
+    shutil.copytree(js_api_docs_root, publish_js_api_root)
+
+
 def main() -> int:
     args = parse_args()
     reference_root = Path(args.reference_root).resolve()
@@ -196,6 +211,10 @@ def main() -> int:
     release_projects = copy_reference_sites(reference_root, publish_reference_root)
     write_reference_index(publish_reference_root, release_projects)
     write_unique_project_aliases(publish_reference_root, release_projects)
+
+    publish_js_api_docs = args.js_api_docs_root is not None
+    if publish_js_api_docs:
+        copy_js_api_docs(Path(args.js_api_docs_root).resolve(), output_root / "js-api")
 
     test_blueprints: list[str] = []
     for test_dir in sorted(path for path in test_root.iterdir() if path.is_dir()):
@@ -236,6 +255,14 @@ def main() -> int:
                         ],
                         "</ul>",
                     ]
+                ),
+                *(
+                    [
+                        "<h2>JavaScript API</h2>",
+                        "<p><a href=\"js-api/\">Open JavaScript API documentation</a></p>",
+                    ]
+                    if publish_js_api_docs
+                    else []
                 ),
                 "<h2>Test Blueprints</h2>",
                 "<p><a href=\"test-blueprints/\">Open categorized test blueprint index</a></p>",

--- a/tests/harness/test_prepare_reference_blueprints_pages.py
+++ b/tests/harness/test_prepare_reference_blueprints_pages.py
@@ -13,18 +13,28 @@ PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 
 
 class PrepareReferenceBlueprintPagesTests(unittest.TestCase):
-    def run_helper(self, reference_root: Path, test_root: Path, output_root: Path) -> subprocess.CompletedProcess[str]:
+    def run_helper(
+        self,
+        reference_root: Path,
+        test_root: Path,
+        output_root: Path,
+        *,
+        js_api_docs_root: Path | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        command = [
+            sys.executable,
+            "scripts/prepare_reference_blueprints_pages.py",
+            "--reference-root",
+            str(reference_root),
+            "--test-root",
+            str(test_root),
+            "--output-root",
+            str(output_root),
+        ]
+        if js_api_docs_root is not None:
+            command.extend(["--js-api-docs-root", str(js_api_docs_root)])
         return subprocess.run(
-            [
-                sys.executable,
-                "scripts/prepare_reference_blueprints_pages.py",
-                "--reference-root",
-                str(reference_root),
-                "--test-root",
-                str(test_root),
-                "--output-root",
-                str(output_root),
-            ],
+            command,
             cwd=PACKAGE_ROOT,
             text=True,
             capture_output=True,
@@ -90,6 +100,52 @@ class PrepareReferenceBlueprintPagesTests(unittest.TestCase):
             self.assertIn('href="project-template/"', reference_index)
             self.assertIn('href="noperthedron/"', reference_index)
             self.assertNotIn("reference-blueprints/project-template/", reference_index)
+            self.assertNotIn("js-api/", landing_index)
+
+    def test_prepare_pages_stages_javascript_api_docs_when_requested(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            reference_root = tmp_path / "reference-blueprints"
+            test_root = tmp_path / "test-blueprints"
+            js_api_docs_root = tmp_path / "jsdoc-api"
+            output_root = tmp_path / "_site"
+
+            (reference_root / "project-template" / "html-multi").mkdir(parents=True)
+            (reference_root / "project-template" / "html-multi" / "index.html").write_text(
+                "reference project template",
+                encoding="utf-8",
+            )
+            (test_root / "preview_runtime_showcase" / "html-multi").mkdir(parents=True)
+            (test_root / "preview_runtime_showcase" / "html-multi" / "index.html").write_text(
+                "test showcase",
+                encoding="utf-8",
+            )
+            js_api_docs_root.mkdir()
+            (js_api_docs_root / "index.html").write_text("js api docs", encoding="utf-8")
+            (js_api_docs_root / "module-blueprint-preview-api.html").write_text(
+                "preview api",
+                encoding="utf-8",
+            )
+
+            result = self.run_helper(
+                reference_root,
+                test_root,
+                output_root,
+                js_api_docs_root=js_api_docs_root,
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+            self.assertEqual(
+                (output_root / "js-api" / "index.html").read_text(encoding="utf-8"),
+                "js api docs",
+            )
+            self.assertEqual(
+                (output_root / "js-api" / "module-blueprint-preview-api.html").read_text(encoding="utf-8"),
+                "preview api",
+            )
+            landing_index = (output_root / "index.html").read_text(encoding="utf-8")
+            self.assertIn("JavaScript API", landing_index)
+            self.assertIn('href="js-api/"', landing_index)
 
     def test_prepare_pages_stages_release_namespaced_reference_blueprints(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
Backport #200 to `v4.30.0`.

## Primary Review
- Primary review: #200
- Keep review comments on #200 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.30.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- README conflict resolution keeps the existing v4.30 API documentation wording while adding the JavaScript API docs link.