### PR TITLE
fix: harden graph preview keys

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -371,7 +371,8 @@ def allRenderedGraphs
 Generated `blueprint-manifest.json` includes a `graphs` array. Each entry
 contains `schemaVersion`, `nodes`, `edges`, and `groups`, with status enums,
 dependency axes, preview keys, hrefs when traversal resolved them, and visual
-metadata for renderers that want Blueprint's default styling.
+metadata for renderers that want Blueprint's default styling. Graph schema
+version 2 serializes each node `previewKey` as a string or `null`.
 
 That finished traversal state is the stable boundary. Consumers should not
 reconstruct graph hrefs or titles from lower-level traversal internals when the
@@ -382,9 +383,10 @@ nodes that have no rendered occurrence in the current site are omitted from the
 public graph; explicit unknown-reference diagnostics are retained. Finalized
 graph node `previewKey` values are selected preview keys: when a statement
 preview is unavailable but a proof preview exists, graph and relation UI can
-point at the proof preview. When a retained node has no renderable preview, the
-finalized `previewKey` is the empty string and bundled graph variants omit the
-node from `previewKeyByNodeId`. Use fixed facet keys such as
+point at the proof preview. Bodyless source-backed nodes can point at their
+`externalMarkup:<label>` preview. When a retained node has no renderable
+preview, the finalized `previewKey` is `null` and bundled graph variants omit
+the node from `previewKeyByNodeId`. Use fixed facet keys such as
 `PreviewCache.statementKey` or `PreviewCache.proofKey` only when your code is
 explicitly requesting that facet.
 

--- a/src/VersoBlueprint/Graph.lean
+++ b/src/VersoBlueprint/Graph.lean
@@ -7,6 +7,7 @@ Author: Emilio J. Gallego Arias
 import VersoBlueprint.Environment
 import VersoBlueprint.Informal.Block.Model
 import VersoBlueprint.Lib.HtmlId
+import VersoBlueprint.Lib.PreviewKey
 import VersoBlueprint.PreviewCache
 import VersoBlueprint.ProvedStatus
 
@@ -242,8 +243,8 @@ structure NodeData where
   kind : Option Data.NodeKind := none
   parent : Option Name := none
   href : Option String := none
-  /-- Selected preview-cache key for this node, or the empty string when no traversal preview exists. -/
-  previewKey : String
+  /-- Selected preview-cache key for this node, if a renderable traversal preview exists. -/
+  previewKey : Option PreviewKey := none
   statementUses : Array Data.UseRef := #[]
   proofUses : Array Data.UseRef := #[]
   statementStatus : StatementStatus := .blocked
@@ -258,7 +259,7 @@ Stable graph data shared by Lean, generated manifests, and browser runtime code.
 `schemaVersion` is bumped only for incompatible public-shape changes.
 -/
 structure GraphData where
-  schemaVersion : Nat := 1
+  schemaVersion : Nat := 2
   key : String := "graph"
   nodes : Array NodeData := #[]
   edges : Array EdgeData := #[]
@@ -944,7 +945,7 @@ def nodeDataWithExternal
       kind := some node.kind
       parent := node.parent
       href := resolveHref? label
-      previewKey := PreviewCache.statementKey label
+      previewKey := PreviewKey.ofString? (PreviewCache.statementKey label)
       statementUses := statementUses node
       proofUses := proofUses node
       statementStatus := statement
@@ -960,7 +961,7 @@ def nodeDataWithExternal
       kind := none
       parent := none
       href := resolveHref? label
-      previewKey := PreviewCache.statementKey label
+      previewKey := PreviewKey.ofString? (PreviewCache.statementKey label)
       statementUses := #[]
       proofUses := #[]
       statementStatus := .blocked
@@ -1426,15 +1427,12 @@ per parent group.
 -/
 def mkGraphVariants (graph : Graph String) (options : GraphOptions)
     (groupTitles : Lean.NameMap String)
-    (previewKeyForLabel : Name → String := fun _ => "") :
+    (previewKeyForLabel : Name → Option PreviewKey := fun _ => none) :
     Array GraphRenderVariant :=
   let previewKeyByNodeId (graph : Graph String) : Array (String × String) :=
     graph.filterMap fun node =>
-      let previewKey := (previewKeyForLabel node.label).trimAscii.toString
-      if previewKey.isEmpty then
-        none
-      else
-        some (graphNodeSvgId node.label, previewKey)
+      previewKeyForLabel node.label |>.map fun previewKey =>
+        (graphNodeSvgId node.label, toString previewKey)
   let resolveGroupTitle : Name → Option String := fun group =>
     groupTitles.get? group
   let parentChildren := graphParentChildren graph
@@ -1492,7 +1490,7 @@ def GraphData.renderVariants (data : GraphData) (options : GraphOptions) : Array
   let previewKeyForLabel label :=
     match data.nodes.find? (fun node => node.label == label) with
     | some node => node.previewKey
-    | none => ""
+    | none => none
   mkGraphVariants data.toGraph options data.groupTitleMap previewKeyForLabel
 
 end Informal.Graph

--- a/src/VersoBlueprint/GraphApi.lean
+++ b/src/VersoBlueprint/GraphApi.lean
@@ -50,7 +50,7 @@ private def enrichNode (state : TraverseState) (node : Informal.Graph.NodeData) 
     Informal.Graph.NodeData :=
   let title := (nodeTitle? state node.label).getD node.title
   let href := nodeHref? state node.label <|> node.href
-  let previewKey := (Informal.PreviewSource.traversalLookupKey? state node.label).getD ""
+  let previewKey := Informal.PreviewSource.traversalRenderablePreviewKey? state node.label
   { node with title, href, previewKey }
 
 private def enrichGroup (state : TraverseState) (group : Informal.Graph.GroupData) :
@@ -63,7 +63,7 @@ private def hasTraversalNode (state : TraverseState) (label : Name) : Bool :=
   (Informal.TraversalIndex.Nodes.data? state label).isSome
 
 private def hasPreviewKey (node : Informal.Graph.NodeData) : Bool :=
-  !node.previewKey.trimAscii.toString.isEmpty
+  node.previewKey.isSome
 
 private def keepFinalNode (state : TraverseState) (node : Informal.Graph.NodeData) : Bool :=
   hasTraversalNode state node.label ||

--- a/src/VersoBlueprint/Lib/PreviewKey.lean
+++ b/src/VersoBlueprint/Lib/PreviewKey.lean
@@ -4,15 +4,18 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Emilio J. Gallego Arias
 -/
 
-import Lean.Data.Json
+import Lean
 
 namespace Informal
 
+open Lean
+
 /-- Non-empty rendered-fragment lookup key for manifest/cache-backed previews. -/
 structure PreviewKey where
+  private mk ::
   /-- Serialized preview key value. -/
   value : String
-deriving Inhabited, Repr, BEq
+deriving Repr, BEq
 
 namespace PreviewKey
 
@@ -25,6 +28,9 @@ instance : ToString PreviewKey where
 
 instance : Lean.ToJson PreviewKey where
   toJson key := Lean.Json.str key.value
+
+instance : Quote PreviewKey where
+  quote key := Syntax.mkCApp ``PreviewKey.mk #[quote key.value]
 
 instance : Lean.FromJson PreviewKey where
   fromJson? json := do

--- a/src/VersoBlueprint/Lib/PreviewSource.lean
+++ b/src/VersoBlueprint/Lib/PreviewSource.lean
@@ -170,25 +170,31 @@ def traversalExternalMarkupLookupKey?
     some (externalMarkupKey label)
 
 /--
-Best preview lookup key for relation entries.
+Best renderable preview lookup key for a Blueprint label in finished traversal
+state.
 
 Prefer the selected statement/proof traversal preview when one exists. Fall back
 to a source-backed external-markup preview for bodyless Blueprint nodes.
 -/
-private def traversalRelationLookupKey?
+private def traversalRenderableLookupKey?
     (s : Verso.Genre.Manual.TraverseState) (label : Name) : Option String :=
   traversalLookupKey? s label <|> traversalExternalMarkupLookupKey? s label
 
 /--
-Best preview key for relation entries.
+Best renderable preview key for a Blueprint label in finished traversal state.
 
 Prefer the selected statement/proof traversal preview when one exists. Fall back
 to a source-backed external-markup preview for bodyless Blueprint nodes.
 -/
-def traversalRelationPreviewKey?
+def traversalRenderablePreviewKey?
     (s : Verso.Genre.Manual.TraverseState) (label : Name) : Option PreviewKey := do
-  let key ← traversalRelationLookupKey? s label
+  let key ← traversalRenderableLookupKey? s label
   PreviewKey.ofString? key
+
+/-- Best preview key for relation entries. -/
+def traversalRelationPreviewKey?
+    (s : Verso.Genre.Manual.TraverseState) (label : Name) : Option PreviewKey :=
+  traversalRenderablePreviewKey? s label
 
 def traversalPreview?
     (s : Verso.Genre.Manual.TraverseState) (label : Name) : Option Preview := do

--- a/src/VersoBlueprint/blueprint-api-types.mjs
+++ b/src/VersoBlueprint/blueprint-api-types.mjs
@@ -255,7 +255,7 @@
  * Graph data exported by the Blueprint manifest or embedded in a graph page.
  *
  * @typedef {Object} BlueprintGraphData
- * @property {number} schemaVersion Graph payload schema version.
+ * @property {number} schemaVersion Graph payload schema version; version 2 uses string-or-null node preview keys.
  * @property {string} key Variant key.
  * @property {unknown[]} nodes Graph node payloads.
  * @property {unknown[]} edges Graph edge payloads.

--- a/tests/VersoBlueprintTests/BlueprintGraph/NodeStatus.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraph/NodeStatus.lean
@@ -120,7 +120,7 @@ def graphDataStatus : GraphData :=
   hasGraphDataNodeWith graphDataStatus `def_formal (fun n =>
     n.title == "Definition 1" &&
     n.href == some "#def-formal" &&
-    n.previewKey == "def_formal--statement" &&
+    n.previewKey == PreviewKey.ofString? "def_formal--statement" &&
     n.kind == some Data.NodeKind.definition &&
     n.statementStatus == .formalized &&
     n.proofStatus == .formalizedWithAncestors &&

--- a/tests/VersoBlueprintTests/BlueprintPreviewSchema.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewSchema.lean
@@ -29,7 +29,29 @@ open Informal.PreviewManifest
       let entryRequired? := do
         let requiredJson ← entrySchema.getObjVal? "required" |>.toOption
         fromJson? (α := Array String) requiredJson |>.toOption
+      let some relatedEntrySchema := defs.get? "Informal.PreviewManifest.RelatedEntry" | return false
+      let some graphNodeSchema := defs.get? "Informal.Graph.NodeData" | return false
       let schemaText := schema.compress
+      let previewKeySchemaHasStringNull (schema : Json) : Bool :=
+        match Json.getObjVal? schema "properties" with
+        | Except.error _ => false
+        | Except.ok propsJson =>
+            match propsJson.getObj? with
+            | Except.error _ => false
+            | Except.ok props =>
+                match props.get? "previewKey" with
+                | none => false
+                | some previewKeyJson =>
+                    match Json.getObjVal? previewKeyJson "anyOf" with
+                    | Except.error _ => false
+                    | Except.ok anyOfJson =>
+                        match anyOfJson.getArr? with
+                        | Except.error _ => false
+                        | Except.ok schemas =>
+                            schemas.any (fun (schema : Json) =>
+                              (schema.getObjValAs? String "type" |>.toOption) == some "string") &&
+                            schemas.any (fun (schema : Json) =>
+                              (schema.getObjValAs? String "type" |>.toOption) == some "null")
       let internalSchemaDesc? := do
         let internalSchemaJson ← fileProps.get? "vbpInternalSchemaVersion"
         internalSchemaJson.getObjValAs? String "description" |>.toOption
@@ -118,6 +140,8 @@ open Informal.PreviewManifest
         kindDesc? == some "Kind (definition, proposition, lemma, theorem, corollary)." &&
         !schemaText.contains "Lean `Name`" &&
         entryKindText.contains "externalMarkup" &&
+        previewKeySchemaHasStringNull relatedEntrySchema &&
+        previewKeySchemaHasStringNull graphNodeSchema &&
         defs.contains "Informal.PreviewManifest.EntryKind" &&
         defs.contains "Informal.Data.UseRef" &&
         defs.contains "Informal.Data.UseOrigin" &&

--- a/tests/VersoBlueprintTests/BlueprintPreviewSource.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewSource.lean
@@ -97,7 +97,7 @@ namespace Verso.VersoBlueprintTests.BlueprintPreviewSource
         label
         title := "Proof fallback"
         displayLabel := "Proof fallback"
-        previewKey := statementKey
+        previewKey := PreviewKey.ofString? statementKey
         visual := { fillcolor := "#ffffff" }
       }]
     }
@@ -106,7 +106,7 @@ namespace Verso.VersoBlueprintTests.BlueprintPreviewSource
     pure <|
       match finalized.nodes[0]? with
       | some node =>
-        node.previewKey == proofKey &&
+        node.previewKey == PreviewKey.ofString? proofKey &&
         variants.any (fun variant =>
           variant.previewKeyByNodeId.any (fun (_, key) => key == proofKey))
       | none => false
@@ -124,7 +124,7 @@ namespace Verso.VersoBlueprintTests.BlueprintPreviewSource
         label
         title := "Missing preview"
         displayLabel := "Missing preview"
-        previewKey := statementKey
+        previewKey := PreviewKey.ofString? statementKey
         visual := { fillcolor := "#ffffff" }
       }]
     }
@@ -150,7 +150,7 @@ namespace Verso.VersoBlueprintTests.BlueprintPreviewSource
         label
         title := "Unknown preview"
         displayLabel := "Unknown preview"
-        previewKey := PreviewCache.statementKey label
+        previewKey := PreviewKey.ofString? (PreviewCache.statementKey label)
         warnings := { unknownRef := true }
         visual := { fillcolor := "#ffffff" }
       }]
@@ -162,8 +162,34 @@ namespace Verso.VersoBlueprintTests.BlueprintPreviewSource
       | some node =>
         node.label == label &&
         node.warnings.unknownRef &&
-        node.previewKey.isEmpty &&
+        node.previewKey.isNone &&
         variants.all (fun variant => variant.previewKeyByNodeId.isEmpty)
+      | none => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (_out, st) ← renderManualDocHtmlStringAndState extension_impls%
+      Verso.VersoBlueprintTests.BlueprintPreviewSource.Provider.externalMarkupPreviewSourceDoc
+    let label := Name.mkSimple "preview.external_bodyless"
+    let externalKey := Informal.PreviewSource.externalMarkupKey label
+    let semantic : Informal.Graph.GraphData := {
+      nodes := #[{
+        label
+        title := "External bodyless"
+        displayLabel := "External bodyless"
+        visual := { fillcolor := "#ffffff" }
+      }]
+    }
+    let finalized := Informal.GraphApi.finalData st semantic
+    let variants := finalized.renderVariants {}
+    pure <|
+      match finalized.nodes[0]? with
+      | some node =>
+        node.previewKey == PreviewKey.ofString? externalKey &&
+          variants.any (fun variant =>
+            variant.previewKeyByNodeId.any (fun (_, key) => key == externalKey))
       | none => false
 
 end Verso.VersoBlueprintTests.BlueprintPreviewSource

--- a/tests/VersoBlueprintTests/BlueprintPreviewSource/Provider.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewSource/Provider.lean
@@ -32,4 +32,14 @@ Proof fallback body.
 :::
 :::::::
 
+#docs (Genre.Manual) externalMarkupPreviewSourceDoc "External Markup Preview Source" :=
+:::::::
+:::theorem "preview.external_bodyless"
+:::
+
+```md "preview.external_bodyless" (slot := statement)
+External-markup body for a graph preview.
+```
+:::::::
+
 end Verso.VersoBlueprintTests.BlueprintPreviewSource.Provider

--- a/tests/browser/test_graph_layout_runtime.py
+++ b/tests/browser/test_graph_layout_runtime.py
@@ -496,7 +496,7 @@ class TestGraphLayoutRuntime:
         expect(graph_card).to_have_attribute("data-bp-graph-module-ok", "true")
         expect(graph_card).to_have_attribute("data-bp-graph-module-count", "1")
         expect(graph_card.locator("[data-bp-custom-client-graph-summary]").first).to_contain_text(
-            "Nodes 57"
+            "Nodes 58"
         )
 
     def test_graph_legend_is_collapsed_by_default_and_tracks_variant_switch(self, server: str, page: Page):

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -860,11 +860,11 @@ class TestPreviewRuntimeRegressions:
         expect(graph_card).to_have_attribute("data-bp-graph-module-ok", "true")
         expect(graph_card).to_have_attribute("data-bp-graph-module-count", "1")
         expect(graph_card).to_have_attribute("data-bp-graph-module-key", re.compile(r"^graph:#<"))
-        expect(graph_card).to_have_attribute("data-bp-graph-node-count", "57")
+        expect(graph_card).to_have_attribute("data-bp-graph-node-count", "58")
         expect(graph_card).to_have_attribute("data-bp-graph-edge-count", "15")
         expect(graph_card).to_have_attribute("data-bp-graph-group-count", "4")
         expect(graph_card.locator("[data-bp-custom-client-graph-summary]").first).to_contain_text(
-            "Nodes 57"
+            "Nodes 58"
         )
         used_target_link = graph_card.locator('[data-bp-graph-node-label="used_target"]').first
         expect(used_target_link).to_have_text(re.compile(r"Definition"))


### PR DESCRIPTION
This PR hardens graph preview-key handling so generated graph data uses a typed non-empty preview key when present, serializes absence as `null`, and keeps bodyless source-backed external-markup nodes visible through their canonical preview keys.

Backport v4.31.0: #270
Backport v4.30.0: #271