### PR TITLE
feat: publish reference blueprint PDFs

### DIFF
--- a/.github/workflows/reference-blueprints-deploy.yml
+++ b/.github/workflows/reference-blueprints-deploy.yml
@@ -89,6 +89,16 @@ jobs:
         run: |
           curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+      - name: Install PDF toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            python3-pygments \
+            texlive-fonts-extra \
+            texlive-fonts-recommended \
+            texlive-latex-extra \
+            texlive-luatex \
+            texlive-plain-generic
       - name: Restore Lake package cache
         uses: actions/cache@v5
         with:
@@ -127,8 +137,9 @@ jobs:
         run: |
           lean --version
           lake --version
+          lualatex --version | head -n 1
           python3 --version
-      - name: Generate release reference blueprints
+      - name: Generate release reference blueprints with PDFs
         run: |
           python3 -m scripts.blueprint_reference_harness generate \
             --manifest _out/deploy-projects/${{ matrix.project_id }}.json \

--- a/.github/workflows/reference-blueprints.yml
+++ b/.github/workflows/reference-blueprints.yml
@@ -58,6 +58,16 @@ jobs:
         run: |
           curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+      - name: Install PDF toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            python3-pygments \
+            texlive-fonts-extra \
+            texlive-fonts-recommended \
+            texlive-latex-extra \
+            texlive-luatex \
+            texlive-plain-generic
       - name: Restore Lake package cache
         uses: actions/cache@v5
         with:
@@ -96,9 +106,10 @@ jobs:
         run: |
           lean --version
           lake --version
+          lualatex --version | head -n 1
           python3 --version
-      - name: Generate reference blueprint
-        run: ./scripts/generate-reference-blueprints.sh --allow-unsafe-root-release --reference-package-mode move --project ${{ matrix.project_id }}
+      - name: Generate reference blueprint with PDF
+        run: ./scripts/generate-reference-blueprints.sh --allow-unsafe-root-release --reference-package-mode move --pdf --project ${{ matrix.project_id }}
       - name: Report disk usage after reference generation
         if: ${{ always() }}
         run: ./scripts/report-ci-disk-usage.sh "after reference generation" --reference-cache-key "${{ matrix.reference_cache_key }}" --artifact-path "${{ matrix.artifact_path }}"
@@ -166,15 +177,14 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           pattern: reference-blueprints-*
-          path: _out/reference-blueprints
-          merge-multiple: true
+          path: _out/reference-blueprints-artifacts
       - name: Download test blueprints artifact
         uses: actions/download-artifact@v7
         with:
           name: test-blueprints
           path: _out/test-blueprints
       - name: Prepare site artifact
-        run: python3 ./scripts/prepare_reference_blueprints_pages.py
+        run: python3 ./scripts/prepare_reference_blueprints_pages.py --reference-root _out/reference-blueprints-artifacts
       - name: Upload site artifact
         uses: actions/upload-artifact@v7
         with:

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -690,6 +690,8 @@ pushes to release branches named like `v4.30.0`, and manual dispatch, it:
 - resolves the current branch's release target from `branch-policy.json`
 - builds only project targets for that release that set
   `publish_reference: true`
+- builds `pdf/main.pdf` for those reference targets, using the workflow's
+  installed TeX toolchain
 - builds the local `test-blueprints/` artifact set, including
   `preview_runtime_showcase`
 - stages a branch-local site artifact under `_site/` only when the selected
@@ -715,7 +717,9 @@ default-development catalog and passes it to the release-branch harness with
 `--manifest`; the deploy job therefore does not rely on stale branch-local
 `projects.json` refs. The per-project target entry also owns any RC override,
 so two projects in the same release line can deploy against different release
-candidate tags when needed.
+candidate tags when needed. Deploy one-project manifests append `--pdf` to the
+selected generator command, so checked-out release branches can publish PDFs
+without needing a new reference-harness CLI flag.
 
 The current published project/release split is intentionally not duplicated
 here. Read `tests/harness/projects.json`; every project target marked
@@ -728,6 +732,8 @@ release includes:
 - `_site/index.html`
 - `_site/reference-blueprints/<project-id>/` for each deployable reference
   target selected on that branch
+- `_site/reference-blueprints/<project-id>/pdf/main.pdf` for each deployable
+  reference target selected on that branch
 - `_site/test-blueprints/index.html`
 - `_site/test-blueprints/preview_runtime_showcase/`
 - `_site/test-blueprints/<slug>/`
@@ -743,6 +749,8 @@ includes:
 - `_site/js-api/`
 - `_site/reference-blueprints/<release-id>/<project-id>/` for each selected
   reference target across all deployable release slices
+- `_site/reference-blueprints/<release-id>/<project-id>/pdf/main.pdf` for each
+  selected reference target's deployed PDF
 - `_site/test-blueprints/index.html`
 - `_site/test-blueprints/preview_runtime_showcase/`
 - `_site/test-blueprints/<slug>/`
@@ -758,6 +766,9 @@ The shared staging helper understands both input shapes:
 - a single-release local/CI artifact rooted at `_out/reference-blueprints/<project-id>/`
 - or a deploy-time combined artifact rooted at
   `_out/reference-blueprints/<release-id>/<project-id>/`
+
+For either input shape, it copies `pdf/main.pdf` next to the staged HTML and
+adds an index link only when that PDF exists.
 
 The staging helper is:
 

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -1177,8 +1177,12 @@ The PDF is written to `_out/site/pdf/main.pdf`. The default engine is
 `lualatex`, run with `-shell-escape` because Verso TeX output may include
 assets that require it. Use `--pdf-engine <cmd>` for another
 lualatex-compatible command and `--pdf-runs <n>` to change the number of LaTeX
-passes. `--pdf` implies `--with-tex`; `--with-tex` alone still only writes the
-TeX tree under `_out/site/tex/`.
+passes. The generated prelude uses standard TeX Live packages plus the Source
+font packages; on Ubuntu CI, install `python3-pygments`, `texlive-luatex`,
+`texlive-latex-extra`, `texlive-fonts-recommended`, and
+`texlive-fonts-extra`, and `texlive-plain-generic`. `--pdf` implies
+`--with-tex`; `--with-tex` alone still only writes the TeX tree under
+`_out/site/tex/`.
 
 ### HTML and PDF Feature Support
 

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -547,7 +547,13 @@ def release_target_manifest_entry(target: HarnessReleaseTarget) -> dict[str, obj
     }
 
 
-def project_manifest_entry(project: HarnessProject) -> dict[str, object]:
+def command_with_pdf(command: tuple[str, ...]) -> tuple[str, ...]:
+    if "--pdf" in command:
+        return command
+    return (*command, "--pdf")
+
+
+def project_manifest_entry(project: HarnessProject, *, include_pdf: bool = False) -> dict[str, object]:
     if project.selected_release is None:
         raise ValueError(f"project `{project.project_id}` is missing selected release metadata")
 
@@ -579,7 +585,12 @@ def project_manifest_entry(project: HarnessProject) -> dict[str, object]:
     if project.build_command is not None:
         entry["build_command"] = list(project.build_command)
     if project.generate_command is not None:
-        entry["generate_command"] = list(project.generate_command)
+        generate_command = project.generate_command
+        if include_pdf:
+            generate_command = command_with_pdf(generate_command)
+        entry["generate_command"] = list(generate_command)
+    elif include_pdf:
+        raise ValueError(f"project `{project.project_id}` needs a `generate_command` to publish PDF output")
     validation: dict[str, object] = {}
     if project.panel_regression_script is not None:
         validation["panel_regression_script"] = project.panel_regression_script
@@ -590,11 +601,16 @@ def project_manifest_entry(project: HarnessProject) -> dict[str, object]:
     return entry
 
 
-def deploy_project_manifest(target: HarnessReleaseTarget, project: HarnessProject) -> dict[str, object]:
+def deploy_project_manifest(
+    target: HarnessReleaseTarget,
+    project: HarnessProject,
+    *,
+    include_pdf: bool = True,
+) -> dict[str, object]:
     return {
         "version": 2,
         "release_targets": [release_target_manifest_entry(target)],
-        "projects": [project_manifest_entry(project)],
+        "projects": [project_manifest_entry(project, include_pdf=include_pdf)],
     }
 
 

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -15,7 +15,7 @@ from scripts.blueprint_harness_releases import (
     release_branch_from_lean_ref,
     rewrite_lean_toolchain,
 )
-from scripts.blueprint_harness_projects import HarnessProject, reference_dependency_cache_key
+from scripts.blueprint_harness_projects import HarnessProject, command_with_pdf, reference_dependency_cache_key
 from scripts.blueprint_harness_project_commands import (
     discard_untracked_project_manifest,
     format_project_command,
@@ -920,7 +920,14 @@ def sync_reference_local_checkout(
     return local_dir
 
 
-def generate_in_repo_command_project(layout, output_root: Path, project: HarnessProject, *, skip_build: bool) -> None:
+def generate_in_repo_command_project(
+    layout,
+    output_root: Path,
+    project: HarnessProject,
+    *,
+    skip_build: bool,
+    pdf: bool = False,
+) -> None:
     project_dir = layout.package_root / project.project_root
     if not project_dir.exists():
         raise SystemExit(f"[blueprint-harness] missing in-repo project root for `{project.project_id}`: {project_dir}")
@@ -932,6 +939,9 @@ def generate_in_repo_command_project(layout, output_root: Path, project: Harness
     original_manifest = snapshot_tracked_project_manifest(project_dir)
     try:
         with maybe_in_repo_blueprint_dependency_override(project_dir, layout.package_root, log=True):
+            generate_command = project.generate_command or ()
+            if pdf:
+                generate_command = command_with_pdf(generate_command)
             run_project_update_build_generate(
                 layout.package_root,
                 project_dir,
@@ -941,7 +951,7 @@ def generate_in_repo_command_project(layout, output_root: Path, project: Harness
                     reconcile_toolchains=False,
                 ),
                 build_command=project.build_command,
-                generate_command=project.generate_command or (),
+                generate_command=generate_command,
                 format_command=lambda command: format_project_command(
                     command,
                     reference_command_placeholders(
@@ -966,6 +976,7 @@ def generate_git_project(
     *,
     skip_build: bool,
     package_mode: str = REFERENCE_PACKAGE_MODE_COPY,
+    pdf: bool = False,
 ) -> None:
     package_mode = validate_reference_package_mode(package_mode)
     rebuild_and_log_embedded_asset_owners(layout.package_root)
@@ -987,12 +998,15 @@ def generate_git_project(
             seed_lake_path_builds_from_dependency_cache(layout, project, project_dir)
 
         with local_blueprint_dependency_override(layout.package_root, project_dir, restore_lakefile=False, log=True):
+            generate_command = project.generate_command or ()
+            if pdf:
+                generate_command = command_with_pdf(generate_command)
             run_project_update_build_generate(
                 layout.package_root,
                 project_dir,
                 update_project=update_reference_project,
                 build_command=project.build_command,
-                generate_command=project.generate_command or (),
+                generate_command=generate_command,
                 format_command=lambda command: format_project_command(
                     command,
                     reference_command_placeholders(

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -31,6 +31,7 @@ from scripts.blueprint_harness_paths import detect_harness_layout, resolve_outpu
 from scripts.blueprint_harness_projects import (
     HarnessProject,
     HarnessReleaseTarget,
+    command_with_pdf,
     project_target_rc,
     project_target_toolchain,
     project_target_verso_ref,
@@ -615,7 +616,23 @@ def build_in_repo_projects(package_root: Path, projects: list[HarnessProject]) -
         run(lean_low_priority_command(package_root, "lake", "build", *targets), cwd=package_root)
 
 
-def render_in_repo_projects(package_root: Path, output_root: Path, projects: list[HarnessProject], serial: bool) -> None:
+def reference_executable_args(package_root: Path, project: HarnessProject, output_dir: Path, *, pdf: bool) -> list[str]:
+    args = [
+        str(ensure_prebuilt_executable(package_root, project.generator or project.project_id)),
+        "--output",
+        str(output_dir),
+    ]
+    return list(command_with_pdf(tuple(args))) if pdf else args
+
+
+def render_in_repo_projects(
+    package_root: Path,
+    output_root: Path,
+    projects: list[HarnessProject],
+    serial: bool,
+    *,
+    pdf: bool = False,
+) -> None:
     output_root.mkdir(parents=True, exist_ok=True)
     if serial:
         for project in projects:
@@ -623,9 +640,7 @@ def render_in_repo_projects(package_root: Path, output_root: Path, projects: lis
             run(
                 lean_low_priority_command(
                     package_root,
-                    str(ensure_prebuilt_executable(package_root, project.generator or project.project_id)),
-                    "--output",
-                    str(output_dir),
+                    *reference_executable_args(package_root, project, output_dir, pdf=pdf),
                 ),
                 cwd=package_root,
             )
@@ -638,9 +653,7 @@ def render_in_repo_projects(package_root: Path, output_root: Path, projects: lis
             output_dir.mkdir(parents=True, exist_ok=True)
             command = lean_low_priority_command(
                 package_root,
-                str(ensure_prebuilt_executable(package_root, project.generator or project.project_id)),
-                "--output",
-                str(output_dir),
+                *reference_executable_args(package_root, project, output_dir, pdf=pdf),
             )
             print(f"[blueprint-reference-harness] launching {project.project_id} -> {output_dir}", flush=True)
             procs.append((project.project_id, subprocess.Popen(command, cwd=package_root)))
@@ -668,6 +681,7 @@ def generate_projects(
     serial: bool,
     allow_local_build: bool,
     reference_package_mode: str = REFERENCE_PACKAGE_MODE_COPY,
+    pdf: bool = False,
 ) -> None:
     in_repo_projects = [project for project in projects if project.in_repo_project]
     in_repo_target_projects = [project for project in in_repo_projects if project.in_repo_target_project]
@@ -692,7 +706,7 @@ def generate_projects(
         elif not skip_build and not use_local_build:
             for project in in_repo_target_projects:
                 ensure_prebuilt_executable(layout.package_root, project.generator or project.project_id)
-        render_in_repo_projects(layout.package_root, output_root, in_repo_target_projects, serial)
+        render_in_repo_projects(layout.package_root, output_root, in_repo_target_projects, serial, pdf=pdf)
 
     if in_repo_command_projects:
         print(f"[blueprint-reference-harness] package root: {layout.package_root}")
@@ -702,7 +716,7 @@ def generate_projects(
             print(f"[blueprint-reference-harness] output root: {output_root}")
         for project in in_repo_command_projects:
             print(f"[blueprint-reference-harness] in-repo project: {project.project_id} ({project.project_root})")
-            generate_in_repo_command_project(layout, output_root, project, skip_build=skip_build)
+            generate_in_repo_command_project(layout, output_root, project, skip_build=skip_build, pdf=pdf)
 
     for project in git_projects:
         print(f"[blueprint-reference-harness] reference checkout: {project.project_id}")
@@ -712,6 +726,7 @@ def generate_projects(
             project,
             skip_build=skip_build,
             package_mode=reference_package_mode,
+            pdf=pdf,
         )
 
 
@@ -730,6 +745,7 @@ def command_generate(args: argparse.Namespace) -> int:
         serial=args.serial,
         allow_local_build=args.allow_local_build,
         reference_package_mode=getattr(args, "reference_package_mode", REFERENCE_PACKAGE_MODE_COPY),
+        pdf=args.pdf,
     )
 
     print(f"[blueprint-reference-harness] project manifest: {manifest_path}")
@@ -1085,6 +1101,11 @@ def add_generation_commands(subparsers) -> None:
         "--skip-build",
         action="store_true",
         help="Skip project builds and only run already-built or command-only generation steps.",
+    )
+    generate.add_argument(
+        "--pdf",
+        action="store_true",
+        help="Also build pdf/main.pdf for each generated reference blueprint.",
     )
     add_allow_unsafe_root_release_argument(generate)
     add_serial_argument(generate)

--- a/scripts/prepare_reference_blueprints_pages.py
+++ b/scripts/prepare_reference_blueprints_pages.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 import html
 from pathlib import Path
 import shutil
@@ -37,13 +38,26 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def html_link(project_id: str, *, release: str | None = None, prefix: str = "reference-blueprints/") -> str:
-    label = html.escape(project_id)
-    if release is None:
-        href = f"{prefix}{label}/"
-    else:
-        href = f"{prefix}{html.escape(release)}/{label}/"
-    return f'<li><a href="{href}">{label}</a></li>'
+PDF_OUTPUT = Path("pdf") / "main.pdf"
+REFERENCE_ARTIFACT_PREFIX = "reference-blueprints-"
+
+
+@dataclass(frozen=True)
+class ReferenceProject:
+    project_id: str
+    has_pdf: bool = False
+
+
+def html_link(
+    project: ReferenceProject,
+    *,
+    prefix: str = "reference-blueprints/",
+) -> str:
+    label = html.escape(project.project_id)
+    href = f"{prefix}{label}/"
+    pdf_href = f"{prefix}{label}/pdf/main.pdf"
+    pdf_link = f' <a href="{pdf_href}">PDF</a>' if project.has_pdf else ""
+    return f'<li><a href="{href}">{label}</a>{pdf_link}</li>'
 
 
 def html_test_link(slug: str) -> str:
@@ -58,9 +72,18 @@ def html_release_link(release: str, *, prefix: str = "reference-blueprints/") ->
     return f'<li><a href="{href}">{label}</a></li>'
 
 
-def write_reference_index(reference_root: Path, release_projects: dict[str | None, list[str]]) -> None:
+def reference_project_id(project_dir: Path) -> str:
+    name = project_dir.name
+    if name.startswith(REFERENCE_ARTIFACT_PREFIX):
+        artifact_project_id = name.removeprefix(REFERENCE_ARTIFACT_PREFIX)
+        if artifact_project_id:
+            return artifact_project_id
+    return name
+
+
+def write_reference_index(reference_root: Path, release_projects: dict[str | None, list[ReferenceProject]]) -> None:
     if None in release_projects:
-        items = [html_link(project_id, prefix="") for project_id in release_projects[None]]
+        items = [html_link(project, prefix="") for project in release_projects[None]]
         body = [
             "<!doctype html>",
             "<html lang=\"en\">",
@@ -91,7 +114,7 @@ def write_reference_index(reference_root: Path, release_projects: dict[str | Non
             "<body>",
             f"<h1>Reference Blueprints {html.escape(release)}</h1>",
             "<ul>",
-            *[html_link(project_id, prefix="") for project_id in projects],
+            *[html_link(project, prefix="") for project in projects],
             "</ul>",
             "</body>",
             "</html>",
@@ -135,7 +158,7 @@ def write_redirect_alias(alias_root: Path, target_href: str, *, label: str) -> N
     (alias_root / "index.html").write_text("\n".join(body) + "\n", encoding="utf-8")
 
 
-def write_unique_project_aliases(reference_root: Path, release_projects: dict[str | None, list[str]]) -> None:
+def write_unique_project_aliases(reference_root: Path, release_projects: dict[str | None, list[ReferenceProject]]) -> None:
     if None in release_projects:
         return
 
@@ -143,7 +166,7 @@ def write_unique_project_aliases(reference_root: Path, release_projects: dict[st
     for release, projects in release_projects.items():
         assert release is not None
         for project in projects:
-            releases_by_project.setdefault(project, []).append(release)
+            releases_by_project.setdefault(project.project_id, []).append(release)
 
     for project, releases in releases_by_project.items():
         if len(releases) != 1:
@@ -159,25 +182,54 @@ def write_unique_project_aliases(reference_root: Path, release_projects: dict[st
         )
 
 
-def copy_reference_sites(reference_root: Path, publish_reference_root: Path) -> dict[str | None, list[str]]:
-    release_projects: dict[str | None, list[str]] = {}
+def copy_reference_project(
+    project_dir: Path,
+    publish_project_root: Path,
+    *,
+    project_id: str | None = None,
+) -> ReferenceProject:
+    project_id = project_id or reference_project_id(project_dir)
+    shutil.copytree(project_dir / "html-multi", publish_project_root)
+    pdf_path = project_dir / PDF_OUTPUT
+    has_pdf = pdf_path.exists()
+    if has_pdf:
+        publish_pdf = publish_project_root / PDF_OUTPUT
+        publish_pdf.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(pdf_path, publish_pdf)
+    return ReferenceProject(project_id, has_pdf=has_pdf)
+
+
+def copy_reference_sites(reference_root: Path, publish_reference_root: Path) -> dict[str | None, list[ReferenceProject]]:
+    release_projects: dict[str | None, list[ReferenceProject]] = {}
     children = sorted(path for path in reference_root.iterdir() if path.is_dir())
     if all((child / "html-multi").exists() for child in children):
-        projects: list[str] = []
+        projects: list[ReferenceProject] = []
         for project_dir in children:
-            shutil.copytree(project_dir / "html-multi", publish_reference_root / project_dir.name)
-            projects.append(project_dir.name)
+            project_id = reference_project_id(project_dir)
+            projects.append(
+                copy_reference_project(
+                    project_dir,
+                    publish_reference_root / project_id,
+                    project_id=project_id,
+                )
+            )
         release_projects[None] = projects
         return release_projects
 
     for release_dir in children:
-        projects: list[str] = []
+        projects: list[ReferenceProject] = []
         for project_dir in sorted(path for path in release_dir.iterdir() if path.is_dir()):
             site_dir = project_dir / "html-multi"
             if not site_dir.exists():
                 continue
-            shutil.copytree(site_dir, publish_reference_root / release_dir.name / project_dir.name)
-            projects.append(project_dir.name)
+            project_id = reference_project_id(project_dir)
+            projects.append(
+                copy_reference_project(
+                    project_dir,
+                    publish_reference_root / release_dir.name / project_id,
+                    project_id=project_id,
+                )
+            )
         if projects:
             release_projects[release_dir.name] = projects
     return release_projects
@@ -251,7 +303,7 @@ def main() -> int:
                 *(
                     [
                         "<ul>",
-                        *[html_link(project_id) for project_id in release_projects[None]],
+                        *[html_link(project) for project in release_projects[None]],
                         "</ul>",
                     ]
                     if None in release_projects

--- a/src/VersoBlueprint/TeX/Pdf.lean
+++ b/src/VersoBlueprint/TeX/Pdf.lean
@@ -29,11 +29,13 @@ private def processOutputTail (text : String) (lineCount : Nat := 30) : String :
     String.intercalate "\n" <| lines.drop (lines.length - lineCount)
 
 private def processFailureText (out : IO.Process.Output) : String :=
+  let stdout := processOutputTail out.stdout
   let stderr := processOutputTail out.stderr
-  if stderr.isEmpty then
-    processOutputTail out.stdout
-  else
-    stderr
+  match stdout.isEmpty, stderr.isEmpty with
+  | true, true => ""
+  | false, true => s!"stdout:\n{stdout}"
+  | true, false => s!"stderr:\n{stderr}"
+  | false, false => s!"stdout:\n{stdout}\nstderr:\n{stderr}"
 
 private def compileArgs (pdfDir : System.FilePath) : Array String :=
   #[

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -155,6 +155,11 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertEqual(parser.parse_args(["generate", "--reference-package-mode", "move"]).reference_package_mode, "move")
         self.assertEqual(parser.parse_args(["validate", "--reference-package-mode", "move"]).reference_package_mode, "move")
 
+    def test_reference_generate_parses_pdf(self) -> None:
+        parser = reference_harness_mod.build_parser()
+        self.assertFalse(parser.parse_args(["generate"]).pdf)
+        self.assertTrue(parser.parse_args(["generate", "--pdf"]).pdf)
+
     def test_reference_projects_parses_release_filter(self) -> None:
         parser = reference_harness_mod.build_parser()
         args = parser.parse_args(["projects", "--release", "v4.29.0"])
@@ -1050,6 +1055,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             project=None,
             release=None,
             skip_build=False,
+            pdf=False,
             allow_unsafe_root_release=False,
             serial=False,
             allow_local_build=False,
@@ -1082,6 +1088,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             project=None,
             release="v4.28.0",
             skip_build=False,
+            pdf=False,
             allow_unsafe_root_release=False,
             serial=False,
             allow_local_build=False,
@@ -1933,7 +1940,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         with patched_attrs(
             reference_harness_mod,
             ensure_prebuilt_executable=lambda _package_root, _exe_name: Path("/tmp/demo"),
-            render_in_repo_projects=lambda _package_root, _output_root, _projects, _serial: None,
+            render_in_repo_projects=lambda _package_root, _output_root, _projects, _serial, *, pdf=False: None,
         ):
             generate_projects(
                 layout,

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -10,6 +10,7 @@ import unittest
 from scripts.blueprint_harness_projects import (
     HarnessProject,
     IN_REPO_PROJECT_SOURCE_KIND,
+    command_with_pdf,
     default_project_manifest,
     deploy_matrix_from_controller_catalog,
     load_project_catalog,
@@ -56,6 +57,16 @@ def load_project_catalog_text(text: str, manifest_path: Path | str):
 
 
 class BlueprintHarnessProjectsTests(unittest.TestCase):
+    def test_command_with_pdf_appends_pdf_once(self) -> None:
+        self.assertEqual(
+            command_with_pdf(("lake", "exe", "blueprint-gen")),
+            ("lake", "exe", "blueprint-gen", "--pdf"),
+        )
+        self.assertEqual(
+            command_with_pdf(("lake", "exe", "blueprint-gen", "--pdf")),
+            ("lake", "exe", "blueprint-gen", "--pdf"),
+        )
+
     def init_git_repo(self, root: Path) -> None:
         subprocess.run(["git", "init"], cwd=root, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
@@ -529,13 +540,27 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
 
         self.assertIn("emit_reference_release_matrix.py", workflow_text)
         self.assertIn("pattern: reference-blueprints-*", workflow_text)
+        self.assertIn("path: _out/reference-blueprints-artifacts", workflow_text)
+        self.assertIn("--reference-root _out/reference-blueprints-artifacts", workflow_text)
+        self.assertNotIn("merge-multiple: true", workflow_text)
         self.assertIn("--project ${{ matrix.project_id }}", workflow_text)
+        self.assertIn("--pdf --project ${{ matrix.project_id }}", workflow_text)
+        self.assertIn("Install PDF toolchain", workflow_text)
+        self.assertIn("Generate reference blueprint with PDF", workflow_text)
+        self.assertIn("lualatex --version", workflow_text)
+        self.assertIn("texlive-fonts-extra", workflow_text)
+        self.assertIn("texlive-plain-generic", workflow_text)
         self.assertIn("matrix.reference_cache_key", workflow_text)
         self.assertIn(".worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/packages", workflow_text)
         self.assertIn(".worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/path-builds", workflow_text)
         self.assertIn("reference-deps-v2-${{ matrix.reference_cache_key }}", workflow_text)
         self.assertIn(".worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/path-builds", deploy_workflow_text)
         self.assertIn("reference-deploy-deps-v2-${{ matrix.reference_cache_key }}", deploy_workflow_text)
+        self.assertIn("Install PDF toolchain", deploy_workflow_text)
+        self.assertIn("Generate release reference blueprints with PDFs", deploy_workflow_text)
+        self.assertIn("lualatex --version", deploy_workflow_text)
+        self.assertIn("texlive-fonts-extra", deploy_workflow_text)
+        self.assertIn("texlive-plain-generic", deploy_workflow_text)
 
         for entry in matrix["include"]:
             self.assertEqual(entry["artifact_name"], f"reference-blueprints-{entry['project_id']}")
@@ -698,6 +723,10 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             manifest_by_project["old-release-project"]["projects"][0]["source"]["project_root"],
             "old-controller",
         )
+        self.assertEqual(
+            manifest_by_project["old-release-project"]["projects"][0]["generate_command"],
+            ["lake", "exe", "blueprint-gen", "--pdf"],
+        )
         self.assertEqual(matrix_by_project["old-release-project"]["project_root"], "old-controller")
         self.assertEqual(matrix_by_project["old-release-project"]["rc"], "")
         self.assertEqual(matrix_by_project["old-release-project"]["toolchain"], "v4.28.0")
@@ -705,6 +734,10 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(
             manifest_by_project["new-release-project"]["projects"][0]["targets"],
             [{"release": "v4.29.0", "ref": "new-controller-ref", "rc": "4.29-rc1"}],
+        )
+        self.assertEqual(
+            manifest_by_project["new-release-project"]["projects"][0]["generate_command"],
+            ["lake", "exe", "blueprint-gen", "--pdf"],
         )
         self.assertNotIn("rc", manifest_by_project["new-release-project"]["release_targets"][0])
         self.assertEqual(matrix_by_project["new-release-project"]["rc"], "4.29-rc1")
@@ -1575,7 +1608,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 commands_mod.run = lambda command, *, cwd: commands.append(command)
                 commands_mod.run_with_heartbeat = lambda command, *, cwd, label: commands.append(command)
 
-                generate_git_project(layout, output_root, project, skip_build=False)
+                generate_git_project(layout, output_root, project, skip_build=False, pdf=True)
             finally:
                 for name, value in originals.items():
                     if name == "command_rewrite_local_blueprint_dependency":
@@ -1592,6 +1625,13 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(commands[0], reference_submodule_update_command())
         self.assertIn(["lake", "update", "VersoBlueprint"], commands)
         self.assertTrue(any(command[1:] == ["lake", "build"] for command in commands))
+        self.assertTrue(
+            any(
+                command[1:]
+                == ["lake", "exe", "blueprint-gen", "--output", str(output_root / "external-blueprint"), "--pdf"]
+                for command in commands
+            )
+        )
 
     def test_generate_git_project_move_mode_restores_packages_after_failure(self) -> None:
         import scripts.blueprint_harness_references as refs_mod

--- a/tests/harness/test_prepare_reference_blueprints_pages.py
+++ b/tests/harness/test_prepare_reference_blueprints_pages.py
@@ -69,6 +69,8 @@ class PrepareReferenceBlueprintPagesTests(unittest.TestCase):
                 "reference project template",
                 encoding="utf-8",
             )
+            (reference_root / "project-template" / "pdf").mkdir(parents=True)
+            (reference_root / "project-template" / "pdf" / "main.pdf").write_bytes(b"project template pdf")
             (reference_root / "noperthedron" / "html-multi").mkdir(parents=True)
             (reference_root / "noperthedron" / "html-multi" / "index.html").write_text(
                 "reference noperthedron",
@@ -95,6 +97,10 @@ class PrepareReferenceBlueprintPagesTests(unittest.TestCase):
                 "reference project template",
             )
             self.assertEqual(
+                (output_root / "reference-blueprints" / "project-template" / "pdf" / "main.pdf").read_bytes(),
+                b"project template pdf",
+            )
+            self.assertEqual(
                 (output_root / "test-blueprints" / "preview_runtime_showcase" / "html-multi" / "index.html").read_text(
                     encoding="utf-8"
                 ),
@@ -107,6 +113,7 @@ class PrepareReferenceBlueprintPagesTests(unittest.TestCase):
 
             landing_index = (output_root / "index.html").read_text(encoding="utf-8")
             self.assertIn("reference-blueprints/project-template/", landing_index)
+            self.assertIn("reference-blueprints/project-template/pdf/main.pdf", landing_index)
             self.assertIn("reference-blueprints/noperthedron/", landing_index)
             self.assertIn("Open reference blueprint index", landing_index)
             self.assertIn("test-blueprints/", landing_index)
@@ -114,9 +121,71 @@ class PrepareReferenceBlueprintPagesTests(unittest.TestCase):
 
             reference_index = (output_root / "reference-blueprints" / "index.html").read_text(encoding="utf-8")
             self.assertIn('href="project-template/"', reference_index)
+            self.assertIn('href="project-template/pdf/main.pdf"', reference_index)
             self.assertIn('href="noperthedron/"', reference_index)
+            self.assertNotIn('href="noperthedron/pdf/main.pdf"', reference_index)
             self.assertNotIn("reference-blueprints/project-template/", reference_index)
             self.assertNotIn("js-api/", landing_index)
+
+    def test_prepare_pages_stages_downloaded_reference_artifact_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            reference_root = tmp_path / "reference-blueprints-artifacts"
+            test_root = tmp_path / "test-blueprints"
+            output_root = tmp_path / "_site"
+
+            (reference_root / "reference-blueprints-project-template" / "html-multi").mkdir(parents=True)
+            (
+                reference_root
+                / "reference-blueprints-project-template"
+                / "html-multi"
+                / "index.html"
+            ).write_text("reference project template", encoding="utf-8")
+            (reference_root / "reference-blueprints-project-template" / "pdf").mkdir(parents=True)
+            (reference_root / "reference-blueprints-project-template" / "pdf" / "main.pdf").write_bytes(
+                b"project template pdf"
+            )
+            (reference_root / "reference-blueprints-noperthedron" / "html-multi").mkdir(parents=True)
+            (reference_root / "reference-blueprints-noperthedron" / "html-multi" / "index.html").write_text(
+                "reference noperthedron",
+                encoding="utf-8",
+            )
+
+            (test_root / "preview_runtime_showcase" / "html-multi").mkdir(parents=True)
+            (test_root / "preview_runtime_showcase" / "html-multi" / "index.html").write_text(
+                "test showcase",
+                encoding="utf-8",
+            )
+
+            result = self.run_helper(reference_root, test_root, output_root)
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+            self.assertEqual(
+                (output_root / "reference-blueprints" / "project-template" / "index.html").read_text(
+                    encoding="utf-8"
+                ),
+                "reference project template",
+            )
+            self.assertEqual(
+                (output_root / "reference-blueprints" / "project-template" / "pdf" / "main.pdf").read_bytes(),
+                b"project template pdf",
+            )
+            self.assertEqual(
+                (output_root / "reference-blueprints" / "noperthedron" / "index.html").read_text(encoding="utf-8"),
+                "reference noperthedron",
+            )
+            self.assertFalse((output_root / "reference-blueprints" / "reference-blueprints-project-template").exists())
+
+            landing_index = (output_root / "index.html").read_text(encoding="utf-8")
+            self.assertIn("reference-blueprints/project-template/", landing_index)
+            self.assertIn("reference-blueprints/project-template/pdf/main.pdf", landing_index)
+            self.assertNotIn("reference-blueprints/reference-blueprints-project-template/", landing_index)
+
+            reference_index = (output_root / "reference-blueprints" / "index.html").read_text(encoding="utf-8")
+            self.assertIn('href="project-template/"', reference_index)
+            self.assertIn('href="project-template/pdf/main.pdf"', reference_index)
+            self.assertIn('href="noperthedron/"', reference_index)
+            self.assertNotIn("reference-blueprints-project-template", reference_index)
 
     def test_prepare_pages_stages_javascript_api_docs_when_requested(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -207,6 +276,10 @@ class PrepareReferenceBlueprintPagesTests(unittest.TestCase):
                 "reference noperthedron v4.29.0",
                 encoding="utf-8",
             )
+            (reference_root / "v4.29.0" / "noperthedron" / "pdf").mkdir(parents=True)
+            (reference_root / "v4.29.0" / "noperthedron" / "pdf" / "main.pdf").write_bytes(
+                b"noperthedron pdf v4.29.0"
+            )
 
             (test_root / "preview_runtime_showcase" / "html-multi").mkdir(parents=True)
             (test_root / "preview_runtime_showcase" / "html-multi" / "index.html").write_text(
@@ -238,6 +311,17 @@ class PrepareReferenceBlueprintPagesTests(unittest.TestCase):
                 ).read_text(encoding="utf-8"),
                 "reference noperthedron v4.29.0",
             )
+            self.assertEqual(
+                (
+                    output_root
+                    / "reference-blueprints"
+                    / "v4.29.0"
+                    / "noperthedron"
+                    / "pdf"
+                    / "main.pdf"
+                ).read_bytes(),
+                b"noperthedron pdf v4.29.0",
+            )
 
             release_index = (output_root / "reference-blueprints" / "index.html").read_text(encoding="utf-8")
             self.assertIn('href="v4.28.0/"', release_index)
@@ -250,6 +334,8 @@ class PrepareReferenceBlueprintPagesTests(unittest.TestCase):
             ).read_text(encoding="utf-8")
             self.assertIn('href="project-template/"', release_project_index)
             self.assertIn('href="noperthedron/"', release_project_index)
+            self.assertIn('href="noperthedron/pdf/main.pdf"', release_project_index)
+            self.assertNotIn('href="project-template/pdf/main.pdf"', release_project_index)
             self.assertNotIn("reference-blueprints/v4.29.0/noperthedron/", release_project_index)
 
             alias_index = (output_root / "reference-blueprints" / "noperthedron" / "index.html").read_text(


### PR DESCRIPTION
This PR publishes generated PDF artifacts for reference blueprints in GitHub Pages and verifies them in the reference-blueprint CI artifacts.

- Add a reference-harness --pdf option and use it in the Reference Blueprints workflow so PR artifacts contain pdf/main.pdf.
- Append --pdf to deploy-time one-project reference manifests without depending on newer release-branch harness flags.
- Copy pdf/main.pdf into the staged Pages artifact and link it from generated reference indexes when present.
- Install the PDF toolchain in reference/deploy workflows and document the deployed PDF layout.

Backport v4.31.0: exempt: Deploy workflow and Pages staging are controlled from the default-development branch; release branches already have PDF generation support.
Backport v4.30.0: exempt: Deploy workflow and Pages staging are controlled from the default-development branch; release branches already have PDF generation support.