### PR TITLE
doc: clarify JavaScript API docs publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,10 +109,10 @@ jobs:
         run: npm run build:types
       - name: Check JavaScript API declarations
         run: npm run check:types
-      - name: Generate JavaScript API docs
-        run: npm run docs
-      - name: Check JavaScript API docs
-        run: npm run check:docs
+      # CI validates the generated API docs and uploads them as a review artifact.
+      # The Pages deployment workflow rebuilds its own published copy.
+      - name: Generate and check JavaScript API docs
+        run: ./scripts/generate-js-api-docs.sh
       - name: Upload JavaScript API docs artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/reference-blueprints-deploy.yml
+++ b/.github/workflows/reference-blueprints-deploy.yml
@@ -208,6 +208,8 @@ jobs:
           echo "manifest_path=${{ needs.resolve-deploy-releases.outputs.manifest_path }}"
           echo "deployable_release_count=${{ needs.resolve-deploy-releases.outputs.deployable_release_count }}"
           echo "deployable_project_count=${{ needs.resolve-deploy-releases.outputs.deployable_project_count }}"
+      # The deploy workflow runs on an isolated runner and assembles the public
+      # Pages artifact, so it rebuilds the published /js-api/ docs itself.
       - name: Set up Node
         uses: actions/setup-node@v5
         with:
@@ -215,10 +217,8 @@ jobs:
           cache: npm
       - name: Install JavaScript dependencies
         run: npm ci
-      - name: Generate JavaScript API docs
-        run: npm run docs
-      - name: Check JavaScript API docs
-        run: npm run check:docs
+      - name: Generate and check JavaScript API docs
+        run: ./scripts/generate-js-api-docs.sh
       - name: Download release reference artifacts
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/reference-blueprints.yml
+++ b/.github/workflows/reference-blueprints.yml
@@ -161,17 +161,6 @@ jobs:
         run: |
           echo "release_id=${{ needs.resolve-reference-release.outputs.release_id }}"
           echo "deploy_pages=${{ needs.resolve-reference-release.outputs.deploy_pages }}"
-      - name: Set up Node
-        uses: actions/setup-node@v5
-        with:
-          node-version: "22"
-          cache: npm
-      - name: Install JavaScript dependencies
-        run: npm ci
-      - name: Generate JavaScript API docs
-        run: npm run docs
-      - name: Check JavaScript API docs
-        run: npm run check:docs
       - name: Download reference blueprint artifacts
         uses: actions/download-artifact@v7
         with:
@@ -184,7 +173,7 @@ jobs:
           name: test-blueprints
           path: _out/test-blueprints
       - name: Prepare site artifact
-        run: python3 ./scripts/prepare_reference_blueprints_pages.py --js-api-docs-root _out/jsdoc-api
+        run: python3 ./scripts/prepare_reference_blueprints_pages.py
       - name: Upload site artifact
         uses: actions/upload-artifact@v7
         with:

--- a/README.md
+++ b/README.md
@@ -226,6 +226,11 @@ Useful maintainer commands:
 - `npm run docs`
 - `npm run check:docs`
 
+The rendered API reference is deployed on GitHub Pages at
+[leanprover.github.io/verso-blueprint/js-api/](https://leanprover.github.io/verso-blueprint/js-api/).
+CI also uploads the same generated HTML as the `js-api-docs` artifact on each
+`ci.yml` run for PR-local inspection.
+
 Custom clients can import the generated preview module directly from a rendered
 site:
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -8,6 +8,12 @@ For authoring syntax and rendering behavior, see
 [`MANUAL.md`](./MANUAL.md). For the architecture boundaries behind these APIs,
 see [`DESIGN_RATIONALE.md`](./DESIGN_RATIONALE.md).
 
+For exact JavaScript signatures, typedefs, return shapes, and module-level
+examples, use the
+[generated JavaScript API reference](https://leanprover.github.io/verso-blueprint/js-api/).
+This source document is the curated integration guide: it explains which API
+surface to choose and where the stability boundaries are.
+
 If you are not sure where to start, read [Choosing an API](#choosing-an-api)
 first. The short version is:
 
@@ -22,6 +28,8 @@ first. The short version is:
   fragments
 - use the Lean graft/render APIs when a generator wants to place Blueprint nodes
   into a custom page
+- use the generated JavaScript API reference, not this guide, for exhaustive
+  browser export documentation
 
 ## Contents
 
@@ -402,6 +410,11 @@ Generated sites emit importable modules under `-verso-data/api/`:
 - `preview.mjs`
 - `graph.mjs`
 
+This section is a navigation guide for choosing the right generated module. It
+is intentionally not the exhaustive JavaScript reference. Use the
+[generated JavaScript API reference](https://leanprover.github.io/verso-blueprint/js-api/)
+for complete export lists, signatures, typedefs, result shapes, and examples.
+
 The relative path depends on the generated page location. Root generated pages
 can import from `-verso-data/api/...`; nested generated pages commonly import
 from `../-verso-data/api/...`. Generated clients that need to resolve the
@@ -525,13 +538,13 @@ if (target) {
 }
 ```
 
-The generated ESM modules expose these entrypoint groups:
+At a high level, the public generated browser modules are:
 
-| Module | Exports |
+| Module | Purpose |
 | --- | --- |
-| `api/data.mjs` | URL helpers: `dataUrl`, `manifestUrl`, `htmlCacheUrl`, `dataApiModuleUrl`, `previewApiModuleUrl`; data API creation/default access: `createPreviewData`, `currentDataApi`, `getDataApi`, `ready`; manifest/cache helpers: `loadManifest`, `readManifestStatus`, `loadManifestEntry`, `loadHtmlCache`, `readHtmlCacheStatus`, `loadHtmlCacheEntry`; preview-key helpers: `previewKey`, `statementPreviewKey`. |
-| `api/preview.mjs` | URL helpers: `dataUrl`, `manifestUrl`, `htmlCacheUrl`, `dataApiModuleUrl`, `previewApiModuleUrl`; renderer creation/default access: `createPreview`, `currentRenderApi`, `getRenderApi`, `ready`; manifest/cache helpers: `loadManifest`, `readManifestStatus`, `loadManifestEntry`, `loadHtmlCache`, `readHtmlCacheStatus`, `loadHtmlCacheEntry`; preview/render helpers: `previewKey`, `statementPreviewKey`, `resolvePreview`, `renderPreviewInto`, `resolveCanonicalPreview`, `renderCanonicalPreviewInto`, `renderNode`, `hydrate`. |
-| `api/graph.mjs` | URL helpers: `dataUrl`, `graphApiModuleUrl`; graph-data helpers: `getGraphData`, `getGraphVariants`, `loadManifestGraphs`, `loadGraphs`; graph rendering helpers: `renderGraphBlock`, `renderGraphs`. |
+| `api/data.mjs` | Data-only clients: generated-data URLs, manifest/cache loading, status readers, and preview-key helpers. |
+| `api/preview.mjs` | Render-capable clients: data helpers plus preview resolution, fragment insertion, canonical node rendering, label-based `renderNode`, and hydration. |
+| `api/graph.mjs` | Graph clients: finalized graph loading, embedded graph-block data access, and graph-block rendering with an explicit preview renderer. |
 
 Only the files listed in this table are public generated-site browser API
 entrypoints. Other generated JavaScript files under `-verso-data/`, including
@@ -540,8 +553,11 @@ the `blueprint-*-core.mjs`, `blueprint-api-common.mjs`, and
 generated page runtime or by those public entrypoints.
 
 The exact JavaScript signatures, typedefs, and module-level examples are
-generated from JSDoc. In CI they are published as the `js-api-docs` artifact;
-locally, run `npm run docs` and open `_out/jsdoc-api/index.html`.
+generated from JSDoc and published on GitHub Pages at
+[leanprover.github.io/verso-blueprint/js-api/](https://leanprover.github.io/verso-blueprint/js-api/).
+CI also uploads the same generated HTML as an artifact named `js-api-docs` for
+PR-local inspection.
+Locally, run `npm run docs` and open `_out/jsdoc-api/index.html`.
 
 ## Browser Runtime API
 
@@ -766,7 +782,10 @@ renderer from a generated Manual page.
 
 External clients should start from the stable API below. These entry points are
 the contract for audit interfaces, dashboards, slide adapters, comparison
-views, and browser-only examples.
+views, and browser-only examples. This table is a compact stability index used
+by the docs tests to keep the public method set aligned with the runtime source;
+the generated JavaScript API reference remains the detailed signature and type
+reference.
 
 | Entry point | Use |
 | --- | --- |

--- a/doc/JS_API_DOCS.md
+++ b/doc/JS_API_DOCS.md
@@ -144,11 +144,12 @@ module pages, local links, and Blueprint typedef anchors.
 
 CI uses the generated docs in two places:
 
+- The Pages deployment workflow rebuilds and checks the same docs, then stages
+  them under `_site/js-api/` so the public deployment exposes them at
+  [leanprover.github.io/verso-blueprint/js-api/](https://leanprover.github.io/verso-blueprint/js-api/).
 - `ci.yml` uploads `_out/jsdoc-api` as the `js-api-docs` artifact for direct
-  inspection from pull requests and branch runs.
-- The Pages assembly workflows rebuild and check the same docs, then stage
-  them under `_site/js-api/` so the deployed site exposes them at
-  `https://leanprover.github.io/verso-blueprint/js-api/`.
+  inspection from pull requests and branch runs. Those artifact URLs are
+  run-specific, so use the Pages deployment as the stable documentation link.
 
 For the curated integration guide that also covers Lean APIs, generated data
 files, and stability policy, see `doc/API.md` in the source repository.

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -676,8 +676,6 @@ pushes to release branches named like `v4.30.0`, and manual dispatch, it:
   `publish_reference: true`
 - builds the local `test-blueprints/` artifact set, including
   `preview_runtime_showcase`
-- builds and checks the generated JavaScript API documentation when assembling
-  a deployable site artifact
 - stages a branch-local site artifact under `_site/` only when the selected
   release target has `deploy_pages: true`
 - uploads that assembled site as a normal workflow artifact
@@ -712,12 +710,15 @@ The branch-local site artifact produced by `reference-blueprints.yml` for one
 release includes:
 
 - `_site/index.html`
-- `_site/js-api/`
 - `_site/reference-blueprints/<project-id>/` for each deployable reference
   target selected on that branch
 - `_site/test-blueprints/index.html`
 - `_site/test-blueprints/preview_runtime_showcase/`
 - `_site/test-blueprints/<slug>/`
+
+It intentionally does not include `_site/js-api/`; CI validates and uploads the
+generated JavaScript API docs as a review artifact, while the deploy workflow
+rebuilds the published copy for Pages.
 
 The combined Pages artifact produced by `reference-blueprints-deploy.yml`
 includes:
@@ -729,6 +730,12 @@ includes:
 - `_site/test-blueprints/index.html`
 - `_site/test-blueprints/preview_runtime_showcase/`
 - `_site/test-blueprints/<slug>/`
+
+GitHub Pages deployments run through the `github-pages` environment. When the
+default-development branch advances to a new release line, update that
+environment's deployment branch policy to allow the new default branch before
+expecting Pages to publish. If the generated site artifact is correct but the
+`Deploy Pages` job fails immediately without step logs, check this policy first.
 
 The shared staging helper understands both input shapes:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -81,6 +81,9 @@ script map, not a second command reference.
   Thin wrapper for patch-review artifact generation: always rebuilds the full
   reference blueprint catalog and then generates all or selected local test
   blueprints.
+- `generate-js-api-docs.sh`
+  Generate the Docdash JavaScript API reference and run the generated-docs
+  smoke check used by CI and Pages assembly.
 - `generate-test-blueprints.sh`
   Thin wrapper for the local test-blueprint generator.
 - `validate-test-blueprints.sh`

--- a/scripts/generate-js-api-docs.sh
+++ b/scripts/generate-js-api-docs.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+npm run docs
+npm run check:docs

--- a/scripts/prepare_reference_blueprints_pages.py
+++ b/scripts/prepare_reference_blueprints_pages.py
@@ -9,7 +9,10 @@ import shutil
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Prepare a GitHub Pages site for the generated reference and test blueprints."
+        description=(
+            "Prepare a GitHub Pages site for generated reference blueprints, "
+            "test blueprints, and optional JavaScript API docs."
+        )
     )
     parser.add_argument(
         "--reference-root",
@@ -237,7 +240,12 @@ def main() -> int:
                 "<title>Verso Blueprint Rendered Artifacts</title>",
                 "<body>",
                 "<h1>Verso Blueprint Rendered Artifacts</h1>",
-                "<p>Generated reference and test sites assembled from the current workflow run.</p>",
+                (
+                    "<p>Generated reference sites, test sites, and JavaScript API docs "
+                    "assembled from the current workflow run.</p>"
+                    if publish_js_api_docs
+                    else "<p>Generated reference and test sites assembled from the current workflow run.</p>"
+                ),
                 "<h2>Reference Blueprints</h2>",
                 "<p><a href=\"reference-blueprints/\">Open reference blueprint index</a></p>",
                 *(

--- a/tests/harness/test_prepare_reference_blueprints_pages.py
+++ b/tests/harness/test_prepare_reference_blueprints_pages.py
@@ -13,6 +13,22 @@ PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 
 
 class PrepareReferenceBlueprintPagesTests(unittest.TestCase):
+    def write_minimal_inputs(self, root: Path) -> tuple[Path, Path]:
+        reference_root = root / "reference-blueprints"
+        test_root = root / "test-blueprints"
+
+        (reference_root / "project-template" / "html-multi").mkdir(parents=True)
+        (reference_root / "project-template" / "html-multi" / "index.html").write_text(
+            "reference project template",
+            encoding="utf-8",
+        )
+        (test_root / "preview_runtime_showcase" / "html-multi").mkdir(parents=True)
+        (test_root / "preview_runtime_showcase" / "html-multi" / "index.html").write_text(
+            "test showcase",
+            encoding="utf-8",
+        )
+        return reference_root, test_root
+
     def run_helper(
         self,
         reference_root: Path,
@@ -105,21 +121,10 @@ class PrepareReferenceBlueprintPagesTests(unittest.TestCase):
     def test_prepare_pages_stages_javascript_api_docs_when_requested(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
-            reference_root = tmp_path / "reference-blueprints"
-            test_root = tmp_path / "test-blueprints"
             js_api_docs_root = tmp_path / "jsdoc-api"
             output_root = tmp_path / "_site"
 
-            (reference_root / "project-template" / "html-multi").mkdir(parents=True)
-            (reference_root / "project-template" / "html-multi" / "index.html").write_text(
-                "reference project template",
-                encoding="utf-8",
-            )
-            (test_root / "preview_runtime_showcase" / "html-multi").mkdir(parents=True)
-            (test_root / "preview_runtime_showcase" / "html-multi" / "index.html").write_text(
-                "test showcase",
-                encoding="utf-8",
-            )
+            reference_root, test_root = self.write_minimal_inputs(tmp_path)
             js_api_docs_root.mkdir()
             (js_api_docs_root / "index.html").write_text("js api docs", encoding="utf-8")
             (js_api_docs_root / "module-blueprint-preview-api.html").write_text(
@@ -146,6 +151,39 @@ class PrepareReferenceBlueprintPagesTests(unittest.TestCase):
             landing_index = (output_root / "index.html").read_text(encoding="utf-8")
             self.assertIn("JavaScript API", landing_index)
             self.assertIn('href="js-api/"', landing_index)
+            self.assertIn("JavaScript API docs assembled", landing_index)
+
+    def test_prepare_pages_rejects_missing_javascript_api_docs_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            reference_root, test_root = self.write_minimal_inputs(tmp_path)
+            output_root = tmp_path / "_site"
+
+            result = self.run_helper(
+                reference_root,
+                test_root,
+                output_root,
+                js_api_docs_root=tmp_path / "missing-jsdoc-api",
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("missing JavaScript API docs root", result.stderr)
+
+    def test_prepare_pages_rejects_javascript_api_docs_without_index(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            reference_root, test_root = self.write_minimal_inputs(tmp_path)
+            js_api_docs_root = tmp_path / "jsdoc-api"
+            output_root = tmp_path / "_site"
+            js_api_docs_root.mkdir()
+
+            result = self.run_helper(
+                reference_root,
+                test_root,
+                output_root,
+                js_api_docs_root=js_api_docs_root,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("JavaScript API docs root is missing index.html", result.stderr)
 
     def test_prepare_pages_stages_release_namespaced_reference_blueprints(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
This PR clarifies the JavaScript API docs publication path: it centralizes docs generation/checking in one helper, documents the stable Pages URL, stages js-api docs in the Pages helper with tests, and records the Pages deployment branch-policy requirement.

Backport v4.30.0: #204