### PR TITLE
[backport v4.31.0] feat: support retiring squash-merged worktrees

### DIFF
--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -568,6 +568,9 @@ The local coordination layer is now machine-readable and untracked.
   branch when one exists, and prunes its stale reference clones
 - detached linked worktrees are also retireable once their `HEAD` commit is
   reachable from that worktree's preferred release ref
+- after a GitHub squash merge, pass `--merged-pr <number>` so `worktree-retire`
+  can verify that the merged PR head SHA, head branch, and base branch match the
+  local worktree before force-deleting the local branch
 - by default, each session should only retire or delete worktrees and branches
   it created or landed itself; broader cleanup should be explicit
 
@@ -592,6 +595,7 @@ python3 -m scripts.blueprint_harness worktree-list
 python3 -m scripts.blueprint_harness worktree-claim harness-rework --unlock --priority P0 --status review
 python3 -m scripts.blueprint_harness worktree-prune-candidates
 python3 -m scripts.blueprint_harness worktree-retire <name> --dry-run
+python3 -m scripts.blueprint_harness worktree-retire <name> --merged-pr <number>
 ```
 
 `worktree-list` already refreshes the local metadata before printing.

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -157,9 +157,9 @@ def current_commit_subject(repo_root: Path) -> str:
     return subject
 
 
-def github_pr_title(repo_root: Path, pr_number: int) -> str | None:
+def github_pr_view_json(repo_root: Path, pr_number: int, fields: tuple[str, ...]) -> dict[str, object] | None:
     result = subprocess.run(
-        ["gh", "pr", "view", str(pr_number), "--repo", PUBLIC_REPOSITORY, "--json", "title"],
+        ["gh", "pr", "view", str(pr_number), "--repo", PUBLIC_REPOSITORY, "--json", ",".join(fields)],
         cwd=repo_root,
         check=False,
         text=True,
@@ -171,8 +171,50 @@ def github_pr_title(repo_root: Path, pr_number: int) -> str | None:
         payload = json.loads(result.stdout)
     except json.JSONDecodeError:
         return None
+    return payload if isinstance(payload, dict) else None
+
+
+def github_pr_title(repo_root: Path, pr_number: int) -> str | None:
+    payload = github_pr_view_json(repo_root, pr_number, ("title",))
+    if payload is None:
+        return None
     title = payload.get("title") if isinstance(payload, dict) else None
     return title if isinstance(title, str) and title.strip() else None
+
+
+def branch_name_from_ref(ref: str) -> str:
+    for prefix in ("refs/remotes/origin/", "refs/heads/", "origin/"):
+        if ref.startswith(prefix):
+            return ref.removeprefix(prefix)
+    return ref
+
+
+def worktree_merged_pr_validation_error(
+    repo_root: Path,
+    pr_number: int,
+    worktree: GitWorktree,
+    base_ref: str,
+) -> str | None:
+    payload = github_pr_view_json(
+        repo_root,
+        pr_number,
+        ("state", "baseRefName", "headRefName", "headRefOid"),
+    )
+    if payload is None:
+        return f"unable to read GitHub PR #{pr_number}"
+    state = payload.get("state")
+    if state != "MERGED":
+        return f"GitHub PR #{pr_number} is not merged"
+    base_ref_name = payload.get("baseRefName")
+    if base_ref_name != branch_name_from_ref(base_ref):
+        return f"GitHub PR #{pr_number} base `{base_ref_name}` does not match `{base_ref}`"
+    head_ref_oid = payload.get("headRefOid")
+    if head_ref_oid != worktree.head:
+        return f"GitHub PR #{pr_number} head `{head_ref_oid}` does not match worktree head `{worktree.head}`"
+    head_ref_name = payload.get("headRefName")
+    if worktree.branch is not None and head_ref_name != worktree.branch:
+        return f"GitHub PR #{pr_number} head branch `{head_ref_name}` does not match `{worktree.branch}`"
+    return None
 
 
 def resolve_main_pr_title(repo_root: Path, args: argparse.Namespace) -> str:
@@ -1016,13 +1058,28 @@ def command_worktree_retire(args: argparse.Namespace) -> int:
         raise SystemExit(f"[blueprint-harness] cannot retire a linked worktree attached to `{release_branch}`")
     merge_subject = branch or worktree.head
     base_ref = preferred_worktree_base_ref(path)
-    if not ref_merged_into_worktree_base(layout.repo_root, merge_subject, path):
-        if branch is None:
+    merged_by_ancestry = ref_merged_into_worktree_base(layout.repo_root, merge_subject, path)
+    merged_pr = getattr(args, "merged_pr", None)
+    merge_mode = "ancestry"
+    branch_delete_flag = "-d"
+    if not merged_by_ancestry:
+        if merged_pr is not None:
+            validation_error = worktree_merged_pr_validation_error(layout.repo_root, merged_pr, worktree, base_ref)
+            if validation_error is None:
+                merge_mode = f"github-pr-{merged_pr}"
+                branch_delete_flag = "-D"
+            else:
+                raise SystemExit(f"[blueprint-harness] cannot retire worktree `{name}`: {validation_error}")
+        else:
+            squash_hint = "; pass `--merged-pr <number>` after a squash merge"
+            if branch is None:
+                raise SystemExit(
+                    f"[blueprint-harness] detached worktree `{name}` is at `{worktree.head}` "
+                    f"which is not merged into `{base_ref}`{squash_hint}"
+                )
             raise SystemExit(
-                f"[blueprint-harness] detached worktree `{name}` is at `{worktree.head}` "
-                f"which is not merged into `{base_ref}`"
+                f"[blueprint-harness] branch `{branch}` is not merged into `{base_ref}`{squash_hint}"
             )
-        raise SystemExit(f"[blueprint-harness] branch `{branch}` is not merged into `{base_ref}`")
     if not worktree_is_clean(path):
         raise SystemExit(f"[blueprint-harness] worktree `{name}` has local modifications")
 
@@ -1030,12 +1087,13 @@ def command_worktree_retire(args: argparse.Namespace) -> int:
     print(f"path={path}")
     print(f"branch={branch or ''}")
     print(f"head={worktree.head}")
+    print(f"merge_mode={merge_mode}")
     if args.dry_run:
         return 0
 
     run(["git", "worktree", "remove", str(path)], cwd=layout.repo_root)
     if branch is not None:
-        run(["git", "branch", "-d", branch], cwd=layout.repo_root)
+        run(["git", "branch", branch_delete_flag, branch], cwd=layout.repo_root)
 
     manifest_path = resolve_manifest_path(None, layout.package_root)
     try:
@@ -1402,6 +1460,15 @@ def add_worktree_lifecycle_commands(subparsers) -> None:
         "--dry-run",
         action="store_true",
         help="Print the target worktree without deleting it.",
+    )
+    worktree_retire.add_argument(
+        "--merged-pr",
+        type=int,
+        default=None,
+        help=(
+            "Allow retiring a clean worktree whose branch was squash-merged by "
+            "verifying the merged GitHub PR head and base."
+        ),
     )
     worktree_retire.set_defaults(func=command_worktree_retire)
 

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -742,6 +742,136 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         ):
             self.assertIsNone(harness_mod.github_pr_title(Path("/tmp/worktree"), 11))
 
+    def test_worktree_merged_pr_validation_accepts_matching_metadata(self) -> None:
+        worktree = GitWorktree(
+            name="demo",
+            path=Path("/tmp/repo/.worktrees/demo"),
+            head="abc123",
+            branch="feat/demo",
+            root_checkout=False,
+        )
+        with patched_attrs(
+            harness_mod,
+            github_pr_view_json=lambda _repo_root, _pr_number, _fields: {
+                "state": "MERGED",
+                "baseRefName": "v4.31.0",
+                "headRefName": "feat/demo",
+                "headRefOid": "abc123",
+            },
+        ):
+            self.assertIsNone(
+                harness_mod.worktree_merged_pr_validation_error(
+                    Path("/tmp/repo"),
+                    152,
+                    worktree,
+                    "origin/v4.31.0",
+                )
+            )
+
+    def test_worktree_merged_pr_validation_rejects_mismatched_head(self) -> None:
+        worktree = GitWorktree(
+            name="demo",
+            path=Path("/tmp/repo/.worktrees/demo"),
+            head="abc123",
+            branch="feat/demo",
+            root_checkout=False,
+        )
+        with patched_attrs(
+            harness_mod,
+            github_pr_view_json=lambda _repo_root, _pr_number, _fields: {
+                "state": "MERGED",
+                "baseRefName": "v4.31.0",
+                "headRefName": "feat/demo",
+                "headRefOid": "def456",
+            },
+        ):
+            error = harness_mod.worktree_merged_pr_validation_error(
+                Path("/tmp/repo"),
+                152,
+                worktree,
+                "origin/v4.31.0",
+            )
+
+        self.assertIn("does not match worktree head", error)
+
+    def test_worktree_merged_pr_validation_rejects_unmerged_pr(self) -> None:
+        worktree = GitWorktree(
+            name="demo",
+            path=Path("/tmp/repo/.worktrees/demo"),
+            head="abc123",
+            branch="feat/demo",
+            root_checkout=False,
+        )
+        with patched_attrs(
+            harness_mod,
+            github_pr_view_json=lambda _repo_root, _pr_number, _fields: {
+                "state": "OPEN",
+                "baseRefName": "v4.31.0",
+                "headRefName": "feat/demo",
+                "headRefOid": "abc123",
+            },
+        ):
+            error = harness_mod.worktree_merged_pr_validation_error(
+                Path("/tmp/repo"),
+                152,
+                worktree,
+                "origin/v4.31.0",
+            )
+
+        self.assertIn("is not merged", error)
+
+    def test_worktree_merged_pr_validation_rejects_mismatched_base(self) -> None:
+        worktree = GitWorktree(
+            name="demo",
+            path=Path("/tmp/repo/.worktrees/demo"),
+            head="abc123",
+            branch="feat/demo",
+            root_checkout=False,
+        )
+        with patched_attrs(
+            harness_mod,
+            github_pr_view_json=lambda _repo_root, _pr_number, _fields: {
+                "state": "MERGED",
+                "baseRefName": "v4.30.0",
+                "headRefName": "feat/demo",
+                "headRefOid": "abc123",
+            },
+        ):
+            error = harness_mod.worktree_merged_pr_validation_error(
+                Path("/tmp/repo"),
+                152,
+                worktree,
+                "origin/v4.31.0",
+            )
+
+        self.assertIn("base `v4.30.0` does not match `origin/v4.31.0`", error)
+
+    def test_worktree_merged_pr_validation_rejects_mismatched_branch(self) -> None:
+        worktree = GitWorktree(
+            name="demo",
+            path=Path("/tmp/repo/.worktrees/demo"),
+            head="abc123",
+            branch="feat/demo",
+            root_checkout=False,
+        )
+        with patched_attrs(
+            harness_mod,
+            github_pr_view_json=lambda _repo_root, _pr_number, _fields: {
+                "state": "MERGED",
+                "baseRefName": "v4.31.0",
+                "headRefName": "feat/other",
+                "headRefOid": "abc123",
+            },
+        ):
+            error = harness_mod.worktree_merged_pr_validation_error(
+                Path("/tmp/repo"),
+                152,
+                worktree,
+                "origin/v4.31.0",
+            )
+
+        self.assertIn("head branch `feat/other` does not match `feat/demo`", error)
+
     def test_prepare_backport_pr_requires_title_when_github_lookup_fails(self) -> None:
         args = argparse.Namespace(
             release="v4.28.0",
@@ -1618,6 +1748,136 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 ["git", "branch", "-d", backport.branch],
             ],
         )
+
+    def test_worktree_retire_accepts_verified_squash_merged_pr(self) -> None:
+        args = argparse.Namespace(name="demo", dry_run=False, merged_pr=152)
+        layout = SimpleNamespace(
+            repo_root=Path("/tmp/repo"),
+            package_root=Path("/tmp/package"),
+            worktree_name=None,
+            reference_source_cache_root=Path("/tmp/cache"),
+            reference_dependency_cache_root=Path("/tmp/deps"),
+            reference_project_root=Path("/tmp/reference-root"),
+        )
+        demo = GitWorktree(
+            name="demo",
+            path=Path("/tmp/repo/.worktrees/demo"),
+            head="abc123",
+            branch="feat/demo",
+            root_checkout=False,
+        )
+        commands: list[list[str]] = []
+        seen_prs: list[int] = []
+
+        def fake_pr_validation(_repo_root, pr_number, worktree, base_ref):
+            seen_prs.append(pr_number)
+            self.assertEqual(worktree, demo)
+            self.assertEqual(base_ref, "origin/v4.31.0")
+            return None
+
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            worktree_record_map=lambda _repo_root: (
+                {
+                    "demo": SimpleNamespace(
+                        name="demo",
+                        locked=False,
+                    )
+                },
+                Path("/tmp/repo/.worktrees/registry.json"),
+            ),
+            git_worktree_map=lambda _repo_root: {"demo": demo},
+            preferred_worktree_base_ref=lambda _path: "origin/v4.31.0",
+            ref_merged_into_worktree_base=lambda _repo_root, _ref, _path: False,
+            worktree_merged_pr_validation_error=fake_pr_validation,
+            worktree_is_clean=lambda _path: True,
+            local_release_ref=lambda _repo_root: "v4.31.0",
+            run=lambda command, *, cwd: commands.append(command),
+            resolve_manifest_path=lambda _path_text, _package_root: Path("/tmp/projects.json"),
+            load_project_catalog_manifest=lambda _manifest_path: SimpleNamespace(projects=()),
+            git_worktrees=lambda _repo_root: [],
+            reference_prune_plan=lambda *_args, **_kwargs: [],
+        ):
+            self.assertEqual(harness_mod.command_worktree_retire(args), 0)
+
+        self.assertEqual(seen_prs, [152])
+        self.assertEqual(
+            commands,
+            [
+                ["git", "worktree", "remove", str(demo.path)],
+                ["git", "branch", "-D", demo.branch],
+            ],
+        )
+
+    def test_worktree_retire_rejects_unverified_squash_merged_pr(self) -> None:
+        args = argparse.Namespace(name="demo", dry_run=False, merged_pr=152)
+        layout = SimpleNamespace(
+            repo_root=Path("/tmp/repo"),
+            package_root=Path("/tmp/package"),
+            worktree_name=None,
+        )
+        demo = GitWorktree(
+            name="demo",
+            path=Path("/tmp/repo/.worktrees/demo"),
+            head="abc123",
+            branch="feat/demo",
+            root_checkout=False,
+        )
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            worktree_record_map=lambda _repo_root: (
+                {
+                    "demo": SimpleNamespace(
+                        name="demo",
+                        locked=False,
+                    )
+                },
+                Path("/tmp/repo/.worktrees/registry.json"),
+            ),
+            git_worktree_map=lambda _repo_root: {"demo": demo},
+            preferred_worktree_base_ref=lambda _path: "origin/v4.31.0",
+            ref_merged_into_worktree_base=lambda _repo_root, _ref, _path: False,
+            worktree_merged_pr_validation_error=lambda *_args: "GitHub PR #152 is not merged",
+            local_release_ref=lambda _repo_root: "v4.31.0",
+        ):
+            with self.assertRaisesRegex(SystemExit, "GitHub PR #152 is not merged"):
+                harness_mod.command_worktree_retire(args)
+
+    def test_worktree_retire_hints_for_unverified_squash_merge(self) -> None:
+        args = argparse.Namespace(name="demo", dry_run=False)
+        layout = SimpleNamespace(
+            repo_root=Path("/tmp/repo"),
+            package_root=Path("/tmp/package"),
+            worktree_name=None,
+        )
+        demo = GitWorktree(
+            name="demo",
+            path=Path("/tmp/repo/.worktrees/demo"),
+            head="abc123",
+            branch="feat/demo",
+            root_checkout=False,
+        )
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            worktree_record_map=lambda _repo_root: (
+                {
+                    "demo": SimpleNamespace(
+                        name="demo",
+                        locked=False,
+                    )
+                },
+                Path("/tmp/repo/.worktrees/registry.json"),
+            ),
+            git_worktree_map=lambda _repo_root: {"demo": demo},
+            preferred_worktree_base_ref=lambda _path: "origin/v4.31.0",
+            ref_merged_into_worktree_base=lambda _repo_root, _ref, _path: False,
+            local_release_ref=lambda _repo_root: "v4.31.0",
+        ):
+            with self.assertRaisesRegex(SystemExit, "pass `--merged-pr <number>` after a squash merge"):
+                harness_mod.command_worktree_retire(args)
 
     def test_worktree_retire_rejects_locked_worktree(self) -> None:
         args = argparse.Namespace(name="demo", dry_run=False)


### PR DESCRIPTION
## Summary
Backport #246 to `v4.31.0`.

## Primary Review
- Primary review: #246
- Keep review comments on #246 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.31.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.