### PR TITLE
Refresh 4.32 reference blueprint wrapper refs

### DIFF
--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -45,7 +45,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "3fe5dd86508397e36cb2b6fc203d7ed53d540e9b",
+          "ref": "b3782cb14debb0bdb30e86036e90d6e7bff784ff",
           "publish_reference": true,
           "rc": "4.32-rc1"
         }
@@ -93,7 +93,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "5e564cb8308d50729279ddce9cb2053ab500b221",
+          "ref": "675805c5b382b6f6a0ddcaf5f82ffa0dd8870d53",
           "publish_reference": true,
           "rc": "4.32-rc1"
         }


### PR DESCRIPTION
Updates the v4.32 reference blueprint catalog after the wrapper repositories refreshed their VersoBlueprint manifest pins to the merged v4.32.0 branch head.

Refs:
- verso-flt: 675805c5b382b6f6a0ddcaf5f82ffa0dd8870d53
- verso-noperthedron: b3782cb14debb0bdb30e86036e90d6e7bff784ff

Backport v4.31.0: exempt: v4.32 catalog-only reference ref update
Backport v4.30.0: exempt: v4.32 catalog-only reference ref update

Local validation:
- python3 -m unittest tests.harness.test_blueprint_harness_projects.BlueprintHarnessProjectsTests.test_default_manifest_contains_release_projects tests.harness.test_prepare_reference_blueprints_pages.PrepareReferenceBlueprintPagesTests.test_readme_uses_release_namespaced_reference_links
- reference-blueprints harness metadata checks for both wrappers

Note: wrapper source/build content is unchanged; only lake-manifest.json VersoBlueprint resolved rev moved from 99816ca to 23dcc1d.
