### PR TITLE
fix: handle semantic-only preview references

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -312,6 +312,10 @@ source; `.none` keeps
 external-markup entries semantic-only with no generated HTML-cache fragment.
 Relation, graph, and Lean-code preview references are serialized only when the
 referenced preview key resolves through both the manifest and HTML cache.
+Page-local relation panels and graph widgets that are rendered before generated
+data finalization may still start from traversal preview candidates; browser
+preview APIs report semantic-only missing bodies as
+`semantic-preview-body-missing` rather than as stale cache data.
 Set `showSourceNotice := false` when an embedding context should omit the
 visible source-backed notice from generated fragments.
 
@@ -1131,6 +1135,7 @@ The most common failure `reason` values are:
 - `declaration-entry-missing`
 - `manifest-entry-missing`
 - `html-cache-entry-missing`
+- `semantic-preview-body-missing`
 - `canonical-href-missing`
 - `canonical-preview-node-missing`
 - `canonical-preview-load-failed`
@@ -1141,6 +1146,11 @@ The most common failure `reason` values are:
 - `external-markup-node-shell-missing`
 - `external-markup-node-shell-load-failed`
 - `source-missing`
+
+`semantic-preview-body-missing` means the manifest entry exists and the HTML
+cache is loaded, but the entry is semantic-only in this artifact set and has no
+rendered preview body. This is distinct from `html-cache-entry-missing`, which
+signals a preview key that should have a cache fragment but does not.
 
 Treat `html` and `canonicalHtml` as opaque rendered fragments. Use
 `manifestEntry` for semantic facts such as labels, titles, dependency metadata,

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -113,18 +113,19 @@ Work:
    source previews into fuller VBP-rendered review interfaces that consume
    manifest `sourceDocuments` and `entry.sources`; keep PDF viewers, text
    excerpts, and crop overlays out of the browser API contract
-10. scheduled follow-up: deduplicate the source metadata resolver with
-   manifest/data lookup helpers now that both `api/data.mjs` and
-   `api/preview.mjs` expose it. The target shape is one data-layer primitive for
-   preview-key/manifest-entry input normalization, missing-entry reasons,
-   source-document joins, and source-ref normalization semantics.
-11. scheduled follow-up: align page-local preview triggers with finalized
-   manifest/cache preview availability. Today generated JSON clears traversal
-   preview candidates that lack cache bodies, but page-local relation-panel
-   markup and embedded graph-block JSON are still derived during traversal. The
-   follow-up should either pass preview availability into page-local relation
-   and graph rendering or make the browser runtimes disable semantic-only
-   missing-cache previews without reporting them as broken generated data.
+10. keep the landed source metadata resolver on the data-layer path:
+   `api/preview.mjs` delegates source-provenance lookup through the same data API
+   primitive as `api/data.mjs`, so preview-key/manifest-entry input
+   normalization, missing-entry reasons, source-document joins, and source-ref
+   normalization semantics have one runtime owner.
+11. keep the landed runtime-side semantic-only preview handling aligned with
+   generated-data finalization. Generated JSON clears traversal preview
+   candidates that lack cache bodies; page-local relation-panel markup and
+   embedded graph-block JSON are still derived during traversal, so browser
+   runtimes distinguish `semantic-preview-body-missing` from stale or broken
+   cache loads. A later Lean-side pass may pass preview availability into
+   page-local relation and graph rendering earlier, but should preserve this
+   runtime distinction.
 12. upstream follow-up: propose a Verso portable-hover-fragment helper for the
    current external-declaration bridge. The target shape is a Verso-owned API
    that renders highlighted snippets with local hover ids, carries the local
@@ -140,9 +141,11 @@ model instead of recomputing similar facts in several layers.
 
 Work:
 
-1. prioritize a deduplication pass after source provenance lands, starting with
-   repeated traversal-store decoding, manifest filtering, and validation-message
-   assembly patterns that now exist across preview, source, and status data
+1. continue the deduplication pass after source provenance lands. The first
+   cleanup moved shared manifest-entry predicates, queryability, and rendered-body
+   requirements onto `PreviewManifest.Entry`; remaining candidates include
+   repeated traversal-store decoding and validation-message assembly patterns
+   across preview, source, and status data
 2. revisit `Informal.Environment.InProgress` after the widget path no longer
    needs elaboration-time syntax; today it remains separate from `Data.Node`
    because it owns directive-stack state, preview blocks, and `elabStx`

--- a/src/VersoBlueprint/Commands/graph.mjs
+++ b/src/VersoBlueprint/Commands/graph.mjs
@@ -404,6 +404,7 @@ function attachPreviewHandlers(previewUtils, graphBlock, graphContainer, preview
     const previewKey = nodeId ? (previewKeys.get(nodeId) || "") : "";
     if (!previewKey) return;
     const resolved = await previewUtils.resolvePreviewHtml(previewKey);
+    if (resolved && resolved.reason === "semantic-preview-body-missing") return;
     const html = resolved.html || "";
     if (requestToken !== graphState.previewRequestToken) return;
     if (!html) return;

--- a/src/VersoBlueprint/Commands/preview-runtime-api.mjs
+++ b/src/VersoBlueprint/Commands/preview-runtime-api.mjs
@@ -1,7 +1,6 @@
 import { collectPreviewTemplates, escapeHtml, previewDebug, previewDebugLabel } from "./preview-runtime-base.mjs";
 import { createBlueprintDataApi } from "./preview-runtime-data.mjs";
 import { renderBlueprintNodeInto, renderBlueprintPreviewInto, renderCanonicalBlueprintPreviewInto, resolveBlueprintPreview, resolveCanonicalBlueprintPreview } from "./preview-runtime-render.mjs";
-import { resolveSourceMetadata } from "./preview-runtime-source-metadata.mjs";
 import { hydrateRenderedPreview, registerPreviewHydrator } from "./preview-runtime-hydration.mjs";
 import { bindAnchoredPopover } from "./preview-runtime-lifecycle.mjs";
 import { createPreviewPanel, createPreviewSurface, hidePreviewSurfaces, previewMessageHtml, renderPreviewIntoSurface, resolvePreviewHtml } from "./preview-runtime-surface.mjs";
@@ -142,7 +141,7 @@ export function createPreviewRuntimeApi(options) {
       );
     },
     resolveSourceMetadata: function (source, options) {
-      return resolveSourceMetadata(
+      return dataApi.resolveSourceMetadata(
         source,
         mergePreviewRenderOptions(defaultRenderOptions, options)
       );

--- a/src/VersoBlueprint/Commands/preview-runtime-render.mjs
+++ b/src/VersoBlueprint/Commands/preview-runtime-render.mjs
@@ -46,6 +46,35 @@ import { hydrateRenderedPreview } from "./preview-runtime-hydration.mjs";
     return requireBlueprintDataApi(options).htmlCacheDiagnosticHtml(previewKey);
   }
 
+  function htmlCacheReady(options) {
+    const dataApi = requireBlueprintDataApi(options);
+    if (typeof dataApi.readHtmlCacheStatus !== "function") return false;
+    const status = dataApi.readHtmlCacheStatus();
+    return !!(status && status.state === "ready");
+  }
+
+  function semanticOnlyPreviewBodyMissing(entry, options) {
+    return !!(
+      entry &&
+      typeof entry === "object" &&
+      entry.targetKind === "externalMarkup" &&
+      htmlCacheReady(options)
+    );
+  }
+
+  function semanticOnlyPreviewDiagnosticHtml(previewKey) {
+    const key = typeof previewKey === "string" ? previewKey.trim() : "";
+    const keyHtml = key ? "<p>Requested preview: <code>" + escapeHtml(key) + "</code></p>" : "";
+    return (
+      "<div class=\"bp_html_cache_preview_notice\">" +
+      "<p><strong>Preview body unavailable.</strong></p>" +
+      "<p>This Blueprint entry is present in the manifest, but this generated artifact set " +
+      "does not include a rendered preview body for it.</p>" +
+      keyHtml +
+      "</div>"
+    );
+  }
+
   export async function resolveBlueprintPreview(previewKey, options) {
     const key = typeof previewKey === "string" ? previewKey.trim() : "";
     if (!key) {
@@ -78,6 +107,17 @@ import { hydrateRenderedPreview } from "./preview-runtime-hydration.mjs";
       };
     }
     if (!html) {
+      if (semanticOnlyPreviewBodyMissing(manifestEntry, options)) {
+        return {
+          ok: false,
+          key: key,
+          reason: "semantic-preview-body-missing",
+          manifestEntry: manifestEntry,
+          htmlCacheEntry: htmlCacheEntry,
+          html: "",
+          diagnosticHtml: semanticOnlyPreviewDiagnosticHtml(key)
+        };
+      }
       return {
         ok: false,
         key: key,

--- a/src/VersoBlueprint/Commands/preview-runtime-surface.mjs
+++ b/src/VersoBlueprint/Commands/preview-runtime-surface.mjs
@@ -448,8 +448,16 @@ import { bindCloseOnce, bindDismissHandlers, bindPanelRepositioner, bindPreviewT
           ? result.diagnosticHtml
           : "";
         const resultTitle = previewResultTitle(result);
+        const semanticOnlyDiagnostic =
+          result && result.reason === "semantic-preview-body-missing"
+            ? fallbackDiagnostic(
+                "semanticOnlyDiagnostic",
+                "This preview target does not have a rendered preview entry."
+              )
+            : "";
         replaceBody(
-          diagnosticHtml ||
+          semanticOnlyDiagnostic ||
+            diagnosticHtml ||
             fallbackDiagnostic("fallbackDiagnostic", "The preview cache content could not be loaded."),
           diagnosticRenderOptions,
           resultTitle
@@ -485,6 +493,7 @@ import { bindCloseOnce, bindDismissHandlers, bindPanelRepositioner, bindPreviewT
       return {
         ok: false,
         key: result && typeof result.key === "string" ? result.key : previewKey,
+        reason: result && typeof result.reason === "string" ? result.reason : "",
         html: result && typeof result.diagnosticHtml === "string" ? result.diagnosticHtml : "",
         result: result || null
       };
@@ -492,6 +501,7 @@ import { bindCloseOnce, bindDismissHandlers, bindPanelRepositioner, bindPreviewT
       return {
         ok: false,
         key: previewKey,
+        reason: "preview-load-failed",
         html: previewMessageHtml({
           kind: "error",
           title: "Preview unavailable",

--- a/src/VersoBlueprint/Informal/Block/relation-panel.mjs
+++ b/src/VersoBlueprint/Informal/Block/relation-panel.mjs
@@ -127,6 +127,9 @@
         fallbackDiagnostic: relationPreviewDiagnosticOptions(
           "The preview cache content could not be loaded."
         ),
+        semanticOnlyDiagnostic: relationPreviewDiagnosticOptions(
+          "This relation target does not have a rendered preview entry."
+        ),
         exceptionDiagnostic: relationPreviewDiagnosticOptions(
           "The preview cache content could not be loaded. Refresh the page, or rebuild the site if this persists."
         )

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -1206,6 +1206,46 @@ structure PreviewMetadataLoss where
   missingLeanCodePreviewKeys : Array String := #[]
 deriving Repr, ToJson, FromJson
 
+/-- Whether this manifest entry represents an informal Blueprint block. -/
+def Entry.isBlock (entry : Entry) : Bool :=
+  match entry.targetKind with
+  | .block => true
+  | _ => false
+
+/-- Whether this manifest entry represents a source-backed external-markup node. -/
+def Entry.isExternalMarkup (entry : Entry) : Bool :=
+  match entry.targetKind with
+  | .externalMarkup => true
+  | _ => false
+
+/-- Whether this manifest entry represents an informal Blueprint node target. -/
+def Entry.isBlueprintNodeTarget (entry : Entry) : Bool :=
+  entry.isBlock || entry.isExternalMarkup
+
+/-- Whether this manifest entry represents the statement facet. -/
+def Entry.isStatement (entry : Entry) : Bool :=
+  match entry.facet with
+  | .statement => true
+  | _ => false
+
+/-- Whether this manifest entry is a statement-facet Blueprint node query row. -/
+def Entry.isQueryableStatement (entry : Entry) : Bool :=
+  entry.isStatement && entry.isBlueprintNodeTarget
+
+/-- Whether this manifest entry's authored public label matches `label`. -/
+def Entry.matchesAuthoredLabel (entry : Entry) (label : String) : Bool :=
+  entry.authoredLabel == label
+
+/--
+Whether generated-data consistency checks require a rendered-fragment cache body
+for this manifest entry.
+
+External-markup entries can be intentionally semantic-only when source-backed
+nodes are generated without cache fragments.
+-/
+def Entry.requiresRenderedBody (entry : Entry) : Bool :=
+  !entry.isExternalMarkup
+
 /--
 Find the manifest entry that should carry metadata for a traversal preview.
 
@@ -1215,7 +1255,7 @@ than as ordinary block entries, but the label/facet provenance is still the same
 def File.findPreviewMetadataEntry? (file : File) (metadata : PreviewCache.Metadata) :
     Option Entry :=
   file.previews.find? fun entry =>
-    (entry.targetKind == .block || entry.targetKind == .externalMarkup) &&
+    entry.isBlueprintNodeTarget &&
       entry.label == metadata.label && entry.facet == metadata.facet
 
 private def missingPreviewLeanCodeKeys (entry? : Option Entry)
@@ -1285,24 +1325,6 @@ def File.entriesWithSource (file : File) : Array Entry :=
 def File.entriesForSourceDocument (file : File) (id : String) : Array Entry :=
   file.previews.filter fun entry => entry.hasSourceDocument id
 
-/-- Whether this manifest entry represents an informal Blueprint block. -/
-def Entry.isBlock (entry : Entry) : Bool :=
-  match entry.targetKind with
-  | .block => true
-  | _ => false
-
-/-- Whether this manifest entry represents a source-backed external-markup node. -/
-def Entry.isExternalMarkup (entry : Entry) : Bool :=
-  match entry.targetKind with
-  | .externalMarkup => true
-  | _ => false
-
-/-- Whether this manifest entry represents the statement facet. -/
-def Entry.isStatement (entry : Entry) : Bool :=
-  match entry.facet with
-  | .statement => true
-  | _ => false
-
 /-- Statement-facet block entries, the primary row set for client label queries. -/
 def File.blockStatementEntries (file : File) : Array Entry :=
   file.previews.filter (fun entry => entry.isBlock && entry.isStatement)
@@ -1314,13 +1336,12 @@ but they still carry the same semantic label, dependency, ownership, and source
 metadata as block entries.
 -/
 def File.queryableStatementEntries (file : File) : Array Entry :=
-  file.previews.filter fun entry =>
-    entry.isStatement && (entry.isBlock || entry.isExternalMarkup)
+  file.previews.filter (·.isQueryableStatement)
 
 /-- All block entries matching the authored public label string, including non-statement facets. -/
 def File.findBlockEntriesByLabel (file : File) (label : String) : Array Entry :=
   file.previews.filter fun entry =>
-    entry.isBlock && entry.authoredLabel == label
+    entry.isBlock && entry.matchesAuthoredLabel label
 
 /--
 All queryable Blueprint entries matching the authored public label string,
@@ -1329,9 +1350,9 @@ including non-statement facets for normal blocks.
 def File.findQueryableEntriesByLabel (file : File) (label : String) : Array Entry :=
   file.previews.filter fun entry =>
     if entry.isBlock then
-      entry.authoredLabel == label
+      entry.matchesAuthoredLabel label
     else
-      entry.isExternalMarkup && entry.isStatement && entry.authoredLabel == label
+      entry.isExternalMarkup && entry.isStatement && entry.matchesAuthoredLabel label
 
 /--
 Best public block entry for a label.

--- a/src/VersoBlueprint/Vbp.lean
+++ b/src/VersoBlueprint/Vbp.lean
@@ -360,17 +360,12 @@ private def checkGraphPreviewKeys
     (fun errors variant => checkGraphVariantPreviewKeys index graph.key variant errors)
     errors
 
-private def entryRequiresRenderedBody (entry : Entry) : Bool :=
-  match entry.targetKind with
-  | .externalMarkup => false
-  | .block | .leanDecl | .inlineLeanCode | .citation => true
-
 def checkGeneratedData (manifest : ManifestFile) (htmlCache : HtmlCacheFile) : Array String :=
   let index := Informal.PreviewManifest.PreviewArtifactIndex.ofFiles manifest htmlCache
   let errors := manifest.previews.foldl
     (fun errors entry =>
       let errors :=
-        if entryRequiresRenderedBody entry then
+        if entry.requiresRenderedBody then
           pushMissingCacheKey index errors s!"entry {entry.key}" entry.key
         else
           errors

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -321,16 +321,24 @@ private def jsonArrayHasNullField (values : Array Json) (field : String) : Bool 
 #guard_msgs in
 #eval
   show Bool from
-    sampleManifest.blockStatementEntries.size == 2 &&
-      sampleExternalManifest.queryableStatementEntries.size == 3 &&
-      (sampleManifest.findPrimaryBlockEntry? "addition_assoc").map (·.key) ==
-        some "informal:addition_assoc:statement" &&
-      (sampleExternalManifest.findPrimaryQueryableEntry? "external_bodyless").map (·.key) ==
-        some (Informal.PreviewManifest.externalMarkupEntryKey (label "external_bodyless")) &&
-      sampleMetadataManifest.ownerValues == #["Alpha", "Zed"] &&
-      sampleMetadataManifest.tagValues == #["alpha", "beta", "zeta"] &&
-      sampleMetadataManifest.workQueueEntries.map (·.authoredLabel) ==
-        #["zeta_statement", "alpha_statement"]
+    match
+      sampleExternalManifest.findPrimaryQueryableEntry? "external_bodyless",
+      sampleManifest.findPrimaryQueryableEntry? "addition_assoc" with
+    | some externalEntry, some blockEntry =>
+        sampleManifest.blockStatementEntries.size == 2 &&
+          sampleExternalManifest.queryableStatementEntries.size == 3 &&
+          (sampleManifest.findPrimaryBlockEntry? "addition_assoc").map (·.key) ==
+            some "informal:addition_assoc:statement" &&
+          externalEntry.key ==
+            Informal.PreviewManifest.externalMarkupEntryKey (label "external_bodyless") &&
+          externalEntry.isQueryableStatement &&
+          !externalEntry.requiresRenderedBody &&
+          blockEntry.requiresRenderedBody &&
+          sampleMetadataManifest.ownerValues == #["Alpha", "Zed"] &&
+          sampleMetadataManifest.tagValues == #["alpha", "beta", "zeta"] &&
+          sampleMetadataManifest.workQueueEntries.map (·.authoredLabel) ==
+            #["zeta_statement", "alpha_statement"]
+    | _, _ => false
 
 private partial def freshVbpFixtureRoot : IO System.FilePath := do
   let suffix ← IO.rand 0 1000000000000

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -2027,6 +2027,74 @@ class TestPreviewRuntimeRegressions:
         assert attempts["count"] > 1
         assert_no_runtime_errors(errors)
 
+    def test_semantic_only_external_markup_preview_has_explicit_reason(
+        self, server: str, page: Page
+    ):
+        errors = record_runtime_errors(page)
+        page.goto(f"{server}/Custom-Render-Client/")
+
+        result = page.evaluate(
+            blueprint_render_api_script(
+                """
+                const { createPreview } = await import(api.previewApiModuleUrl());
+                const unavailableSourceLocation = {
+                    ok: false,
+                    location: null,
+                    error: "source location unavailable"
+                };
+                const manifestPayload = {
+                    sourceDocuments: [],
+                    previews: [
+                        {
+                            key: "externalMarkup:semantic_only_external",
+                            targetKind: "externalMarkup",
+                            label: "semantic_only_external",
+                            authoredLabel: "semantic_only_external",
+                            facet: "statement",
+                            title: "Semantic-only external theorem",
+                            sourceLocation: unavailableSourceLocation,
+                            externalMarkup: [],
+                            sources: []
+                        }
+                    ],
+                    graphs: []
+                };
+                const htmlCachePayload = { entries: [] };
+                const preview = createPreview({
+                    fetchJson(url) {
+                        return String(url).includes("blueprint-html-cache.json")
+                            ? htmlCachePayload
+                            : manifestPayload;
+                    }
+                });
+                const host = document.createElement("div");
+                document.body.appendChild(host);
+                const key = "externalMarkup:semantic_only_external";
+                const resolved = await preview.resolvePreview(key);
+                const rendered = await preview.renderPreviewInto(host, key);
+                return {
+                    resolvedOk: resolved.ok,
+                    resolvedReason: resolved.reason,
+                    renderedOk: rendered.ok,
+                    renderedReason: rendered.reason,
+                    manifestStatus: preview.readManifestStatus(),
+                    htmlCacheStatus: preview.readHtmlCacheStatus(),
+                    html: host.innerHTML
+                };
+                """
+            )
+        )
+
+        assert result["resolvedOk"] is False
+        assert result["resolvedReason"] == "semantic-preview-body-missing"
+        assert result["renderedOk"] is False
+        assert result["renderedReason"] == "semantic-preview-body-missing"
+        assert result["manifestStatus"]["state"] == "ready"
+        assert result["htmlCacheStatus"]["state"] == "ready"
+        assert "Preview body unavailable" in result["html"]
+        assert "Preview HTML cache unavailable" not in result["html"]
+        assert_no_runtime_errors(errors)
+
     def test_used_by_panel_loads_html_cache_backed_preview(self, server: str, page: Page):
         errors = record_runtime_errors(page)
         page.goto(f"{server}/Preview-Relationships/")

--- a/tests/harness/test_preview_runtime_api_docs.py
+++ b/tests/harness/test_preview_runtime_api_docs.py
@@ -352,6 +352,8 @@ class PreviewRuntimeApiDocsTests(unittest.TestCase):
         self.assertNotIn("function sourceMetadataHtml", source_metadata)
         self.assertIn("export const previewRuntimeSourceMetadata = {", source_metadata)
         self.assertNotIn("function sourceMetadataHtml(result, options)", render)
+        self.assertNotIn('from "./preview-runtime-source-metadata.mjs";', api)
+        self.assertIn("return dataApi.resolveSourceMetadata(", api)
         self.assertIn("function hydrateRenderedPreview(root, options)", hydration)
         self.assertIn("function renderBlueprintMath(root)", hydration)
         self.assertIn("function registerPreviewHydrator(name, fn)", hydration)


### PR DESCRIPTION
This PR makes semantic-only external-markup preview references explicit across generated-data checks and browser preview surfaces, so intentional missing preview bodies are not reported as stale or broken cache data.

Backport v4.31.0: #297
Backport v4.30.0: #298