### PR TITLE
fix: finalize manifest preview references

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -128,9 +128,12 @@ Generated Blueprint sites write reusable data under `-verso-data/`:
   generated-page hrefs, graph records, labels, dependency data, Lean-code
   associations, group data, ownership, tags, priority, effort, status metadata,
   and display metadata.
-- `blueprint-html-cache.json` contains rendered body fragments keyed by the
-  same preview keys. It is presentation data; do not parse it to rediscover
-  graph topology, labels, statuses, or dependency relationships.
+- `blueprint-html-cache.json` contains rendered body fragments keyed by
+  preview keys for entries that have generated preview bodies. Some semantic
+  entries, such as source-backed external markup generated with
+  `--external-markup-render none`, intentionally have no cache fragment. The
+  cache is presentation data; do not parse it to rediscover graph topology,
+  labels, statuses, or dependency relationships.
 - `api/graph.mjs` exposes graph-data helpers for ordinary browser `import`
   usage, plus graph-block rendering helpers for pages that carry generated
   graph markup.
@@ -301,6 +304,8 @@ raw HTML disabled and falls back to escaped source if MD4Lean cannot render the
 fragment; TeX falls back to escaped source. `.source` always emits escaped
 source; `.none` keeps
 external-markup entries semantic-only with no generated HTML-cache fragment.
+Relation, graph, and Lean-code preview references are serialized only when the
+referenced preview key resolves through both the manifest and HTML cache.
 Set `showSourceNotice := false` when an embedding context should omit the
 visible source-backed notice from generated fragments.
 
@@ -319,9 +324,10 @@ Manifest entries serialize several label-like fields with distinct roles:
   punctuation.
 
 Relation entries in `uses`, `usedBy`, and `group.entries` carry their own
-`previewKey` field. That field is either a non-empty manifest/cache key or
-`null` when the related node has no rendered preview. Fresh generated data does
-not use an empty string as a no-preview sentinel.
+`previewKey` field. That field is either a non-empty key that resolves through
+both the manifest and rendered-fragment cache, or `null` when the related node
+has no manifest/cache-backed preview in the generated artifact set. Fresh
+generated data does not use an empty string as a no-preview sentinel.
 
 Use `Informal.PreviewManifest.previewMetadataLosses state manifest` to audit
 whether traversal-preview metadata survived manifest construction. A non-empty
@@ -385,19 +391,22 @@ finalized graph data is available.
 
 Finalized graph data is traversal-backed. Imported semantic nodes or code-only
 nodes that have no rendered occurrence in the current site are omitted from the
-public graph; explicit unknown-reference diagnostics are retained. Finalized
-graph node `previewKey` values are selected preview keys: when a statement
-preview is unavailable but a proof preview exists, graph and relation UI can
-point at the proof preview. Bodyless source-backed nodes can point at their
-`externalMarkup:<label>` preview. When a retained node has no renderable
-preview, the finalized `previewKey` is `null` and bundled graph variants omit
-the node from `previewKeyByNodeId`. Use fixed facet keys such as
+public graph; explicit unknown-reference diagnostics are retained. Graph node
+`previewKey` values are selected preview keys finalized against the generated
+manifest/cache pair: when a statement preview is unavailable but a proof preview
+exists, graph and relation UI can point at the proof preview. Bodyless
+source-backed nodes can point at their `externalMarkup:<label>` preview only
+when that key has a manifest entry and rendered cache body. When a retained node
+has no manifest/cache-backed preview in the generated artifact set, the finalized
+`previewKey` is `null` and bundled graph variants omit the node from
+`previewKeyByNodeId`. Use fixed facet keys such as
 `PreviewCache.statementKey` or `PreviewCache.proofKey` only when your code is
 explicitly requesting that facet.
 
 | Need | Use |
 | --- | --- |
-| Best rendered preview for one label from finished traversal state | `PreviewSource.Selection` or the finalized node `previewKey` |
+| Best preview candidate for one label from finished traversal state | `PreviewSource.Selection` |
+| Manifest/cache-backed preview key in generated data | Finalized relation or graph node `previewKey` |
 | Explicit statement facet identity | `PreviewCache.statementKey label` |
 | Explicit proof facet identity | `PreviewCache.proofKey label` |
 

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -599,8 +599,9 @@ the manifest owns semantics, and the cache owns presentation. The manifest is
 the authoritative source for labels, authored/display label strings, facets,
 titles, hrefs, group membership, relation topology, Lean-code associations,
 ownership metadata, tags, priority, effort, and external markup metadata. The
-rendered-fragment cache stores opaque HTML bodies keyed by the same preview keys,
-plus the Verso hover payloads needed by those bodies.
+rendered-fragment cache stores opaque HTML bodies keyed by preview keys for
+entries that have generated preview bodies, plus the Verso hover payloads
+needed by those bodies.
 
 Consumers should join the two files by preview key at the last responsible
 moment. A renderer may use the manifest entry to decide what the object means
@@ -625,12 +626,14 @@ rendering of manifest semantics, not a second data source.
 
 Source-backed external-markup fragments follow the same split. The manifest
 entry owns the label, facet, Lean preview keys, code data, source language,
-slot, and optional source range. The cache entry owns only the generated body
-fragment: MD4Lean-rendered Markdown with raw HTML disabled by default, or
-escaped source text for TeX and `--external-markup-render source`. Shared
-source summaries and escaped source blocks live in `Informal.ExternalMarkupView`,
-so source-location display and preview-cache rendering do not grow separate
-escaping or range-formatting rules.
+slot, and optional source range. When external markup rendering is enabled, the
+cache entry owns only the generated body fragment: MD4Lean-rendered Markdown
+with raw HTML disabled by default, or escaped source text for TeX and
+`--external-markup-render source`. With `--external-markup-render none`, the
+manifest entry remains semantic and intentionally has no rendered-fragment cache
+body. Shared source summaries and escaped source blocks live in
+`Informal.ExternalMarkupView`, so source-location display and external-markup
+body rendering do not grow separate escaping or range-formatting rules.
 
 The generation boundary is:
 
@@ -652,6 +655,13 @@ that boundary loses semantic data such as Lean preview keys, downstream
 fallbacks should report or copy the existing traversal metadata rather than
 reconstruct it from rendered markup.
 
+Serialized preview references are finalized at this boundary. Relation entries,
+graph nodes, graph variants, and Lean-code associations may start from
+traversal-time preview candidates, but the generated JSON keeps a `previewKey`
+only when that key resolves through both the manifest and rendered-fragment
+cache. Semantic manifest entries without cache bodies remain queryable without
+advertising a missing rendered preview.
+
 ### Body Fragments vs Full Node Wrappers
 
 The rendered-fragment cache should not grow into a second node-wrapper cache
@@ -662,7 +672,9 @@ intentional:
   are small enough to use in hovers, relation panels, custom cards, Slides, and
   generated consumers that provide their own wrapper.
 - `blueprint-manifest.json` stores the semantic entry, including the generated
-  page `href` and preview key needed to find the canonical page occurrence.
+  page `href` and the entry key used as its stable manifest identity. Separate
+  relation, graph, and Lean-code `previewKey` references are emitted only when
+  the target key resolves through both the manifest and rendered-fragment cache.
 - the generated HTML page remains the owner of the exact page-level node shell:
   heading layout, wrapper attributes, relation-panel placement, code extras,
   folded state, and any future page-local affordances.
@@ -953,13 +965,15 @@ manifest/cache lookup key, and the phase-local preview payload together, so
 environment-time and traversal-time callers share the same statement-then-proof
 fallback rule without learning each other's storage details.
 
-Callers should distinguish selected preview keys from fixed facet keys. Browser
-surfaces such as graph node hovers, summary previews, and relation-panel entries
-should use `PreviewSource.Selection` when traversal state is available, because
-they want the best rendered preview for a label. Code that is explicitly naming
-a facet, such as grafting `statement` or `proof` from a manifest/cache pair,
-should use `PreviewCache.statementKey` or `PreviewCache.proofKey` so the fixed
-identity is visible at the call site.
+Callers should distinguish selected preview candidates from fixed facet keys.
+Browser surfaces such as graph node hovers, summary previews, and relation-panel
+entries should use `PreviewSource.Selection` when traversal state is available,
+because they want the best candidate preview for a label in that phase. Public
+generated JSON must still finalize those candidates against the manifest/cache
+coverage before exposing them as `previewKey` values. Code that is explicitly
+naming a facet, such as grafting `statement` or `proof` from a manifest/cache
+pair, should use `PreviewCache.statementKey` or `PreviewCache.proofKey` so the
+fixed identity is visible at the call site.
 
 Manifest construction is still a whole-domain consumer rather than a
 one-label selection caller. It asks `PreviewSource` to enumerate decoded
@@ -1089,8 +1103,8 @@ callers.
 Some previews are rendered inside a full page, while others are rendered in
 isolated contexts such as editor or LSP hovers. Isolated renderers therefore
 cannot rely on page-global hover tables. That is why Blueprint sometimes
-rewrites hover payloads into self-contained HTML. Generated preview-cache
-fragments are not treated as isolated snippets: they keep normal
+rewrites hover payloads into self-contained HTML. Generated cache fragments are
+not treated as isolated snippets: they keep normal
 `data-verso-hover` attributes and carry hover payloads as cache side data, so
 generated pages and Slides can use the standard Verso hover path without
 duplicating hover HTML into every fragment.

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -1083,7 +1083,10 @@ the stable render API table.
   `previewManifest?` to `slidesMainWithBlueprintPreviews`.
 - `Blueprint HTML cache entry not found` means the manifest entry was found, but
   the matching rendered-fragment body was not in `blueprint-html-cache.json`.
-  Keep the manifest and cache from the same Blueprint render.
+  Keep the manifest and cache from the same Blueprint render. For source-backed
+  external-markup entries generated with `--external-markup-render none`, a
+  semantic manifest entry without a cache body is expected; custom renderers
+  should treat those entries as metadata-only.
 - `siteBase` only affects Slides link rewriting. Manual grafts resolve from the
   current document traversal state and do not need it.
 - `-header`, `+compact`, and `+boxed` are presentation options only. They do not

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -1,6 +1,6 @@
 # Blueprint Roadmap
 
-Last reviewed: 2026-07-07
+Last reviewed: 2026-07-08
 
 This document tracks repository-local engineering work for `verso-blueprint`.
 Requests that should eventually move into upstream `verso`, Lake, or Lean live
@@ -118,6 +118,13 @@ Work:
    `api/preview.mjs` expose it. The target shape is one data-layer primitive for
    preview-key/manifest-entry input normalization, missing-entry reasons,
    source-document joins, and source-ref normalization semantics.
+11. scheduled follow-up: align page-local preview triggers with finalized
+   manifest/cache preview availability. Today generated JSON clears traversal
+   preview candidates that lack cache bodies, but page-local relation-panel
+   markup and embedded graph-block JSON are still derived during traversal. The
+   follow-up should either pass preview availability into page-local relation
+   and graph rendering or make the browser runtimes disable semantic-only
+   missing-cache previews without reporting them as broken generated data.
 
 ### Data Model and Status Semantics
 
@@ -192,7 +199,7 @@ Work:
    diagnostics
 3. keep reference blueprint generation and validation distinct from small
    browser-regression fixtures
-4. add direct regression coverage for preview-cache keying and JSON roundtrips
+4. add direct regression coverage for preview-key normalization and JSON roundtrips
 5. add low-cost Python coverage for harness manifest, path, and worktree logic
    so routine harness changes do not require full example rebuilds
 6. add PR preview deployment that reuses the assembled reference `_site`

--- a/src/VersoBlueprint/Graph.lean
+++ b/src/VersoBlueprint/Graph.lean
@@ -156,7 +156,7 @@ One rendered graph view.
 The bundled renderer uses variants for the full graph, the synthetic group
 overview, and per-group subgraphs. The `selectOnNodeId` and `hoverOnNodeId`
 arrays describe variant transitions keyed by SVG node id, and
-`previewKeyByNodeId` maps SVG nodes to preview-cache keys.
+`previewKeyByNodeId` maps SVG nodes to manifest/cache-backed preview keys.
 -/
 structure GraphRenderVariant where
   /-- Stable key used by the graph view selector and variant links. -/
@@ -171,7 +171,7 @@ structure GraphRenderVariant where
   selectOnNodeId : Array (String × String) := #[]
   /-- Node ids that preview another variant on hover. -/
   hoverOnNodeId : Array (String × String) := #[]
-  /-- Node ids that open Blueprint preview-cache entries. Nodes without renderable previews are omitted. -/
+  /-- Node ids that open manifest/cache-backed previews; nodes without such previews are omitted. -/
   previewKeyByNodeId : Array (String × String) := #[]
 deriving Inhabited, Repr, ToJson, FromJson, Quote
 
@@ -243,7 +243,7 @@ structure NodeData where
   kind : Option Data.NodeKind := none
   parent : Option Name := none
   href : Option String := none
-  /-- Selected preview-cache key for this node, if a renderable traversal preview exists. -/
+  /-- Selected manifest/cache-backed preview key for this node, if available. -/
   previewKey : Option PreviewKey := none
   statementUses : Array Data.UseRef := #[]
   proofUses : Array Data.UseRef := #[]

--- a/src/VersoBlueprint/GraphApi.lean
+++ b/src/VersoBlueprint/GraphApi.lean
@@ -50,7 +50,7 @@ private def enrichNode (state : TraverseState) (node : Informal.Graph.NodeData) 
     Informal.Graph.NodeData :=
   let title := (nodeTitle? state node.label).getD node.title
   let href := nodeHref? state node.label <|> node.href
-  let previewKey := Informal.PreviewSource.traversalRenderablePreviewKey? state node.label
+  let previewKey := Informal.PreviewSource.traversalPreviewCandidateKey? state node.label
   { node with title, href, previewKey }
 
 private def enrichGroup (state : TraverseState) (group : Informal.Graph.GroupData) :
@@ -62,14 +62,14 @@ private def enrichGroup (state : TraverseState) (group : Informal.Graph.GroupDat
 private def hasTraversalNode (state : TraverseState) (label : Name) : Bool :=
   (Informal.TraversalIndex.Nodes.data? state label).isSome
 
-private def hasPreviewKey (node : Informal.Graph.NodeData) : Bool :=
+private def hasPreviewCandidate (node : Informal.Graph.NodeData) : Bool :=
   node.previewKey.isSome
 
 private def keepFinalNode (state : TraverseState) (node : Informal.Graph.NodeData) : Bool :=
   hasTraversalNode state node.label ||
     node.warnings.unknownRef ||
     node.href.isSome ||
-    hasPreviewKey node
+    hasPreviewCandidate node
 
 private def labelSet (nodes : Array Informal.Graph.NodeData) : Lean.NameSet :=
   nodes.foldl (init := {}) fun acc node => acc.insert node.label
@@ -103,9 +103,10 @@ Finalize graph data against a completed traversal state.
 This is the single projection from semantic graph data to public graph data:
 rendered page JSON and manifest/cache output both use it so href, title, and
 group metadata stay consistent. The projection keeps nodes that are backed by
-the current traversal, nodes with an explicit href/preview key, and unknown-ref
-diagnostics; imported or code-only semantic nodes with no rendered occurrence in
-the current site are omitted from the public graph.
+the current traversal, nodes with an explicit href or traversal preview
+candidate, and unknown-ref diagnostics; imported or code-only semantic nodes
+with no rendered occurrence in the current site are omitted from the public
+graph.
 -/
 def finalData (state : TraverseState) (data : Informal.Graph.GraphData) :
     Informal.Graph.GraphData :=

--- a/src/VersoBlueprint/Lib/PreviewKey.lean
+++ b/src/VersoBlueprint/Lib/PreviewKey.lean
@@ -10,7 +10,7 @@ namespace Informal
 
 open Lean
 
-/-- Non-empty rendered-fragment lookup key for manifest/cache-backed previews. -/
+/-- Non-empty serialized preview-key value. -/
 structure PreviewKey where
   private mk ::
   /-- Serialized preview key value. -/

--- a/src/VersoBlueprint/Lib/PreviewSource.lean
+++ b/src/VersoBlueprint/Lib/PreviewSource.lean
@@ -170,31 +170,35 @@ def traversalExternalMarkupLookupKey?
     some (externalMarkupKey label)
 
 /--
-Best renderable preview lookup key for a Blueprint label in finished traversal
+Best preview candidate lookup key for a Blueprint label in finished traversal
 state.
 
 Prefer the selected statement/proof traversal preview when one exists. Fall back
-to a source-backed external-markup preview for bodyless Blueprint nodes.
+to a source-backed external-markup preview for bodyless Blueprint nodes. Final
+generated data still checks whether the candidate has both a manifest entry and
+rendered-fragment cache body before serializing it as a `previewKey`.
 -/
-private def traversalRenderableLookupKey?
+private def traversalPreviewCandidateLookupKey?
     (s : Verso.Genre.Manual.TraverseState) (label : Name) : Option String :=
   traversalLookupKey? s label <|> traversalExternalMarkupLookupKey? s label
 
 /--
-Best renderable preview key for a Blueprint label in finished traversal state.
+Best preview candidate key for a Blueprint label in finished traversal state.
 
 Prefer the selected statement/proof traversal preview when one exists. Fall back
-to a source-backed external-markup preview for bodyless Blueprint nodes.
+to a source-backed external-markup preview for bodyless Blueprint nodes. Final
+generated data still checks whether the candidate has both a manifest entry and
+rendered-fragment cache body before serializing it as a `previewKey`.
 -/
-def traversalRenderablePreviewKey?
+def traversalPreviewCandidateKey?
     (s : Verso.Genre.Manual.TraverseState) (label : Name) : Option PreviewKey := do
-  let key ← traversalRenderableLookupKey? s label
+  let key ← traversalPreviewCandidateLookupKey? s label
   PreviewKey.ofString? key
 
-/-- Best preview key for relation entries. -/
+/-- Best preview candidate key for relation entries. -/
 def traversalRelationPreviewKey?
     (s : Verso.Genre.Manual.TraverseState) (label : Name) : Option PreviewKey :=
-  traversalRenderablePreviewKey? s label
+  traversalPreviewCandidateKey? s label
 
 def traversalPreview?
     (s : Verso.Genre.Manual.TraverseState) (label : Name) : Option Preview := do

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -774,7 +774,7 @@ structure RelatedEntry where
   title : String
   /-- Canonical link target for the related informal node, if available. -/
   href : Option String := none
-  /-- Rendered-fragment cache key for this related node's preview, if available. -/
+  /-- Manifest/cache-backed preview key for this related node, if available. -/
   previewKey : Option Informal.PreviewKey := none
   /-- Statement/proof dependency axes through which this related node is connected. -/
   axes : Array RelationAxis := #[]
@@ -786,24 +786,12 @@ private def jsonObjValAsD [FromJson α] (json : Json) (field : String) (fallback
   | .ok value => fromJson? value
   | .error _ => pure fallback
 
-private def previewKeyFromJson? (json : Json) : Except String (Option Informal.PreviewKey) :=
-  match json with
-  | .null => pure none
-  | .str raw =>
-      match Informal.PreviewKey.ofString? raw with
-      | some key => pure (some key)
-      | none => .error "expected non-empty preview key string or null"
-  | _ => .error "expected non-empty preview key string or null"
-
 instance : FromJson RelatedEntry where
   fromJson? json := do
     let label ← json.getObjValAs? Name "label"
     let title ← json.getObjValAs? String "title"
     let href ← jsonObjValAsD json "href" (none : Option String)
-    let previewKey ←
-      match json.getObjVal? "previewKey" with
-      | .ok value => previewKeyFromJson? value
-      | .error _ => pure none
+    let previewKey ← jsonObjValAsD json "previewKey" (none : Option Informal.PreviewKey)
     let axes ← jsonObjValAsD json "axes" (#[] : Array RelationAxis)
     pure { label, title, href, previewKey, axes }
 
@@ -859,7 +847,7 @@ structure Entry where
   statementUses : Array Informal.Data.UseRef := #[]
   /-- Structured proof use metadata, preserving origin and intent tags. -/
   proofUses : Array Informal.Data.UseRef := #[]
-  /-- Rendered-fragment cache keys for Lean declaration previews associated with this entry. -/
+  /-- Manifest/cache-backed preview keys for Lean declaration previews associated with this entry. -/
   leanCodePreviewKeys : Array String := #[]
   /-- Canonical Lean code data associated with this informal node, if any. -/
   codeData : Option Informal.BlockCodeData := none
@@ -1115,6 +1103,90 @@ def Index.findEntry? (index : Index) (key : String) : Option Entry :=
 
 def File.findEntry? (file : File) (key : String) : Option Entry :=
   file.index.findEntry? key
+
+/--
+Indexes over the generated manifest/cache pair used to decide whether a
+serialized preview reference can render.
+-/
+structure PreviewArtifactIndex where
+  manifestIndex : Index := {}
+  htmlCacheIndex : HtmlCache.Index := {}
+
+def PreviewArtifactIndex.ofFiles (manifest : File) (htmlCache : HtmlCache.File) :
+    PreviewArtifactIndex := {
+  manifestIndex := manifest.index
+  htmlCacheIndex := htmlCache.index
+}
+
+def PreviewArtifactIndex.hasManifestKey
+    (index : PreviewArtifactIndex) (key : String) : Bool :=
+  (index.manifestIndex.findEntry? key).isSome
+
+def PreviewArtifactIndex.hasCacheKey
+    (index : PreviewArtifactIndex) (key : String) : Bool :=
+  (index.htmlCacheIndex.findEntry? key).isSome
+
+def PreviewArtifactIndex.resolves (index : PreviewArtifactIndex) (key : String) :
+    Bool :=
+  index.hasManifestKey key && index.hasCacheKey key
+
+private def PreviewArtifactIndex.previewKey?
+    (index : PreviewArtifactIndex) (key? : Option Informal.PreviewKey) :
+    Option Informal.PreviewKey :=
+  key?.filter fun key => index.resolves key.value
+
+private def PreviewArtifactIndex.previewKeyString?
+    (index : PreviewArtifactIndex) (key : String) : Option String :=
+  if index.resolves key then some key else none
+
+private def RelatedEntry.finalizePreviewReferences
+    (index : PreviewArtifactIndex) (entry : RelatedEntry) : RelatedEntry :=
+  { entry with previewKey := index.previewKey? entry.previewKey }
+
+private def GroupRelation.finalizePreviewReferences
+    (index : PreviewArtifactIndex) (group : GroupRelation) : GroupRelation :=
+  { group with entries := group.entries.map (RelatedEntry.finalizePreviewReferences index) }
+
+private def Entry.finalizePreviewReferences
+    (index : PreviewArtifactIndex) (entry : Entry) : Entry :=
+  {
+    entry with
+      leanCodePreviewKeys := entry.leanCodePreviewKeys.filter index.resolves
+      uses := entry.uses.map (RelatedEntry.finalizePreviewReferences index)
+      usedBy := entry.usedBy.map (RelatedEntry.finalizePreviewReferences index)
+      group := entry.group.map (GroupRelation.finalizePreviewReferences index)
+  }
+
+private def graphNodeFinalizePreviewReferences
+    (index : PreviewArtifactIndex) (node : Informal.Graph.NodeData) :
+    Informal.Graph.NodeData :=
+  { node with previewKey := index.previewKey? node.previewKey }
+
+private def graphVariantFinalizePreviewReferences
+    (index : PreviewArtifactIndex) (variant : Informal.Graph.GraphRenderVariant) :
+    Informal.Graph.GraphRenderVariant :=
+  {
+    variant with
+      previewKeyByNodeId := variant.previewKeyByNodeId.filterMap fun (nodeId, key) =>
+        (index.previewKeyString? key).map fun key => (nodeId, key)
+  }
+
+private def graphFinalizePreviewReferences
+    (index : PreviewArtifactIndex) (graph : Informal.Graph.GraphData) :
+    Informal.Graph.GraphData :=
+  {
+    graph with
+      nodes := graph.nodes.map (graphNodeFinalizePreviewReferences index)
+      variants := graph.variants.map (graphVariantFinalizePreviewReferences index)
+  }
+
+private def File.finalizePreviewReferences (file : File) (htmlCache : HtmlCache.File) : File :=
+  let index := PreviewArtifactIndex.ofFiles file htmlCache
+  {
+    file with
+      previews := file.previews.map (Entry.finalizePreviewReferences index)
+      graphs := file.graphs.map (graphFinalizePreviewReferences index)
+  }
 
 /-- Manifest metadata that was present during traversal but is absent from export. -/
 structure PreviewMetadataLoss where
@@ -2055,13 +2127,12 @@ def buildPreviewDataFiles
   let previews := (traversalPreviews ++ externalMarkupPreviews ++ leanCodePreviews ++ citationPreviews).qsort (fun a b => a.key < b.key)
   let htmlEntries := (traversalHtml ++ externalMarkupHtml ++ leanCodeHtml ++ citationHtml).qsort (fun a b => a.key < b.key)
   let graphs := Informal.GraphApi.cachedData state
-  pure {
-    manifest := { previews, graphs, sourceDocuments }
-    htmlCache := {
-      entries := htmlEntries
-      hoverDocs := HtmlCache.HoverDoc.ofDedup hoverState.dedup
-    }
+  let htmlCache : HtmlCache.File := {
+    entries := htmlEntries
+    hoverDocs := HtmlCache.HoverDoc.ofDedup hoverState.dedup
   }
+  let manifest : File := { previews, graphs, sourceDocuments }
+  pure { manifest := manifest.finalizePreviewReferences htmlCache, htmlCache }
 
 private def dumpManifest
     (text : Part Manual)

--- a/src/VersoBlueprint/Vbp.lean
+++ b/src/VersoBlueprint/Vbp.lean
@@ -18,6 +18,7 @@ abbrev Entry := Informal.PreviewManifest.Entry
 abbrev RelatedEntry := Informal.PreviewManifest.RelatedEntry
 abbrev GroupRelation := Informal.PreviewManifest.GroupRelation
 abbrev RelationAxis := Informal.PreviewManifest.RelationAxis
+abbrev PreviewArtifactIndex := Informal.PreviewManifest.PreviewArtifactIndex
 
 def defaultSite : FilePath := "_out" / "site"
 
@@ -296,53 +297,102 @@ def readGeneratedData (site : FilePath) : IO GeneratedData := do
   let htmlCache ← readHtmlCacheForSite site
   pure { manifest, htmlCache }
 
-def cacheKeySet (cache : HtmlCacheFile) : Std.HashSet String :=
-  cache.entries.foldl (fun keys entry => keys.insert entry.key) {}
-
-def manifestKeySet (manifest : ManifestFile) : Std.HashSet String :=
-  manifest.previews.foldl (fun keys entry => keys.insert entry.key) {}
-
 private def pushMissingCacheKey
-    (keys : Std.HashSet String) (errors : Array String) (context key : String) : Array String :=
-  if keys.contains key then
+    (index : PreviewArtifactIndex) (errors : Array String) (context key : String) :
+    Array String :=
+  if index.hasCacheKey key then
     errors
   else
     errors.push s!"missing HTML cache entry for {context}: {key}"
 
+private def pushMissingManifestKey
+    (index : PreviewArtifactIndex) (errors : Array String) (context key : String) :
+    Array String :=
+  if index.hasManifestKey key then
+    errors
+  else
+    errors.push s!"missing manifest entry for {context}: {key}"
+
+private def checkPreviewReference
+    (index : PreviewArtifactIndex) (context key : String) (errors : Array String) :
+    Array String :=
+  let errors := pushMissingManifestKey index errors context key
+  pushMissingCacheKey index errors context key
+
 private def checkRelatedEntries
-    (cacheKeys : Std.HashSet String) (context : String) (entries : Array RelatedEntry)
+    (index : PreviewArtifactIndex) (context : String) (entries : Array RelatedEntry)
     (errors : Array String) : Array String :=
   entries.foldl
     (fun errors entry =>
       match entry.previewKey with
       | none => errors
       | some key =>
-        pushMissingCacheKey cacheKeys errors
-          s!"{context} relation {Informal.PreviewManifest.labelString entry.label}"
-          key.value)
+        let context := s!"{context} relation {Informal.PreviewManifest.labelString entry.label}"
+        checkPreviewReference index context key.value errors)
     errors
 
+private def checkGraphNodePreviewKey
+    (index : PreviewArtifactIndex) (graphKey : String) (node : Informal.Graph.NodeData)
+    (errors : Array String) : Array String :=
+  match node.previewKey with
+  | none => errors
+  | some key =>
+      checkPreviewReference index
+        s!"graph {graphKey} node {Informal.PreviewManifest.labelString node.label}"
+        key.value errors
+
+private def checkGraphVariantPreviewKeys
+    (index : PreviewArtifactIndex) (graphKey : String)
+    (variant : Informal.Graph.GraphRenderVariant) (errors : Array String) : Array String :=
+  variant.previewKeyByNodeId.foldl
+    (fun errors (nodeId, key) =>
+      checkPreviewReference index
+        s!"graph {graphKey} variant {variant.key} node {nodeId}"
+        key errors)
+    errors
+
+private def checkGraphPreviewKeys
+    (index : PreviewArtifactIndex) (graph : Informal.Graph.GraphData)
+    (errors : Array String) : Array String :=
+  let errors :=
+    graph.nodes.foldl (fun errors node => checkGraphNodePreviewKey index graph.key node errors) errors
+  graph.variants.foldl
+    (fun errors variant => checkGraphVariantPreviewKeys index graph.key variant errors)
+    errors
+
+private def entryRequiresRenderedBody (entry : Entry) : Bool :=
+  match entry.targetKind with
+  | .externalMarkup => false
+  | .block | .leanDecl | .citation => true
+
 def checkGeneratedData (manifest : ManifestFile) (htmlCache : HtmlCacheFile) : Array String :=
-  let manifestKeys := manifestKeySet manifest
-  let cacheKeys := cacheKeySet htmlCache
-  manifest.previews.foldl
+  let index := Informal.PreviewManifest.PreviewArtifactIndex.ofFiles manifest htmlCache
+  let errors := manifest.previews.foldl
     (fun errors entry =>
-      let errors := pushMissingCacheKey cacheKeys errors s!"entry {entry.key}" entry.key
+      let errors :=
+        if entryRequiresRenderedBody entry then
+          pushMissingCacheKey index errors s!"entry {entry.key}" entry.key
+        else
+          errors
       let errors := entry.leanCodePreviewKeys.foldl
         (fun errors key =>
           let errors :=
-            if manifestKeys.contains key then errors else errors.push s!"missing manifest entry for Lean preview key {key}"
-          pushMissingCacheKey cacheKeys errors s!"Lean preview key on {entry.key}" key)
+            if index.hasManifestKey key then
+              errors
+            else
+              errors.push s!"missing manifest entry for Lean preview key {key}"
+          pushMissingCacheKey index errors s!"Lean preview key on {entry.key}" key)
         errors
-      let errors := checkRelatedEntries cacheKeys s!"uses of {entry.key}" entry.uses errors
-      let errors := checkRelatedEntries cacheKeys s!"used-by of {entry.key}" entry.usedBy errors
+      let errors := checkRelatedEntries index s!"uses of {entry.key}" entry.uses errors
+      let errors := checkRelatedEntries index s!"used-by of {entry.key}" entry.usedBy errors
       match entry.group with
       | none => errors
       | some group =>
-          checkRelatedEntries cacheKeys
+          checkRelatedEntries index
             s!"group {Informal.PreviewManifest.labelString group.label} on {entry.key}"
             group.entries errors)
     #[]
+  manifest.graphs.foldl (fun errors graph => checkGraphPreviewKeys index graph errors) errors
 
 def checkJsonFromErrors
     (manifest : ManifestFile) (htmlCache : HtmlCacheFile) (errors : Array String) : Json :=

--- a/src/VersoBlueprint/blueprint-api-types.mjs
+++ b/src/VersoBlueprint/blueprint-api-types.mjs
@@ -240,14 +240,14 @@
 /**
  * Related Blueprint node reference attached to a manifest entry.
  *
- * `previewKey` is `null` when the related node has no renderable manifest/cache
- * preview. Non-empty strings are exact rendered-fragment cache keys.
+ * `previewKey` is `null` when the related node has no manifest/cache-backed
+ * preview. Non-empty strings are exact preview keys.
  *
  * @typedef {Object} BlueprintRelatedEntry
  * @property {string} label Canonical Blueprint node label.
  * @property {string} title Resolved display title for the related node.
  * @property {string | null} href Link to the canonical generated node, when available.
- * @property {string | null} previewKey Rendered-fragment cache key for this related node's preview, when available.
+ * @property {string | null} previewKey Manifest/cache-backed preview key for this related node, when available.
  * @property {string[]} axes Statement/proof dependency axes connecting the related node.
  */
 
@@ -341,8 +341,8 @@
 /**
  * Public graph node payload.
  *
- * `previewKey` is the selected best renderable preview for this label. It is
- * `null` when the retained graph node has no manifest/cache preview.
+ * `previewKey` is the finalized manifest/cache-backed preview key for this
+ * label. It is `null` when the retained graph node has no generated preview.
  *
  * @typedef {Object} BlueprintGraphNode
  * @property {string} label Canonical Blueprint node label.
@@ -351,7 +351,7 @@
  * @property {string | null} kind Node kind, when available.
  * @property {string | null} parent Parent/group label, when available.
  * @property {string | null} href Link to the canonical generated node, when available.
- * @property {string | null} previewKey Selected rendered-fragment cache key, when available.
+ * @property {string | null} previewKey Finalized manifest/cache-backed preview key, when available.
  * @property {BlueprintUseRef[]} statementUses Structured statement dependency refs.
  * @property {BlueprintUseRef[]} proofUses Structured proof dependency refs.
  * @property {string} statementStatus Statement-track status.
@@ -382,7 +382,7 @@
  * @property {Record<string, unknown>} [options] Rendering options emitted with the variant.
  * @property {BlueprintGraphNodeIdPair[]} selectOnNodeId Two-item `[svgNodeId, variantKey]` pairs selected when the variant is active.
  * @property {BlueprintGraphNodeIdPair[]} hoverOnNodeId Two-item `[svgNodeId, variantKey]` pairs highlighted on hover.
- * @property {BlueprintGraphNodeIdPair[]} previewKeyByNodeId Two-item `[svgNodeId, previewKey]` pairs; nodes without renderable previews are omitted.
+ * @property {BlueprintGraphNodeIdPair[]} previewKeyByNodeId Two-item `[svgNodeId, previewKey]` pairs; nodes without manifest/cache-backed previews are omitted.
  */
 
 /**

--- a/tests/VersoBlueprintTests/BlueprintExternalMarkup.lean
+++ b/tests/VersoBlueprintTests/BlueprintExternalMarkup.lean
@@ -715,6 +715,48 @@ external markup.
       narrativeChecks ++ nativeChecks ++ theorem21Checks ++ selectedMarkdownChecks ++ theorem22Checks ++
         definition23Checks ++ proposition24Checks ++ rewriteChecks
 
+/-- info: #[] -/
+#guard_msgs in
+#eval
+  show IO (Array String) from do
+    let (_showcaseHtml, showcaseState) ←
+      renderManualDocHtmlStringAndState extension_impls% externalMarkupShowcaseDoc
+    let showcaseFiles ←
+      Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ()) showcaseState
+        ({ mode := .none } : Informal.ExternalMarkupRender.Config)
+    let theorem21Label := Name.mkSimple "ImportedPaper:Theorem2.1"
+    let proposition24Label := Name.mkSimple "ImportedPaper:Proposition2.4"
+    let rewriteLabel := Name.mkSimple "showcase.native.rewrite"
+    let theorem21Key := Informal.PreviewManifest.externalMarkupEntryKey theorem21Label
+    let proposition24Key := Informal.PreviewManifest.externalMarkupEntryKey proposition24Label
+    let rewriteKey := Informal.PreviewCache.statementKey rewriteLabel
+    let some theorem21Entry := previewEntry? showcaseFiles.manifest theorem21Key
+      | return #["missing theorem 2.1 no-render entry"]
+    let some proposition24Entry := previewEntry? showcaseFiles.manifest proposition24Key
+      | return #["missing proposition 2.4 no-render entry"]
+    let some rewriteEntry := previewEntry? showcaseFiles.manifest rewriteKey
+      | return #["missing native rewrite no-render entry"]
+    let checks : Array (String × Bool) := #[
+      ("theorem 2.1 semantic entry", entryIsExternalMarkup theorem21Entry),
+      ("theorem 2.1 no HTML", (showcaseFiles.htmlCache.findHtml? theorem21Key).isNone),
+      ("theorem 2.1 keeps Lean keys",
+        theorem21Entry.leanCodePreviewKeys.any (hasSubstr · "Nat.add") &&
+          theorem21Entry.leanCodePreviewKeys.any (hasSubstr · "Nat.mul")),
+      ("proposition 2.4 use preview cleared",
+        proposition24Entry.uses.any (fun entry =>
+          entry.label == theorem21Label &&
+            entry.previewKey.isNone)),
+      ("theorem 2.1 used-by preview cleared",
+        theorem21Entry.usedBy.any (fun entry =>
+          entry.label == proposition24Label &&
+            entry.previewKey.isNone)),
+      ("native rewrite external use preview cleared",
+        rewriteEntry.uses.any (fun entry =>
+          entry.label == theorem21Label &&
+            entry.previewKey.isNone))
+    ]
+    pure <| failedCheckLabels checks
+
 /-- info: true -/
 #guard_msgs in
 #eval

--- a/tests/VersoBlueprintTests/BlueprintPreviewSchema.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewSchema.lean
@@ -135,7 +135,7 @@ open Informal.PreviewManifest
         authoredLabelDesc? == some "Authored/display label text, preserving string-authored punctuation without pretty-name quoting." &&
         proofUsesDesc? == some "Structured proof use metadata, preserving origin and intent tags." &&
         displayCaptionDesc? == some "Structured heading caption for renderers that need to lay out the title." &&
-        leanCodePreviewKeysDesc? == some "Rendered-fragment cache keys for Lean declaration previews associated with this entry." &&
+        leanCodePreviewKeysDesc? == some "Manifest/cache-backed preview keys for Lean declaration previews associated with this entry." &&
         (internalSchemaDesc?.getD "").contains "not a public" &&
         (internalSchemaDesc?.getD "").contains "compatibility promise" &&
         sourceLocationDesc? == some "Source location lookup result for this manifest entry." &&

--- a/tests/VersoBlueprintTests/BlueprintPreviewSource.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewSource.lean
@@ -192,4 +192,27 @@ namespace Verso.VersoBlueprintTests.BlueprintPreviewSource
             variant.previewKeyByNodeId.any (fun (_, key) => key == externalKey))
       | none => false
 
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (_out, st) ← renderManualDocHtmlStringAndState extension_impls%
+      Verso.VersoBlueprintTests.BlueprintPreviewSource.Provider.externalMarkupGraphPreviewSourceDoc
+    let label := Name.mkSimple "preview.external_graph_bodyless"
+    let externalKey := Informal.PreviewSource.externalMarkupKey label
+    let files ← Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ()) st
+      ({ mode := .none } : Informal.ExternalMarkupRender.Config)
+    let some entry := files.manifest.previews.find? (fun entry => entry.key == externalKey)
+      | return false
+    let some graph := files.manifest.graphs[0]?
+      | return false
+    let some node := graph.nodes.find? (fun node => node.label == label)
+      | return false
+    pure <|
+      entry.targetKind == .externalMarkup &&
+        (files.htmlCache.findHtml? externalKey).isNone &&
+        node.previewKey.isNone &&
+        graph.variants.all (fun variant =>
+          variant.previewKeyByNodeId.all (fun (_, key) => key != externalKey))
+
 end Verso.VersoBlueprintTests.BlueprintPreviewSource

--- a/tests/VersoBlueprintTests/BlueprintPreviewSource/Provider.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewSource/Provider.lean
@@ -42,4 +42,16 @@ External-markup body for a graph preview.
 ```
 :::::::
 
+#docs (Genre.Manual) externalMarkupGraphPreviewSourceDoc "External Markup Graph Preview Source" :=
+:::::::
+:::theorem "preview.external_graph_bodyless"
+:::
+
+```md "preview.external_graph_bodyless" (slot := statement)
+External-markup body for a generated graph preview.
+```
+
+{blueprint_graph}
+:::::::
+
 end Verso.VersoBlueprintTests.BlueprintPreviewSource.Provider

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
@@ -30,6 +30,21 @@ private def sampleMissingPreviewPanelEntry : Informal.RelatedPanel.PanelEntry :=
 #guard_msgs in
 #eval
   show Bool from
+    let decoded := Lean.fromJson? (α := Informal.PreviewKey) (Lean.Json.str "  externalMarkup:Chapter2  ")
+    let emptyRejected := Lean.fromJson? (α := Informal.PreviewKey) (Lean.Json.str "")
+    let whitespaceRejected := Lean.fromJson? (α := Informal.PreviewKey) (Lean.Json.str "   ")
+    match decoded, emptyRejected, whitespaceRejected with
+    | .ok key, .error emptyMessage, .error whitespaceMessage =>
+        toString key == "externalMarkup:Chapter2" &&
+          Lean.toJson key == Lean.Json.str "externalMarkup:Chapter2" &&
+          emptyMessage.contains "expected non-empty preview key" &&
+          whitespaceMessage.contains "expected non-empty preview key"
+    | _, _, _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
     let entry : Informal.PreviewManifest.RelatedEntry := {
       label := Lean.Name.mkSimple "target"
       title := "Target"

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -102,6 +102,81 @@ private def sampleEmptyRelationCache : HtmlCacheFile := {
   ]
 }
 
+private def sampleSemanticOnlyExternalManifest : ManifestFile := {
+  previews := #[
+    {
+      key := Informal.PreviewManifest.externalMarkupEntryKey (label "semantic_only_external")
+      targetKind := .externalMarkup
+      label := label "semantic_only_external"
+      facet := .statement
+      kind := some .theorem
+      title := "Semantic-only external theorem"
+    }
+  ]
+}
+
+private def sampleSemanticOnlyExternalCache : HtmlCacheFile := {
+  entries := #[]
+}
+
+private def sampleCacheOnlyRelationManifest : ManifestFile := {
+  previews := #[
+    {
+      key := "informal:relation_source:statement"
+      targetKind := .block
+      label := label "relation_source"
+      facet := .statement
+      kind := some .theorem
+      title := "Theorem 1"
+      uses := #[related "cache_only_relation" "Cache-only relation" "informal:cache_only_relation:statement"]
+    }
+  ]
+}
+
+private def sampleCacheOnlyRelationCache : HtmlCacheFile := {
+  entries := #[
+    { key := "informal:relation_source:statement", html := "<div>relation source</div>" },
+    { key := "informal:cache_only_relation:statement", html := "<div>cache only</div>" }
+  ]
+}
+
+private def sampleGraphReferenceManifest : ManifestFile := {
+  previews := #[
+    {
+      key := Informal.PreviewManifest.externalMarkupEntryKey (label "semantic_graph_target")
+      targetKind := .externalMarkup
+      label := label "semantic_graph_target"
+      facet := .statement
+      kind := some .theorem
+      title := "Semantic graph target"
+    }
+  ]
+  graphs := #[{
+    key := "graph-fixture"
+    nodes := #[{
+      label := label "semantic_graph_target"
+      title := "Semantic graph target"
+      displayLabel := "Semantic graph target"
+      previewKey :=
+        Informal.PreviewKey.ofString?
+          (Informal.PreviewManifest.externalMarkupEntryKey (label "semantic_graph_target"))
+      visual := { fillcolor := "#ffffff" }
+    }]
+    variants := #[{
+      key := "full"
+      label := "Full"
+      dot := "digraph {}"
+      previewKeyByNodeId := #[("node-1", "informal:cache_only_graph:statement")]
+    }]
+  }]
+}
+
+private def sampleGraphReferenceCache : HtmlCacheFile := {
+  entries := #[
+    { key := "informal:cache_only_graph:statement", html := "<div>cache only graph</div>" }
+  ]
+}
+
 private def sampleCache : HtmlCacheFile := {
   entries := #[
     { key := "informal:addition_spec:statement", html := "<div>addition spec</div>" },
@@ -526,6 +601,42 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
 #eval
   show Bool from
     VersoBlueprint.Vbp.checkGeneratedData sampleEmptyRelationManifest sampleEmptyRelationCache |>.isEmpty
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    VersoBlueprint.Vbp.checkGeneratedData
+      sampleSemanticOnlyExternalManifest sampleSemanticOnlyExternalCache |>.isEmpty
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    let errors := VersoBlueprint.Vbp.checkGeneratedData
+      sampleCacheOnlyRelationManifest sampleCacheOnlyRelationCache
+    errors.any (fun err =>
+      err.contains "missing manifest entry for uses of informal:relation_source:statement relation cache_only_relation" &&
+        err.contains "informal:cache_only_relation:statement") &&
+      !errors.any (fun err =>
+        err.contains "missing HTML cache entry" &&
+          err.contains "informal:cache_only_relation:statement")
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    let errors := VersoBlueprint.Vbp.checkGeneratedData
+      sampleGraphReferenceManifest sampleGraphReferenceCache
+    errors.any (fun err =>
+      err.contains "missing HTML cache entry for graph graph-fixture node semantic_graph_target" &&
+        err.contains (Informal.PreviewManifest.externalMarkupEntryKey (label "semantic_graph_target"))) &&
+      errors.any (fun err =>
+        err.contains "missing manifest entry for graph graph-fixture variant full node node-1" &&
+          err.contains "informal:cache_only_graph:statement") &&
+      !errors.any (fun err =>
+        err.contains "missing HTML cache entry for graph graph-fixture variant full node node-1" &&
+          err.contains "informal:cache_only_graph:statement")
 
 /-- info: true -/
 #guard_msgs in


### PR DESCRIPTION
This PR makes manifest preview references reflect actual manifest/cache availability while keeping semantic-only external-markup entries queryable.

- Decode relation preview keys through the shared PreviewKey type and serialize missing previews as null rather than empty strings.
- Finalize relation, Lean-code, and graph preview references against manifest/cache coverage before writing generated JSON.
- Teach vbp query/check about semantic-only external-markup entries and graph preview references.
- Document the manifest/cache contract and add regression coverage for external-markup, relation, graph, and VBP behavior.

Backport v4.31.0: #283
Backport v4.30.0: #284
