### PR TITLE
[backport v4.31.0] fix: query source-backed external markup nodes

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -269,9 +269,14 @@ and Lean-declaration chain without scraping rendered HTML.
 
 Lean-side clients that need common manifest queries should use the helper
 methods on `Informal.PreviewManifest.File` rather than reimplementing filters:
-`blockStatementEntries`, `findBlockEntriesByLabel`, `findPrimaryBlockEntry?`,
-`sourceDocument?`, `entriesWithSource`, `entriesForSourceDocument`,
-`ownerValues`, `tagValues`, and `workQueueEntries`. Entry-level helpers
+`queryableStatementEntries`, `findQueryableEntriesByLabel`,
+`findPrimaryQueryableEntry?`, `blockStatementEntries`,
+`findBlockEntriesByLabel`, `findPrimaryBlockEntry?`, `sourceDocument?`,
+`entriesWithSource`, `entriesForSourceDocument`, `ownerValues`, `tagValues`,
+and `workQueueEntries`. Use the queryable helpers for the same node selection
+as `lake exe vbp query`; use the block-only helpers when a consumer explicitly
+needs rendered block entries and should exclude source-backed bodyless
+external-markup nodes. Entry-level helpers
 `Entry.hasSourceDocument`, `Entry.matchesText`, and `Entry.matchesCode` provide
 the same source filtering and search predicates used by the `lake exe vbp query`
 interface.
@@ -282,7 +287,7 @@ import VersoBlueprint.PreviewManifest
 def primaryNodeTitle?
     (manifest : Informal.PreviewManifest.File)
     (label : String) : Option String :=
-  (manifest.findPrimaryBlockEntry? label).map (·.title)
+  (manifest.findPrimaryQueryableEntry? label).map (·.title)
 
 def workQueueLabels
     (manifest : Informal.PreviewManifest.File) : Array String :=
@@ -560,9 +565,11 @@ def renderAuditNode
 
 Use `PreviewManifest.File.findEntry?` and
 `PreviewManifest.HtmlCache.File.findHtml?` when you need direct lookup. For
-client-facing node lists, prefer `PreviewManifest.File.blockStatementEntries`
-and `findPrimaryBlockEntry?` so label/facet selection matches the generated
-`vbp` query API. Code panels can reuse `HtmlCache.File.codeHtmlBodies`.
+client-facing node lists, prefer
+`PreviewManifest.File.queryableStatementEntries` and
+`findPrimaryQueryableEntry?` so label/facet selection matches the generated
+`vbp` query API, including source-backed bodyless external-markup nodes. Code
+panels can reuse `HtmlCache.File.codeHtmlBodies`.
 
 `renderNodeFromManifestCache` has three diagnostic branches that custom
 interfaces can keep or override with `ManifestRenderConfig.renderMissingNode`:

--- a/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
+++ b/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
@@ -10,7 +10,6 @@ import VersoBlueprint.Informal.Block.Store
 import VersoBlueprint.Informal.Group
 import VersoBlueprint.Lib.HoverRender
 import VersoBlueprint.Lib.PreviewSource
-import VersoBlueprint.PreviewCache
 import VersoBlueprint.TraversalIndex
 
 /-!
@@ -65,7 +64,7 @@ private def groupRenderInfo?
 /-- One previewable row in a Blueprint related-entry panel. -/
 structure PanelEntry where
   previewId : String
-  previewKey : String
+  previewKey : Option Informal.PreviewKey := none
   previewTitle : String
   label : Data.Label
   href : Option String := none
@@ -337,13 +336,6 @@ private def usesPreviewId (sourceLabel targetLabel : Data.Label) : String :=
 private def groupPreviewId (targetLabel sourceLabel : Data.Label) : String :=
   s!"bp-group-{Informal.HoverRender.previewKey (toString targetLabel)}-{Informal.HoverRender.previewKey (toString sourceLabel)}"
 
-private def previewLookupKey (source : BlockData) : String :=
-  PreviewCache.key source.label (PreviewCache.Facet.ofInProgressKind source.kind)
-
-private def nonEmptyPreviewLookupKey? (key : String) : Option String :=
-  let key := key.trimAscii.toString
-  if key.isEmpty then none else some key
-
 /-- Render a relation-row badge with semantic relation styling classes. -/
 private def relationBadge (className title text : String) : Output.Html :=
   open Verso.Output.Html in
@@ -416,7 +408,7 @@ private def mkBlockEntry {m}
   let href := Informal.TraversalIndex.Nodes.href? ctx.state source.label
   pure {
     previewId
-    previewKey := previewLookupKey source
+    previewKey := Informal.PreviewSource.traversalRelationPreviewKey? ctx.state source.label
     previewTitle
     label := source.label
     href
@@ -432,7 +424,7 @@ private def mkLabelEntry {m}
   let previewTitle := s!"{label}"
   pure {
     previewId
-    previewKey := (Informal.PreviewSource.traversalLookupKey? ctx.state label).getD ""
+    previewKey := Informal.PreviewSource.traversalRelationPreviewKey? ctx.state label
     previewTitle
     label
     href := Informal.TraversalIndex.Nodes.href? ctx.state label
@@ -472,7 +464,7 @@ def renderPanel (cfg : PanelConfig) (entries : Array PanelEntry) : Output.Html :
       if html.isEmpty then none else some html
     Informal.HoverRender.inlinePreviewNode
       chipNode entry.previewId entry.previewTitle
-      (previewLookupKey? := nonEmptyPreviewLookupKey? entry.previewKey)
+      (previewLookupKey? := entry.previewKey.map (toString ·))
       (previewHeaderLabel? := some s!"{entry.label}")
       (previewHeaderHref? := entry.href)
       (previewFooterHtml? := previewFooterHtml?)
@@ -505,8 +497,8 @@ def renderPanel (cfg : PanelConfig) (entries : Array PanelEntry) : Output.Html :
         ("data-bp-relation-preview-id", entry.previewId),
         ("data-bp-relation-preview-title", entry.previewTitle)
       ]
-      if let some previewKey := nonEmptyPreviewLookupKey? entry.previewKey then
-        attrs := attrs.push ("data-bp-relation-preview-key", previewKey)
+      if let some previewKey := entry.previewKey then
+        attrs := attrs.push ("data-bp-relation-preview-key", toString previewKey)
       for attr in Informal.HoverRender.previewHeaderLinkAttrs (some s!"{entry.label}") entry.href do
         attrs := attrs.push attr
       pure attrs

--- a/src/VersoBlueprint/Lib/PreviewKey.lean
+++ b/src/VersoBlueprint/Lib/PreviewKey.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import Lean.Data.Json
+
+namespace Informal
+
+/-- Non-empty rendered-fragment lookup key for manifest/cache-backed previews. -/
+structure PreviewKey where
+  /-- Serialized preview key value. -/
+  value : String
+deriving Inhabited, Repr, BEq
+
+namespace PreviewKey
+
+def ofString? (raw : String) : Option PreviewKey :=
+  let value := raw.trimAscii.toString
+  if value.isEmpty then none else some { value }
+
+instance : ToString PreviewKey where
+  toString key := key.value
+
+instance : Lean.ToJson PreviewKey where
+  toJson key := Lean.Json.str key.value
+
+instance : Lean.FromJson PreviewKey where
+  fromJson? json := do
+    let raw ← Lean.fromJson? (α := String) json
+    match ofString? raw with
+    | some key => pure key
+    | none => .error "expected non-empty preview key"
+
+end PreviewKey
+
+end Informal

--- a/src/VersoBlueprint/Lib/PreviewSource.lean
+++ b/src/VersoBlueprint/Lib/PreviewSource.lean
@@ -11,6 +11,7 @@ import VersoBlueprint.Data
 import VersoBlueprint.Environment
 import VersoBlueprint.PreviewCache
 import VersoBlueprint.PreviewRender
+import VersoBlueprint.Lib.PreviewKey
 import VersoBlueprint.Resolve
 import VersoBlueprint.TraversalIndex
 
@@ -167,6 +168,27 @@ def traversalExternalMarkupLookupKey?
     none
   else
     some (externalMarkupKey label)
+
+/--
+Best preview lookup key for relation entries.
+
+Prefer the selected statement/proof traversal preview when one exists. Fall back
+to a source-backed external-markup preview for bodyless Blueprint nodes.
+-/
+private def traversalRelationLookupKey?
+    (s : Verso.Genre.Manual.TraverseState) (label : Name) : Option String :=
+  traversalLookupKey? s label <|> traversalExternalMarkupLookupKey? s label
+
+/--
+Best preview key for relation entries.
+
+Prefer the selected statement/proof traversal preview when one exists. Fall back
+to a source-backed external-markup preview for bodyless Blueprint nodes.
+-/
+def traversalRelationPreviewKey?
+    (s : Verso.Genre.Manual.TraverseState) (label : Name) : Option PreviewKey := do
+  let key ← traversalRelationLookupKey? s label
+  PreviewKey.ofString? key
 
 def traversalPreview?
     (s : Verso.Genre.Manual.TraverseState) (label : Name) : Option Preview := do

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -770,11 +770,35 @@ structure RelatedEntry where
   title : String
   /-- Canonical link target for the related informal node, if available. -/
   href : Option String := none
-  /-- Rendered-fragment cache key for this related node's statement preview. -/
-  previewKey : String
+  /-- Rendered-fragment cache key for this related node's preview, if available. -/
+  previewKey : Option Informal.PreviewKey := none
   /-- Statement/proof dependency axes through which this related node is connected. -/
   axes : Array RelationAxis := #[]
-deriving Inhabited, Repr, ToJson, FromJson
+deriving Inhabited, Repr, ToJson
+
+private def jsonObjValAsD [FromJson α] (json : Json) (field : String) (fallback : α) :
+    Except String α :=
+  match json.getObjVal? field with
+  | .ok value => fromJson? value
+  | .error _ => pure fallback
+
+private def previewKeyFromJson? (json : Json) : Except String (Option Informal.PreviewKey) :=
+  match json with
+  | .null => pure none
+  | .str raw => pure (Informal.PreviewKey.ofString? raw)
+  | _ => .error "expected preview key string or null"
+
+instance : FromJson RelatedEntry where
+  fromJson? json := do
+    let label ← json.getObjValAs? Name "label"
+    let title ← json.getObjValAs? String "title"
+    let href ← jsonObjValAsD json "href" (none : Option String)
+    let previewKey ←
+      match json.getObjVal? "previewKey" with
+      | .ok value => previewKeyFromJson? value
+      | .error _ => pure none
+    let axes ← jsonObjValAsD json "axes" (#[] : Array RelationAxis)
+    pure { label, title, href, previewKey, axes }
 
 /-- Manifest-owned group metadata for an informal node. -/
 structure GroupRelation where
@@ -1183,6 +1207,12 @@ def Entry.isBlock (entry : Entry) : Bool :=
   | .block => true
   | _ => false
 
+/-- Whether this manifest entry represents a source-backed external-markup node. -/
+def Entry.isExternalMarkup (entry : Entry) : Bool :=
+  match entry.targetKind with
+  | .externalMarkup => true
+  | _ => false
+
 /-- Whether this manifest entry represents the statement facet. -/
 def Entry.isStatement (entry : Entry) : Bool :=
   match entry.facet with
@@ -1193,10 +1223,31 @@ def Entry.isStatement (entry : Entry) : Bool :=
 def File.blockStatementEntries (file : File) : Array Entry :=
   file.previews.filter (fun entry => entry.isBlock && entry.isStatement)
 
+/--
+Statement-facet entries that should be visible as Blueprint nodes to query
+clients. Bodyless source-backed nodes are exported as external-markup entries,
+but they still carry the same semantic label, dependency, ownership, and source
+metadata as block entries.
+-/
+def File.queryableStatementEntries (file : File) : Array Entry :=
+  file.previews.filter fun entry =>
+    entry.isStatement && (entry.isBlock || entry.isExternalMarkup)
+
 /-- All block entries matching the authored public label string, including non-statement facets. -/
 def File.findBlockEntriesByLabel (file : File) (label : String) : Array Entry :=
   file.previews.filter fun entry =>
     entry.isBlock && entry.authoredLabel == label
+
+/--
+All queryable Blueprint entries matching the authored public label string,
+including non-statement facets for normal blocks.
+-/
+def File.findQueryableEntriesByLabel (file : File) (label : String) : Array Entry :=
+  file.previews.filter fun entry =>
+    if entry.isBlock then
+      entry.authoredLabel == label
+    else
+      entry.isExternalMarkup && entry.isStatement && entry.authoredLabel == label
 
 /--
 Best public block entry for a label.
@@ -1208,26 +1259,37 @@ def File.findPrimaryBlockEntry? (file : File) (label : String) : Option Entry :=
   let entries := file.findBlockEntriesByLabel label
   entries.find? (·.isStatement) <|> entries[0]?
 
+/--
+Best public query entry for a label.
+
+Statement entries are primary because most clients ask for node metadata rather
+than a proof-only rendered facet. Bodyless source-backed nodes are represented
+by statement-facet external-markup entries and participate in the same lookup.
+-/
+def File.findPrimaryQueryableEntry? (file : File) (label : String) : Option Entry :=
+  let entries := file.findQueryableEntriesByLabel label
+  entries.find? (·.isStatement) <|> entries[0]?
+
 private def pushUniqueString (values : Array String) (value : String) : Array String :=
   if values.contains value then values else values.push value
 
-/-- Sorted owner names present on statement-facet block entries. -/
+/-- Sorted owner names present on queryable statement entries. -/
 def File.ownerValues (file : File) : Array String :=
-  let owners := file.blockStatementEntries.foldl (init := #[]) fun owners entry =>
+  let owners := file.queryableStatementEntries.foldl (init := #[]) fun owners entry =>
       match entry.ownerDisplayName with
       | none => owners
       | some owner => pushUniqueString owners owner
   owners.qsort (· < ·)
 
-/-- Sorted tag values present on statement-facet block entries. -/
+/-- Sorted tag values present on queryable statement entries. -/
 def File.tagValues (file : File) : Array String :=
-  let tags := file.blockStatementEntries.foldl (init := #[]) fun tags entry =>
+  let tags := file.queryableStatementEntries.foldl (init := #[]) fun tags entry =>
       entry.tags.foldl pushUniqueString tags
   tags.qsort (· < ·)
 
-/-- Statement-facet block entries carrying work-queue metadata. -/
+/-- Queryable statement entries carrying work-queue metadata. -/
 def File.workQueueEntries (file : File) : Array Entry :=
-  file.blockStatementEntries.filter fun entry =>
+  file.queryableStatementEntries.filter fun entry =>
     entry.ownerDisplayName.isSome || entry.priority.isSome ||
       entry.effort.isSome || !entry.tags.isEmpty
 
@@ -1329,6 +1391,8 @@ private partial def schemaForType (ty : Expr) : StateT SchemaState MetaM Json :=
   | .const ``String _ =>
       pure <| Json.mkObj [("type", Json.str "string")]
   | .const ``Name _ =>
+      pure <| Json.mkObj [("type", Json.str "string")]
+  | .const ``Informal.PreviewKey _ =>
       pure <| Json.mkObj [("type", Json.str "string")]
   | .const ``Bool _ =>
       pure <| Json.mkObj [("type", Json.str "boolean")]
@@ -1625,7 +1689,7 @@ private def relatedEntryForLabel
     label
     title := blockTitle state label .statement blockData?
     href := blockHref state label
-    previewKey := (Informal.PreviewSource.traversalLookupKey? state label).getD ""
+    previewKey := Informal.PreviewSource.traversalRelationPreviewKey? state label
     axes
   }
 
@@ -1637,7 +1701,7 @@ private def relatedEntryForBlock
     label := blockData.label
     title := blockTitle state blockData.label .statement (some blockData)
     href := blockHref state blockData.label
-    previewKey := (Informal.PreviewSource.traversalLookupKey? state blockData.label).getD ""
+    previewKey := Informal.PreviewSource.traversalRelationPreviewKey? state blockData.label
     axes
   }
 

--- a/src/VersoBlueprint/PreviewManifest/RelatedPanel.lean
+++ b/src/VersoBlueprint/PreviewManifest/RelatedPanel.lean
@@ -15,8 +15,11 @@ open Verso.Output
 open Verso.Output.Html
 
 def RelatedEntry.displayLabel (entry : RelatedEntry) : String :=
-  let label := entry.label.toString
-  if label.isEmpty then entry.previewKey else label
+  let label := labelString entry.label |>.trimAscii.toString
+  if !label.isEmpty then
+    label
+  else
+    entry.previewKey.map (toString ·) |>.getD "unlabeled relation"
 
 def RelatedEntry.displayTitle (entry : RelatedEntry) : String :=
   let title := entry.title.trimAscii.toString

--- a/src/VersoBlueprint/Vbp.lean
+++ b/src/VersoBlueprint/Vbp.lean
@@ -97,7 +97,7 @@ private def relatedEntryJson (entry : RelatedEntry) : Json :=
     ("label", nameJson entry.label),
     ("title", Json.str entry.title),
     ("href", optionStringJson entry.href),
-    ("previewKey", Json.str entry.previewKey),
+    ("previewKey", toJson entry.previewKey),
     ("axes", Json.arr (entry.axes.map relationAxisJson))
   ]
 
@@ -193,7 +193,7 @@ private def countsJson (counts : Array (String × Nat)) : Json :=
   Json.mkObj (counts.toList.map fun (key, count) => (key, Json.num count))
 
 private def statsJson (manifest : ManifestFile) : Json :=
-  let entries := manifest.blockStatementEntries
+  let entries := manifest.queryableStatementEntries
   let byKind := entries.foldl (fun counts entry => incrementCount counts (kindString entry.kind)) #[]
   let byOwner := entries.foldl
     (fun counts entry => entry.ownerDisplayName.map (incrementCount counts ·) |>.getD counts)
@@ -216,7 +216,7 @@ private def missingLabelJson (label : String) : Json :=
 
 private def withPrimaryEntry
     (manifest : ManifestFile) (label : String) (mkJson : Entry → Json) : Except String Json :=
-  match manifest.findPrimaryBlockEntry? label with
+  match manifest.findPrimaryQueryableEntry? label with
   | some entry => .ok (mkJson entry)
   | none => .ok (missingLabelJson label)
 
@@ -226,7 +226,7 @@ def queryJson (manifest : ManifestFile) (args : List String) : Except String Jso
       .ok querySelectorsJson
   | ["labels"] =>
       .ok <| responseJson [
-        ("labels", Json.arr (manifest.blockStatementEntries.map entrySummaryJson))
+        ("labels", Json.arr (manifest.queryableStatementEntries.map entrySummaryJson))
       ]
   | ["node", label] =>
       withPrimaryEntry manifest label entryResponseJson
@@ -263,12 +263,12 @@ def queryJson (manifest : ManifestFile) (args : List String) : Except String Jso
   | ["search", text] =>
       .ok <| responseJson [
         ("query", Json.str text),
-        ("labels", Json.arr (manifest.blockStatementEntries |>.filter (fun entry => entry.matchesText text) |>.map entrySummaryJson))
+        ("labels", Json.arr (manifest.queryableStatementEntries |>.filter (fun entry => entry.matchesText text) |>.map entrySummaryJson))
       ]
   | ["code", decl] =>
       .ok <| responseJson [
         ("query", Json.str decl),
-        ("labels", Json.arr (manifest.blockStatementEntries |>.filter (fun entry => entry.matchesCode decl) |>.map entrySummaryJson))
+        ("labels", Json.arr (manifest.queryableStatementEntries |>.filter (fun entry => entry.matchesCode decl) |>.map entrySummaryJson))
       ]
   | ["stats"] =>
       .ok (statsJson manifest)
@@ -314,9 +314,12 @@ private def checkRelatedEntries
     (errors : Array String) : Array String :=
   entries.foldl
     (fun errors entry =>
-      pushMissingCacheKey cacheKeys errors
-        s!"{context} relation {Informal.PreviewManifest.labelString entry.label}"
-        entry.previewKey)
+      match entry.previewKey with
+      | none => errors
+      | some key =>
+        pushMissingCacheKey cacheKeys errors
+          s!"{context} relation {Informal.PreviewManifest.labelString entry.label}"
+          key.value)
     errors
 
 def checkGeneratedData (manifest : ManifestFile) (htmlCache : HtmlCacheFile) : Array String :=

--- a/tests/VersoBlueprintTests/BlueprintExternalMarkup.lean
+++ b/tests/VersoBlueprintTests/BlueprintExternalMarkup.lean
@@ -563,6 +563,8 @@ external markup.
       Informal.PreviewManifest.externalMarkupEntryKey (Name.mkSimple "ImportedPaper:Definition2.3")
     let proposition24Key :=
       Informal.PreviewManifest.externalMarkupEntryKey (Name.mkSimple "ImportedPaper:Proposition2.4")
+    let theorem21PreviewKey := Informal.PreviewKey.ofString? theorem21Key
+    let proposition24PreviewKey := Informal.PreviewKey.ofString? proposition24Key
     let rewriteKey := Informal.PreviewCache.statementKey (Name.mkSimple "showcase.native.rewrite")
     let some nativeEntry := previewEntry? manifest nativeKey
       | return #["missing native entry"]
@@ -639,6 +641,10 @@ external markup.
       ("theorem 2.1 source page", entryHasSourcePage theorem21Entry "imported-paper" "12"),
       ("theorem 2.1 markdown badge", hasSubstr theorem21Html "bp_external_markup_badge_markdown"),
       ("theorem 2.1 source preview", htmlHasSourcePreview theorem21Html "imported-paper" "p. 12"),
+      ("theorem 2.1 used-by external preview key",
+        theorem21Entry.usedBy.any (fun entry =>
+          entry.label == Name.mkSimple "ImportedPaper:Proposition2.4" &&
+            entry.previewKey == proposition24PreviewKey)),
       ("theorem 2.1 rendered markdown", hasSubstr theorem21Html "<h1>Theorem 2.1</h1>")
     ]
     let selectedMarkdownChecks : Array (String × Bool) := #[
@@ -685,6 +691,10 @@ external markup.
       ("proposition 2.4 source page 16", entryHasSourcePage proposition24Entry "imported-paper" "16"),
       ("proposition 2.4 source preview", htmlHasSourcePreview proposition24Html "imported-paper" "pp. 15, 16"),
       ("proposition 2.4 statement use", proposition24Entry.statementUses.any (fun use => use.label == Name.mkSimple "ImportedPaper:Theorem2.1")),
+      ("proposition 2.4 use preview key",
+        proposition24Entry.uses.any (fun entry =>
+          entry.label == Name.mkSimple "ImportedPaper:Theorem2.1" &&
+            entry.previewKey == theorem21PreviewKey)),
       ("proposition 2.4 rendered markdown", hasSubstr proposition24Html "<h3>Proposition 2.4</h3>")
     ]
     let rewriteChecks : Array (String × Bool) := #[
@@ -695,6 +705,10 @@ external markup.
       ("rewrite source page", entryHasSourcePage rewriteEntry "imported-paper" "17"),
       ("rewrite source preview", htmlHasSourcePreview showcaseHtml "imported-paper" "p. 17"),
       ("rewrite statement use", rewriteEntry.statementUses.any (fun use => use.label == Name.mkSimple "ImportedPaper:Theorem2.1")),
+      ("rewrite use preview key",
+        rewriteEntry.uses.any (fun entry =>
+          entry.label == Name.mkSimple "ImportedPaper:Theorem2.1" &&
+            entry.previewKey == theorem21PreviewKey)),
       ("metadata losses", showcaseLosses.isEmpty)
     ]
     pure <| failedCheckLabels <|

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
@@ -15,14 +15,13 @@ open Verso.VersoBlueprintTests.BlueprintPreviewWiring.Shared
 
 private def samplePanelEntry : Informal.RelatedPanel.PanelEntry := {
   previewId := "preview"
-  previewKey := "preview-key"
+  previewKey := Informal.PreviewKey.ofString? "preview-key"
   previewTitle := "Target"
   label := Lean.Name.mkSimple "target"
 }
 
 private def sampleMissingPreviewPanelEntry : Informal.RelatedPanel.PanelEntry := {
   previewId := "missing-preview"
-  previewKey := ""
   previewTitle := "Missing Preview"
   label := Lean.Name.mkSimple "missing.preview"
 }
@@ -34,7 +33,7 @@ private def sampleMissingPreviewPanelEntry : Informal.RelatedPanel.PanelEntry :=
     let entry : Informal.PreviewManifest.RelatedEntry := {
       label := Lean.Name.mkSimple "target"
       title := "Target"
-      previewKey := "informal:target:statement"
+      previewKey := Informal.PreviewKey.ofString? "informal:target:statement"
       axes := #[.statement, .proof]
     }
     let badges := entry.badgesHtml.asString
@@ -42,6 +41,27 @@ private def sampleMissingPreviewPanelEntry : Informal.RelatedPanel.PanelEntry :=
       hasSubstr badges "bp_relation_badge_proof" &&
       hasSubstr badges "title=\"Declared in the statement\"" &&
       hasSubstr badges "title=\"Declared in the proof\""
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    let punctuatedLabel : Informal.PreviewManifest.RelatedEntry := {
+      label := Lean.Name.mkSimple "Chapter2:Introduction"
+      title := "Introduction"
+    }
+    let unlabeledWithPreview : Informal.PreviewManifest.RelatedEntry := {
+      label := Lean.Name.mkSimple ""
+      title := ""
+      previewKey := Informal.PreviewKey.ofString? "externalMarkup:Chapter2"
+    }
+    let unlabeledWithoutPreview : Informal.PreviewManifest.RelatedEntry := {
+      label := Lean.Name.mkSimple ""
+      title := ""
+    }
+    punctuatedLabel.displayLabel == "Chapter2:Introduction" &&
+      unlabeledWithPreview.displayLabel == "externalMarkup:Chapter2" &&
+      unlabeledWithoutPreview.displayLabel == "unlabeled relation"
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -16,7 +16,15 @@ private def related (value title key : String) : RelatedEntry :=
   {
     label := label value
     title := title
-    previewKey := key
+    previewKey := Informal.PreviewKey.ofString? key
+    axes := #[.statement]
+  }
+
+private def relatedWithoutPreview (value title : String) : RelatedEntry :=
+  {
+    label := label value
+    title := title
+    href := some s!"{value}/"
     axes := #[.statement]
   }
 
@@ -54,6 +62,43 @@ private def sampleManifest : ManifestFile := {
       facet := .statement
       title := "Nat.add_assoc"
     }
+  ]
+}
+
+private def sampleExternalManifest : ManifestFile := {
+  previews := sampleManifest.previews.push {
+    key := Informal.PreviewManifest.externalMarkupEntryKey (label "external_bodyless")
+    targetKind := .externalMarkup
+    label := label "external_bodyless"
+    facet := .statement
+    kind := some .corollary
+    title := "Corollary 3"
+    statementUses := #[{ label := label "addition_spec" }]
+    uses := #[related "addition_spec" "Definition 1" "informal:addition_spec:statement"]
+    leanCodePreviewKeys := #["lean:Nat.mul_assoc"]
+    ownerDisplayName := some "Source Author"
+    tags := #["external-source", "starter"]
+    priority := some "medium"
+  }
+}
+
+private def sampleEmptyRelationManifest : ManifestFile := {
+  previews := #[
+    {
+      key := "informal:relation_source:statement"
+      targetKind := .block
+      label := label "relation_source"
+      facet := .statement
+      kind := some .theorem
+      title := "Theorem 1"
+      uses := #[relatedWithoutPreview "relation_target" "Target without preview"]
+    }
+  ]
+}
+
+private def sampleEmptyRelationCache : HtmlCacheFile := {
+  entries := #[
+    { key := "informal:relation_source:statement", html := "<div>relation source</div>" }
   ]
 }
 
@@ -103,6 +148,11 @@ private def jsonBoolField? (json : Json) (field : String) : Option Bool :=
   | .ok value => some value
   | .error _ => none
 
+private def jsonNullField (json : Json) (field : String) : Bool :=
+  match jsonField? json field with
+  | some .null => true
+  | _ => false
+
 private def jsonNatField? (json : Json) (field : String) : Option Nat :=
   match json.getObjValAs? Nat field with
   | .ok value => some value
@@ -123,6 +173,9 @@ private def jsonArrayContainsString (values : Array Json) (expected : String) : 
 
 private def jsonArrayHasStringField (values : Array Json) (field expected : String) : Bool :=
   values.any (fun json => jsonStringField? json field == some expected)
+
+private def jsonArrayHasNullField (values : Array Json) (field : String) : Bool :=
+  values.any (fun json => jsonNullField json field)
 
 /-- info: true -/
 #guard_msgs in
@@ -176,8 +229,11 @@ private def jsonArrayHasStringField (values : Array Json) (field expected : Stri
 #eval
   show Bool from
     sampleManifest.blockStatementEntries.size == 2 &&
+      sampleExternalManifest.queryableStatementEntries.size == 3 &&
       (sampleManifest.findPrimaryBlockEntry? "addition_assoc").map (·.key) ==
         some "informal:addition_assoc:statement" &&
+      (sampleExternalManifest.findPrimaryQueryableEntry? "external_bodyless").map (·.key) ==
+        some (Informal.PreviewManifest.externalMarkupEntryKey (label "external_bodyless")) &&
       sampleMetadataManifest.ownerValues == #["Alpha", "Zed"] &&
       sampleMetadataManifest.tagValues == #["alpha", "beta", "zeta"] &&
       sampleMetadataManifest.workQueueEntries.map (·.authoredLabel) ==
@@ -256,6 +312,21 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
 #guard_msgs in
 #eval
   show Bool from
+    match VersoBlueprint.Vbp.queryJson sampleExternalManifest ["labels"] with
+    | .ok json =>
+        match jsonArrayField? json "labels" with
+        | some labels =>
+            jsonHasApiStability json &&
+              jsonArrayHasStringField labels "label" "external_bodyless" &&
+              jsonArrayHasStringField labels "authoredLabel" "external_bodyless" &&
+              !jsonArrayHasStringField labels "label" "Nat.add_assoc"
+        | none => false
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
     match VersoBlueprint.Vbp.queryJson sampleManifest ["node", "addition_assoc"] with
     | .ok json =>
         match jsonArrayField? json "statementUses" with
@@ -273,6 +344,22 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
 #guard_msgs in
 #eval
   show Bool from
+    match VersoBlueprint.Vbp.queryJson sampleExternalManifest ["node", "external_bodyless"] with
+    | .ok json =>
+        match jsonArrayField? json "statementUses" with
+        | some statementUses =>
+            jsonHasApiStability json &&
+              jsonStringField? json "targetKind" == some "externalMarkup" &&
+              jsonStringField? json "label" == some "external_bodyless" &&
+              jsonStringField? json "ownerDisplayName" == some "Source Author" &&
+              jsonArrayHasStringField statementUses "label" "addition_spec"
+        | none => false
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
     match VersoBlueprint.Vbp.queryJson sampleManifest ["used-by", "addition_spec"] with
     | .ok json =>
         match jsonArrayField? json "usedBy" with
@@ -281,6 +368,21 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
               jsonStringField? json "label" == some "addition_spec" &&
               jsonArrayHasStringField usedBy "label" "addition_assoc" &&
               jsonArrayHasStringField usedBy "previewKey" "informal:addition_assoc:statement"
+        | none => false
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.queryJson sampleEmptyRelationManifest ["uses", "relation_source"] with
+    | .ok json =>
+        match jsonArrayField? json "uses" with
+        | some uses =>
+            jsonHasApiStability json &&
+              jsonArrayHasStringField uses "label" "relation_target" &&
+              jsonArrayHasNullField uses "previewKey" &&
+              !jsonArrayHasStringField uses "previewKey" ""
         | none => false
     | .error _ => false
 
@@ -346,6 +448,19 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
 #guard_msgs in
 #eval
   show Bool from
+    match VersoBlueprint.Vbp.queryJson sampleExternalManifest ["code", "Nat.mul_assoc"] with
+    | .ok json =>
+        match jsonArrayField? json "labels" with
+        | some labels =>
+            jsonStringField? json "query" == some "Nat.mul_assoc" &&
+              jsonArrayHasStringField labels "label" "external_bodyless"
+        | none => false
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
     match VersoBlueprint.Vbp.queryJson sampleManifest ["stats"] with
     | .ok json =>
         match jsonField? json "byKind", jsonField? json "byTag" with
@@ -355,6 +470,21 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
               jsonNatField? byKind "definition" == some 1 &&
               jsonNatField? byKind "theorem" == some 1 &&
               jsonNatField? byTag "starter" == some 2
+        | _, _ => false
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.queryJson sampleExternalManifest ["stats"] with
+    | .ok json =>
+        match jsonField? json "byKind", jsonField? json "byTag" with
+        | some byKind, some byTag =>
+            jsonHasApiStability json &&
+              jsonNatField? json "statements" == some 3 &&
+              jsonNatField? byKind "corollary" == some 1 &&
+              jsonNatField? byTag "external-source" == some 1
         | _, _ => false
     | .error _ => false
 
@@ -390,6 +520,12 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
 #eval
   show Bool from
     VersoBlueprint.Vbp.checkGeneratedData sampleManifest sampleCache |>.isEmpty
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    VersoBlueprint.Vbp.checkGeneratedData sampleEmptyRelationManifest sampleEmptyRelationCache |>.isEmpty
 
 /-- info: true -/
 #guard_msgs in


### PR DESCRIPTION
## Summary
Backport #256 to `v4.31.0`.

## Primary Review
- Primary review: #256
- Keep review comments on #256 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.31.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.