### PR TITLE
Update reference blueprint catalog

### DIFF
--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -32,7 +32,7 @@
       "targets": [
         {
           "release": "v4.31.0",
-          "ref": "3b1f86c48b9e37de9f06909733dbb7b35ae2afbb",
+          "ref": "2f2355f7a88c2bc3b74a1dd790df4da018cf6339",
           "publish_reference": true
         }
       ],
@@ -51,7 +51,7 @@
       "targets": [
         {
           "release": "v4.30.0",
-          "ref": "ac8317da7ab793cfe8025b06a3faa69c0ab07e85",
+          "ref": "406882e214dfd36614e8681c0406394857fd0af5",
           "publish_reference": true
         }
       ],
@@ -70,7 +70,7 @@
       "targets": [
         {
           "release": "v4.31.0",
-          "ref": "9b337d6b35044b8226afd3f23ea36872e95cbcee",
+          "ref": "04ed7e578ab59571e7821f4b21c2e77c4071c18a",
           "publish_reference": true
         }
       ],
@@ -89,7 +89,7 @@
       "targets": [
         {
           "release": "v4.30.0",
-          "ref": "63212580856eca0dc15697af28abf54575daa3e3",
+          "ref": "fc70036bd3333b3ec8595d067c9b3f960938b78a",
           "rc": "4.30-rc2",
           "publish_reference": true
         }

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -32,7 +32,7 @@
       "targets": [
         {
           "release": "v4.31.0",
-          "ref": "023ba906e2977186e863472393e4251b2477bfd6",
+          "ref": "3b1f86c48b9e37de9f06909733dbb7b35ae2afbb",
           "publish_reference": true
         }
       ],
@@ -51,7 +51,7 @@
       "targets": [
         {
           "release": "v4.30.0",
-          "ref": "516bab06c7f65aa60e265e56edc42acf75b51cf9",
+          "ref": "ac8317da7ab793cfe8025b06a3faa69c0ab07e85",
           "publish_reference": true
         }
       ],
@@ -70,7 +70,7 @@
       "targets": [
         {
           "release": "v4.31.0",
-          "ref": "d0a3dea89451218916bfd4a29e07ea5c557f6d0b",
+          "ref": "9b337d6b35044b8226afd3f23ea36872e95cbcee",
           "publish_reference": true
         }
       ],
@@ -89,7 +89,7 @@
       "targets": [
         {
           "release": "v4.30.0",
-          "ref": "73c4bac9073120109e2338e545c945d0fb87323e",
+          "ref": "63212580856eca0dc15697af28abf54575daa3e3",
           "rc": "4.30-rc2",
           "publish_reference": true
         }


### PR DESCRIPTION
Updates the reference blueprint catalog to the wrapper refs published during the maintenance pass:

- `verso-carleson`: `fc70036bd3333b3ec8595d067c9b3f960938b78a`
- `verso-flt`: `04ed7e578ab59571e7821f4b21c2e77c4071c18a`
- `verso-noperthedron`: `2f2355f7a88c2bc3b74a1dd790df4da018cf6339`
- `spherepackingblueprint`: `406882e214dfd36614e8681c0406394857fd0af5`

This refresh picks up the current VBP reference-build path, where reference generation is catalog-driven through commands such as `lake lean FooMain.lean -- --run FooMain.lean --output ...` instead of the older `lean env ...` style.

Validation run locally:

- `python3 -m unittest tests.harness.test_blueprint_harness_projects tests.harness.test_prepare_reference_blueprints_pages`
- build-backed `compute-repair-work --build` completed for the four wrappers before publishing their refs

Backport v4.30.0: exempt: catalog-only reference updates for reference blueprint refs.