### PR TITLE
fix: gate deploy PDFs to current release

### DIFF
--- a/.github/workflows/reference-blueprints-deploy.yml
+++ b/.github/workflows/reference-blueprints-deploy.yml
@@ -65,6 +65,7 @@ jobs:
           echo "project_id=${{ matrix.project_id }}"
           echo "hash=${{ matrix.hash }}"
           echo "reference_cache_key=${{ matrix.reference_cache_key }}"
+          echo "publish_pdf=${{ matrix.publish_pdf }}"
       - name: Match reference target toolchain
         if: ${{ matrix.rc != '' }}
         run: printf 'leanprover/lean4:${{ matrix.toolchain }}\n' > lean-toolchain
@@ -90,6 +91,7 @@ jobs:
           curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
       - name: Install PDF toolchain
+        if: ${{ matrix.publish_pdf }}
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -137,9 +139,11 @@ jobs:
         run: |
           lean --version
           lake --version
-          lualatex --version | head -n 1
+          if [ "${{ matrix.publish_pdf }}" = "true" ]; then
+            lualatex --version | head -n 1
+          fi
           python3 --version
-      - name: Generate release reference blueprints with PDFs
+      - name: Generate release reference blueprints
         run: |
           python3 -m scripts.blueprint_reference_harness generate \
             --manifest _out/deploy-projects/${{ matrix.project_id }}.json \

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -718,8 +718,9 @@ default-development catalog and passes it to the release-branch harness with
 `projects.json` refs. The per-project target entry also owns any RC override,
 so two projects in the same release line can deploy against different release
 candidate tags when needed. Deploy one-project manifests append `--pdf` to the
-selected generator command, so checked-out release branches can publish PDFs
-without needing a new reference-harness CLI flag.
+selected generator command only for the default-development release target, so
+the current published catalog includes PDFs while archived release targets stay
+HTML-only unless their deploy policy is deliberately expanded.
 
 The current published project/release split is intentionally not duplicated
 here. Read `tests/harness/projects.json`; every project target marked
@@ -750,7 +751,7 @@ includes:
 - `_site/reference-blueprints/<release-id>/<project-id>/` for each selected
   reference target across all deployable release slices
 - `_site/reference-blueprints/<release-id>/<project-id>/pdf/main.pdf` for each
-  selected reference target's deployed PDF
+  selected reference target whose deploy matrix entry enables `publish_pdf`
 - `_site/test-blueprints/index.html`
 - `_site/test-blueprints/preview_runtime_showcase/`
 - `_site/test-blueprints/<slug>/`

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -617,6 +617,8 @@ def deploy_project_manifest(
 def deploy_matrix_from_controller_catalog(
     controller_catalog: HarnessProjectCatalog,
     deployable_targets: tuple[HarnessReleaseTarget, ...],
+    *,
+    pdf_release_id: str | None = None,
 ) -> dict[str, list[dict[str, object]]]:
     include: list[dict[str, object]] = []
     for target in deployable_targets:
@@ -628,6 +630,7 @@ def deploy_matrix_from_controller_catalog(
             )
         for project in controller_projects:
             fields = reference_project_target_fields(project, target)
+            publish_pdf = target.release_id == pdf_release_id
             include.append(
                 {
                     "release_id": target.release_id,
@@ -641,7 +644,8 @@ def deploy_matrix_from_controller_catalog(
                     "reference_cache_key": fields["reference_cache_key"],
                     "artifact_name": deploy_project_artifact_name(project),
                     "artifact_path": deploy_project_artifact_path(project),
-                    "project_manifest": deploy_project_manifest(target, project),
+                    "publish_pdf": publish_pdf,
+                    "project_manifest": deploy_project_manifest(target, project, include_pdf=publish_pdf),
                 }
             )
     return {"include": include}

--- a/scripts/emit_reference_deploy_matrix.py
+++ b/scripts/emit_reference_deploy_matrix.py
@@ -10,6 +10,7 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.blueprint_harness_paths import detect_harness_layout
+from scripts.blueprint_harness_branches import load_branch_policy
 from scripts.blueprint_harness_projects import (
     deploy_matrix_from_controller_catalog,
     load_project_catalog,
@@ -43,7 +44,12 @@ def payload(args: argparse.Namespace) -> dict[str, object]:
         for target in catalog.release_targets
         if target.deploy_pages
     )
-    matrix = deploy_matrix_from_controller_catalog(catalog, deployable_targets)
+    policy = load_branch_policy(layout.package_root)
+    matrix = deploy_matrix_from_controller_catalog(
+        catalog,
+        deployable_targets,
+        pdf_release_id=policy.default_dev_branch,
+    )
     deployable_release_count = len({entry["release_id"] for entry in matrix["include"]})
     return {
         "manifest_path": str(manifest_path),

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -557,7 +557,9 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertIn(".worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/path-builds", deploy_workflow_text)
         self.assertIn("reference-deploy-deps-v2-${{ matrix.reference_cache_key }}", deploy_workflow_text)
         self.assertIn("Install PDF toolchain", deploy_workflow_text)
-        self.assertIn("Generate release reference blueprints with PDFs", deploy_workflow_text)
+        self.assertIn("if: ${{ matrix.publish_pdf }}", deploy_workflow_text)
+        self.assertIn("publish_pdf=${{ matrix.publish_pdf }}", deploy_workflow_text)
+        self.assertIn("Generate release reference blueprints", deploy_workflow_text)
         self.assertIn("lualatex --version", deploy_workflow_text)
         self.assertIn("texlive-fonts-extra", deploy_workflow_text)
         self.assertIn("texlive-plain-generic", deploy_workflow_text)
@@ -697,6 +699,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         matrix = deploy_matrix_from_controller_catalog(
             controller_catalog,
             controller_catalog.release_targets,
+            pdf_release_id="v4.29.0",
         )
 
         self.assertEqual(
@@ -725,8 +728,9 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         )
         self.assertEqual(
             manifest_by_project["old-release-project"]["projects"][0]["generate_command"],
-            ["lake", "exe", "blueprint-gen", "--pdf"],
+            ["lake", "exe", "blueprint-gen"],
         )
+        self.assertFalse(matrix_by_project["old-release-project"]["publish_pdf"])
         self.assertEqual(matrix_by_project["old-release-project"]["project_root"], "old-controller")
         self.assertEqual(matrix_by_project["old-release-project"]["rc"], "")
         self.assertEqual(matrix_by_project["old-release-project"]["toolchain"], "v4.28.0")
@@ -739,6 +743,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             manifest_by_project["new-release-project"]["projects"][0]["generate_command"],
             ["lake", "exe", "blueprint-gen", "--pdf"],
         )
+        self.assertTrue(matrix_by_project["new-release-project"]["publish_pdf"])
         self.assertNotIn("rc", manifest_by_project["new-release-project"]["release_targets"][0])
         self.assertEqual(matrix_by_project["new-release-project"]["rc"], "4.29-rc1")
         self.assertEqual(matrix_by_project["new-release-project"]["toolchain"], "v4.29.0-rc1")
@@ -747,9 +752,50 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             manifest_by_project["new-release-second-project"]["projects"][0]["targets"],
             [{"release": "v4.29.0", "ref": "new-second-controller-ref", "rc": "4.29-rc2"}],
         )
+        self.assertEqual(
+            manifest_by_project["new-release-second-project"]["projects"][0]["generate_command"],
+            ["lake", "exe", "blueprint-gen", "--pdf"],
+        )
+        self.assertTrue(matrix_by_project["new-release-second-project"]["publish_pdf"])
         self.assertEqual(matrix_by_project["new-release-second-project"]["rc"], "4.29-rc2")
         self.assertEqual(matrix_by_project["new-release-second-project"]["toolchain"], "v4.29.0-rc2")
         self.assertEqual(matrix_by_project["new-release-second-project"]["verso_ref"], "v4.29.0-rc2")
+
+    def test_default_deploy_matrix_publishes_pdfs_only_for_default_dev_release(self) -> None:
+        catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
+        branch_policy = load_branch_policy(PACKAGE_ROOT)
+        deployable_targets = tuple(target for target in catalog.release_targets if target.deploy_pages)
+
+        matrix = deploy_matrix_from_controller_catalog(
+            catalog,
+            deployable_targets,
+            pdf_release_id=branch_policy.default_dev_branch,
+        )
+
+        rows = {
+            (entry["release_id"], entry["project_id"]): entry
+            for entry in matrix["include"]
+        }
+        self.assertFalse(rows[("v4.30.0", "spherepackingblueprint")]["publish_pdf"])
+        self.assertFalse(rows[("v4.30.0", "verso-carleson")]["publish_pdf"])
+        self.assertNotIn(
+            "--pdf",
+            rows[("v4.30.0", "spherepackingblueprint")]["project_manifest"]["projects"][0]["generate_command"],
+        )
+        self.assertNotIn(
+            "--pdf",
+            rows[("v4.30.0", "verso-carleson")]["project_manifest"]["projects"][0]["generate_command"],
+        )
+
+        current_release_projects = [
+            entry
+            for (release_id, _project_id), entry in rows.items()
+            if release_id == branch_policy.default_dev_branch
+        ]
+        self.assertTrue(current_release_projects)
+        for entry in current_release_projects:
+            self.assertTrue(entry["publish_pdf"])
+            self.assertIn("--pdf", entry["project_manifest"]["projects"][0]["generate_command"])
 
     def test_git_checkout_project_is_supported(self) -> None:
         manifest_data = {


### PR DESCRIPTION
This PR keeps reference-blueprint Pages deploys from forcing PDF generation on archived release targets. Deploy manifests now request PDFs only for the default-development release target, while archived release slices remain HTML-only and continue to stage PDFs only when present.

Backport v4.31.0: exempt: Deploy workflow and Pages staging policy are controlled from the default-development branch.
Backport v4.30.0: exempt: Deploy workflow and Pages staging policy are controlled from the default-development branch.