### PR TITLE
feat: add Blueprint PDF generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ For the broader rendered artifact index, including published reference
 blueprints and local test fixtures, see the
 [published rendered artifact index](https://leanprover.github.io/verso-blueprint/).
 
+By default, generators write the HTML site under `_out/site/html-multi/`. Passing
+`--pdf` to `lake exe blueprint-gen` also emits TeX and runs `lualatex` to write
+`_out/site/pdf/main.pdf`; use `--pdf-engine <cmd>` for another
+lualatex-compatible command.
+
 ## Three-Level Blueprint Model
 
 Blueprint keeps three related layers separate:

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -193,6 +193,16 @@ supports:
 lake exe blueprint-gen --output _out/site
 ```
 
+To build a PDF as well as the HTML site, pass `--pdf`:
+
+```bash
+lake exe blueprint-gen --output _out/site --pdf
+```
+
+This writes `_out/site/pdf/main.pdf`. PDF generation requires a local
+`lualatex`-compatible command; use `--pdf-engine <cmd>` if your command has a
+different name.
+
 ## What to change first
 
 After copying the template:

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -128,6 +128,15 @@ scripts/lean-low-priority lake test
 ./scripts/validate-test-blueprints.sh --skip-generate
 ```
 
+PDF changes can add the optional real-engine smoke check:
+
+```bash
+./scripts/validate-test-blueprints.sh --run-real-pdf-smoke
+```
+
+The smoke check builds `project_template` with `--pdf`, verifies
+`pdf/main.pdf`, and skips itself when `lualatex` is not installed.
+
 Use browser pytest directly only when the patch changes browser runtime or
 interaction behavior:
 

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -1167,6 +1167,52 @@ Then the compiled-executable path remains available:
 lake exe blueprint-gen --output _out/site
 ```
 
+To emit TeX and compile a PDF in the same run, pass `--pdf`:
+
+```bash
+lake exe blueprint-gen --output _out/site --pdf
+```
+
+The PDF is written to `_out/site/pdf/main.pdf`. The default engine is
+`lualatex`, run with `-shell-escape` because Verso TeX output may include
+assets that require it. Use `--pdf-engine <cmd>` for another
+lualatex-compatible command and `--pdf-runs <n>` to change the number of LaTeX
+passes. `--pdf` implies `--with-tex`; `--with-tex` alone still only writes the
+TeX tree under `_out/site/tex/`.
+
+### HTML and PDF Feature Support
+
+PDF generation is a static TeX/PDF output path. It is useful for reading,
+archiving, and print-oriented review, but it is not a replacement for the
+interactive HTML site. Unless a generator disables the HTML modes explicitly,
+`--pdf` still writes the usual HTML and preview-data artifacts in addition to
+the TeX tree and `main.pdf`.
+
+The table below describes the current built-in rendering behavior. The PDF
+column refers to what appears in `_out/site/pdf/main.pdf`, not to data files
+that may still be emitted alongside the HTML site. PDF status values mean:
+`Supported` renders directly in PDF, `Static only` renders without HTML
+interaction, `Partial` renders only selected static pieces, `Notice only`
+renders a pointer to the HTML output, and `Not in PDF` is absent from
+`main.pdf`.
+
+| Feature | HTML site | PDF status | PDF output |
+| --- | --- | --- | --- |
+| Ordinary Manual prose, headings, lists, and structure | Full generated HTML pages | Supported | Static TeX/PDF via Verso's TeX renderer |
+| Blueprint statement and proof blocks | Numbered headers, metadata chips, folding, relation panels, Lean status, previews, and authored body content | Static only | Static title and authored body content; no folding, chips, panels, or hover UI |
+| Math and project TeX macros | KaTeX-rendered math, with best-effort KaTeX linting during elaboration | Supported | LaTeX math in the generated TeX/PDF; Blueprint inserts project TeX preludes into the generated TeX |
+| Citations and bibliography | Linked citation and bibliography UI | Supported | Static citations and bibliography entries |
+| `{uses ...}` and `{bpref ...}` inline references | Links, preview triggers, and dependency metadata | Static only | Static inline text, or the resolved target title when no inline text is provided |
+| Attached Lean code | Code panels, Lean declaration summaries, hovers, and preview data | Static only | Static code content when present; no hovers, status widgets, or runtime previews |
+| Attached Rust code | Styled and foldable Rust code panels | Static only | Static verbatim Rust code block |
+| External Markdown or TeX markup attachments | Stored in the manifest; headers show attachment badges; bodyless Markdown-backed nodes can render source-backed HTML cache fragments | Partial | Explicit external-markup blocks render only when shown with `(display := summary)` or `(display := source)`; source-backed HTML cache bodies are not converted into PDF bodies |
+| Source provenance and source-PDF spans | Source chips, manifest entries, and data/preview API access for source document ids and text/PDF spans | Not in PDF | Not shown as source chips or page overlays in the PDF |
+| Dependency graph and progress summary pages | Interactive graph and summary views with runtime controls and previews | Notice only | Static notice pointing readers to the HTML output |
+| Grafted Blueprint nodes | Rendered from the preview manifest and HTML cache | Partial | Inserted graft nodes render as a static notice; side-by-side authored content still renders statically |
+| Browser preview runtime, relation panels, and interactive controls | Supported in generated HTML | Not in PDF | Not available in PDF |
+| Preview manifest, HTML cache, and JavaScript APIs | Emitted for generated-data and browser consumers | Not in PDF | Not embedded in `main.pdf`; still emitted alongside HTML unless those outputs are disabled |
+| Slides and other generator-side consumers | Supported through their own HTML/data render paths | Not in PDF | Not part of the `--pdf` output path |
+
 ## Blueprint Options
 
 Set Blueprint options with ordinary Lean `set_option` commands in the module

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -59,6 +59,7 @@ lean_lib VersoBlueprintTests where
     `VersoBlueprintTests.BlueprintRustCode,
     `VersoBlueprintTests.BlueprintSummaryLinks,
     `VersoBlueprintTests.BlueprintSummaryStatus,
+    `VersoBlueprintTests.BlueprintTeXCleanup,
     `VersoBlueprintTests.BlueprintTexMacros,
     `VersoBlueprintTests.BlueprintExternalMarkup,
     `VersoBlueprintTests.ExternalDeclRender,

--- a/project_template/README.md
+++ b/project_template/README.md
@@ -102,6 +102,15 @@ which is especially helpful in cold CI jobs and Mathlib-heavy projects. If you
 want a compiled executable for repeated local runs,
 `lake exe blueprint-gen --output _out/site` still works.
 
+To build a PDF locally, run:
+
+```bash
+lake exe blueprint-gen --output _out/site --pdf
+```
+
+This writes `_out/site/pdf/main.pdf` and requires a `lualatex`-compatible
+command on `PATH`.
+
 ## GitHub Pages
 
 The template includes `.github/workflows/pages.yml`.

--- a/scripts/blueprint_test_blueprints.py
+++ b/scripts/blueprint_test_blueprints.py
@@ -413,6 +413,7 @@ def validate_test_blueprint_outputs(
     skip_generate: bool = False,
     skip_panel_regression: bool = False,
     skip_browser_tests: bool = False,
+    run_real_pdf_smoke: bool = False,
     stop_on_first_failure: bool = False,
 ) -> int:
     failures: list[StepFailure] = []
@@ -446,7 +447,62 @@ def validate_test_blueprint_outputs(
         )
     )
 
+    if run_real_pdf_smoke and not (stop_on_first_failure and failures):
+        if failure := run_real_pdf_smoke_check(package_root, output_root):
+            failures.append(failure)
+
     return print_failure_summary(failures, prefix=TEST_BLUEPRINT_HARNESS_PREFIX)
+
+
+def run_real_pdf_smoke_check(package_root: Path, output_root: Path) -> StepFailure | None:
+    if shutil.which("lualatex") is None:
+        print(f"{TEST_BLUEPRINT_HARNESS_PREFIX} real PDF smoke skipped: lualatex not found")
+        return None
+
+    project_dir = package_root / "project_template"
+    output_dir = output_root / "_real-pdf-smoke"
+    original_manifest = snapshot_tracked_project_manifest(project_dir)
+    try:
+        with maybe_in_repo_blueprint_dependency_override(project_dir, package_root, log=True):
+            run_project_update_build_generate(
+                package_root,
+                project_dir,
+                update_project=lambda: run_project_lake_update(package_root, project_dir),
+                build_command=("lake", "build", "ProjectTemplate"),
+                generate_command=(
+                    "lake",
+                    "exe",
+                    "blueprint-gen",
+                    "--output",
+                    "{output_dir}",
+                    "--pdf",
+                ),
+                format_command=lambda command: format_project_command(
+                    command,
+                    {
+                        "package_root": package_root,
+                        "project_dir": project_dir,
+                        "output_dir": output_dir,
+                        "slug": "_real-pdf-smoke",
+                    },
+                ),
+                skip_build=False,
+                project_id="real-pdf-smoke",
+            )
+    except subprocess.CalledProcessError as err:
+        return _subprocess_failure("real PDF smoke", err)
+    except SystemExit as err:
+        return StepFailure("real PDF smoke", str(err))
+    finally:
+        restore_tracked_project_manifest(original_manifest)
+
+    pdf_path = output_dir / "pdf" / "main.pdf"
+    if not pdf_path.exists():
+        return StepFailure("real PDF smoke", f"missing expected PDF: {pdf_path}")
+    if pdf_path.stat().st_size == 0:
+        return StepFailure("real PDF smoke", f"empty PDF: {pdf_path}")
+    print(f"{TEST_BLUEPRINT_HARNESS_PREFIX} real PDF smoke wrote {pdf_path}")
+    return None
 
 
 def find_test_blueprint(fixtures: list[StandaloneTestBlueprint], slug: str) -> StandaloneTestBlueprint:
@@ -538,6 +594,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Skip configured Playwright browser regression suites.",
     )
     validate.add_argument(
+        "--run-real-pdf-smoke",
+        action="store_true",
+        help="If lualatex is available, build project_template with --pdf and check pdf/main.pdf.",
+    )
+    validate.add_argument(
         "--pytest-arg",
         action="append",
         default=[],
@@ -596,6 +657,7 @@ def main() -> int:
             skip_generate=args.skip_generate,
             skip_panel_regression=args.skip_panel_regression,
             skip_browser_tests=args.skip_browser_tests,
+            run_real_pdf_smoke=args.run_real_pdf_smoke,
             stop_on_first_failure=args.stop_on_first_failure,
         )
     raise SystemExit("unreachable")

--- a/src/VersoBlueprint/Cite.lean
+++ b/src/VersoBlueprint/Cite.lean
@@ -13,6 +13,7 @@ import VersoBlueprint.Informal.Block.Store
 import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.Lib.HoverRender
 import VersoBlueprint.Resolve
+import VersoBlueprint.TeX
 import VersoBlueprint.TraversalIndex
 
 open Lean Elab Command
@@ -519,6 +520,7 @@ inline_extension Inline.bpCite (citations : List CiteItem) (style : CitationStyl
     pure none
   extraCss := citeAssetBundle.css
   extraJs := citeAssetBundle.js
+  usePackages := Informal.TeX.standardMathUsePackages
   toTeX :=
     open Verso.Output.TeX in
     some <| fun go _id data content => do

--- a/src/VersoBlueprint/Commands/Bibliography.lean
+++ b/src/VersoBlueprint/Commands/Bibliography.lean
@@ -12,6 +12,7 @@ import VersoBlueprint.Commands.Common
 import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.PreviewCache
 import VersoBlueprint.Resolve
+import VersoBlueprint.TeX
 import VersoBlueprint.TraversalIndex
 
 namespace Informal.Commands
@@ -36,6 +37,7 @@ def bibliographyAssetBundle : BlueprintAssetBundle :=
 open Verso Doc Elab Genre Manual in
 block_extension Block.bibliography (biblio : BibliographyData) where
   data := toJson biblio
+  usePackages := Informal.TeX.standardMathUsePackages
   traverse id data _contents := do
     let some biblio ← Informal.ExtensionDecode.decode? (α := BibliographyData) data
         (fun _ => "Malformed data in Block.bibliography.traverse")
@@ -46,7 +48,17 @@ block_extension Block.bibliography (biblio : BibliographyData) where
       modify fun st =>
         Informal.TraversalIndex.Bibliography.saveId st entry.label id
     return none
-  toTeX := none
+  toTeX :=
+    open Verso.Output.TeX in
+    some <| fun goI _goB _id data _blocks => do
+      let .ok data := fromJson? (α := BibliographyData) data
+        | Verso.reportError s!"Malformed data in Block.bibliography.toTeX: {data}"
+          pure .empty
+      let entries := data.entries.toArray.qsort (fun a b => a.citation.sortKey < b.citation.sortKey)
+      let items ← entries.mapM fun entry => do
+        let rendered ← entry.citation.bibTeX goI
+        pure \TeX{\item[\Lean{entry.label}] \Lean{rendered} s!"\n"}
+      pure \TeX{\begin{description}\Lean{items}\end{description}}
   toHtml :=
     open Verso.Doc.Html in
     open Verso.Output.Html in

--- a/src/VersoBlueprint/Commands/Graph.lean
+++ b/src/VersoBlueprint/Commands/Graph.lean
@@ -17,6 +17,7 @@ import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.PreviewCache
 import VersoBlueprint.Lib.PreviewSource
 import VersoBlueprint.Resolve
+import VersoBlueprint.TeX
 import VersoBlueprint.TraversalIndex
 
 namespace Informal.Commands
@@ -80,6 +81,7 @@ block_extension Block.graph (graphData : GraphBlockData) where
   -- for TOC
   -- localContentItem _ _ _ := none
   data := toJson graphData
+  usePackages := Informal.TeX.standardMathUsePackages
   traverse id data _contents := do
       match ← Informal.ExtensionDecode.decode? (α := GraphBlockData) data
           (fun _ => "Malformed data in Block.graph.traverse") with
@@ -89,7 +91,10 @@ block_extension Block.graph (graphData : GraphBlockData) where
       | Option.none =>
         pure ()
       return none
-  toTeX := none
+  toTeX :=
+    open Verso.Output.TeX in
+    some <| fun _goI _goB _id _data _blocks =>
+      pure <| .text "The dependency graph is available in the HTML output."
   toHtml :=
     open Verso.Doc.Html in
     open Verso.Output.Html in

--- a/src/VersoBlueprint/Commands/Summary/Sections.lean
+++ b/src/VersoBlueprint/Commands/Summary/Sections.lean
@@ -12,6 +12,7 @@ import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.Lib.HoverRender
 import VersoBlueprint.Lib.PreviewSource
 import VersoBlueprint.Resolve
+import VersoBlueprint.TeX
 import VersoBlueprint.TraversalIndex
 
 /-!
@@ -415,9 +416,13 @@ private def summaryBlockToHtml : BlockToHtml Manual (ReaderT AllRemotes (ReaderT
 open Verso Doc Elab Genre Manual in
 block_extension Block.summary (summary : Summary) where
   data := toJson summary
+  usePackages := Informal.TeX.standardMathUsePackages
   traverse _id _data _contents := do
     return none
-  toTeX := none
+  toTeX :=
+    open Verso.Output.TeX in
+    some <| fun _goI _goB _id _data _blocks =>
+      pure <| .text "The Blueprint summary is available in the HTML output."
   toHtml := some summaryBlockToHtml
   extraCss := summaryAssetBundle.css
   extraJs := summaryAssetBundle.js

--- a/src/VersoBlueprint/Graft.lean
+++ b/src/VersoBlueprint/Graft.lean
@@ -15,6 +15,7 @@ import VersoBlueprint.Graft.Render
 import VersoBlueprint.PreviewManifest.BlockRender
 import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.Slides.Node
+import VersoBlueprint.TeX
 
 set_option doc.verso true
 
@@ -148,8 +149,12 @@ private def renderManualGraftNode
 open Verso Doc Elab Genre Manual in
 block_extension Block.blueprintGraftNode (cfg : Informal.Graft.BlueprintNodeConfig) where
   data := toJson cfg
+  usePackages := Informal.TeX.standardMathUsePackages
   traverse _ _ _ := pure none
-  toTeX := none
+  toTeX :=
+    open Verso.Output.TeX in
+    some <| fun _goI _goB _id _data _blocks =>
+      pure <| .text "This Blueprint graft node is available in the HTML output."
   extraCss := manualGraftAssetBundle.css
   extraJs := manualGraftAssetBundle.js
   toHtml :=
@@ -167,8 +172,9 @@ block_extension Block.blueprintGraftNode (cfg : Informal.Graft.BlueprintNodeConf
 open Verso Doc Elab Genre Manual in
 block_extension Block.blueprintGraftSideBySide (cfg : Informal.Graft.SideBySideConfig) where
   data := toJson cfg
+  usePackages := Informal.TeX.standardMathUsePackages
   traverse _ _ _ := pure none
-  toTeX := none
+  toTeX := some <| fun _goI goB _id _data blocks => blocks.mapM goB
   extraCss := manualGraftAssetBundle.css
   extraJs := manualGraftAssetBundle.js
   toHtml :=

--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -30,6 +30,7 @@ import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.PreviewRender
 import VersoBlueprint.Resolve
 import VersoBlueprint.Source.Metadata
+import VersoBlueprint.TeX
 import VersoBlueprint.TraversalIndex
 import VersoBlueprint.Profiling
 
@@ -61,6 +62,7 @@ block_extension Block.informal (data : BlockData) where
   -- for TOC
   -- localContentItem _ _ _ := none
   data := toJson data
+  usePackages := Informal.TeX.standardMathUsePackages
   traverse id data _contents := do
     -- XXX: (maybe) lift the Except into the main monad error thread
     match ← ExtensionDecode.decode? (α := BlockData) data
@@ -79,7 +81,15 @@ block_extension Block.informal (data : BlockData) where
         | none =>
             modify fun st => Informal.TraversalIndex.SourceRefs.saveData st blockData.label sourceRef
       return none
-  toTeX := none
+  toTeX := some <| fun _goI goB _id data blocks => do
+      let .ok data := fromJson? (α := BlockData) data
+        | Verso.reportError s!"Malformed data in Block.informal.toTeX: {data}"
+          pure .empty
+      let st ← Verso.Doc.TeX.state
+      let data := data.withResolvedNumbering st
+      let title := data.displayTitle st
+      let body ← blocks.mapM goB
+      pure <| Informal.TeX.quotedBlock title body
   extraCss := Informal.Block.Assets.blockCssAssets
   extraJs := Informal.Block.Assets.blockJsAssets
   toHtml :=

--- a/src/VersoBlueprint/Informal/Code.lean
+++ b/src/VersoBlueprint/Informal/Code.lean
@@ -19,6 +19,7 @@ import VersoBlueprint.Lean
 import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.Profiling
 import VersoBlueprint.Resolve
+import VersoBlueprint.TeX
 import VersoBlueprint.TraversalIndex
 
 open Verso Doc Elab
@@ -55,6 +56,7 @@ private partial def previewCodeBlocks
 
 block_extension Block.informalCode (data : InlineCodeData) where
   data := toJson data
+  usePackages := Informal.TeX.standardMathUsePackages
   traverse id data _contents := do
     let some cdata ← ExtensionDecode.decode? (α := InlineCodeData) data
         (fun _ => s!"Malformed data: {data}")
@@ -88,7 +90,15 @@ block_extension Block.informalCode (data : InlineCodeData) where
       modify λ s => Informal.TraversalIndex.InlineCode.saveId s label id
       modify λ s => Informal.TraversalIndex.InlineCode.saveData s label (toJson cdata)
       pure none
-  toTeX := none
+  toTeX := some <| fun _goI goB _id data blocks => do
+      let title ←
+        match fromJson? (α := InlineCodeData) data with
+        | .ok cdata => pure s!"Lean code for {cdata.label}"
+        | .error err =>
+          Verso.reportError s!"Malformed data in Block.informalCode.toTeX ({err}): {data}"
+          pure "Lean code"
+      let body ← blocks.mapM goB
+      pure <| Informal.TeX.boldHeadingBlocks title body
   extraCss := Informal.Block.Assets.codeCssAssets
   extraJs := ([] : List String)
   toHtml :=
@@ -253,6 +263,7 @@ deriving Repr, Inhabited, FromJson, ToJson, Quote
 
 block_extension Block.externalMarkup (data : ExternalMarkupBlockData) where
   data := toJson data
+  usePackages := Informal.TeX.standardMathUsePackages
   traverse id data _contents := do
     let some cdata ← ExtensionDecode.decode? (α := ExternalMarkupBlockData) data
         (fun _ => s!"Malformed external markup data: {data}")
@@ -274,7 +285,18 @@ block_extension Block.externalMarkup (data : ExternalMarkupBlockData) where
       modify fun s => Informal.TraversalIndex.ExternalMarkup.saveId s cdata.label id
       modify fun s => Informal.TraversalIndex.ExternalMarkup.saveData s cdata.label (toJson updated)
     pure none
-  toTeX := none
+  toTeX :=
+    open Verso.Output.TeX in
+    some <| fun _goI _goB _id data _blocks => do
+      let .ok cdata := fromJson? (α := ExternalMarkupBlockData) data
+        | Verso.reportError s!"Malformed external markup data in Block.externalMarkup.toTeX: {data}"
+          pure .empty
+      let summary := ExternalMarkupView.displaySummary cdata.markup
+      match cdata.display with
+      | .hidden => pure .empty
+      | .summary => pure <| .text summary
+      | .source =>
+        pure <| Informal.TeX.verbatimBlock summary cdata.markup.raw
   extraCss := ({} : Std.HashSet CSS)
   extraJs := ([] : List String)
   toHtml :=

--- a/src/VersoBlueprint/Informal/RustBlock.lean
+++ b/src/VersoBlueprint/Informal/RustBlock.lean
@@ -13,6 +13,7 @@ import VersoBlueprint.Informal.Code
 import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.Profiling
 import VersoBlueprint.Informal.RustPanel
+import VersoBlueprint.TeX
 import VersoBlueprint.TraversalIndex
 
 open Verso Doc Elab
@@ -26,6 +27,7 @@ def rustBlockAssetBundle : Informal.Commands.BlueprintAssetBundle :=
 
 block_extension Block.informalRustCode (data : Informal.Rust.InlineCodeData) where
   data := toJson data
+  usePackages := Informal.TeX.standardMathUsePackages
   traverse id data _contents := do
     let some cdata ← ExtensionDecode.decode? (α := Informal.Rust.InlineCodeData) data
         (fun _ => s!"Malformed Rust data: {data}")
@@ -38,7 +40,12 @@ block_extension Block.informalRustCode (data : Informal.Rust.InlineCodeData) whe
       modify fun s => Informal.TraversalIndex.RustInlineCode.saveId s cdata.label id
       modify fun s => Informal.TraversalIndex.RustInlineCode.saveData s cdata.label cdata
       pure none
-  toTeX := none
+  toTeX := some <| fun _goI _goB _id data _blocks => do
+      let some cdata ← ExtensionDecode.decode? (α := Informal.Rust.InlineCodeData) data
+          (fun _ => s!"Malformed Rust code data: {data}")
+        | pure .empty
+      let title := s!"Rust code for {cdata.label}"
+      pure <| Informal.TeX.verbatimBlock title cdata.raw
   extraCss := rustBlockAssetBundle.css
   extraJs := rustBlockAssetBundle.js
   toHtml :=

--- a/src/VersoBlueprint/Informal/Uses.lean
+++ b/src/VersoBlueprint/Informal/Uses.lean
@@ -16,6 +16,7 @@ import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.Lib.HoverRender
 import VersoBlueprint.PreviewCache
 import VersoBlueprint.Profiling
+import VersoBlueprint.TeX
 import VersoBlueprint.TraversalIndex
 
 open Verso Doc Elab
@@ -116,6 +117,7 @@ private def wrapUseLinkPreview (node : Verso.Output.Html)
 
 inline_extension Inline.informal (data : InlineData) where
   data := toJson data
+  usePackages := Informal.TeX.standardMathUsePackages
   traverse _id data _contents := do
     let some _ ← ExtensionDecode.decode? (α := InlineData) data
         (fun _ => s!"Malformed data in Inline.informal traversal: {data}")
@@ -168,7 +170,34 @@ inline_extension Inline.informal (data : InlineData) where
             renderedInlines
         let hovered := wrapUseLinkPreview plainContent st label block
         return {{<span>{{hovered}}</span>}}
-  toTeX := none
+  toTeX :=
+    open Verso.Output.TeX in
+    some <| fun goI _id data inlines => do
+      let .ok inlineData := fromJson? (α := InlineData) data
+        | Verso.reportError s!"Malformed data in Inline.informal.toTeX: {data}"
+          pure .empty
+      if inlines.isEmpty then
+        let st ← Verso.Doc.TeX.state
+        let storedBlock? := resolveStoredBlockData? st inlineData.label
+        let resolvedBlock : Option BlockData :=
+          match inlineData.block, storedBlock? with
+          | some b, some stored =>
+            some {
+              b with
+              partPrefix := b.partPrefix <|> stored.partPrefix
+              globalCount := b.globalCount <|> stored.globalCount
+            }
+          | none, some stored => some stored
+          | some b, none => some b
+          | none, none => none
+        match resolvedBlock with
+        | some block =>
+          let block := block.withResolvedNumbering st
+          pure <| .text (block.displayTitle st)
+        | none =>
+          pure <| .text s!"{inlineData.label}"
+      else
+        inlines.mapM goI
 
 private def Data.Node.toBlockInfo (node : Data.Node) (label : Data.Label) : BlockData :=
   {

--- a/src/VersoBlueprint/Math.lean
+++ b/src/VersoBlueprint/Math.lean
@@ -9,6 +9,7 @@ import VersoManual
 import VersoBlueprint.Lib.ExtensionDecode
 import VersoBlueprint.MathLint
 import VersoBlueprint.Macros
+import VersoBlueprint.TeX
 
 open Verso Doc Elab
 open Verso.Genre Manual
@@ -33,6 +34,27 @@ private def mathClasses (mode : MathMode) : String :=
   "bp_math " ++ match mode with
     | .inline => "inline"
     | .display => "display"
+
+private def displayMathEnvironments : List String := [
+  "align",
+  "align*",
+  "alignat",
+  "alignat*",
+  "equation",
+  "equation*",
+  "flalign",
+  "flalign*",
+  "gather",
+  "gather*",
+  "multline",
+  "multline*"
+]
+
+private def isDisplayMathSource (source : String) : Bool :=
+  let source := source.trimAscii.toString
+  source.startsWith "\\[" ||
+    displayMathEnvironments.any fun env =>
+      source.startsWith ("\\begin{" ++ env ++ "}")
 
 /-- Narrow the warning site from the whole math literal down to the offending source slice when possible. -/
 private def lintWarningRef? [Monad m] [MonadFileMap m]
@@ -77,6 +99,7 @@ private def mathHtmlAssets (texPrelude : String) : HtmlAssets :=
 
 inline_extension Inline.bpMath (data : BpMathData) where
   data := toJson data
+  usePackages := Informal.TeX.standardMathUsePackages
   traverse _id data _contents := do
     let some { texPrelude, .. } ← Informal.ExtensionDecode.decode? (α := BpMathData) data
         (fun _ => s!"Malformed blueprint math payload during traversal: {data}")
@@ -93,7 +116,11 @@ inline_extension Inline.bpMath (data : BpMathData) where
         | pure .empty
       pure <| match mode with
         | .inline => .raw s!"${source}$"
-        | .display => .raw s!"\\[{source}\\]"
+        | .display =>
+            if isDisplayMathSource source then
+              .raw s!"\n{source.trimAscii.toString}\n"
+            else
+              .raw s!"\\[{source}\\]"
   toHtml :=
     open Verso.Doc.Html in
     some <| fun _goI _id data _contents => do

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -26,6 +26,8 @@ import VersoBlueprint.Html
 import VersoBlueprint.Process
 import VersoBlueprint.Resolve
 import VersoBlueprint.Source.Data
+import VersoBlueprint.TeX.Cleanup
+import VersoBlueprint.TeX.Pdf
 import VersoBlueprint.TraversalIndex
 
 namespace Informal.PreviewManifest
@@ -1944,6 +1946,12 @@ private def dumpManifest
     (extensionImpls : ExtensionImpls)
     (config : RenderConfig := {})
     (externalMarkupConfig : Informal.ExternalMarkupRender.Config := {}) : IO UInt32 := do
+  let options ←
+    match parsePdfOptions options with
+    | .ok (_, options) => pure options
+    | .error err =>
+        IO.eprintln err
+        return 2
   let errorCount : IO.Ref Nat ← IO.mkRef 0
   let logError msg := do
     errorCount.modify (· + 1)
@@ -1964,6 +1972,12 @@ private def dumpHtmlCache
     (extensionImpls : ExtensionImpls)
     (config : RenderConfig := {})
     (externalMarkupConfig : Informal.ExternalMarkupRender.Config := {}) : IO UInt32 := do
+  let options ←
+    match parsePdfOptions options with
+    | .ok (_, options) => pure options
+    | .error err =>
+        IO.eprintln err
+        return 2
   let errorCount : IO.Ref Nat ← IO.mkRef 0
   let logError msg := do
     errorCount.modify (· + 1)
@@ -2097,12 +2111,14 @@ def blueprintMain (text : Part Manual)
     (extensionImpls : ExtensionImpls := by exact extension_impls%)
     (options : List String)
     (config : RenderConfig := {})
-    (extraSteps : List ExtraStep := []) : IO UInt32 :=
+    (extraSteps : List ExtraStep := [])
+    (pdfOptions : PdfOptions := {}) : IO UInt32 :=
   ReaderT.run go extensionImpls
 where
   go : ReaderT ExtensionImpls IO UInt32 := do
     let extensionImpls ← read
     let cfg ← parseRenderConfigOptions (withBuildMetadataAssets config) options
+    let cfg := if pdfOptions.enabled then { cfg with emitTeX := true } else cfg
     let buildMetadata ← readBuildMetadata
     let extraSteps := emitBuildMetadata buildMetadata :: extraSteps
 
@@ -2111,6 +2127,7 @@ where
         if cfg.verbose then
           IO.println "Saving TeX"
         emitTeX cfg.toConfig text
+        Informal.TeX.Cleanup.patchFile cfg.toConfig text
 
       emitBlueprintHtml extraSteps cfg.emitHtmlSingle .single cfg text
         traverseHtmlSingle emitHtmlSingle
@@ -2121,6 +2138,8 @@ where
         if cfg.verbose then
           IO.println s!"Saving word counts to {wcFile}"
         wordCount wcFile cfg.toConfig text
+      if pdfOptions.enabled then
+        Informal.TeX.Pdf.compile pdfOptions cfg.toConfig
     Verso.runWithLogger (action.run extensionImpls)
 
 def blueprintMainWithPreviewData
@@ -2133,7 +2152,14 @@ def blueprintMainWithPreviewData
   let (dumped?, options, externalMarkupConfig) ← handleCliFlags text options extensionImpls config
   if let some code := dumped? then
     return code
+  let (pdfOptions, options) ←
+    match parsePdfOptions options with
+    | .ok parsed => pure parsed
+    | .error err =>
+        IO.eprintln err
+        return 2
   blueprintMain text (extensionImpls := extensionImpls) (options := options) (config := config)
     (extraSteps := emitBlueprintPreviewData extensionImpls externalMarkupConfig :: extraSteps)
+    (pdfOptions := pdfOptions)
 
 end Informal.PreviewManifest

--- a/src/VersoBlueprint/PreviewManifest/Cli.lean
+++ b/src/VersoBlueprint/PreviewManifest/Cli.lean
@@ -87,6 +87,48 @@ def parseExternalMarkupRenderOptionsIO
   | .ok parsed => pure parsed
   | .error err => throw <| IO.userError err
 
+def pdfFlag : String := "--pdf"
+def pdfEngineFlag : String := "--pdf-engine"
+def pdfRunsFlag : String := "--pdf-runs"
+
+structure PdfOptions where
+  enabled : Bool := false
+  engine : String := "lualatex"
+  runs : Nat := 2
+deriving Inhabited, Repr, BEq
+
+private partial def parsePdfOptionsCore :
+    List String → PdfOptions → List String → Except String (PdfOptions × List String)
+  | [], opts, rest => .ok (opts, rest.reverse)
+  | flag :: args, opts, rest =>
+      if flag == pdfFlag then
+        parsePdfOptionsCore args { opts with enabled := true } rest
+      else if flag == pdfEngineFlag then
+        match args with
+        | engine :: more =>
+            let engine := engine.trimAscii.toString
+            if engine.isEmpty then
+              .error s!"empty value after {pdfEngineFlag}"
+            else
+              parsePdfOptionsCore more { opts with enabled := true, engine } rest
+        | [] => .error s!"missing value after {pdfEngineFlag}"
+      else if flag == pdfRunsFlag then
+        match args with
+        | raw :: more =>
+            match raw.toNat? with
+            | some runs =>
+                if runs == 0 then
+                  .error s!"invalid {pdfRunsFlag} value '{raw}'; expected a positive integer"
+                else
+                  parsePdfOptionsCore more { opts with enabled := true, runs } rest
+            | none => .error s!"invalid {pdfRunsFlag} value '{raw}'"
+        | [] => .error s!"missing value after {pdfRunsFlag}"
+      else
+        parsePdfOptionsCore args opts (flag :: rest)
+
+def parsePdfOptions (args : List String) : Except String (PdfOptions × List String) :=
+  parsePdfOptionsCore args {} []
+
 def dumpSchemaFlag : String := "--dump-schema"
 def dumpManifestFlag : String := "--dump-manifest"
 def dumpHtmlCacheFlag : String := "--dump-html-cache"
@@ -99,6 +141,11 @@ def helpText : String := String.intercalate "\n" [
   s!"  {dumpHtmlCacheFlag}  Print the generated rendered-fragment cache JSON and exit.",
   s!"  {externalMarkupRenderFlag} <mode>  Render source-backed external fragments in the cache ({Informal.ExternalMarkupRender.Mode.cliValues}; default markdown, rendered by MD4Lean with source fallback).",
   s!"  {helpFlag}              Show this help text and exit.",
+  "",
+  "Blueprint PDF options:",
+  s!"  {pdfFlag}               Emit TeX and build pdf/main.pdf with lualatex.",
+  s!"  {pdfEngineFlag} <cmd>  Use a lualatex-compatible command for PDF builds.",
+  s!"  {pdfRunsFlag} <n>      Number of LaTeX passes for PDF builds, default 2.",
   "",
   "Standard manual rendering options:",
   "  --output <dir>",

--- a/src/VersoBlueprint/TeX.lean
+++ b/src/VersoBlueprint/TeX.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import Verso.Output.TeX
+
+namespace Informal.TeX
+
+open Verso.Output.TeX
+
+def standardMathUsePackages : List String := [
+  "\\usepackage{amsmath}",
+  "\\usepackage{amssymb}",
+  "\\usepackage{mathtools}"
+]
+
+def standardMathFallbackPreamble : String :=
+  String.intercalate "\n" [
+    "\\providecommand{\\R}{\\mathbb{R}}",
+    "\\providecommand{\\N}{\\mathbb{N}}",
+    "\\providecommand{\\Z}{\\mathbb{Z}}",
+    "\\providecommand{\\C}{\\mathbb{C}}"
+  ]
+
+def withStandardMathFallbacks (preamble : String) : String :=
+  if preamble.trimAscii.isEmpty then
+    standardMathFallbackPreamble
+  else
+    preamble ++ "\n" ++ standardMathFallbackPreamble
+
+def boldHeading (title : String) (body : Verso.Output.TeX := .empty) : Verso.Output.TeX :=
+  .seq #[
+    .raw "\\par\\noindent",
+    .command "textbf" #[] #[.text title],
+    .raw "\\par\n",
+    body
+  ]
+
+def boldHeadingBlocks (title : String) (body : Array Verso.Output.TeX) : Verso.Output.TeX :=
+  boldHeading title (.seq body)
+
+def quotedBlock (title : String) (body : Array Verso.Output.TeX) : Verso.Output.TeX :=
+  boldHeading title (.environment "quote" #[] #[] body)
+
+def verbatimBlock (title source : String) : Verso.Output.TeX :=
+  boldHeading title (.environment "verbatim" #[] #[] #[.raw source])
+
+end Informal.TeX

--- a/src/VersoBlueprint/TeX/Cleanup.lean
+++ b/src/VersoBlueprint/TeX/Cleanup.lean
@@ -1,0 +1,199 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import Lean
+import Std.Data.HashSet
+import VersoManual
+import VersoBlueprint.Math
+
+namespace Informal.TeX.Cleanup
+
+open Lean Verso Doc
+open Verso.Genre Manual
+
+private def insertNonempty (items : Std.HashSet String) (item : String) : Std.HashSet String :=
+  if item.trimAscii.isEmpty then items else items.insert item
+
+private partial def collectBpMathTeXPreludesInline
+    (items : Std.HashSet String) : Doc.Inline Manual → Std.HashSet String
+  | .text .. | .code .. | .math .. | .linebreak .. | .image .. => items
+  | .emph inlines | .bold inlines | .concat inlines =>
+      inlines.foldl collectBpMathTeXPreludesInline items
+  | .link inlines _ | .footnote _ inlines =>
+      inlines.foldl collectBpMathTeXPreludesInline items
+  | .other inline inlines =>
+      let items := inlines.foldl collectBpMathTeXPreludesInline items
+      if inline.name == ``Informal.Math.Inline.bpMath then
+        match fromJson? (α := Informal.Math.BpMathData) inline.data with
+        | .ok data => insertNonempty items (Informal.TeX.withStandardMathFallbacks data.texPrelude)
+        | .error _ => items
+      else
+        items
+
+private partial def collectBpMathTeXPreludesBlock
+    (items : Std.HashSet String) : Doc.Block Manual → Std.HashSet String
+  | .para inlines => inlines.foldl collectBpMathTeXPreludesInline items
+  | .code .. => items
+  | .blockquote blocks | .concat blocks | .other _ blocks =>
+      blocks.foldl collectBpMathTeXPreludesBlock items
+  | .ul listItems | .ol _ listItems =>
+      listItems.foldl (init := items) fun items item =>
+        item.contents.foldl collectBpMathTeXPreludesBlock items
+  | .dl descItems =>
+      descItems.foldl (init := items) fun items item =>
+        let items := item.term.foldl collectBpMathTeXPreludesInline items
+        item.desc.foldl collectBpMathTeXPreludesBlock items
+
+private partial def collectBpMathTeXPreludesPart
+    (items : Std.HashSet String) (part : Part Manual) : Std.HashSet String :=
+  let items := part.title.foldl collectBpMathTeXPreludesInline items
+  let items := part.content.foldl collectBpMathTeXPreludesBlock items
+  part.subParts.foldl collectBpMathTeXPreludesPart items
+
+def blueprintTeXPreambleInsertion (text : Part Manual) : Option String :=
+  let preludes := collectBpMathTeXPreludesPart {} text |>.toArray
+  if preludes.isEmpty then
+    none
+  else
+    let preludes := preludes.qsort (· < ·)
+    some <| String.intercalate "\n" <|
+      ["% Blueprint TeX prelude"] ++ preludes.toList ++ ["% End Blueprint TeX prelude"]
+
+def insertBeforeFirst (source marker insertion : String) : Option String :=
+  match source.splitOn marker with
+  | before :: after :: rest =>
+      some <| before ++ insertion ++ marker ++ String.intercalate marker (after :: rest)
+  | _ => none
+
+private def lineMatches (line marker : String) : Bool :=
+  line.trimAscii.toString == marker
+
+private def beginsEnvironment (line env : String) : Bool :=
+  let line := line.trimAscii.toString
+  let marker := "\\begin{" ++ env ++ "}"
+  line == marker || line.startsWith (marker ++ "[")
+
+private def verbatimEndMarker? (line : String) : Option String :=
+  if beginsEnvironment line "LeanVerbatim" then
+    some "\\end{LeanVerbatim}"
+  else if beginsEnvironment line "FileVerbatim" then
+    some "\\end{FileVerbatim}"
+  else if beginsEnvironment line "verbatim" then
+    some "\\end{verbatim}"
+  else if beginsEnvironment line "Verbatim" then
+    some "\\end{Verbatim}"
+  else
+    none
+
+private def isWhitespaceLine (line : String) : Bool :=
+  line.trimAscii.isEmpty
+
+def trimWhitespaceEdgeLines (lines : List String) : List String :=
+  let lines := lines.dropWhile isWhitespaceLine
+  (lines.reverse.dropWhile isWhitespaceLine).reverse
+
+private partial def takeThroughLine (marker : String) :
+    List String → Option (List String × String × List String)
+  | [] => none
+  | line :: rest =>
+      if lineMatches line marker then
+        some ([], line, rest)
+      else
+        match takeThroughLine marker rest with
+        | none => none
+        | some (body, endLine, rest) => some (line :: body, endLine, rest)
+
+private partial def stripLineStartDisplayFencesLines : List String → List String
+  | [] => []
+  | line :: rest =>
+      match verbatimEndMarker? line with
+      | some endMarker =>
+          match takeThroughLine endMarker rest with
+          | some (body, endLine, after) =>
+              line :: body ++ endLine :: stripLineStartDisplayFencesLines after
+          | none =>
+              line :: rest
+      | none =>
+          let line := if line.startsWith "$$" then (line.drop 2).toString else line
+          line :: stripLineStartDisplayFencesLines rest
+
+def stripLineStartDisplayFences (source : String) : String :=
+  String.intercalate "\n" <| stripLineStartDisplayFencesLines (source.splitOn "\n")
+
+private def compactVerbatimBegin? (line : String) : Option String :=
+  if lineMatches line "\\begin{LeanVerbatim}" then
+    some "\\end{LeanVerbatim}"
+  else if lineMatches line "\\begin{FileVerbatim}" then
+    some "\\end{FileVerbatim}"
+  else
+    none
+
+private partial def compactVerbatimBlocksLines : List String → List String
+  | [] => []
+  | line :: rest =>
+      match compactVerbatimBegin? line with
+      | some endMarker =>
+          match takeThroughLine endMarker rest with
+          | some (body, endLine, after) =>
+              line :: trimWhitespaceEdgeLines body ++ endLine :: compactVerbatimBlocksLines after
+          | none =>
+              line :: compactVerbatimBlocksLines rest
+      | none =>
+          line :: compactVerbatimBlocksLines rest
+
+def compactVerbatimBlocks (source : String) : String :=
+  String.intercalate "\n" <| compactVerbatimBlocksLines (source.splitOn "\n")
+
+private def diagnosticDecorationDefinitionReplacements : List (String × String) := [
+  (
+    "\\newcommand{\\errorDecorate}[1]{\\coloredwave{errorColor}{#1}}",
+    "\\newcommand{\\errorDecorate}[1]{#1}"
+  ),
+  (
+    "\\newcommand{\\infoDecorate}[1]{\\coloredwave{infoColor}{#1}}",
+    "\\newcommand{\\infoDecorate}[1]{#1}"
+  ),
+  (
+    "\\newcommand{\\warningDecorate}[1]{\\coloredwave{warningColor}{#1}}",
+    "\\newcommand{\\warningDecorate}[1]{#1}"
+  )
+]
+
+def simplifyDiagnosticDecorations (source : String) : String :=
+  diagnosticDecorationDefinitionReplacements.foldl
+    (fun source replacement => source.replace replacement.1 replacement.2)
+    source
+
+def patchSourceBase (source : String) : String :=
+  simplifyDiagnosticDecorations <| compactVerbatimBlocks <| stripLineStartDisplayFences source
+
+def patchSourceWithPreamble (source : String) (insertion? : Option String) :
+    String × Option String :=
+  let source := patchSourceBase source
+  match insertion? with
+  | none => (source, none)
+  | some insertion =>
+      let marker := "\n\\title{"
+      match insertBeforeFirst source marker ("\n" ++ insertion) with
+      | some updated => (updated, none)
+      | none => (source, some "marker not found")
+
+def patchSource (source : String) (text : Part Manual) : String × Option String :=
+  patchSourceWithPreamble source (blueprintTeXPreambleInsertion text)
+
+def patchFile (cfg : Verso.Genre.Manual.Config)
+    (text : Part Manual) : BuildLogT IO Unit := do
+  let texPath := cfg.destination / "tex" / "main.tex"
+  unless ← texPath.pathExists do
+    return
+  let original ← IO.FS.readFile texPath
+  let (updated, error?) := patchSource original text
+  if let some error := error? then
+    Verso.reportError s!"Could not insert Blueprint TeX prelude in {texPath}: {error}"
+  unless updated == original do
+    IO.FS.writeFile texPath updated
+
+end Informal.TeX.Cleanup

--- a/src/VersoBlueprint/TeX/Pdf.lean
+++ b/src/VersoBlueprint/TeX/Pdf.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoManual
+import VersoBlueprint.PreviewManifest.Cli
+
+namespace Informal.TeX.Pdf
+
+open Verso (BuildLogT)
+
+abbrev PdfOptions := Informal.PreviewManifest.PdfOptions
+
+private def absolutePath (path : System.FilePath) : IO System.FilePath := do
+  let path := path.normalize
+  if path.isAbsolute then
+    pure path
+  else
+    pure <| ((← IO.currentDir) / path).normalize
+
+private def processOutputTail (text : String) (lineCount : Nat := 30) : String :=
+  let text := text.trimAscii.toString
+  if text.isEmpty then
+    ""
+  else
+    let lines := text.splitOn "\n"
+    String.intercalate "\n" <| lines.drop (lines.length - lineCount)
+
+private def processFailureText (out : IO.Process.Output) : String :=
+  let stderr := processOutputTail out.stderr
+  if stderr.isEmpty then
+    processOutputTail out.stdout
+  else
+    stderr
+
+private def compileArgs (pdfDir : System.FilePath) : Array String :=
+  #[
+    "-shell-escape",
+    "-halt-on-error",
+    "-interaction=nonstopmode",
+    s!"-output-directory={pdfDir}",
+    "main.tex"
+  ]
+
+private def texCacheEnv (cacheRoot : System.FilePath) : Array (String × Option String) :=
+  #[
+    ("TEXMFVAR", some s!"{cacheRoot / "var"}"),
+    ("TEXMFCACHE", some s!"{cacheRoot / "cache"}"),
+    ("TEXMFCONFIG", some s!"{cacheRoot / "config"}")
+  ]
+
+private def prepareTexCache (cacheRoot : System.FilePath) : IO Unit := do
+  IO.FS.createDirAll (cacheRoot / "var")
+  IO.FS.createDirAll (cacheRoot / "cache")
+  IO.FS.createDirAll (cacheRoot / "config")
+
+private def generatedFilenames : Array String :=
+  #["main.pdf", "main.aux", "main.toc", "main.out", "main.log"]
+
+private def removeGeneratedFileIfExists (path : System.FilePath) : BuildLogT IO Unit := do
+  if ← path.pathExists then
+    if ← path.isDir then
+      Verso.reportError s!"Refusing to remove directory at generated PDF output path {path}"
+    else
+      IO.FS.removeFile path
+
+private def clearGeneratedFiles (pdfDir : System.FilePath) : BuildLogT IO Unit := do
+  for filename in generatedFilenames do
+    removeGeneratedFileIfExists (pdfDir / filename)
+
+private def compilePass
+    (opts : PdfOptions)
+    (texDir pdfDir cacheRoot : System.FilePath)
+    (pass : Nat)
+    (verbose : Bool) : BuildLogT IO Bool := do
+  let args := compileArgs pdfDir
+  prepareTexCache cacheRoot
+  if verbose then
+    IO.println s!"Building PDF pass {pass}: {opts.engine} {String.intercalate " " args.toList}"
+  try
+    let out ← IO.Process.output { cmd := opts.engine, args, cwd := texDir, env := texCacheEnv cacheRoot }
+    if out.exitCode == 0 then
+      if verbose then
+        let stdout := out.stdout.trimAscii.toString
+        unless stdout.isEmpty do
+          IO.println stdout
+      pure true
+    else
+      let details := processFailureText out
+      let suffix := if details.isEmpty then "" else s!"\n{details}"
+      Verso.reportError s!"PDF build failed on pass {pass} with exit code {out.exitCode}.{suffix}"
+      pure false
+  catch err =>
+    Verso.reportError s!"PDF build failed to start `{opts.engine}`: {err}"
+    pure false
+
+def compile (opts : PdfOptions) (cfg : Verso.Genre.Manual.Config) : BuildLogT IO Unit := do
+  let destination ← absolutePath cfg.destination
+  let texDir := destination / "tex"
+  let texPath := texDir / "main.tex"
+  unless ← texPath.pathExists do
+    Verso.reportError s!"PDF build requested, but TeX output is missing at {texPath}"
+    return
+  let pdfDir := destination / "pdf"
+  IO.FS.createDirAll pdfDir
+  clearGeneratedFiles pdfDir
+  let cacheRoot := destination / "tex-cache"
+  for pass in [1:opts.runs + 1] do
+    unless ← compilePass opts texDir pdfDir cacheRoot pass cfg.verbose do
+      return
+  let pdfPath := pdfDir / "main.pdf"
+  if ← pdfPath.pathExists then
+    if cfg.verbose then
+      IO.println s!"Saved PDF to {pdfPath}"
+  else
+    Verso.reportError s!"PDF build completed, but expected output is missing at {pdfPath}"
+
+end Informal.TeX.Pdf

--- a/src/VersoBlueprint/VbpMain.lean
+++ b/src/VersoBlueprint/VbpMain.lean
@@ -14,13 +14,14 @@ namespace VersoBlueprint.Vbp.Main
 
 private def mainCommandLines : List String := [
   "lake exe vbp discover",
-  "lake exe vbp build [--output <dir>] [--serve] [--port <n>]",
+  "lake exe vbp build [--output <dir>] [--pdf] [--serve] [--port <n>]",
   "lake exe vbp query [--site <dir>] <selector>",
   "lake exe vbp check [--site <dir>]"
 ]
 
 private def defaultHelpLines : List String := [
   "build writes _out/site",
+  "--pdf builds _out/site/pdf/main.pdf from the generated TeX",
   "query and check read _out/site",
   "--serve serves the generated html-multi directory after a successful build",
   "--serve --port <n> serves on a fixed port"
@@ -163,6 +164,9 @@ def discover : IO UInt32 := do
 
 structure BuildOptions where
   output : FilePath := VersoBlueprint.Vbp.defaultOutput
+  pdf : Bool := false
+  pdfEngine? : Option String := none
+  pdfRuns? : Option Nat := none
   serve : Bool := false
   port? : Option Nat := none
 
@@ -182,17 +186,47 @@ private def parseTcpPort (raw : String) : Except String Nat :=
         .error s!"invalid --port value '{raw}'; expected a TCP port between 0 and {maxTcpPort}"
   | none => .error s!"invalid --port value '{raw}'"
 
+private def parsePositiveNatOption (option raw : String) : Except String Nat :=
+  match raw.toNat? with
+  | some n =>
+      if n == 0 then
+        .error s!"invalid {option} value '{raw}'; expected a positive integer"
+      else
+        .ok n
+  | none => .error s!"invalid {option} value '{raw}'"
+
 private partial def parseBuildOptionsCore : List String → BuildOptions → Except String BuildOptions
   | [], opts => .ok opts
   | "--output" :: dir :: args, opts => parseBuildOptionsCore args { opts with output := FilePath.mk dir }
   | "--output" :: [], _ => .error "missing value after --output"
-  | "--serve" :: args, opts => parseBuildOptionsCore args { opts with serve := true }
-  | "--port" :: raw :: args, opts =>
-      match parseTcpPort raw with
-      | .ok port => parseBuildOptionsCore args { opts with port? := some port }
-      | .error err => .error err
-  | "--port" :: [], _ => .error "missing value after --port"
-  | arg :: _, _ => .error s!"unknown build option '{arg}'"
+  | arg :: args, opts =>
+      if arg == Informal.PreviewManifest.pdfFlag then
+        parseBuildOptionsCore args { opts with pdf := true }
+      else if arg == Informal.PreviewManifest.pdfEngineFlag then
+        match args with
+        | engine :: more =>
+            let engine := engine.trimAscii.toString
+            if engine.isEmpty then
+              .error s!"empty value after {Informal.PreviewManifest.pdfEngineFlag}"
+            else
+              parseBuildOptionsCore more { opts with pdf := true, pdfEngine? := some engine }
+        | [] => .error s!"missing value after {Informal.PreviewManifest.pdfEngineFlag}"
+      else if arg == Informal.PreviewManifest.pdfRunsFlag then
+        match args with
+        | raw :: more =>
+            match parsePositiveNatOption Informal.PreviewManifest.pdfRunsFlag raw with
+            | .ok runs => parseBuildOptionsCore more { opts with pdf := true, pdfRuns? := some runs }
+            | .error err => .error err
+        | [] => .error s!"missing value after {Informal.PreviewManifest.pdfRunsFlag}"
+      else
+        match arg, args with
+        | "--serve", args => parseBuildOptionsCore args { opts with serve := true }
+        | "--port", raw :: args =>
+            match parseTcpPort raw with
+            | .ok port => parseBuildOptionsCore args { opts with port? := some port }
+            | .error err => .error err
+        | "--port", [] => .error "missing value after --port"
+        | arg, _ => .error s!"unknown build option '{arg}'"
 
 private def validateBuildOptions (opts : BuildOptions) : Except String BuildOptions :=
   if opts.port?.isSome && !opts.serve then
@@ -253,14 +287,24 @@ private def generatorRunArgs (generatorFile output : FilePath) : Array String :=
   #["lean", generatorFile.toString, "--", "--run", generatorFile.toString,
     "--output", output.toString]
 
-private def buildPlan (output : FilePath) : IO (Except String BuildPlan) := do
+private def pdfGeneratorArgs (opts : BuildOptions) : Array String :=
+  let args := if opts.pdf then #[Informal.PreviewManifest.pdfFlag] else #[]
+  let args :=
+    match opts.pdfEngine? with
+    | some engine => args ++ #[Informal.PreviewManifest.pdfEngineFlag, engine]
+    | none => args
+  match opts.pdfRuns? with
+  | some runs => args ++ #[Informal.PreviewManifest.pdfRunsFlag, toString runs]
+  | none => args
+
+private def buildPlan (opts : BuildOptions) : IO (Except String BuildPlan) := do
   match ← projectInfo with
   | .error err => pure (.error err)
   | .ok info =>
       pure (.ok {
         packageName := info.packageName,
         generatorPrepareArgs := #["lean", info.generatorFile.toString],
-        generatorArgs := generatorRunArgs info.generatorFile output
+        generatorArgs := generatorRunArgs info.generatorFile opts.output ++ pdfGeneratorArgs opts
       })
 
 private def serveScript : String := String.intercalate "\n" [
@@ -301,7 +345,7 @@ def build (args : List String) : IO UInt32 := do
       IO.eprintln err
       pure 2
   | .ok opts =>
-      match ← buildPlan opts.output with
+      match ← buildPlan opts with
       | .error err =>
           IO.eprintln err
           pure 1

--- a/tests/VersoBlueprintTests.lean
+++ b/tests/VersoBlueprintTests.lean
@@ -1,5 +1,6 @@
 import VersoBlueprintTests.Blueprint
 import VersoBlueprintTests.BlueprintMainWrapper
+import VersoBlueprintTests.BlueprintTeXCleanup
 import VersoBlueprintTests.ExternalDeclRender
 import VersoBlueprintTests.RuntimeCache
 import VersoBlueprintTests.TestBlueprintRegistry

--- a/tests/VersoBlueprintTests/BlueprintMainWrapper.lean
+++ b/tests/VersoBlueprintTests/BlueprintMainWrapper.lean
@@ -9,8 +9,13 @@ import VersoBlueprintTests.Blueprint.Support
 
 namespace Verso.VersoBlueprintTests.BlueprintMainWrapper
 
-open Verso.Genre.Manual
+open Verso Genre Manual
 open Verso.VersoBlueprintTests.Blueprint.Support
+
+#docs (Manual) pdfSmokeDoc "PDF Smoke" :=
+:::::::
+This tiny document exercises PDF engine invocation.
+:::::::
 
 /-- info: true -/
 #guard_msgs in
@@ -107,5 +112,102 @@ open Verso.VersoBlueprintTests.Blueprint.Support
         appearsBefore out "<h1>Example</h1>" "class=\"bp_build_metadata\"" &&
         appearsBefore out "class=\"bp_build_metadata\"" "class=\"authors\""
   | none => false
+
+private partial def freshPdfSmokeRoot : IO System.FilePath := do
+  let suffix ← IO.rand 0 1000000000000
+  let cwd ← IO.currentDir
+  let root :=
+    cwd / ".lake" / "build" / "tmp" /
+      "verso-blueprint-pdf-smoke-test" / toString suffix
+  if ← root.pathExists then
+    freshPdfSmokeRoot
+  else
+    pure root
+
+private def fakePdfEngineScript : String := r#"#!/bin/sh
+set -eu
+outdir=""
+for arg in "$@"; do
+  case "$arg" in
+    -output-directory=*) outdir="${arg#-output-directory=}" ;;
+  esac
+done
+if [ -z "$outdir" ]; then
+  echo "missing output directory" >&2
+  exit 2
+fi
+printf '%s\n' "$@" > "$outdir/fake-engine-args.txt"
+{
+  printf '%s\n' "${TEXMFVAR:-}"
+  printf '%s\n' "${TEXMFCACHE:-}"
+  printf '%s\n' "${TEXMFCONFIG:-}"
+} > "$outdir/fake-engine-env.txt"
+{
+  for name in main.pdf main.aux main.toc main.out main.log; do
+    if [ -e "$outdir/$name" ]; then
+      printf '%s\n' "$name"
+    fi
+  done
+} > "$outdir/fake-stale-before.txt"
+printf 'fake pdf\n' > "$outdir/main.pdf"
+"#
+
+private def writeFakePdfEngine (root : System.FilePath) : IO System.FilePath := do
+  IO.FS.createDirAll root
+  let engine := root / "fake-pdf-engine.sh"
+  IO.FS.writeFile engine fakePdfEngineScript
+  let chmod ← IO.Process.output { cmd := "chmod", args := #["+x", engine.toString] }
+  unless chmod.exitCode == 0 do
+    throw <| IO.userError s!"chmod failed: {chmod.stderr}"
+  pure engine
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let root ← freshPdfSmokeRoot
+    let engine ← writeFakePdfEngine root
+    let outDir := root / "site"
+    let runPdfBuild : IO UInt32 :=
+      Informal.PreviewManifest.blueprintMain
+        pdfSmokeDoc.toPart
+        (extensionImpls := by exact extension_impls%)
+        (options := [
+          "--output", outDir.toString,
+          "--without-html-single",
+          "--without-html-multi"
+        ])
+        (pdfOptions := {
+          enabled := true
+          engine := engine.toString
+          runs := 1
+        })
+    let code1 ← runPdfBuild
+    let pdfDir := outDir / "pdf"
+    IO.FS.writeFile (pdfDir / "main.aux") "stale aux"
+    IO.FS.writeFile (pdfDir / "main.toc") "stale toc"
+    IO.FS.writeFile (pdfDir / "main.out") "stale out"
+    IO.FS.writeFile (pdfDir / "main.log") "stale log"
+    let code2 ← runPdfBuild
+    let argsLog ← IO.FS.readFile (pdfDir / "fake-engine-args.txt")
+    let envLog ← IO.FS.readFile (pdfDir / "fake-engine-env.txt")
+    let staleBeforeLog ← IO.FS.readFile (pdfDir / "fake-stale-before.txt")
+    pure <|
+      code1 == 0 &&
+        code2 == 0 &&
+        (← (pdfDir / "main.pdf").pathExists) &&
+        !(← (pdfDir / "main.aux").pathExists) &&
+        !(← (pdfDir / "main.toc").pathExists) &&
+        !(← (pdfDir / "main.out").pathExists) &&
+        !(← (pdfDir / "main.log").pathExists) &&
+        (← (outDir / "tex" / "main.tex").pathExists) &&
+        hasSubstr argsLog "-shell-escape" &&
+        hasSubstr argsLog "-halt-on-error" &&
+        hasSubstr argsLog s!"-output-directory={pdfDir}" &&
+        hasSubstr argsLog "main.tex" &&
+        hasSubstr envLog (outDir / "tex-cache" / "var").toString &&
+        hasSubstr envLog (outDir / "tex-cache" / "cache").toString &&
+        hasSubstr envLog (outDir / "tex-cache" / "config").toString &&
+        staleBeforeLog.trimAscii.isEmpty
 
 end Verso.VersoBlueprintTests.BlueprintMainWrapper

--- a/tests/VersoBlueprintTests/BlueprintTeXCleanup.lean
+++ b/tests/VersoBlueprintTests/BlueprintTeXCleanup.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoBlueprint.TeX.Cleanup
+
+namespace Verso.VersoBlueprintTests.BlueprintTeXCleanup
+
+open Informal.TeX.Cleanup
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    stripLineStartDisplayFences "$$as required.\ntext\n$$ x\n  $$kept" ==
+      "as required.\ntext\n x\n  $$kept"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    let source := String.intercalate "\n" [
+      "$$outside",
+      "\\begin{LeanVerbatim}",
+      "$$inside",
+      "\\end{LeanVerbatim}",
+      "\\begin{verbatim}",
+      "$$alsoInside",
+      "\\end{verbatim}"
+    ]
+    stripLineStartDisplayFences source ==
+      String.intercalate "\n" [
+        "outside",
+        "\\begin{LeanVerbatim}",
+        "$$inside",
+        "\\end{LeanVerbatim}",
+        "\\begin{verbatim}",
+        "$$alsoInside",
+        "\\end{verbatim}"
+      ]
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    compactVerbatimBlocks
+        "before\n\\begin{LeanVerbatim}\n\n  \n#check Nat\n\n\\end{LeanVerbatim}\nafter" ==
+      "before\n\\begin{LeanVerbatim}\n#check Nat\n\\end{LeanVerbatim}\nafter"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    compactVerbatimBlocks
+        "\\begin{FileVerbatim}\n\nfirst\n\nsecond\n\n\\end{FileVerbatim}" ==
+      "\\begin{FileVerbatim}\nfirst\n\nsecond\n\\end{FileVerbatim}"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    let source := String.intercalate "\n" [
+      "\\newcommand{\\errorDecorate}[1]{\\coloredwave{errorColor}{#1}}",
+      "\\newcommand{\\infoDecorate}[1]{\\coloredwave{infoColor}{#1}}",
+      "\\newcommand{\\warningDecorate}[1]{\\coloredwave{warningColor}{#1}}"
+    ]
+    let updated := simplifyDiagnosticDecorations source
+    updated.contains "\\newcommand{\\errorDecorate}[1]{#1}" &&
+      updated.contains "\\newcommand{\\infoDecorate}[1]{#1}" &&
+      updated.contains "\\newcommand{\\warningDecorate}[1]{#1}" &&
+      !updated.contains "\\coloredwave{errorColor}{#1}" &&
+      !updated.contains "\\coloredwave{infoColor}{#1}" &&
+      !updated.contains "\\coloredwave{warningColor}{#1}"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    let source := "\\documentclass{book}\n\\title{Demo}\n\\begin{document}"
+    let (updated, error?) := patchSourceWithPreamble source (some "% Blueprint TeX prelude")
+    error?.isNone &&
+      updated.contains "\n% Blueprint TeX prelude\n\\title{Demo}"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    let (updated, error?) := patchSourceWithPreamble "no title marker" (some "% prelude")
+    updated == "no title marker" && error? == some "marker not found"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    let source := String.intercalate "\n" [
+      "\\documentclass{book}",
+      "\\newcommand{\\warningDecorate}[1]{\\coloredwave{warningColor}{#1}}",
+      "\\title{Demo}",
+      "$$as required.",
+      "\\begin{LeanVerbatim}",
+      "",
+      "#check Nat",
+      "",
+      "\\end{LeanVerbatim}"
+    ]
+    let (updated, error?) := patchSourceWithPreamble source (some "% prelude")
+    error?.isNone &&
+      updated.contains "\\newcommand{\\warningDecorate}[1]{#1}" &&
+      updated.contains "\n% prelude\n\\title{Demo}" &&
+      updated.contains "\nas required.\n" &&
+      updated.contains "\\begin{LeanVerbatim}\n#check Nat\n\\end{LeanVerbatim}"
+
+end Verso.VersoBlueprintTests.BlueprintTeXCleanup

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -134,9 +134,42 @@ private def jsonArrayHasStringField (values : Array Json) (field expected : Stri
       text.contains "selectors" &&
       text.contains "all <label>" &&
       text.contains "search <text>" &&
+      text.contains "lake exe vbp build [--output <dir>] [--pdf]" &&
+      text.contains "--pdf builds _out/site/pdf/main.pdf" &&
       text.contains "--serve --port <n>" &&
       text.contains "build writes _out/site" &&
       !text.contains "lake exe vbp query [--site <dir>] node <label>"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    let text := Informal.PreviewManifest.helpText
+    text.contains "Blueprint PDF options:" &&
+      text.contains "--pdf" &&
+      text.contains "--pdf-engine <cmd>" &&
+      text.contains "--pdf-runs <n>"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match Informal.PreviewManifest.parsePdfOptions
+        ["--output", "_out/custom", "--pdf", "--pdf-engine", "xelatex", "--pdf-runs", "3", "--verbose"] with
+    | .ok (opts, rest) =>
+        opts.enabled &&
+          opts.engine == "xelatex" &&
+          opts.runs == 3 &&
+          rest == ["--output", "_out/custom", "--verbose"]
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match Informal.PreviewManifest.parsePdfOptions ["--pdf-runs", "0"] with
+    | .ok _ => false
+    | .error err => err.contains "expected a positive integer"
 
 /-- info: true -/
 #guard_msgs in
@@ -423,6 +456,19 @@ private def writeManifestOnlySite (site : System.FilePath) : IO Unit := do
     | .ok opts =>
         opts.serve &&
           opts.port? == some 8080
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.Main.parseBuildOptions
+        ["--output", "_out/custom", "--pdf", "--pdf-engine", "xelatex", "--pdf-runs", "3"] {} with
+    | .ok opts =>
+        opts.output.toString == "_out/custom" &&
+          opts.pdf &&
+          opts.pdfEngine? == some "xelatex" &&
+          opts.pdfRuns? == some 3
     | .error _ => false
 
 /-- info: true -/


### PR DESCRIPTION
This PR adds an optional PDF output path for Blueprint generators alongside the existing HTML outputs.

- Add --pdf, --pdf-engine, and --pdf-runs handling for blueprint-gen and vbp build.
- Render Blueprint-specific blocks, citations, references, external markup notices, and project TeX preludes in static TeX/PDF output.
- Add TeX cleanup, PDF compilation helpers, real-engine smoke coverage, and HTML/PDF feature documentation.

Backport v4.31.0: #250
Backport v4.30.0: #251