### PR TITLE
[backport v4.31.0] fix: require manifest source locations in JS API

### DIFF
--- a/src/VersoBlueprint/Commands/preview-runtime-data.mjs
+++ b/src/VersoBlueprint/Commands/preview-runtime-data.mjs
@@ -61,8 +61,14 @@ import { resolveSourceMetadata } from "./preview-runtime-source-metadata.mjs";
     return entry && typeof entry.href === "string" ? entry.href : "";
   }
 
-  function manifestEntrySourceLocation(entry) {
-    return entry.sourceLocation;
+  function validateManifestEntrySourceLocation(entry, index) {
+    const sourceLocation = entry.sourceLocation;
+    if (!sourceLocation || typeof sourceLocation !== "object" || Array.isArray(sourceLocation)) {
+      throw new Error("Blueprint manifest entry " + index + " is missing sourceLocation");
+    }
+    if (typeof sourceLocation.ok !== "boolean") {
+      throw new Error("Blueprint manifest entry " + index + " sourceLocation.ok must be boolean");
+    }
   }
 
   function missingPreviewLookupResult(fields, message) {
@@ -80,7 +86,7 @@ import { resolveSourceMetadata } from "./preview-runtime-source-metadata.mjs";
       reason: "",
       manifestEntry: manifestEntry,
       href: manifestEntryHref(manifestEntry),
-      sourceLocation: manifestEntrySourceLocation(manifestEntry)
+      sourceLocation: manifestEntry.sourceLocation
     }, fields || {});
   }
 
@@ -636,13 +642,7 @@ import { resolveSourceMetadata } from "./preview-runtime-source-metadata.mjs";
       entryName: "Blueprint manifest entry",
       duplicateMessage: "Blueprint manifest contains duplicate key ",
       validateEntry(entry, index) {
-        const sourceLocation = entry.sourceLocation;
-        if (!sourceLocation || typeof sourceLocation !== "object" || Array.isArray(sourceLocation)) {
-          throw new Error("Blueprint manifest entry " + index + " is missing sourceLocation");
-        }
-        if (typeof sourceLocation.ok !== "boolean") {
-          throw new Error("Blueprint manifest entry " + index + " sourceLocation.ok must be boolean");
-        }
+        validateManifestEntrySourceLocation(entry, index);
       }
     });
   }

--- a/src/VersoBlueprint/Commands/preview-runtime-data.mjs
+++ b/src/VersoBlueprint/Commands/preview-runtime-data.mjs
@@ -62,9 +62,7 @@ import { resolveSourceMetadata } from "./preview-runtime-source-metadata.mjs";
   }
 
   function manifestEntrySourceLocation(entry) {
-    return entry && entry.sourceLocation
-      ? entry.sourceLocation
-      : sourceLocationUnavailable(sourceLocationMessages.unavailable);
+    return entry.sourceLocation;
   }
 
   function missingPreviewLookupResult(fields, message) {
@@ -636,7 +634,16 @@ import { resolveSourceMetadata } from "./preview-runtime-source-metadata.mjs";
       objectMessage: "Blueprint manifest must be an object with a previews array",
       missingArrayMessage: "Blueprint manifest is missing previews array",
       entryName: "Blueprint manifest entry",
-      duplicateMessage: "Blueprint manifest contains duplicate key "
+      duplicateMessage: "Blueprint manifest contains duplicate key ",
+      validateEntry(entry, index) {
+        const sourceLocation = entry.sourceLocation;
+        if (!sourceLocation || typeof sourceLocation !== "object" || Array.isArray(sourceLocation)) {
+          throw new Error("Blueprint manifest entry " + index + " is missing sourceLocation");
+        }
+        if (typeof sourceLocation.ok !== "boolean") {
+          throw new Error("Blueprint manifest entry " + index + " sourceLocation.ok must be boolean");
+        }
+      }
     });
   }
 

--- a/src/VersoBlueprint/blueprint-api-types.mjs
+++ b/src/VersoBlueprint/blueprint-api-types.mjs
@@ -238,7 +238,7 @@
  * @property {string} authoredLabel Authored/display label without Lean pretty-name quoting.
  * @property {string} [facet] Rendered facet such as `statement` or `proof`.
  * @property {string} [href] Link to the canonical generated node.
- * @property {BlueprintSourceLocationResult} [sourceLocation] Original source location lookup result for this entry.
+ * @property {BlueprintSourceLocationResult} sourceLocation Original source location lookup result for this entry.
  * @property {BlueprintExternalMarkup[]} [externalMarkup] Attached external source snippets.
  * @property {BlueprintSourceRef[]} [sources] Original source refs for this entry.
  */

--- a/tests/VersoBlueprintTests/BlueprintPreviewSchema.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewSchema.lean
@@ -23,6 +23,12 @@ open Informal.PreviewManifest
       let Except.ok fileProps := filePropsJson.getObj? | return false
       let Except.ok entryPropsJson := Json.getObjVal? entrySchema "properties" | return false
       let Except.ok entryProps := entryPropsJson.getObj? | return false
+      let fileRequired? := do
+        let requiredJson ← fileSchema.getObjVal? "required" |>.toOption
+        fromJson? (α := Array String) requiredJson |>.toOption
+      let entryRequired? := do
+        let requiredJson ← entrySchema.getObjVal? "required" |>.toOption
+        fromJson? (α := Array String) requiredJson |>.toOption
       let schemaText := schema.compress
       let internalSchemaDesc? := do
         let internalSchemaJson ← fileProps.get? "vbpInternalSchemaVersion"
@@ -49,6 +55,8 @@ open Informal.PreviewManifest
       let authoredLabelDesc? := do
         let authoredLabelJson ← entryProps.get? "authoredLabel"
         authoredLabelJson.getObjValAs? String "description" |>.toOption
+      let some fileRequired := fileRequired? | return false
+      let some entryRequired := entryRequired? | return false
       let some useRefProps := useRefProps? | return false
       let displayCaptionDesc? := do
         let displayCaptionJson ← entryProps.get? "displayCaption"
@@ -59,6 +67,7 @@ open Informal.PreviewManifest
         !fileProps.contains "schemaVersion" &&
         !fileProps.contains "traverseState" &&
         fileProps.contains "vbpInternalSchemaVersion" &&
+        fileRequired.contains manifestInternalSchemaVersionField &&
         fileProps.contains "previews" &&
         fileProps.contains "sourceDocuments" &&
         entryProps.contains "key" &&
@@ -72,6 +81,7 @@ open Informal.PreviewManifest
         entryProps.contains "displayLabel" &&
         entryProps.contains "href" &&
         entryProps.contains "sourceLocation" &&
+        entryRequired.contains "sourceLocation" &&
         entryProps.contains "parent" &&
         entryProps.contains "parentTitle" &&
         entryProps.contains "statementUses" &&

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -719,6 +719,11 @@ class TestPreviewRuntimeRegressions:
                         }
                     );
                     const customCalls = [];
+                    const unavailableSourceLocation = {
+                        ok: false,
+                        location: null,
+                        error: "source location unavailable"
+                    };
                     const customFetchJson = function (url) {
                         customCalls.push(url);
                         if (url.endsWith("blueprint-manifest.json")) {
@@ -728,7 +733,8 @@ class TestPreviewRuntimeRegressions:
                                         key: "custom_loader--statement",
                                         label: "custom_loader",
                                         facet: "statement",
-                                        title: "Custom loader"
+                                        title: "Custom loader",
+                                        sourceLocation: unavailableSourceLocation
                                     }
                                 ],
                                 graphs: [
@@ -1185,6 +1191,48 @@ class TestPreviewRuntimeRegressions:
 
         assert_no_runtime_errors(errors)
 
+    def test_public_data_api_requires_manifest_source_location(
+        self, server: str, page: Page
+    ):
+        page.goto(f"{server}/Custom-Render-Client/")
+
+        result = page.evaluate(
+            blueprint_render_api_script(
+                """
+                const { createPreviewData } = await import(api.dataApiModuleUrl());
+                const data = createPreviewData({
+                    fetchJson(url) {
+                        if (url.endsWith("blueprint-manifest.json")) {
+                            return Promise.resolve({
+                                previews: [
+                                    {
+                                        key: "legacy_loader--statement",
+                                        label: "legacy_loader",
+                                        facet: "statement",
+                                        title: "Legacy loader"
+                                    }
+                                ],
+                                graphs: []
+                            });
+                        }
+                        throw new Error("Unexpected custom loader URL: " + url);
+                    }
+                });
+                const manifest = await data.loadManifest();
+                const status = data.readManifestStatus();
+                return {
+                    state: status.state,
+                    message: status.lastError,
+                    manifestSize: manifest.size
+                };
+                """
+            )
+        )
+
+        assert result["state"] == "error"
+        assert result["manifestSize"] == 0
+        assert "missing sourceLocation" in result["message"]
+
     def test_render_node_external_markup_diagnostics(self, server: str, page: Page):
         errors = record_runtime_errors(page)
         page.goto(f"{server}/Custom-Render-Client/")
@@ -1510,6 +1558,11 @@ class TestPreviewRuntimeRegressions:
                 const dataCalls = [];
                 const moduleCalls = [];
                 const previewCalls = [];
+                const unavailableSourceLocation = {
+                    ok: false,
+                    location: null,
+                    error: "source location unavailable"
+                };
                 const manifestPayload = {
                     sourceDocuments: [
                         {
@@ -1527,6 +1580,7 @@ class TestPreviewRuntimeRegressions:
                             label: "sample_node",
                             authoredLabel: "sample_node",
                             facet: "statement",
+                            sourceLocation: unavailableSourceLocation,
                             sources: [
                                 {
                                     document: "paper",
@@ -1648,6 +1702,11 @@ class TestPreviewRuntimeRegressions:
                 """
                 const { createPreview } = await import(api.previewApiModuleUrl());
                 const calls = [];
+                const unavailableSourceLocation = {
+                    ok: false,
+                    location: null,
+                    error: "source location unavailable"
+                };
                 const manifestPayload = {
                     sourceDocuments: [
                         {
@@ -1665,6 +1724,7 @@ class TestPreviewRuntimeRegressions:
                             label: "sample_node",
                             authoredLabel: "sample_node",
                             facet: "statement",
+                            sourceLocation: unavailableSourceLocation,
                             sources: [
                                 {
                                     document: "paper",
@@ -1700,6 +1760,7 @@ class TestPreviewRuntimeRegressions:
                             key: "externalMarkup:external_node",
                             label: "external_node",
                             authoredLabel: "external_node",
+                            sourceLocation: unavailableSourceLocation,
                             externalMarkup: [
                                 {
                                     language: "markdown",
@@ -1725,13 +1786,15 @@ class TestPreviewRuntimeRegressions:
                             key: "unsourced--statement",
                             label: "unsourced",
                             authoredLabel: "unsourced",
-                            facet: "statement"
+                            facet: "statement",
+                            sourceLocation: unavailableSourceLocation
                         },
                         {
                             key: "unknown_source_document--statement",
                             label: "unknown_source_document",
                             authoredLabel: "unknown_source_document",
                             facet: "statement",
+                            sourceLocation: unavailableSourceLocation,
                             sources: [
                                 {
                                     document: "missing-paper",

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -1206,10 +1206,10 @@ class TestPreviewRuntimeRegressions:
                             return Promise.resolve({
                                 previews: [
                                     {
-                                        key: "legacy_loader--statement",
-                                        label: "legacy_loader",
+                                        key: "missing_source_location--statement",
+                                        label: "missing_source_location",
                                         facet: "statement",
-                                        title: "Legacy loader"
+                                        title: "Missing source location"
                                     }
                                 ],
                                 graphs: []


### PR DESCRIPTION
## Summary
Backport #263 to `v4.31.0`.

## Primary Review
- Primary review: #263
- Keep review comments on #263 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.31.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.