### PR TITLE
chore: cache reference path builds

### DIFF
--- a/.github/workflows/reference-blueprints-deploy.yml
+++ b/.github/workflows/reference-blueprints-deploy.yml
@@ -117,9 +117,10 @@ jobs:
         with:
           path: |
             .worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/packages
-          key: ${{ runner.os }}-reference-deploy-deps-v1-${{ matrix.reference_cache_key }}
+            .worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/path-builds
+          key: ${{ runner.os }}-reference-deploy-deps-v2-${{ matrix.reference_cache_key }}
           restore-keys: |
-            ${{ runner.os }}-reference-deploy-deps-v1-${{ matrix.project_id }}-
+            ${{ runner.os }}-reference-deploy-deps-v2-${{ matrix.project_id }}-
       - name: Report disk usage after reference cache restore
         run: ./scripts/report-ci-disk-usage.sh "after reference cache restore" --reference-cache-key "${{ matrix.reference_cache_key }}" --artifact-path "${{ matrix.artifact_path }}"
       - name: Show tool versions

--- a/.github/workflows/reference-blueprints.yml
+++ b/.github/workflows/reference-blueprints.yml
@@ -86,9 +86,10 @@ jobs:
         with:
           path: |
             .worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/packages
-          key: ${{ runner.os }}-reference-deps-v1-${{ matrix.reference_cache_key }}
+            .worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/path-builds
+          key: ${{ runner.os }}-reference-deps-v2-${{ matrix.reference_cache_key }}
           restore-keys: |
-            ${{ runner.os }}-reference-deps-v1-${{ matrix.project_id }}-
+            ${{ runner.os }}-reference-deps-v2-${{ matrix.project_id }}-
       - name: Report disk usage after reference cache restore
         run: ./scripts/report-ci-disk-usage.sh "after reference cache restore" --reference-cache-key "${{ matrix.reference_cache_key }}" --artifact-path "${{ matrix.artifact_path }}"
       - name: Show tool versions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,10 +169,13 @@
   - `_out/test-blueprints/{<slug>,preview_runtime_showcase,state-showcase}/`
 - Default test-blueprint output in a linked worktree:
   - `_out/<worktree>/test-blueprints/{<slug>,preview_runtime_showcase,state-showcase}/`
-- Shared warmed reference blueprint cache for external git-checkout projects:
-  - `.worktrees/_reference-blueprints/cache/{noperthedron,spherepackingblueprint}/`
+- Shared warmed source checkout cache for external git-checkout projects:
+  - `.worktrees/_reference-blueprints/cache/<source-ref-key>/`
+- Shared warmed dependency cache for external git-checkout projects:
+  - `.worktrees/_reference-blueprints/deps/<source-ref-key>/packages/`
+  - `.worktrees/_reference-blueprints/deps/<source-ref-key>/path-builds/`
 - Current-checkout local reference blueprint clones for external git-checkout projects:
-  - `.worktrees/_reference-blueprints/by-worktree/<checkout>/{noperthedron,spherepackingblueprint}/`
+  - `.worktrees/_reference-blueprints/by-worktree/<checkout>/<source-ref-key>/`
 
 ## Mathlib and Worktree Reuse
 

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -517,8 +517,10 @@ The harness is worktree-aware:
 - in a linked worktree it writes artifacts to `_out/<worktree>/...`
 - by default it prefers reusing the root checkout's prepared package `.lake`
   artifacts and binaries
-- it also keeps shared warmed reference dependency package caches under
-  `.worktrees/_reference-blueprints/deps/<source-ref-key>/packages`
+- it also keeps shared warmed reference dependency caches under
+  `.worktrees/_reference-blueprints/deps/<source-ref-key>/`, with downloaded
+  Lake packages under `packages/` and external path-dependency build trees under
+  `path-builds/`
 - those shared caches are keyed by external repository, project root, and
   selected project ref; they preserve expensive pinned dependency state such as
   Mathlib package builds, not generated Blueprint site artifacts
@@ -602,8 +604,10 @@ python3 -m scripts.blueprint_harness worktree-retire <name> --dry-run
 - the default validation catalog mixes in-repo projects with external reference
   blueprints; the larger published reference blueprints live in external
   repositories
-- the harness warms shared reference dependency packages under
-  `.worktrees/_reference-blueprints/deps/<source-ref-key>/packages`
+- the harness warms shared reference dependency caches under
+  `.worktrees/_reference-blueprints/deps/<source-ref-key>/`, including Lake
+  packages and `.lake/build` trees for external path dependencies such as
+  formalization submodules
 - the cache key is derived from the external repository URL, project root, and
   selected project ref, so one project can keep separate caches for different
   Lean/mathlib release pins
@@ -611,8 +615,8 @@ python3 -m scripts.blueprint_harness worktree-retire <name> --dry-run
   `.worktrees/_reference-blueprints/cache/<source-ref-key>/`
 - each checkout gets its own local clone under
   `.worktrees/_reference-blueprints/by-worktree/<checkout>/<source-ref-key>/`,
-  seeded from the dependency package cache so transitive build artifacts stay
-  warm across worktrees
+  seeded from the dependency cache so transitive package and path-dependency
+  build artifacts stay warm across worktrees
 - editable reference-project clones live separately under
   `.worktrees/_reference-blueprints/edit/<checkout>/` and are not touched by
   `sync`, `generate`, or `prune`
@@ -681,9 +685,9 @@ pushes to release branches named like `v4.30.0`, and manual dispatch, it:
 - generates external references from per-job local clones seeded by the keyed
   dependency cache
 - restores and saves external reference dependency caches by the same
-  repository/project-root/ref key used locally, caching only the external
-  project's `.lake/packages/` tree rather than the source checkout or generated
-  Blueprint site's own build output
+  repository/project-root/ref key used locally, caching the external project's
+  `.lake/packages/` tree and `.lake/build` trees for external path dependencies
+  rather than the source checkout or generated Blueprint site's own output
 
 `reference-blueprints-deploy.yml` is the deployment workflow. It runs after a
 successful `reference-blueprints.yml` run on a release branch named like

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -119,8 +119,8 @@ script map, not a second command reference.
   dependency-cache key.
 - `blueprint_harness_references.py`
   Reference-blueprint checkout, editable-clone setup, local override,
-  dependency-package cache warm-up, and prune helpers shared by the reference
-  CLI.
+  dependency package/path-build cache warm-up, and prune helpers shared by the
+  reference CLI.
 - `blueprint_harness_utils.py`
   Shared process-launch helpers used by the harness modules.
 - `blueprint_harness_validation.py`

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
+import json
 import re
 import shutil
 import subprocess
@@ -100,6 +101,10 @@ def reference_dependency_packages_dir(layout, project: HarnessProject) -> Path:
     return reference_dependency_cache_dir(layout, project) / "packages"
 
 
+def reference_dependency_path_builds_dir(layout, project: HarnessProject) -> Path:
+    return reference_dependency_cache_dir(layout, project) / "path-builds"
+
+
 def reference_local_checkout_dir(layout, project: HarnessProject) -> Path:
     return layout.reference_project_checkout_root / reference_dependency_cache_key(project)
 
@@ -128,6 +133,10 @@ def reference_dependency_cache_keys(projects: tuple[HarnessProject, ...] | list[
 
 def lake_packages_dir(project_dir: Path) -> Path:
     return project_dir / ".lake" / "packages"
+
+
+def lake_build_dir(project_dir: Path) -> Path:
+    return project_dir / ".lake" / "build"
 
 
 def read_reference_toolchain_candidate(path: Path) -> ReferenceToolchainCandidate | None:
@@ -266,7 +275,6 @@ def store_lake_packages_in_dependency_cache(
     run(["rsync", "-a", "--delete", f"{source_packages}/", f"{destination_packages}/"], cwd=layout.package_root)
     return destination_packages
 
-
 def discard_lake_packages(project_dir: Path) -> Path | None:
     packages = lake_packages_dir(project_dir)
     if not packages.exists() and not packages.is_symlink():
@@ -276,6 +284,75 @@ def discard_lake_packages(project_dir: Path) -> Path | None:
     else:
         shutil.rmtree(packages)
     return packages
+
+
+def _relative_path_dependency_dirs(project_dir: Path, package_root: Path) -> list[Path]:
+    manifest_path = project_dir / "lake-manifest.json"
+    if not manifest_path.exists():
+        return []
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return []
+    packages = manifest.get("packages")
+    if not isinstance(packages, list):
+        return []
+
+    package_root = package_root.resolve()
+    project_dir = project_dir.resolve()
+    paths: list[Path] = []
+    seen: set[str] = set()
+    for package in packages:
+        if not isinstance(package, dict) or package.get("type") != "path":
+            continue
+        raw_dir = package.get("dir")
+        if not isinstance(raw_dir, str) or not raw_dir:
+            continue
+        dependency_dir = (project_dir / raw_dir).resolve()
+        if dependency_dir == package_root:
+            continue
+        try:
+            relative_dir = dependency_dir.relative_to(project_dir)
+        except ValueError:
+            continue
+        if str(relative_dir) == ".":
+            continue
+        relative_text = relative_dir.as_posix()
+        if relative_text in seen:
+            continue
+        seen.add(relative_text)
+        paths.append(relative_dir)
+    return paths
+
+
+def seed_lake_path_builds_from_dependency_cache(layout, project: HarnessProject, project_dir: Path) -> Path | None:
+    source_root = reference_dependency_path_builds_dir(layout, project)
+    if not source_root.exists():
+        return None
+    copied = False
+    for relative_dir in _relative_path_dependency_dirs(project_dir, layout.package_root):
+        source_build = source_root / relative_dir / ".lake" / "build"
+        if not source_build.exists():
+            continue
+        destination_build = lake_build_dir(project_dir / relative_dir)
+        destination_build.mkdir(parents=True, exist_ok=True)
+        run(["rsync", "-a", f"{source_build}/", f"{destination_build}/"], cwd=layout.package_root)
+        copied = True
+    return source_root if copied else None
+
+
+def store_lake_path_builds_in_dependency_cache(layout, project: HarnessProject, project_dir: Path) -> Path | None:
+    destination_root = reference_dependency_path_builds_dir(layout, project)
+    copied = False
+    for relative_dir in _relative_path_dependency_dirs(project_dir, layout.package_root):
+        source_build = lake_build_dir(project_dir / relative_dir)
+        if not source_build.exists():
+            continue
+        destination_build = destination_root / relative_dir / ".lake" / "build"
+        destination_build.mkdir(parents=True, exist_ok=True)
+        run(["rsync", "-a", "--delete", f"{source_build}/", f"{destination_build}/"], cwd=layout.package_root)
+        copied = True
+    return destination_root if copied else None
 
 
 def short_git_ref(ref: str) -> str:
@@ -763,15 +840,18 @@ def sync_reference_cache_checkout(
         seed_lake_packages_from_dependency_cache(layout, project, project_dir, package_mode=package_mode) is not None
         and package_mode == REFERENCE_PACKAGE_MODE_MOVE
     )
+    seed_lake_path_builds_from_dependency_cache(layout, project, project_dir)
     try:
         with local_blueprint_dependency_override(layout.package_root, project_dir, restore_lakefile=True):
             run_reference_lake_update(layout.package_root, project_dir)
+            seed_lake_path_builds_from_dependency_cache(layout, project, project_dir)
             if warm_build and project.build_command is not None:
                 command = lean_low_priority_command(layout.package_root, *project.build_command)
                 try:
                     run_with_heartbeat(command, cwd=project_dir, label=f"{project.project_id}: warm cache build")
                 except subprocess.CalledProcessError as err:
                     raise SystemExit(reference_cache_warm_build_failure_message(layout, project, command, err)) from err
+            store_lake_path_builds_in_dependency_cache(layout, project, project_dir)
             if store_lake_packages_in_dependency_cache(layout, project, project_dir, package_mode=package_mode) is not None:
                 # The dependency cache is now the source of truth. Drop the warmed
                 # cache checkout copy so large external projects do not keep two
@@ -836,6 +916,7 @@ def sync_reference_local_checkout(
             ["rsync", "-a", "--exclude", "/build/", f"{cache_lake}/", f"{local_dir / project.project_root / '.lake'}/"],
             cwd=layout.package_root,
         )
+    seed_lake_path_builds_from_dependency_cache(layout, project, local_dir / project.project_root)
     return local_dir
 
 
@@ -897,15 +978,19 @@ def generate_git_project(
         output_dir = output_dir_for(project, output_root)
         output_dir.mkdir(parents=True, exist_ok=True)
         bootstrap_reference_checkout(project_dir=project_dir)
+        def update_reference_project() -> None:
+            run_reference_lake_update(
+                layout.package_root,
+                project_dir,
+                reconcile_toolchains=True,
+            )
+            seed_lake_path_builds_from_dependency_cache(layout, project, project_dir)
+
         with local_blueprint_dependency_override(layout.package_root, project_dir, restore_lakefile=False, log=True):
             run_project_update_build_generate(
                 layout.package_root,
                 project_dir,
-                update_project=lambda: run_reference_lake_update(
-                    layout.package_root,
-                    project_dir,
-                    reconcile_toolchains=True,
-                ),
+                update_project=update_reference_project,
                 build_command=project.build_command,
                 generate_command=project.generate_command or (),
                 format_command=lambda command: format_project_command(
@@ -921,6 +1006,7 @@ def generate_git_project(
                 skip_build=skip_build,
                 project_id=project.project_id,
             )
+            store_lake_path_builds_in_dependency_cache(layout, project, project_dir)
     finally:
         if borrowed_packages:
             store_lake_packages_in_dependency_cache(layout, project, project_dir, package_mode=package_mode)

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -36,8 +36,10 @@ from scripts.blueprint_harness_references import (
     reference_submodule_update_command,
     reconcile_reference_toolchains,
     require_reference_harness_layout,
+    seed_lake_path_builds_from_dependency_cache,
     seed_reference_edit_checkout_lake,
     seed_lake_packages_from_dependency_cache,
+    store_lake_path_builds_in_dependency_cache,
     store_lake_packages_in_dependency_cache,
     update_git_checkout,
 )
@@ -419,6 +421,90 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(pruned, packages)
         self.assertFalse(packages.exists())
 
+    def test_reference_dependency_path_build_cache_seeds_external_path_dependencies(self) -> None:
+        import scripts.blueprint_harness_references as refs_mod
+
+        project = HarnessProject(
+            project_id="external-blueprint",
+            source_kind="git_checkout",
+            project_root="nested/blueprint",
+            build_target=None,
+            generator=None,
+            repository="https://github.com/example/external-blueprint.git",
+            ref="main",
+            build_command=("lake", "build"),
+            generate_command=("lake", "exe", "blueprint-gen"),
+            site_subdir="html-multi",
+            panel_regression_script=None,
+            browser_tests_path=None,
+            description=None,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cache_key = reference_dependency_cache_key(project)
+            path_builds = root / "deps" / cache_key / "path-builds"
+            project_dir = root / "checkout" / "nested" / "blueprint"
+            package_root = root / "pkg"
+            project_dir.mkdir(parents=True)
+            package_root.mkdir()
+            (path_builds / "Formalization" / ".lake" / "build" / "lib").mkdir(parents=True)
+            (project_dir / "Formalization" / ".lake" / "build" / "lib").mkdir(parents=True)
+            (project_dir / "lake-manifest.json").write_text(
+                json.dumps(
+                    {
+                        "packages": [
+                            {
+                                "name": "VersoBlueprint",
+                                "type": "path",
+                                "dir": "../../../pkg",
+                            },
+                            {
+                                "name": "Formalization",
+                                "type": "path",
+                                "dir": "./Formalization",
+                            },
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            layout = SimpleNamespace(
+                package_root=package_root,
+                reference_dependency_cache_root=root / "deps",
+            )
+
+            original_run = refs_mod.run
+            commands: list[list[str]] = []
+            try:
+                refs_mod.run = lambda command, *, cwd: commands.append(command)
+
+                seeded_from = seed_lake_path_builds_from_dependency_cache(layout, project, project_dir)
+                stored_to = store_lake_path_builds_in_dependency_cache(layout, project, project_dir)
+            finally:
+                refs_mod.run = original_run
+
+        self.assertEqual(seeded_from, path_builds)
+        self.assertEqual(stored_to, path_builds)
+        self.assertEqual(
+            commands,
+            [
+                [
+                    "rsync",
+                    "-a",
+                    f"{path_builds / 'Formalization' / '.lake' / 'build'}/",
+                    f"{project_dir / 'Formalization' / '.lake' / 'build'}/",
+                ],
+                [
+                    "rsync",
+                    "-a",
+                    "--delete",
+                    f"{project_dir / 'Formalization' / '.lake' / 'build'}/",
+                    f"{path_builds / 'Formalization' / '.lake' / 'build'}/",
+                ],
+            ],
+        )
+
     def test_reference_pages_workflow_stages_every_manifest_project(self) -> None:
         catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
         release = resolve_release_target(catalog, "v4.30.0", PACKAGE_ROOT)
@@ -427,12 +513,19 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         workflow_text = (PACKAGE_ROOT / ".github" / "workflows" / "reference-blueprints.yml").read_text(
             encoding="utf-8"
         )
+        deploy_workflow_text = (PACKAGE_ROOT / ".github" / "workflows" / "reference-blueprints-deploy.yml").read_text(
+            encoding="utf-8"
+        )
 
         self.assertIn("emit_reference_release_matrix.py", workflow_text)
         self.assertIn("pattern: reference-blueprints-*", workflow_text)
         self.assertIn("--project ${{ matrix.project_id }}", workflow_text)
         self.assertIn("matrix.reference_cache_key", workflow_text)
         self.assertIn(".worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/packages", workflow_text)
+        self.assertIn(".worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/path-builds", workflow_text)
+        self.assertIn("reference-deps-v2-${{ matrix.reference_cache_key }}", workflow_text)
+        self.assertIn(".worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/path-builds", deploy_workflow_text)
+        self.assertIn("reference-deploy-deps-v2-${{ matrix.reference_cache_key }}", deploy_workflow_text)
 
         for entry in matrix["include"]:
             self.assertEqual(entry["artifact_name"], f"reference-blueprints-{entry['project_id']}")
@@ -1434,6 +1527,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             layout = SimpleNamespace(
                 package_root=root / "pkg",
                 repo_root=root / "repo",
+                reference_dependency_cache_root=root / "deps",
             )
             layout.package_root.mkdir()
             layout.repo_root.mkdir()


### PR DESCRIPTION
This PR extends the shared reference dependency cache to include `.lake/build` trees for external path dependencies, so large formalization submodules can stay warm across reference blueprint runs instead of rebuilding from scratch.

Backport v4.30.0: #235