### PR TITLE
Refresh Noperthedron 4.32 reference catalog

### DIFF
--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -45,7 +45,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "edf9be37d5cb48f1563e57cff60b5d17b51921e0",
+          "ref": "3de67591d70fe602651703d8779e24e1f54f3878",
           "publish_reference": true,
           "rc": "4.32-rc1"
         }


### PR DESCRIPTION
Updates the v4.32 reference blueprint catalog after refreshing the Noperthedron wrapper to upstream commit `a1328e4`.

Refs:
- verso-noperthedron wrapper: 3de67591d70fe602651703d8779e24e1f54f3878
- upstream Noperthedron submodule: a1328e4a15fbddde24c3d137af5040376da7e3ea

Backport v4.31.0: exempt: v4.32 catalog-only reference ref update
Backport v4.30.0: exempt: v4.32 catalog-only reference ref update

Local validation:
- python3 scripts/meta_checkout.py validate verso-noperthedron
- python3 scripts/meta_checkout.py compute-repair-work verso-noperthedron --accept-external-build "local validate passed Main build and generated-site check for a1328e4"
- python3 -m unittest tests.harness.test_blueprint_harness_projects.BlueprintHarnessProjectsTests.test_default_manifest_contains_release_projects tests.harness.test_prepare_reference_blueprints_pages.PrepareReferenceBlueprintPagesTests.test_readme_uses_release_namespaced_reference_links
