### PR TITLE
chore: add reference harness heartbeat logging

### DIFF
--- a/scripts/blueprint_harness_project_commands.py
+++ b/scripts/blueprint_harness_project_commands.py
@@ -11,6 +11,8 @@ from scripts.blueprint_harness_utils import (
     lean_low_priority_command,
     rebuild_embedded_asset_owners,
     run,
+    run_with_heartbeat,
+    timed_step,
 )
 
 
@@ -244,15 +246,21 @@ def run_project_update_build_generate(
     generate_command: tuple[str, ...],
     format_command: Callable[[tuple[str, ...]], list[str]],
     skip_build: bool,
+    project_id: str | None = None,
 ) -> None:
-    update_project()
+    label_prefix = f"{project_id}: " if project_id is not None else ""
+    with timed_step(f"{label_prefix}update project"):
+        update_project()
     if not skip_build and build_command is not None:
-        run(
+        run_with_heartbeat(
             lean_low_priority_command(package_root, *format_command(build_command)),
             cwd=project_dir,
+            label=f"{label_prefix}build project",
         )
-    ensure_and_log_embedded_asset_owner_outputs(package_root)
-    run(
+    with timed_step(f"{label_prefix}embedded asset owner outputs"):
+        ensure_and_log_embedded_asset_owner_outputs(package_root)
+    run_with_heartbeat(
         lean_low_priority_command(package_root, *format_command(generate_command)),
         cwd=project_dir,
+        label=f"{label_prefix}generate project",
     )

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -27,7 +27,7 @@ from scripts.blueprint_harness_project_commands import (
     run_project_update_build_generate,
     snapshot_tracked_project_manifest,
 )
-from scripts.blueprint_harness_utils import format_command, lean_low_priority_command, run
+from scripts.blueprint_harness_utils import format_command, lean_low_priority_command, run, run_with_heartbeat
 
 
 COMMIT_HASH_PATTERN = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
@@ -642,7 +642,7 @@ def bump_reference_project(
     command_output_root = output_root or (layout.artifact_root / "reference-blueprints-edit")
 
     if build_project and project.build_command is not None:
-        run(
+        run_with_heartbeat(
             lean_low_priority_command(
                 layout.package_root,
                 *format_project_command(
@@ -657,12 +657,13 @@ def bump_reference_project(
                 ),
             ),
             cwd=project_dir,
+            label=f"{project.project_id}: edit build project",
         )
 
     if generate_site:
         generated_output = output_dir_for(project, command_output_root)
         generated_output.mkdir(parents=True, exist_ok=True)
-        run(
+        run_with_heartbeat(
             lean_low_priority_command(
                 layout.package_root,
                 *format_project_command(
@@ -677,6 +678,7 @@ def bump_reference_project(
                 ),
             ),
             cwd=project_dir,
+            label=f"{project.project_id}: edit generate project",
         )
 
     pathspec = project_checkout_pathspec(edit_dir, project_dir)
@@ -767,7 +769,7 @@ def sync_reference_cache_checkout(
             if warm_build and project.build_command is not None:
                 command = lean_low_priority_command(layout.package_root, *project.build_command)
                 try:
-                    run(command, cwd=project_dir)
+                    run_with_heartbeat(command, cwd=project_dir, label=f"{project.project_id}: warm cache build")
                 except subprocess.CalledProcessError as err:
                     raise SystemExit(reference_cache_warm_build_failure_message(layout, project, command, err)) from err
             if store_lake_packages_in_dependency_cache(layout, project, project_dir, package_mode=package_mode) is not None:
@@ -870,6 +872,7 @@ def generate_in_repo_command_project(layout, output_root: Path, project: Harness
                     ),
                 ),
                 skip_build=skip_build,
+                project_id=project.project_id,
             )
     finally:
         restore_tracked_project_manifest(original_manifest)
@@ -916,6 +919,7 @@ def generate_git_project(
                     ),
                 ),
                 skip_build=skip_build,
+                project_id=project.project_id,
             )
     finally:
         if borrowed_packages:

--- a/scripts/blueprint_harness_utils.py
+++ b/scripts/blueprint_harness_utils.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from dataclasses import dataclass
 import os
-import subprocess
-import sys
 from pathlib import Path
 import shutil
 import re
+import subprocess
+import sys
+import time
 
 
 @dataclass(frozen=True)
@@ -63,6 +65,60 @@ def format_command(command: list[str]) -> str:
 def run(command: list[str], *, cwd: Path) -> None:
     print(f"[blueprint-harness] $ {format_command(command)}")
     subprocess.run(command, cwd=cwd, check=True)
+
+
+def format_elapsed(seconds: float) -> str:
+    total_seconds = int(seconds)
+    minutes, seconds = divmod(total_seconds, 60)
+    if minutes:
+        return f"{minutes}m{seconds:02d}s"
+    return f"{seconds}s"
+
+
+@contextmanager
+def timed_step(label: str):
+    start = time.monotonic()
+    print(f"[blueprint-harness] starting {label}", flush=True)
+    try:
+        yield
+    except BaseException:
+        elapsed = format_elapsed(time.monotonic() - start)
+        print(f"[blueprint-harness] failed {label} after {elapsed}", flush=True)
+        raise
+    else:
+        elapsed = format_elapsed(time.monotonic() - start)
+        print(f"[blueprint-harness] finished {label} in {elapsed}", flush=True)
+
+
+def run_with_heartbeat(
+    command: list[str],
+    *,
+    cwd: Path,
+    label: str,
+    heartbeat_seconds: int = 60,
+) -> None:
+    print(f"[blueprint-harness] $ {format_command(command)}")
+    with timed_step(label):
+        start = time.monotonic()
+        proc = subprocess.Popen(command, cwd=cwd)
+        try:
+            while True:
+                try:
+                    returncode = proc.wait(timeout=heartbeat_seconds)
+                    break
+                except subprocess.TimeoutExpired:
+                    elapsed = format_elapsed(time.monotonic() - start)
+                    print(
+                        f"[blueprint-harness] still running {label} after {elapsed}: {format_command(command)}",
+                        flush=True,
+                    )
+            if returncode != 0:
+                raise subprocess.CalledProcessError(returncode, command)
+        except BaseException:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
+            raise
 
 
 def run_output(command: list[str], *, cwd: Path) -> str:

--- a/scripts/blueprint_test_blueprints.py
+++ b/scripts/blueprint_test_blueprints.py
@@ -482,6 +482,7 @@ def generate_standalone_test_blueprint(package_root: Path, fixture: StandaloneTe
                     },
                 ),
                 skip_build=False,
+                project_id=fixture.slug,
             )
     finally:
         restore_tracked_project_manifest(original_manifest)

--- a/tests/harness/test_blueprint_harness_project_commands.py
+++ b/tests/harness/test_blueprint_harness_project_commands.py
@@ -246,10 +246,12 @@ class BlueprintHarnessProjectCommandTests(unittest.TestCase):
             package_root.mkdir()
             project_dir.mkdir()
             original_run = commands_mod.run
+            original_run_with_heartbeat = commands_mod.run_with_heartbeat
             original_ensure = commands_mod.ensure_and_log_embedded_asset_owner_outputs
             commands: list[list[str]] = []
             try:
                 commands_mod.run = lambda command, *, cwd: commands.append(command)
+                commands_mod.run_with_heartbeat = lambda command, *, cwd, label: commands.append(command)
                 commands_mod.ensure_and_log_embedded_asset_owner_outputs = (
                     lambda package_root: commands.append(["ensure", str(package_root)]) or []
                 )
@@ -265,6 +267,7 @@ class BlueprintHarnessProjectCommandTests(unittest.TestCase):
                 )
             finally:
                 commands_mod.run = original_run
+                commands_mod.run_with_heartbeat = original_run_with_heartbeat
                 commands_mod.ensure_and_log_embedded_asset_owner_outputs = original_ensure
 
         self.assertEqual(
@@ -287,10 +290,12 @@ class BlueprintHarnessProjectCommandTests(unittest.TestCase):
             package_root.mkdir()
             project_dir.mkdir()
             original_run = commands_mod.run
+            original_run_with_heartbeat = commands_mod.run_with_heartbeat
             original_ensure = commands_mod.ensure_and_log_embedded_asset_owner_outputs
             commands: list[list[str]] = []
             try:
                 commands_mod.run = lambda command, *, cwd: commands.append(command)
+                commands_mod.run_with_heartbeat = lambda command, *, cwd, label: commands.append(command)
                 commands_mod.ensure_and_log_embedded_asset_owner_outputs = (
                     lambda package_root: commands.append(["ensure", str(package_root)]) or []
                 )
@@ -306,6 +311,7 @@ class BlueprintHarnessProjectCommandTests(unittest.TestCase):
                 )
             finally:
                 commands_mod.run = original_run
+                commands_mod.run_with_heartbeat = original_run_with_heartbeat
                 commands_mod.ensure_and_log_embedded_asset_owner_outputs = original_ensure
 
         self.assertEqual(

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -1166,6 +1166,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 "bootstrap_reference_checkout": refs_mod.bootstrap_reference_checkout,
                 "project_lake_update_command": refs_mod.project_lake_update_command,
                 "run": refs_mod.run,
+                "run_with_heartbeat": refs_mod.run_with_heartbeat,
             }
 
             def fake_run(command, *, cwd):
@@ -1173,11 +1174,15 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                     return
                 raise subprocess.CalledProcessError(7, command)
 
+            def fake_run_with_heartbeat(command, *, cwd, label):
+                fake_run(command, cwd=cwd)
+
             try:
                 refs_mod.update_git_checkout = lambda _project, _cache_dir: None
                 refs_mod.bootstrap_reference_checkout = lambda *, project_dir: None
                 refs_mod.project_lake_update_command = lambda _package_root, _project_dir: ["lake", "update"]
                 refs_mod.run = fake_run
+                refs_mod.run_with_heartbeat = fake_run_with_heartbeat
 
                 with self.assertRaises(SystemExit) as raised:
                     refs_mod.sync_reference_cache_checkout(layout, project, warm_build=True)
@@ -1436,6 +1441,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             originals = {
                 "command_rewrite_local_blueprint_dependency": commands_mod.rewrite_local_blueprint_dependency,
                 "command_run": commands_mod.run,
+                "command_run_with_heartbeat": commands_mod.run_with_heartbeat,
                 "sync_reference_cache_checkout": refs_mod.sync_reference_cache_checkout,
                 "sync_reference_local_checkout": refs_mod.sync_reference_local_checkout,
                 "project_lake_update_command": refs_mod.project_lake_update_command,
@@ -1463,6 +1469,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 refs_mod.project_lake_update_command = lambda _package_root, _project_dir: ["lake", "update", "VersoBlueprint"]
                 refs_mod.run = lambda command, *, cwd: commands.append(command)
                 commands_mod.run = lambda command, *, cwd: commands.append(command)
+                commands_mod.run_with_heartbeat = lambda command, *, cwd, label: commands.append(command)
 
                 generate_git_project(layout, output_root, project, skip_build=False)
             finally:
@@ -1471,6 +1478,8 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                         commands_mod.rewrite_local_blueprint_dependency = value
                     elif name == "command_run":
                         commands_mod.run = value
+                    elif name == "command_run_with_heartbeat":
+                        commands_mod.run_with_heartbeat = value
                     else:
                         setattr(refs_mod, name, value)
 
@@ -1717,6 +1726,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 "rewrite_pinned_blueprint_dependency": refs_mod.rewrite_pinned_blueprint_dependency,
                 "project_lake_update_command": refs_mod.project_lake_update_command,
                 "run": refs_mod.run,
+                "run_with_heartbeat": refs_mod.run_with_heartbeat,
                 "git_has_tracked_changes": refs_mod.git_has_tracked_changes,
             }
             commands: list[list[str]] = []
@@ -1733,6 +1743,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 )
                 refs_mod.project_lake_update_command = lambda _package_root, _project_dir: ["lake", "update", "VersoBlueprint"]
                 refs_mod.run = lambda command, *, cwd: commands.append(command)
+                refs_mod.run_with_heartbeat = lambda command, *, cwd, label: commands.append(command)
                 refs_mod.git_has_tracked_changes = lambda _checkout_root, _pathspec: False
 
                 result = bump_reference_project(

--- a/tests/harness/test_blueprint_harness_utils.py
+++ b/tests/harness/test_blueprint_harness_utils.py
@@ -1,4 +1,7 @@
+import contextlib
+import io
 import os
+import subprocess
 import tempfile
 import time
 import unittest
@@ -12,6 +15,7 @@ from scripts.blueprint_harness_utils import (
     ensure_embedded_asset_owner_outputs,
     rebuild_embedded_asset_owners,
     refresh_embedded_asset_owner_mtimes,
+    run_with_heartbeat,
 )
 
 
@@ -112,6 +116,33 @@ class TestBlueprintHarnessUtils(unittest.TestCase):
             ),
         ):
             self.assertIn(EmbeddedAssetOwner(asset, owner, target), EMBEDDED_ASSET_OWNERS)
+
+    def test_run_with_heartbeat_reports_long_running_command(self) -> None:
+        class FakeProcess:
+            def __init__(self) -> None:
+                self.wait_calls = 0
+
+            def wait(self, timeout: int | None = None) -> int:
+                self.wait_calls += 1
+                if self.wait_calls == 1:
+                    raise subprocess.TimeoutExpired(["slow"], timeout)
+                return 0
+
+        fake_process = FakeProcess()
+        out = io.StringIO()
+        with (
+            patch("scripts.blueprint_harness_utils.subprocess.Popen", return_value=fake_process) as popen_mock,
+            patch("scripts.blueprint_harness_utils.time.monotonic", side_effect=[0.0, 0.0, 61.0, 62.0]),
+            contextlib.redirect_stdout(out),
+        ):
+            run_with_heartbeat(["slow"], cwd=Path("/tmp"), label="external build")
+
+        popen_mock.assert_called_once_with(["slow"], cwd=Path("/tmp"))
+        output = out.getvalue()
+        self.assertIn("[blueprint-harness] $ slow", output)
+        self.assertIn("[blueprint-harness] starting external build", output)
+        self.assertIn("[blueprint-harness] still running external build after 1m01s", output)
+        self.assertIn("[blueprint-harness] finished external build in 1m02s", output)
 
     def test_refresh_embedded_asset_owner_mtimes_touches_owner_when_asset_is_newer(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
This PR adds heartbeat logging and explicit timing around long-running reference and test-blueprint harness steps, so CI and local runs report progress while Lake builds and generation are still running.

Backport v4.30.0: #230