### PR TITLE
[backport v4.31.0] fix: diagnose stale Blueprint manifests

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -139,11 +139,17 @@ Generated Blueprint sites write reusable data under `-verso-data/`:
 - `api/preview.mjs` exposes the preview/render API for ordinary browser
   `import` usage.
 
-The manifest is the semantic data contract. Cached HTML is an opaque rendered
-fragment cache that can be inserted and hydrated. The cache also carries the
-Verso hover payloads referenced by those rendered fragments; generated
-Blueprint pages merge them into `-verso-docs.json`, and Slides preloads them
-when rendering a deck.
+The manifest is the semantic data contract for generated-site consumers.
+Cached HTML is an opaque rendered fragment cache that can be inserted and
+hydrated. The cache also carries the Verso hover payloads referenced by those
+rendered fragments; generated Blueprint pages merge them into
+`-verso-docs.json`, and Slides preloads them when rendering a deck.
+
+The manifest may also contain VBP-internal generated-data markers used to
+diagnose stale artifacts. These markers are not public compatibility promises
+and may change whenever VBP needs a new internal reader boundary. Public
+clients should use the semantic entries, graph records, source documents, and
+generated browser APIs described here rather than depending on those markers.
 
 In practice:
 

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -917,7 +917,9 @@ useful for:
 For informal blocks, these files are the same semantic manifest and opaque
 rendered-fragment cache used by generated previews, grafts, Slides, and custom
 clients. See [`API.md#generated-data-files`](./API.md#generated-data-files)
-for the stable consumer contract.
+for the stable consumer contract. The manifest may also include VBP-internal
+generated-data markers for stale-artifact diagnostics; those markers are not
+public compatibility promises.
 
 After building the relevant Lean targets, useful inspection flags on a
 Blueprint generator are:

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -36,15 +36,22 @@ open Lean Elab Command Term Meta
 open Verso Doc
 open Verso.Genre Manual
 
-private def readJsonFileAs [FromJson α] (path : System.FilePath) (description : String) :
-    IO α := do
+private def readJsonFile (path : System.FilePath) (description : String) : IO Json := do
   let json ←
     match Json.parse (← IO.FS.readFile path) with
     | .ok json => pure json
     | .error err => throw <| IO.userError s!"could not parse {description} {path}: {err}"
+  pure json
+
+private def decodeJsonAs [FromJson α] (path : System.FilePath) (description : String)
+    (json : Json) : IO α := do
   match fromJson? (α := α) json with
   | .ok value => pure value
   | .error err => throw <| IO.userError s!"could not decode {description} {path}: {err}"
+
+private def readJsonFileAs [FromJson α] (path : System.FilePath) (description : String) :
+    IO α := do
+  decodeJsonAs path description (← readJsonFile path description)
 
 private def buildMetadataCss : String := r##"
 .bp_build_metadata {
@@ -558,6 +565,20 @@ def manifestFilename : String := "blueprint-manifest.json"
 
 def htmlCacheFilename : String := "blueprint-html-cache.json"
 
+/--
+Internal schema marker for generated Blueprint manifests.
+
+This is a VBP stale-artifact diagnostic marker, not a public interchange
+version. It may change whenever the generated-data reader needs a clean
+incompatibility boundary.
+-/
+def manifestInternalSchemaVersion : Nat := 1
+
+def manifestInternalSchemaVersionField : String := "vbpInternalSchemaVersion"
+
+def manifestRegenerationHint : String :=
+  "run `lake exe vbp build` to regenerate generated data with this VBP version"
+
 def graphApiModuleFilename : String := "blueprint-graph-api.mjs"
 
 def graphCoreModuleFilename : String := "blueprint-graph-core.mjs"
@@ -884,6 +905,11 @@ def Entry.heading (entry : Entry) (displayLabelOverride? : Option String := none
   { caption, label }
 
 structure File where
+  /--
+  Internal generated-data schema marker for VBP tooling; not a public
+  compatibility promise.
+  -/
+  vbpInternalSchemaVersion : Nat := manifestInternalSchemaVersion
   /--
   Semantic manifest entries keyed by `PreviewCache`, `externalMarkupEntryKey`,
   Lean preview key, or citation key.
@@ -1236,8 +1262,33 @@ key order while keeping display-level rendered-HTML deduplication in
 def Index.codeEntries (index : Index) (entry : Entry) : Array Entry :=
   entry.leanCodePreviewKeys.filterMap index.findEntry?
 
+private def unsupportedManifestSchemaMessage (detail : String) : String :=
+  s!"unsupported internal Blueprint manifest schema: {detail}; {manifestRegenerationHint}"
+
+private def checkManifestInternalSchema (json : Json) : Except String Unit := do
+  let versionJson ←
+    match json.getObjVal? manifestInternalSchemaVersionField with
+    | .ok value => pure value
+    | .error _ =>
+        .error <| unsupportedManifestSchemaMessage
+          s!"missing `{manifestInternalSchemaVersionField}`"
+  let version ←
+    match fromJson? (α := Nat) versionJson with
+    | .ok version => pure version
+    | .error _ =>
+        .error <| unsupportedManifestSchemaMessage
+          s!"invalid `{manifestInternalSchemaVersionField}`; expected natural-number marker {manifestInternalSchemaVersion}"
+  if version == manifestInternalSchemaVersion then
+    pure ()
+  else
+    .error <| unsupportedManifestSchemaMessage
+      s!"found `{manifestInternalSchemaVersionField}` {version}, expected {manifestInternalSchemaVersion}"
+
 def readFile (path : System.FilePath) : IO File := do
-  readJsonFileAs path "Blueprint manifest"
+  let json ← readJsonFile path "Blueprint manifest"
+  match checkManifestInternalSchema json with
+  | .ok () => decodeJsonAs path "Blueprint manifest" json
+  | .error err => throw <| IO.userError s!"could not decode Blueprint manifest {path}: {err}"
 
 private structure SchemaState where
   seen : Std.HashSet Name := {}

--- a/tests/VersoBlueprintTests/BlueprintPreviewSchema.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewSchema.lean
@@ -24,6 +24,9 @@ open Informal.PreviewManifest
       let Except.ok entryPropsJson := Json.getObjVal? entrySchema "properties" | return false
       let Except.ok entryProps := entryPropsJson.getObj? | return false
       let schemaText := schema.compress
+      let internalSchemaDesc? := do
+        let internalSchemaJson ← fileProps.get? "vbpInternalSchemaVersion"
+        internalSchemaJson.getObjValAs? String "description" |>.toOption
       let proofUsesDesc? := do
         let proofUsesJson ← entryProps.get? "proofUses"
         proofUsesJson.getObjValAs? String "description" |>.toOption
@@ -53,7 +56,9 @@ open Informal.PreviewManifest
       let entryKindText := (defs.get? "Informal.PreviewManifest.EntryKind").map (·.compress) |>.getD ""
       rootRef == "#/$defs/Informal.PreviewManifest.File" &&
         !fileProps.contains "version" &&
+        !fileProps.contains "schemaVersion" &&
         !fileProps.contains "traverseState" &&
+        fileProps.contains "vbpInternalSchemaVersion" &&
         fileProps.contains "previews" &&
         fileProps.contains "sourceDocuments" &&
         entryProps.contains "key" &&
@@ -97,6 +102,8 @@ open Informal.PreviewManifest
         proofUsesDesc? == some "Structured proof use metadata, preserving origin and intent tags." &&
         displayCaptionDesc? == some "Structured heading caption for renderers that need to lay out the title." &&
         leanCodePreviewKeysDesc? == some "Rendered-fragment cache keys for Lean declaration previews associated with this entry." &&
+        (internalSchemaDesc?.getD "").contains "not a public" &&
+        (internalSchemaDesc?.getD "").contains "compatibility promise" &&
         sourceLocationDesc? == some "Source location lookup result for this manifest entry." &&
         kindDesc? == some "Kind (definition, proposition, lemma, theorem, corollary)." &&
         !schemaText.contains "Lean `Name`" &&

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -200,6 +200,26 @@ private def writeManifestOnlySite (site : System.FilePath) : IO Unit := do
     (dataDir / Informal.PreviewManifest.manifestFilename)
     (toJson sampleManifest).compress
 
+private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Json) : IO Unit := do
+  let dataDir := site / "html-multi" / "-verso-data"
+  IO.FS.createDirAll dataDir
+  IO.FS.writeFile
+    (dataDir / Informal.PreviewManifest.manifestFilename)
+    manifestJson.compress
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    let json := toJson sampleManifest
+    match
+      jsonNatField? json Informal.PreviewManifest.manifestInternalSchemaVersionField,
+      jsonArrayField? json "previews" with
+    | some version, some previews =>
+        version == Informal.PreviewManifest.manifestInternalSchemaVersion &&
+          previews.foldl (fun ok entry => ok && (jsonField? entry "sourceLocation").isSome) true
+    | _, _ => false
+
 /-- info: true -/
 #guard_msgs in
 #eval
@@ -420,6 +440,26 @@ private def writeManifestOnlySite (site : System.FilePath) : IO Unit := do
       pure <| message.contains "run `lake exe vbp build` first" &&
         !message.contains "vbp check"
   pure (queryOk && cacheMissing)
+
+/-- info: true -/
+#guard_msgs in
+#eval do
+  let site ← freshVbpFixtureRoot
+  let staleManifestJson := Json.mkObj [
+    ("previews", Json.arr #[]),
+    ("graphs", Json.arr #[]),
+    ("sourceDocuments", Json.arr #[])
+  ]
+  writeRawManifestOnlySite site staleManifestJson
+  try
+    let _ ← VersoBlueprint.Vbp.readManifestForSite site
+    pure false
+  catch err =>
+    let message := IO.Error.toString err
+    pure <|
+      message.contains "unsupported internal Blueprint manifest schema" &&
+        message.contains Informal.PreviewManifest.manifestInternalSchemaVersionField &&
+        message.contains "lake exe vbp build"
 
 /-- info: true -/
 #guard_msgs in


### PR DESCRIPTION
## Summary
Backport #257 to `v4.31.0`.

## Primary Review
- Primary review: #257
- Keep review comments on #257 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.31.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.