### PR TITLE
Update 4.32 reference blueprint catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,11 +348,11 @@ upstream repositories have been updated and validated for the new Lean release.
   [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/project-template/)
   and [rendered site for v4.31.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.31.0/project-template/)
 - [`ejgallego/verso-noperthedron`](https://github.com/ejgallego/verso-noperthedron),
-  [rendered site for v4.31.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.31.0/noperthedron/)
+  [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/noperthedron/)
 - [`ejgallego/verso-sphere-packing`](https://github.com/ejgallego/verso-sphere-packing),
   [rendered site for v4.30.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.30.0/spherepackingblueprint/)
 - [`ejgallego/verso-flt`](https://github.com/ejgallego/verso-flt),
-  [rendered site for v4.31.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.31.0/verso-flt/)
+  [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/verso-flt/)
 - [`ejgallego/verso-carleson`](https://github.com/ejgallego/verso-carleson),
   [rendered site for v4.30.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.30.0/verso-carleson/)
 

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -93,7 +93,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "2d702fdf5ffa01f6d8ebade5b1194afb4f72f9ff",
+          "ref": "5e564cb8308d50729279ddce9cb2053ab500b221",
           "publish_reference": true,
           "rc": "4.32-rc1"
         }

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -22,7 +22,16 @@
         }
       ],
       "build_command": ["lake", "build", "ProjectTemplate"],
-      "generate_command": ["lake", "lean", "ProjectTemplateMain.lean", "--", "--run", "ProjectTemplateMain.lean", "--output", "{output_dir}"],
+      "generate_command": [
+        "lake",
+        "lean",
+        "ProjectTemplateMain.lean",
+        "--",
+        "--run",
+        "ProjectTemplateMain.lean",
+        "--output",
+        "{output_dir}"
+      ],
       "site_subdir": "html-multi"
     },
     {
@@ -35,9 +44,10 @@
       },
       "targets": [
         {
-          "release": "v4.31.0",
-          "ref": "2f2355f7a88c2bc3b74a1dd790df4da018cf6339",
-          "publish_reference": true
+          "release": "v4.32.0",
+          "ref": "3fe5dd86508397e36cb2b6fc203d7ed53d540e9b",
+          "publish_reference": true,
+          "rc": "4.32-rc1"
         }
       ],
       "build_command": ["lake", "build", "Contents"],
@@ -60,7 +70,16 @@
         }
       ],
       "build_command": ["bash", "scripts/ci-reference-build.sh"],
-      "generate_command": ["lake", "lean", "SpherePackingBlueprintMain.lean", "--", "--run", "SpherePackingBlueprintMain.lean", "--output", "{output_dir}"],
+      "generate_command": [
+        "lake",
+        "lean",
+        "SpherePackingBlueprintMain.lean",
+        "--",
+        "--run",
+        "SpherePackingBlueprintMain.lean",
+        "--output",
+        "{output_dir}"
+      ],
       "site_subdir": "html-multi"
     },
     {
@@ -73,13 +92,23 @@
       },
       "targets": [
         {
-          "release": "v4.31.0",
-          "ref": "04ed7e578ab59571e7821f4b21c2e77c4071c18a",
-          "publish_reference": true
+          "release": "v4.32.0",
+          "ref": "2d702fdf5ffa01f6d8ebade5b1194afb4f72f9ff",
+          "publish_reference": true,
+          "rc": "4.32-rc1"
         }
       ],
       "build_command": ["lake", "build", "FLTBlueprint"],
-      "generate_command": ["lake", "lean", "FLTBlueprintMain.lean", "--", "--run", "FLTBlueprintMain.lean", "--output", "{output_dir}"],
+      "generate_command": [
+        "lake",
+        "lean",
+        "FLTBlueprintMain.lean",
+        "--",
+        "--run",
+        "FLTBlueprintMain.lean",
+        "--output",
+        "{output_dir}"
+      ],
       "site_subdir": "html-multi"
     },
     {
@@ -99,7 +128,16 @@
         }
       ],
       "build_command": ["lake", "build", "CarlesonBlueprint"],
-      "generate_command": ["lake", "lean", "BlueprintMain.lean", "--", "--run", "BlueprintMain.lean", "--output", "{output_dir}"],
+      "generate_command": [
+        "lake",
+        "lean",
+        "BlueprintMain.lean",
+        "--",
+        "--run",
+        "BlueprintMain.lean",
+        "--output",
+        "{output_dir}"
+      ],
       "site_subdir": "html-multi"
     }
   ]

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -159,9 +159,9 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         if current_release.deploy_pages:
             self.assertTrue(resolve_projects_for_release(catalog, current_release.release_id, None))
         expected_external_releases = {
-            "noperthedron": "v4.31.0",
+            "noperthedron": "v4.32.0",
             "spherepackingblueprint": "v4.30.0",
-            "verso-flt": "v4.31.0",
+            "verso-flt": "v4.32.0",
             "verso-carleson": "v4.30.0",
         }
         self.assertTrue(projects[1].git_checkout)
@@ -169,7 +169,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assert_single_current_release_target(
             projects[1], expected_external_releases[projects[1].project_id], publish_reference=True
         )
-        self.assertIsNone(projects[1].targets[0].rc)
+        self.assertEqual(projects[1].targets[0].rc, "4.32-rc1")
         self.assertEqual(projects[1].build_command, ("lake", "build", "Contents"))
         self.assertEqual(
             projects[1].generate_command,
@@ -187,7 +187,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assert_single_current_release_target(
             projects[3], expected_external_releases[projects[3].project_id], publish_reference=True
         )
-        self.assertIsNone(projects[3].targets[0].rc)
+        self.assertEqual(projects[3].targets[0].rc, "4.32-rc1")
         self.assertEqual(projects[4].repository, "https://github.com/ejgallego/verso-carleson.git")
         self.assert_single_current_release_target(
             projects[4], expected_external_releases[projects[4].project_id], publish_reference=True


### PR DESCRIPTION
Adds the 4.32 release-line reference catalog targets for FLT and Noperthedron after wrapper intakes to Lean 4.32.0-rc1.

Validation: prepared with scripts/meta_checkout.py prepare-vbp-catalog-pr from reference-blueprints; wrapper repos were pushed first. After FLT upstream moved again on the same 4.32.0-rc1 toolchain, refreshed `verso-flt` to wrapper commit `5e564cb` and updated this catalog branch. Locally reran `python3 -m unittest discover -s tests/harness -p 'test_*.py'` for the catalog/test fixes, and reran focused catalog/README tests after the FLT ref refresh.

Backport v4.31.0: exempt: 4.32 release-line catalog update only
Backport v4.30.0: exempt: 4.32 release-line catalog update only