### PR TITLE
feat: expose source metadata through data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,8 +237,10 @@ For every natural number $`n`, $`n + 0 = n`.
 
 Current behavior: source provenance is exported in the Blueprint manifest as
 `sourceDocuments` and per-entry `sources`, and kept hidden in rendered pages.
-Browser clients can resolve source-document ids with `loadSourceDocument` or
-load the complete catalog with `loadSourceDocuments`.
+Browser clients can resolve source-document ids with `loadSourceDocument`, load
+the complete catalog with `loadSourceDocuments`, or join entry source refs with
+declared documents using `resolveSourceMetadata` from `api/data.mjs` or
+`api/preview.mjs`.
 Rich audit-interface rendering is planned separately.
 
 ### Rendering to HTML

--- a/doc/API.md
+++ b/doc/API.md
@@ -109,7 +109,7 @@ or is part of Blueprint's generated slide runtime.
 | Regular generated Manual page | `-verso-data/blueprint-page-runtime.mjs` | Creates one renderer with `createPreview()`, starts inline previews, relation panels, graphs, and descriptor-bound template previews. | Nothing extra; `withBlueprintAssets` installs this module. |
 | Generated Blueprint slide deck | `-verso-data/blueprint-slide-runtime.mjs` | Creates one renderer with `createPreview()`, starts inline previews, relation panels, graphs, and slide-node hydration. | Nothing extra; `slidesMainWithBlueprintPreviews` installs this module. |
 | Custom browser page, dashboard, audit view, or slide adapter | `-verso-data/api/preview.mjs` | Manifest/cache loading, preview lookup, rendered-fragment insertion, canonical node loading, math rendering, and hydration. | `createPreview()`, then `resolvePreview`, `renderPreviewInto`, `renderCanonicalPreviewInto`, `renderNode`, or `hydrate`. |
-| Data-only browser or Node-like client | `-verso-data/api/data.mjs` | Manifest/cache URL helpers, loading, status readers, source-document lookup, and graph-data loading without DOM rendering. | `createPreviewData()`, `loadManifest`, `loadSourceDocuments`, `loadHtmlCache`, `loadGraphs`, or single-entry readers. |
+| Data-only browser or Node-like client | `-verso-data/api/data.mjs` | Manifest/cache URL helpers, loading, status readers, source-document lookup, source-metadata resolution, and graph-data loading without DOM rendering. | `createPreviewData()`, `loadManifest`, `loadSourceDocuments`, `resolveSourceMetadata`, `loadHtmlCache`, `loadGraphs`, or single-entry readers. |
 | Graph data or graph rendering | `-verso-data/api/graph.mjs` | Graph JSON discovery, manifest graph loading, graph-block construction, lazy graph runtime loading, and graph initialization. | `loadGraphs`, `getGraphData`, `getGraphVariants`, `renderGraphData(host, graph, { previewUtils })`, or `renderGraphs(root, { previewUtils })`. |
 | Blueprint-owned panels in generated pages | Renderer bundled helpers | Panel slots, content updates, trigger lifetime, dismissal, repositioning, diagnostics, and shared preview lookup. | Feature scripts use `createPreviewSurface`, `renderPreviewIntoSurface`, or `resolvePreviewHtml`; custom clients should not import these helpers directly. |
 | Summary and code-summary previews | Lean-emitted template descriptors plus `preview-runtime-template.mjs` | Selector configuration and binding for preview templates. | Emit descriptor attributes from Lean; no feature-specific startup script is needed. |
@@ -134,8 +134,8 @@ Generated Blueprint sites write reusable data under `-verso-data/`:
 - `api/graph.mjs` exposes graph-data helpers for ordinary browser `import`
   usage, plus graph-block rendering helpers for pages that carry generated
   graph markup.
-- `api/data.mjs` exposes manifest/cache/key/URL helpers for clients that do not
-  need to render DOM previews.
+- `api/data.mjs` exposes manifest/cache/key/URL helpers and source-metadata
+  resolution for clients that do not need to render DOM previews.
 - `api/preview.mjs` exposes the preview/render API for ordinary browser
   `import` usage.
 
@@ -178,10 +178,11 @@ Generated browser APIs expose the same split. Use `loadManifestEntry` or
 extracted page roots. These helpers reuse the cached manifest load; they do not
 fetch a second JSON file.
 
-Render-capable clients can use `resolveSourceMetadata(source)` when they want
-the source refs attached to a preview joined with declared source-document
-metadata. The `source` argument can be a preview key, a manifest entry, or a
-result returned by `resolvePreview`, `resolveCanonicalPreview`, or `renderNode`:
+Clients can use `resolveSourceMetadata(source)` from either `api/data.mjs` or
+`api/preview.mjs` when they want the source refs attached to a preview joined
+with declared source-document metadata. The `source` argument can be a preview
+key, a manifest entry, or a result returned by `resolvePreview`,
+`resolveCanonicalPreview`, or `renderNode`:
 
 ```javascript
 const key = api.statementPreviewKey("Chapter2:Problem2.11.6");
@@ -623,9 +624,7 @@ const data = createPreviewData({ fetchJson });
 
 const manifest = await data.loadManifest();
 const entry = await data.loadManifestEntry(data.previewKey("addition_right_identity", "statement"));
-const sourceDocument = entry?.sources?.[0]
-  ? await data.loadSourceDocument(entry.sources[0].document)
-  : null;
+const sourceMetadata = await data.resolveSourceMetadata(entry);
 const graphs = await loadManifestGraphs(data.manifestUrl(), { fetchJson });
 ```
 
@@ -700,7 +699,7 @@ At a high level, the public generated browser modules are:
 
 | Module | Purpose |
 | --- | --- |
-| `api/data.mjs` | Data-only clients: generated-data URLs, manifest/cache loading, status readers, and preview-key helpers. |
+| `api/data.mjs` | Data-only clients: generated-data URLs, manifest/cache loading, source-metadata resolution, status readers, and preview-key helpers. |
 | `api/preview.mjs` | Render-capable clients: data helpers plus preview resolution, fragment insertion, canonical node rendering, label-based `renderNode`, and hydration. |
 | `api/graph.mjs` | Graph clients: finalized graph loading, embedded graph-block data access, manifest-data graph rendering, and graph-block rendering with an explicit preview renderer. |
 

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -376,7 +376,7 @@ runtime hook or moving code between feature modules.
 | --- | --- | --- | --- |
 | Regular generated Manual pages | `blueprint-page-runtime.mjs` imported from `extraHead` | `blueprint-manifest.json`, `blueprint-html-cache.json`, graph JSON embedded in graph blocks | One `createPreview()` renderer starts inline previews, relation panels, graph blocks, and template-preview descriptor binding. |
 | Custom ESM preview clients | `api/preview.mjs` and caller-created `createPreview()` renderer | Manifest/cache plus optional canonical generated pages | The stable preview API loads data, inserts rendered fragments or canonical nodes, runs math, and hydrates nested Blueprint widgets. |
-| Data-only clients | `api/data.mjs` and caller-created `createPreviewData()` data API | Manifest/cache and manifest graph records | No DOM rendering; callers own all UI and use the data API for URL construction, loading, status, and single-entry lookup. |
+| Data-only clients | `api/data.mjs` and caller-created `createPreviewData()` data API | Manifest/cache, source metadata, and manifest graph records | No DOM rendering; callers own all UI and use the data API for URL construction, loading, status, source-metadata resolution, and single-entry lookup. |
 | Graph clients | `api/graph.mjs` | Finalized graph records from the manifest or graph data embedded beside a graph block | Data helpers stay graph-only; render helpers can construct a standard graph block from manifest data or initialize existing graph markup, lazy-load `Commands/graph.mjs`, and require an explicit preview renderer for graph preview panels. |
 | Blueprint-owned panel features | `blueprint-page-runtime.mjs` or `blueprint-slide-runtime.mjs` passes a renderer into feature startup | Manifest/cache entries and feature-owned Lean-emitted attributes | Feature scripts adapt `createPreviewSurface`, `renderPreviewIntoSurface`, `resolvePreviewHtml`, and lifecycle helpers to concrete panel UIs. |
 | Summary and code-summary previews | Lean emits descriptor attributes; `preview-runtime-template.mjs` binds them at page load and after hydration | Descriptor attributes plus local templates or manifest/cache lookup keys | The shared template binder creates surfaces and triggers; no feature-specific startup module owns this path. |
@@ -526,8 +526,9 @@ The workflow implies a few constraints for renderers:
   handling, URL/key forwarding, default API handles, status fallbacks, and
   method dispatch; `blueprint-data-api.mjs` owns the standalone data-only public
   module; `preview-runtime-data.mjs` owns factory-backed manifest/cache decoding
-  and loading, load-status readers, entry and source-document lookup, and
-  graph-core delegation, and is emitted as an ESM support module for
+  and loading, load-status readers, entry/source-document lookup,
+  source-metadata resolution, and graph-core delegation, and is emitted as an
+  ESM support module for
   `api/data.mjs`/`api/preview.mjs`;
   `preview-runtime-render.mjs` owns manifest/cache joins, rendered-fragment
   insertion, and canonical-node loading through injected data and canonical page
@@ -555,8 +556,8 @@ The workflow implies a few constraints for renderers:
   | API assembly | Assemble the stable render API for `createPreviewRuntimeApi`. | `Commands/preview-runtime-api.mjs` emitted as an ESM support module |
   | Preview URL/key primitives | Resolve `-verso-data` URLs and normalize preview keys for page-runtime and custom ESM clients. | `blueprint-preview-core.mjs` shared implementation file |
   | Generated ESM wrapper mechanics | Share default `dataBaseUrl` setup, URL/key forwarding, default API handles, fallback statuses, and method dispatch across public ESM entrypoints without sharing their stores. | `blueprint-api-common.mjs` internal support file emitted for `api/data.mjs` and `api/preview.mjs` |
-  | Preview data access | Load manifest/cache JSON through the configured `fetchJson` or ambient `fetch`, keep load status, delegate graph data to graph core, and look up entries plus source documents. | `Commands/preview-runtime-data.mjs` emitted as an ESM support module |
-  | Data-only public API | Expose manifest/cache/source-document/graph loading without importing DOM rendering, hydration, or surfaces. | `blueprint-data-api.mjs` re-exported as `api/data.mjs` |
+  | Preview data access | Load manifest/cache JSON through the configured `fetchJson` or ambient `fetch`, keep load status, delegate graph data to graph core, and look up entries plus source documents and source metadata. | `Commands/preview-runtime-data.mjs` emitted as an ESM support module |
+  | Data-only public API | Expose manifest/cache/source-document/source-metadata/graph loading without importing DOM rendering, hydration, or surfaces. | `blueprint-data-api.mjs` re-exported as `api/data.mjs` |
   | Fragment rendering | Resolve manifest/cache pairs through an injected data API, produce diagnostics, insert rendered fragments, and fetch canonical node wrappers through injectable page loaders. | `Commands/preview-runtime-render.mjs` emitted as an ESM support module |
   | Source metadata lookup | Join `entry.sources` with source-document metadata and return structured data without owning presentation. | `Commands/preview-runtime-source-metadata.mjs` emitted as an ESM support module |
   | Hydration registry and explicit hydrator options | Run math rendering plus generated-page feature hydrators after insertion, while allowing custom clients to pass renderer-local or call-local hydrators. | `Commands/preview-runtime-hydration.mjs` emitted as an ESM support module |

--- a/doc/JS_API_DOCS.md
+++ b/doc/JS_API_DOCS.md
@@ -65,12 +65,10 @@ const data = createPreviewData();
 // Load semantic manifest data and build the same preview key Blueprint uses.
 const manifest = await data.loadManifest();
 const entry = manifest.get(data.statementPreviewKey("Chapter2:Problem2.11.6"));
-const sourceDocument = entry?.sources?.[0]
-  ? await data.loadSourceDocument(entry.sources[0].document)
-  : null;
+const sourceMetadata = await data.resolveSourceMetadata(entry);
 
 if (entry) {
-  console.log(entry.href, entry.label, entry.facet, sourceDocument?.title);
+  console.log(entry.href, entry.label, entry.facet, sourceMetadata.sources[0]?.document?.title);
 }
 ```
 
@@ -110,8 +108,8 @@ implementation chunks for generated pages, Slides, and those entrypoints.
   source metadata for previews, and provide call-scoped external-markup fallback
   renderers.
 - [data API](module-blueprint-data-api.html): load generated manifests,
-  rendered-fragment caches, preview keys, and generated-data URLs without
-  installing browser-global render hooks.
+  rendered-fragment caches, source metadata, preview keys, and generated-data
+  URLs without installing browser-global render hooks.
 - [graph API](module-blueprint-graph-api.html): read graph data embedded in
   generated graph pages, load graph records from a manifest, render manifest
   graph data, or render generated graph blocks with an explicit preview
@@ -127,7 +125,7 @@ document Blueprint's private runtime chunks directly.
 | Path | Use | Avoid |
 | --- | --- | --- |
 | `api/preview.mjs` | Custom browser views that render previews or canonical nodes, resolve source metadata for previews, provide external-markup fallbacks, or hydrate already-inserted fragments. | Reading `window.VersoBlueprint` or importing `Commands/*.mjs`. |
-| `api/data.mjs` | Audit tools, dashboards, migration checks, and Node-like clients that only need generated JSON data. | Parsing rendered HTML to rediscover labels, graph topology, status, or dependencies. |
+| `api/data.mjs` | Audit tools, dashboards, migration checks, and Node-like clients that only need generated JSON data or source metadata. | Parsing rendered HTML to rediscover labels, graph topology, status, source provenance, or dependencies. |
 | `api/graph.mjs` | Graph dashboards and custom pages that read or render finalized graph records. | Calling graph render helpers without an explicit `previewUtils` renderer. |
 | `blueprint-page-runtime.mjs` | Regular generated Manual pages; it starts Blueprint's bundled feature scripts for you. | Custom clients that need isolated loaders, custom fetchers, or independent render options. |
 

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -678,9 +678,10 @@ several sourced Blueprint nodes share the same Lean declaration preview.
 Browser clients can resolve those document ids with `loadSourceDocument` or
 read the complete catalog with `loadSourceDocuments`.
 
-Browser clients can call `resolveSourceMetadata` from `api/preview.mjs` to
-resolve source refs for a preview key, manifest entry, or render result. The
-API returns structured source-document metadata and recorded text/PDF spans.
+Browser clients can call `resolveSourceMetadata` from `api/data.mjs` or
+`api/preview.mjs` to resolve source refs for a preview key, manifest entry, or
+render result. The API returns structured source-document metadata and recorded
+text/PDF spans.
 The built-in source preview is intentionally lightweight; richer PDF page
 viewers and crop overlays remain Blueprint/Verso interface work.
 

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -111,11 +111,7 @@ Work:
    source previews into fuller VBP-rendered review interfaces that consume
    manifest `sourceDocuments` and `entry.sources`; keep PDF viewers, text
    excerpts, and crop overlays out of the browser API contract
-10. evaluate whether the metadata-only `resolveSourceMetadata` helper belongs
-   in `api/data.mjs` as well as, or instead of, `api/preview.mjs`. Move it only
-   if the stable client split becomes clearer; until then, avoid another public
-   API churn round
-11. deduplicate the source metadata resolver with manifest/data lookup helpers
+10. deduplicate the source metadata resolver with manifest/data lookup helpers
    once more source consumers exist, so missing-entry, missing-document, and
    source-ref normalization semantics have one implementation
 

--- a/src/VersoBlueprint/Commands/preview-runtime-data.mjs
+++ b/src/VersoBlueprint/Commands/preview-runtime-data.mjs
@@ -1,5 +1,6 @@
 import { dataApiModuleUrl as coreDataApiModuleUrl, dataUrl as coreDataUrl, graphApiModuleUrl as coreGraphApiModuleUrl, htmlCacheUrl as coreHtmlCacheUrl, manifestUrl as coreManifestUrl, previewApiModuleUrl as corePreviewApiModuleUrl, previewKey as corePreviewKey, statementPreviewKey as coreStatementPreviewKey } from "../blueprint-preview-core.mjs";
 import { escapeHtml, previewDebug } from "./preview-runtime-base.mjs";
+import { resolveSourceMetadata } from "./preview-runtime-source-metadata.mjs";
 
   // Generated-data URL helpers.
 
@@ -362,7 +363,12 @@ import { escapeHtml, previewDebug } from "./preview-runtime-base.mjs";
       return loadBlueprintStoreEntryForApi(blueprintHtmlCacheStoreForApi, previewKey, options);
     }
 
-    return {
+    function resolveBlueprintSourceMetadataForApi(source, options) {
+      const opts = Object.assign({}, normalizeBlueprintDataOptions(options), { dataApi });
+      return resolveSourceMetadata(source, opts);
+    }
+
+    const dataApi = {
       dataUrl: blueprintDataUrlForApi,
       fetchJson: fetchBlueprintJsonForApi,
       decodeKeyedEntries: decodeBlueprintKeyedEntries,
@@ -397,11 +403,13 @@ import { escapeHtml, previewDebug } from "./preview-runtime-base.mjs";
       loadStoreEntry: loadBlueprintStoreEntryForApi,
       loadManifestEntry: loadBlueprintManifestEntryForApi,
       loadHtmlCacheEntry: loadBlueprintHtmlCacheEntryForApi,
+      resolveSourceMetadata: resolveBlueprintSourceMetadataForApi,
       setDataBaseUrl: setBlueprintDataBaseUrlForApi,
       setFetchJson: setBlueprintFetchJsonForApi,
       resetStore: resetBlueprintStoreForApi,
       resetStores: resetBlueprintDataStoresForApi
     };
+    return dataApi;
   }
 
   export function decodeBlueprintKeyedEntries(data, spec) {

--- a/src/VersoBlueprint/blueprint-api-types.mjs
+++ b/src/VersoBlueprint/blueprint-api-types.mjs
@@ -434,6 +434,7 @@
  * @property {function(string, BlueprintDataApiOptions=): Promise<(BlueprintManifestEntry | null)>} loadManifestEntry
  * @property {function(BlueprintDataApiOptions=): Promise<BlueprintSourceDocument[]>} loadSourceDocuments
  * @property {function(string, BlueprintDataApiOptions=): Promise<(BlueprintSourceDocument | null)>} loadSourceDocument
+ * @property {function(BlueprintSourceMetadataInput, BlueprintDataApiOptions=): Promise<BlueprintSourceMetadataResult>} resolveSourceMetadata
  * @property {function(string, BlueprintDataApiOptions=): Promise<(BlueprintHtmlCacheEntry | null)>} loadHtmlCacheEntry
  */
 

--- a/src/VersoBlueprint/blueprint-data-api.mjs
+++ b/src/VersoBlueprint/blueprint-data-api.mjs
@@ -21,7 +21,7 @@ import { createBlueprintDataApi } from "./Commands/preview-runtime-data.mjs";
  * @module blueprint-data-api
  */
 
-/** @import { BlueprintDataApiOptions, BlueprintDataApi, BlueprintStoreStatus, BlueprintManifestEntry, BlueprintSourceDocument, BlueprintHtmlCacheEntry } from "./blueprint-api-types.mjs" */
+/** @import { BlueprintDataApiOptions, BlueprintDataApi, BlueprintStoreStatus, BlueprintManifestEntry, BlueprintSourceDocument, BlueprintHtmlCacheEntry, BlueprintSourceMetadataInput, BlueprintSourceMetadataResult } from "./blueprint-api-types.mjs" */
 
 export { version };
 
@@ -259,6 +259,20 @@ export function loadSourceDocument(id, options) {
 }
 
 /**
+ * Resolve original-source provenance for a preview key or manifest entry.
+ *
+ * This joins `entry.sources` with declared source-document metadata. It returns
+ * structured metadata only; callers own PDF/text loading and presentation.
+ *
+ * @param {BlueprintSourceMetadataInput} source Preview key, manifest entry, or render result.
+ * @param {BlueprintDataApiOptions} [options] Optional per-call load overrides.
+ * @returns {Promise<BlueprintSourceMetadataResult>}
+ */
+export function resolveSourceMetadata(source, options) {
+  return callDefaultApi(defaultDataHandle.readDefaultApi, "data", "resolveSourceMetadata", [source, options]);
+}
+
+/**
  * Load a single HTML-cache entry by key.
  *
  * @param {string} key HTML cache key.
@@ -286,6 +300,7 @@ const dataApi = {
   loadManifestEntry,
   loadSourceDocuments,
   loadSourceDocument,
+  resolveSourceMetadata,
   loadHtmlCache,
   readHtmlCacheStatus,
   loadHtmlCacheEntry,

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -1318,6 +1318,9 @@ class TestPreviewRuntimeRegressions:
                 const sameDocument = await data.loadSourceDocument("paper");
                 const missingDocument = await data.loadSourceDocument("missing");
                 const emptyDocument = await data.loadSourceDocument("");
+                const sourceMetadata = await data.resolveSourceMetadata(
+                    data.statementPreviewKey("sample_node")
+                );
                 const manifest = await data.loadManifest();
                 const previewSourceDocument = await preview.loadSourceDocument("paper");
                 const previewSourceDocuments = await preview.loadSourceDocuments();
@@ -1337,6 +1340,11 @@ class TestPreviewRuntimeRegressions:
                     sameObject: sourceDocument === sameDocument,
                     missingDocument,
                     emptyDocument,
+                    dataHasSourceMetadataResolver:
+                        typeof data.resolveSourceMetadata === "function",
+                    dataSourceMetadataOk: sourceMetadata.ok,
+                    dataSourceMetadataDocumentTitle: sourceMetadata.sources[0].document.title,
+                    dataSourceMetadataPage: sourceMetadata.sources[0].spans[0].page,
                     previewSourceDocumentId: previewSourceDocument && previewSourceDocument.id,
                     previewSourceDocumentCount: previewSourceDocuments.length,
                     previewEntrySourceDocument: previewEntry && previewEntry.sources[0].document
@@ -1356,6 +1364,10 @@ class TestPreviewRuntimeRegressions:
         assert result["sameObject"] is True
         assert result["missingDocument"] is None
         assert result["emptyDocument"] is None
+        assert result["dataHasSourceMetadataResolver"] is True
+        assert result["dataSourceMetadataOk"] is True
+        assert result["dataSourceMetadataDocumentTitle"] == "Representation Theory"
+        assert result["dataSourceMetadataPage"] == "42"
         assert result["previewSourceDocumentId"] == "paper"
         assert result["previewSourceDocumentCount"] == 1
         assert result["previewEntrySourceDocument"] == "paper"

--- a/tests/preview_runtime_api_contract.json
+++ b/tests/preview_runtime_api_contract.json
@@ -91,6 +91,7 @@
       "readHtmlCacheStatus",
       "readManifestStatus",
       "ready",
+      "resolveSourceMetadata",
       "statementPreviewKey",
       "version"
     ],


### PR DESCRIPTION
This PR exposes source-provenance metadata resolution through the data-only generated browser API while keeping the existing preview API entry point.

- Add resolveSourceMetadata to createPreviewData()/api/data.mjs by reusing the existing source metadata resolver.
- Update public API types, docs, and contract tests for the data API method.
- Extend browser regression coverage to exercise source metadata resolution through createPreviewData().

Backport v4.30.0: #232