### PR TITLE
[backport v4.30.0] refactor: reuse block render string dedup helper

### DIFF
--- a/src/VersoBlueprint/Informal/Block/Render.lean
+++ b/src/VersoBlueprint/Informal/Block/Render.lean
@@ -368,15 +368,12 @@ private def renderMetadataCodeValue (value : Data.AuthorId) : Verso.Output.Html 
 private def renderMetadataCodeLinkValue (href : String) (value : Data.AuthorId) : Verso.Output.Html :=
   {{<a class="bp_metadata_link bp_metadata_value" href={{href}}><code>s!"{value}"</code></a>}}
 
-private def pushUniqueMetadataString (values : Array String) (value : String) : Array String :=
-  if values.contains value then values else values.push value
-
 private def sourceSpanPages (spans : Array Source.Span) : Array String :=
   spans.foldl
     (init := #[])
     fun pages span =>
       let page := span.page.trimAscii.toString
-      if page.isEmpty then pages else pushUniqueMetadataString pages page
+      if page.isEmpty then pages else pushUniqueString pages page
 
 private def sourcePagesSummary (pages : Array String) : String :=
   match pages.toList with


### PR DESCRIPTION
## Summary
Backport #226 to `v4.30.0`.

## Primary Review
- Primary review: #226
- Keep review comments on #226 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.30.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.