### PR TITLE
test: cover source metadata data export

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -172,23 +172,31 @@ Clients should read `entry.sources`; the manifest does not emit a singular
 source ref, while `.leanDecl` entries can aggregate refs from multiple sourced
 Blueprint nodes that share the same Lean declaration preview.
 
-Generated browser APIs expose the same split. Use `loadManifestEntry` or
-`resolvePreview` to read `entry.sources`, then use `loadSourceDocument` or
-`loadSourceDocuments` to resolve those document ids to titles, PDF paths, and
-extracted page roots. These helpers reuse the cached manifest load; they do not
-fetch a second JSON file.
+Generated browser APIs expose the same split. Data-only clients should use
+`api/data.mjs` when they only need manifest facts: `loadManifestEntry`,
+`loadSourceDocument`, `loadSourceDocuments`, and `resolveSourceMetadata` do not
+import DOM rendering code. Render-capable clients should use `api/preview.mjs`
+when they also need `resolvePreview`, `renderNode`, canonical node loading, or
+hydration. Both entrypoints reuse the cached manifest load; resolving source
+metadata does not fetch a second JSON file.
 
-Clients can use `resolveSourceMetadata(source)` from either `api/data.mjs` or
-`api/preview.mjs` when they want the source refs attached to a preview joined
-with declared source-document metadata. The `source` argument can be a preview
-key, a manifest entry, or a result returned by `resolvePreview`,
-`resolveCanonicalPreview`, or `renderNode`:
+Clients can call `resolveSourceMetadata(source)` from either entrypoint when
+they want the source refs attached to a preview joined with declared
+source-document metadata. The `source` argument can be a preview key, a manifest
+entry, or a result returned by `resolvePreview`, `resolveCanonicalPreview`, or
+`renderNode`:
 
 ```javascript
 const key = api.statementPreviewKey("Chapter2:Problem2.11.6");
 const sourceMetadata = await api.resolveSourceMetadata(key);
 if (sourceMetadata.ok) console.log(sourceMetadata.sources[0].document?.title);
 ```
+
+`api/data.mjs` exposes `resolveSourceMetadata` both as an isolated
+`createPreviewData()` instance method and as a module-level named export. Use
+the instance method when a client supplies a custom `fetchJson`; the module-level
+export is convenient for ordinary generated-site scripts that use the default
+loader.
 
 Generated Blueprint node shells render a compact source chip and lightweight
 source preview from this same manifest data. The API itself returns structured

--- a/doc/JS_API_DOCS.md
+++ b/doc/JS_API_DOCS.md
@@ -57,7 +57,10 @@ data:
 
 ```js
 // Import the data-only API when no DOM rendering is needed.
-import { createPreviewData } from "./-verso-data/api/data.mjs";
+import {
+  createPreviewData,
+  resolveSourceMetadata
+} from "./-verso-data/api/data.mjs";
 
 // Create an isolated data loader for this client.
 const data = createPreviewData();
@@ -66,9 +69,11 @@ const data = createPreviewData();
 const manifest = await data.loadManifest();
 const entry = manifest.get(data.statementPreviewKey("Chapter2:Problem2.11.6"));
 const sourceMetadata = await data.resolveSourceMetadata(entry);
+const sameSourceMetadata = await resolveSourceMetadata(entry);
 
 if (entry) {
   console.log(entry.href, entry.label, entry.facet, sourceMetadata.sources[0]?.document?.title);
+  console.log(sameSourceMetadata.sources[0]?.document?.title);
 }
 ```
 

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -682,6 +682,8 @@ Browser clients can call `resolveSourceMetadata` from `api/data.mjs` or
 `api/preview.mjs` to resolve source refs for a preview key, manifest entry, or
 render result. The API returns structured source-document metadata and recorded
 text/PDF spans.
+Use the data API for metadata-only audit or dashboard clients; use the preview
+API when the same client also renders Blueprint nodes or cached previews.
 The built-in source preview is intentionally lightweight; richer PDF page
 viewers and crop overlays remain Blueprint/Verso interface work.
 

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -111,9 +111,11 @@ Work:
    source previews into fuller VBP-rendered review interfaces that consume
    manifest `sourceDocuments` and `entry.sources`; keep PDF viewers, text
    excerpts, and crop overlays out of the browser API contract
-10. deduplicate the source metadata resolver with manifest/data lookup helpers
-   once more source consumers exist, so missing-entry, missing-document, and
-   source-ref normalization semantics have one implementation
+10. scheduled follow-up: deduplicate the source metadata resolver with
+   manifest/data lookup helpers now that both `api/data.mjs` and
+   `api/preview.mjs` expose it. The target shape is one data-layer primitive for
+   preview-key/manifest-entry input normalization, missing-entry reasons,
+   source-document joins, and source-ref normalization semantics.
 
 ### Data Model and Status Semantics
 

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -1261,9 +1261,14 @@ class TestPreviewRuntimeRegressions:
         result = page.evaluate(
             blueprint_render_api_script(
                 """
-                const { createPreviewData } = await import(api.dataApiModuleUrl());
+                const {
+                    createPreviewData,
+                    resolveSourceMetadata: resolveSourceMetadataFromDataModule,
+                    statementPreviewKey: moduleStatementPreviewKey
+                } = await import(api.dataApiModuleUrl());
                 const { createPreview } = await import(api.previewApiModuleUrl());
                 const dataCalls = [];
+                const moduleCalls = [];
                 const previewCalls = [];
                 const manifestPayload = {
                     sourceDocuments: [
@@ -1321,6 +1326,15 @@ class TestPreviewRuntimeRegressions:
                 const sourceMetadata = await data.resolveSourceMetadata(
                     data.statementPreviewKey("sample_node")
                 );
+                const moduleSourceMetadata = await resolveSourceMetadataFromDataModule(
+                    moduleStatementPreviewKey("sample_node"),
+                    {
+                        fetchJson(url) {
+                            moduleCalls.push(url);
+                            return manifestPayload;
+                        }
+                    }
+                );
                 const manifest = await data.loadManifest();
                 const previewSourceDocument = await preview.loadSourceDocument("paper");
                 const previewSourceDocuments = await preview.loadSourceDocuments();
@@ -1330,6 +1344,7 @@ class TestPreviewRuntimeRegressions:
 
                 return {
                     dataCalls: dataCalls.length,
+                    moduleCalls: moduleCalls.length,
                     previewCalls: previewCalls.length,
                     manifestSize: manifest.size,
                     sourceDocumentCount: sourceDocuments.length,
@@ -1342,9 +1357,15 @@ class TestPreviewRuntimeRegressions:
                     emptyDocument,
                     dataHasSourceMetadataResolver:
                         typeof data.resolveSourceMetadata === "function",
+                    moduleHasSourceMetadataResolver:
+                        typeof resolveSourceMetadataFromDataModule === "function",
                     dataSourceMetadataOk: sourceMetadata.ok,
                     dataSourceMetadataDocumentTitle: sourceMetadata.sources[0].document.title,
                     dataSourceMetadataPage: sourceMetadata.sources[0].spans[0].page,
+                    moduleSourceMetadataOk: moduleSourceMetadata.ok,
+                    moduleSourceMetadataDocumentTitle:
+                        moduleSourceMetadata.sources[0].document.title,
+                    moduleSourceMetadataPage: moduleSourceMetadata.sources[0].spans[0].page,
                     previewSourceDocumentId: previewSourceDocument && previewSourceDocument.id,
                     previewSourceDocumentCount: previewSourceDocuments.length,
                     previewEntrySourceDocument: previewEntry && previewEntry.sources[0].document
@@ -1354,6 +1375,7 @@ class TestPreviewRuntimeRegressions:
         )
 
         assert result["dataCalls"] == 1
+        assert result["moduleCalls"] == 1
         assert result["previewCalls"] == 1
         assert result["manifestSize"] == 1
         assert result["sourceDocumentCount"] == 1
@@ -1365,9 +1387,13 @@ class TestPreviewRuntimeRegressions:
         assert result["missingDocument"] is None
         assert result["emptyDocument"] is None
         assert result["dataHasSourceMetadataResolver"] is True
+        assert result["moduleHasSourceMetadataResolver"] is True
         assert result["dataSourceMetadataOk"] is True
         assert result["dataSourceMetadataDocumentTitle"] == "Representation Theory"
         assert result["dataSourceMetadataPage"] == "42"
+        assert result["moduleSourceMetadataOk"] is True
+        assert result["moduleSourceMetadataDocumentTitle"] == "Representation Theory"
+        assert result["moduleSourceMetadataPage"] == "42"
         assert result["previewSourceDocumentId"] == "paper"
         assert result["previewSourceDocumentCount"] == 1
         assert result["previewEntrySourceDocument"] == "paper"


### PR DESCRIPTION
This PR hardens the source-metadata data API coverage and clarifies the data-vs-preview API split in the docs.

- Exercise the module-level resolveSourceMetadata export from api/data.mjs in the browser regression that already covers source-document manifest lookup.
- Clarify that metadata-only clients should use api/data.mjs while render-capable clients should use api/preview.mjs.
- Record the larger source-metadata resolver/data-layer deduplication as the scheduled follow-up.

Backport v4.30.0: exempt: test/docs-only hardening