### PR TITLE
Refresh Noperthedron 4.32 reference catalog

### DIFF
--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -45,7 +45,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "b3782cb14debb0bdb30e86036e90d6e7bff784ff",
+          "ref": "edf9be37d5cb48f1563e57cff60b5d17b51921e0",
           "publish_reference": true,
           "rc": "4.32-rc1"
         }


### PR DESCRIPTION
Updates the v4.32 reference blueprint catalog after refreshing the Noperthedron wrapper to upstream commit `5b61fa0`.

Refs:
- verso-noperthedron wrapper: edf9be37d5cb48f1563e57cff60b5d17b51921e0
- upstream Noperthedron submodule: 5b61fa061803a09f2f42aa4e6866aa15f6d843d8

Backport v4.31.0: exempt: v4.32 catalog-only reference ref update
Backport v4.30.0: exempt: v4.32 catalog-only reference ref update

Local validation:
- python3 scripts/meta_checkout.py validate verso-noperthedron
- python3 scripts/meta_checkout.py compute-repair-work verso-noperthedron --accept-external-build "local validate passed Main build and generated-site check"
- python3 -m unittest tests.harness.test_blueprint_harness_projects.BlueprintHarnessProjectsTests.test_default_manifest_contains_release_projects tests.harness.test_prepare_reference_blueprints_pages.PrepareReferenceBlueprintPagesTests.test_readme_uses_release_namespaced_reference_links
