### PR TITLE
[backport v4.30.0] feat: report verbose Blueprint build progress

### DIFF
--- a/skills/verso-blueprint/references/vbp.md
+++ b/skills/verso-blueprint/references/vbp.md
@@ -8,7 +8,7 @@ Run `lake exe vbp --help` for complete local CLI usage. The main command forms a
 
 ```bash
 lake exe vbp discover
-lake exe vbp build [--output <dir>] [--serve] [--port <n>]
+lake exe vbp build [--output <dir>] [--pdf] [--verbose] [--serve] [--port <n>]
 lake exe vbp query [--site <dir>] <selector>
 lake exe vbp check
 ```
@@ -36,6 +36,8 @@ Defaults:
 - `build` writes `_out/site`.
 - `query` and `check` read `_out/site`.
 - Pass `--output <dir>` only to choose where `build` writes generated output.
+- Pass `--pdf` to build `_out/site/pdf/main.pdf` from the generated TeX.
+- Pass `--verbose` to show Blueprint generation phase progress while building.
 - Pass `--site <dir>` to `query` or `check` only when reading a non-default site.
 
 ## Build And Serve
@@ -48,6 +50,8 @@ Defaults:
 lake lean <GeneratorMain>.lean
 lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean --output <output>
 ```
+
+`build --verbose` passes `--verbose` through to the generator run, enabling Blueprint generation phase progress after the Lake package build completes.
 
 `build --serve` builds once, then serves `<output>/html-multi` with a local static server and keeps running. Without `--port`, it tries port `8000` and falls back to an available port. With `--serve --port <n>`, it fails if the requested port is unavailable. `--port` is accepted only with `--serve`. The command prints the actual preview URL.
 

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -192,6 +192,110 @@ private def outputDirNameForMode : Mode → String
 private def outDirForMode (cfg : Verso.Genre.Manual.Config) (mode : Mode) : System.FilePath :=
   cfg.destination / outputDirNameForMode mode
 
+private def htmlModeDescription : Mode → String
+  | .single => "single-page"
+  | .multi => "multi-page"
+
+private def elapsedMsText (ms : Nat) : String :=
+  s!"{ms}ms"
+
+private def writeBuildProgress (message : String) : IO Unit := do
+  IO.println s!"Blueprint: {message}"
+  (← IO.getStdout).flush
+
+private def logBuildProgress (verbose : Bool) (message : String) : IO Unit := do
+  if verbose then
+    writeBuildProgress message
+
+private def withTimedBuildProgress
+    {m : Type → Type} [Monad m] [MonadLiftT BaseIO m] [MonadLiftT IO m] {α : Type}
+    (verbose : Bool) (label : String) (action : m α) : m α := do
+  if !verbose then
+    action
+  else
+    liftM (m := m) <| writeBuildProgress s!"starting {label}"
+    let start ← liftM (m := m) IO.monoMsNow
+    let result ← action
+    let finish ← liftM (m := m) IO.monoMsNow
+    liftM (m := m) <|
+      writeBuildProgress s!"finished {label} in {elapsedMsText (finish - start)}"
+    pure result
+
+private structure LeanCodePreviewTiming where
+  key : String
+  kind : String
+  totalMs : Nat
+  renderMs : Nat
+  stringifyMs : Nat
+  blankCheckMs : Nat
+  bytesMs : Nat
+  metadataMs : Nat
+  storeMs : Nat
+  htmlBytes : Nat
+
+private structure LeanCodePreviewTimingTotals where
+  count : Nat := 0
+  totalMs : Nat := 0
+  renderMs : Nat := 0
+  stringifyMs : Nat := 0
+  blankCheckMs : Nat := 0
+  bytesMs : Nat := 0
+  metadataMs : Nat := 0
+  storeMs : Nat := 0
+  htmlBytes : Nat := 0
+
+private def LeanCodePreviewTimingTotals.push
+    (totals : LeanCodePreviewTimingTotals) (timing : LeanCodePreviewTiming) :
+    LeanCodePreviewTimingTotals :=
+  { count := totals.count + 1
+    totalMs := totals.totalMs + timing.totalMs
+    renderMs := totals.renderMs + timing.renderMs
+    stringifyMs := totals.stringifyMs + timing.stringifyMs
+    blankCheckMs := totals.blankCheckMs + timing.blankCheckMs
+    bytesMs := totals.bytesMs + timing.bytesMs
+    metadataMs := totals.metadataMs + timing.metadataMs
+    storeMs := totals.storeMs + timing.storeMs
+    htmlBytes := totals.htmlBytes + timing.htmlBytes }
+
+private def leanCodePreviewTimingKind (entry : Informal.LeanCodePreview.Entry) : String :=
+  match entry.source with
+  | .inlineBlocks .. => "inline"
+  | .externalDecl .. => "external"
+
+private def describeLeanCodePreviewTiming
+    (label : String) (totals : LeanCodePreviewTimingTotals) : String :=
+  s!"{label}: {totals.count} entries, total {elapsedMsText totals.totalMs} " ++
+    s!"(render {elapsedMsText totals.renderMs}, stringify {elapsedMsText totals.stringifyMs}, " ++
+    s!"blank {elapsedMsText totals.blankCheckMs}, bytes {elapsedMsText totals.bytesMs}, " ++
+    s!"metadata {elapsedMsText totals.metadataMs}, store {elapsedMsText totals.storeMs}), " ++
+    s!"{totals.htmlBytes} HTML bytes"
+
+private def logLeanCodePreviewTimings
+    (verbose : Bool) (timings : Array LeanCodePreviewTiming) : IO Unit := do
+  if !verbose then
+    return
+  let (inlineTotals, externalTotals) :=
+    timings.foldl
+      (init := (({} : LeanCodePreviewTimingTotals), ({} : LeanCodePreviewTimingTotals)))
+      fun (inlineTotals, externalTotals) timing =>
+        if timing.kind == "inline" then
+          (inlineTotals.push timing, externalTotals)
+        else
+          (inlineTotals, externalTotals.push timing)
+  logBuildProgress true <|
+    "Lean code preview breakdown: " ++
+      describeLeanCodePreviewTiming "inline" inlineTotals ++ "; " ++
+      describeLeanCodePreviewTiming "external" externalTotals
+  let slowest := timings.qsort (fun a b => a.totalMs > b.totalMs)
+  for timing in slowest.extract 0 (Nat.min 5 slowest.size) do
+    logBuildProgress true <|
+      s!"slow Lean code preview: {timing.totalMs}ms " ++
+      s!"(render {timing.renderMs}ms, stringify {timing.stringifyMs}ms, " ++
+      s!"blank {timing.blankCheckMs}ms, bytes {timing.bytesMs}ms, " ++
+      s!"metadata {timing.metadataMs}ms, store {timing.storeMs}ms), " ++
+      s!"{timing.htmlBytes} HTML bytes, " ++
+      s!"{timing.kind}, {timing.key}"
+
 private def htmlStringIsBlank (html : String) : Bool :=
   html.all Char.isWhitespace
 
@@ -2035,28 +2139,98 @@ private def buildLeanCodeEntries
     (impls : ExtensionImpls)
     (logError : String → IO Unit)
     (state : TraverseState)
-    (hoverState : Verso.Code.Hover.State Output.Html) :
+    (hoverState : Verso.Code.Hover.State Output.Html)
+    (verbose : Bool := false) :
     IO (Array Entry × Array HtmlCache.Entry × Verso.Code.Hover.State Output.Html) := do
   let mut entries := #[]
   let mut htmlEntries := #[]
   let mut hoverState := hoverState
-  let sourceRefs := leanCodePreviewSourceRefs state
-  for decoded in Informal.TraversalIndex.LeanCodePreviews.entries state do
+  let mut timings := #[]
+  let sourceRefs ←
+    if verbose then
+      let sourceRefsStart ← IO.monoMsNow
+      let sourceRefs := leanCodePreviewSourceRefs state
+      let sourceRefsFinish ← IO.monoMsNow
+      logBuildProgress true
+        s!"Lean code preview source refs built in {elapsedMsText (sourceRefsFinish - sourceRefsStart)}"
+      pure sourceRefs
+    else
+      pure <| leanCodePreviewSourceRefs state
+  let decodedEntries ←
+    if verbose then
+      let decodeStart ← IO.monoMsNow
+      let decodedEntries := Informal.TraversalIndex.LeanCodePreviews.entries state
+      let decodeFinish ← IO.monoMsNow
+      logBuildProgress true <|
+        s!"Lean code preview entries decoded in {elapsedMsText (decodeFinish - decodeStart)} " ++
+        s!"({decodedEntries.size} stored entries)"
+      pure decodedEntries
+    else
+      pure <| Informal.TraversalIndex.LeanCodePreviews.entries state
+  for decoded in decodedEntries do
     match decoded with
     | .error err =>
       logError s!"Blueprint manifest: malformed Lean-code preview entry {err.canonicalName}: {err.message}"
     | .ok stored =>
       let entry := stored.data
       let key := stored.canonicalName
-      let rendered ← Informal.LeanCodePreview.renderWithState entry impls state
-        (logError := logError) (hoverState := hoverState)
-      hoverState := rendered.hoverState
-      let html := rendered.html.asString
-      if htmlStringIsBlank html then
-        continue
-      let manifestEntry := leanCodePreviewManifestEntry state sourceRefs key entry
-      entries := entries.push manifestEntry
-      htmlEntries := htmlEntries.push { key := manifestEntry.key, html }
+      if verbose then
+        let start ← IO.monoMsNow
+        let rendered ← Informal.LeanCodePreview.renderWithState entry impls state
+          (logError := logError) (hoverState := hoverState)
+        let renderFinish ← IO.monoMsNow
+        hoverState := rendered.hoverState
+        let html := rendered.html.asString
+        let stringifyFinish ← IO.monoMsNow
+        let htmlIsEmpty := htmlStringIsBlank html
+        let blankCheckFinish ← IO.monoMsNow
+        let htmlBytes := html.utf8ByteSize
+        let bytesFinish ← IO.monoMsNow
+        if htmlIsEmpty then
+          timings := timings.push {
+            key
+            kind := leanCodePreviewTimingKind entry
+            totalMs := bytesFinish - start
+            renderMs := renderFinish - start
+            stringifyMs := stringifyFinish - renderFinish
+            blankCheckMs := blankCheckFinish - stringifyFinish
+            bytesMs := bytesFinish - blankCheckFinish
+            metadataMs := 0
+            storeMs := 0
+            htmlBytes
+          }
+          continue
+        let manifestEntry := leanCodePreviewManifestEntry state sourceRefs key entry
+        let metadataFinish ← IO.monoMsNow
+        entries := entries.push manifestEntry
+        htmlEntries := htmlEntries.push { key := manifestEntry.key, html }
+        let storeFinish ← IO.monoMsNow
+        timings := timings.push {
+          key
+          kind := leanCodePreviewTimingKind entry
+          totalMs := storeFinish - start
+          renderMs := renderFinish - start
+          stringifyMs := stringifyFinish - renderFinish
+          blankCheckMs := blankCheckFinish - stringifyFinish
+          bytesMs := bytesFinish - blankCheckFinish
+          metadataMs := metadataFinish - bytesFinish
+          storeMs := storeFinish - metadataFinish
+          htmlBytes
+        }
+      else
+        let rendered ← Informal.LeanCodePreview.renderWithState entry impls state
+          (logError := logError) (hoverState := hoverState)
+        hoverState := rendered.hoverState
+        let html := rendered.html.asString
+        if htmlStringIsBlank html then
+          continue
+        let manifestEntry := leanCodePreviewManifestEntry state sourceRefs key entry
+        entries := entries.push manifestEntry
+        htmlEntries := htmlEntries.push { key := manifestEntry.key, html }
+  if verbose then
+    logBuildProgress true <|
+      s!"Lean code preview emitted {entries.size} manifest entries"
+  logLeanCodePreviewTimings verbose timings
   pure (entries, htmlEntries, hoverState)
 
 private def renderCitationEntryHtml
@@ -2140,18 +2314,36 @@ def buildPreviewDataFiles
     (impls : ExtensionImpls)
     (logError : String → IO Unit)
     (state : TraverseState)
-    (externalMarkupConfig : Informal.ExternalMarkupRender.Config := {}) : IO Files := do
+    (externalMarkupConfig : Informal.ExternalMarkupRender.Config := {})
+    (verbose : Bool := false) : IO Files := do
   let hoverState := HtmlCache.initialHoverState
-  let (traversalPreviews, traversalHtml, hoverState) ← buildTraversalEntries impls logError state hoverState
+  let (traversalPreviews, traversalHtml, hoverState) ←
+    withTimedBuildProgress verbose "building traversal preview entries" <|
+      buildTraversalEntries impls logError state hoverState
   let (externalMarkupPreviews, externalMarkupHtml) ←
-    buildExternalMarkupEntries logError state traversalPreviews externalMarkupConfig
-  let (leanCodePreviews, leanCodeHtml, hoverState) ← buildLeanCodeEntries impls logError state hoverState
-  let (citationPreviews, citationHtml, hoverState) ← buildCitationEntries impls logError state hoverState
-  let sourceDocuments ← buildSourceDocuments logError state
-  validateSourceRefs logError sourceDocuments state
-  let previews := (traversalPreviews ++ externalMarkupPreviews ++ leanCodePreviews ++ citationPreviews).qsort (fun a b => a.key < b.key)
-  let htmlEntries := (traversalHtml ++ externalMarkupHtml ++ leanCodeHtml ++ citationHtml).qsort (fun a b => a.key < b.key)
-  let graphs := Informal.GraphApi.cachedData state
+    withTimedBuildProgress verbose "building external markup manifest entries" <|
+      buildExternalMarkupEntries logError state traversalPreviews externalMarkupConfig
+  let (leanCodePreviews, leanCodeHtml, hoverState) ←
+    withTimedBuildProgress verbose "building Lean code preview entries" <|
+      buildLeanCodeEntries impls logError state hoverState (verbose := verbose)
+  let (citationPreviews, citationHtml, hoverState) ←
+    withTimedBuildProgress verbose "building citation preview entries" <|
+      buildCitationEntries impls logError state hoverState
+  let sourceDocuments ←
+    withTimedBuildProgress verbose "building source document catalog" <|
+      buildSourceDocuments logError state
+  withTimedBuildProgress verbose "validating source references" <|
+    validateSourceRefs logError sourceDocuments state
+  let (previews, htmlEntries, graphs) ←
+    withTimedBuildProgress verbose "assembling Blueprint manifest/cache indexes" <| do
+      let previews :=
+        (traversalPreviews ++ externalMarkupPreviews ++ leanCodePreviews ++ citationPreviews).qsort
+          (fun a b => a.key < b.key)
+      let htmlEntries :=
+        (traversalHtml ++ externalMarkupHtml ++ leanCodeHtml ++ citationHtml).qsort
+          (fun a b => a.key < b.key)
+      let graphs := Informal.GraphApi.cachedData state
+      pure (previews, htmlEntries, graphs)
   let htmlCache : HtmlCache.File := {
     entries := htmlEntries
     hoverDocs := HtmlCache.HoverDoc.ofDedup hoverState.dedup
@@ -2176,8 +2368,11 @@ private def dumpManifest
     errorCount.modify (· + 1)
     IO.eprintln msg
   let cfg ← ReaderT.run (parseRenderConfigOptions config options) extensionImpls
-  let (_text, traverseState) ← ReaderT.run (Verso.Genre.Manual.traverseHtmlMulti logError cfg text) extensionImpls
+  let traverseCfg := { cfg with verbose := false }
+  let (_text, traverseState) ←
+    ReaderT.run (Verso.Genre.Manual.traverseHtmlMulti logError traverseCfg text) extensionImpls
   let files ← buildPreviewDataFiles extensionImpls logError traverseState externalMarkupConfig
+    (verbose := cfg.verbose)
   reportPreviewMetadataLossWarnings IO.eprintln traverseState files.manifest
   IO.println <| jsonPretty <| toJson files.manifest
   if (← errorCount.get) == 0 then pure 0 else pure 1
@@ -2199,8 +2394,11 @@ private def dumpHtmlCache
     errorCount.modify (· + 1)
     IO.eprintln msg
   let cfg ← ReaderT.run (parseRenderConfigOptions config options) extensionImpls
-  let (_text, traverseState) ← ReaderT.run (Verso.Genre.Manual.traverseHtmlMulti logError cfg text) extensionImpls
+  let traverseCfg := { cfg with verbose := false }
+  let (_text, traverseState) ←
+    ReaderT.run (Verso.Genre.Manual.traverseHtmlMulti logError traverseCfg text) extensionImpls
   let files ← buildPreviewDataFiles extensionImpls logError traverseState externalMarkupConfig
+    (verbose := cfg.verbose)
   reportPreviewMetadataLossWarnings IO.eprintln traverseState files.manifest
   IO.println <| jsonPretty <| toJson files.htmlCache
   if (← errorCount.get) == 0 then pure 0 else pure 1
@@ -2234,16 +2432,28 @@ def emitBlueprintPreviewData
     (extensionImpls : ExtensionImpls)
     (externalMarkupConfig : Informal.ExternalMarkupRender.Config := {}) :
     ExtraStep := fun mode logError cfg state _text => do
+  let modeDescription := htmlModeDescription mode
   let files ← buildPreviewDataFiles extensionImpls logError state externalMarkupConfig
+    (verbose := cfg.verbose)
   reportPreviewMetadataLossWarnings IO.eprintln state files.manifest
+  let countSummary :=
+    s!"{files.manifest.previews.size} previews, " ++
+    s!"{files.htmlCache.entries.size} HTML cache entries, " ++
+    s!"{files.manifest.sourceDocuments.size} source documents, " ++
+    s!"{files.manifest.graphs.size} graphs"
+  logBuildProgress cfg.verbose s!"{modeDescription} preview data contains {countSummary}"
   let outDir := outDirForMode cfg mode
   let dataDir := outDir / "-verso-data"
-  IO.FS.createDirAll dataDir
-  IO.FS.writeFile (dataDir / manifestFilename) (toJson files.manifest).compress
-  IO.FS.writeFile (dataDir / htmlCacheFilename) (toJson files.htmlCache).compress
-  writeBlueprintRuntimeModules dataDir
-  mergeHtmlCacheHoverDocsIntoVersoDocs (outDir / "-verso-docs.json") files.htmlCache
-  emitPublicXref mode logError cfg state
+  withTimedBuildProgress cfg.verbose s!"writing {modeDescription} Blueprint manifest/cache files" <| do
+    IO.FS.createDirAll dataDir
+    IO.FS.writeFile (dataDir / manifestFilename) (toJson files.manifest).compress
+    IO.FS.writeFile (dataDir / htmlCacheFilename) (toJson files.htmlCache).compress
+  withTimedBuildProgress cfg.verbose s!"writing {modeDescription} Blueprint runtime modules" <|
+    writeBlueprintRuntimeModules dataDir
+  withTimedBuildProgress cfg.verbose s!"merging {modeDescription} hover docs" <|
+    mergeHtmlCacheHoverDocsIntoVersoDocs (outDir / "-verso-docs.json") files.htmlCache
+  withTimedBuildProgress cfg.verbose s!"writing {modeDescription} public xref" <|
+    emitPublicXref mode logError cfg state
 
 def handleDumpSchemaFlag (args : List String) : IO (Option UInt32 × List String) := do
   if args.contains dumpSchemaFlag then
@@ -2295,27 +2505,37 @@ private def emitBlueprintHtml
     (traverse : HtmlTraverse)
     (emit : HtmlEmitter) :
     ReaderT ExtensionImpls IO Unit := do
+  let modeDescription := htmlModeDescription mode
   let outDir := outputDirNameForMode mode
   match how with
   | .no => pure ()
   | .immediately =>
-      if cfg.verbose then
-        IO.println s!"Saving {match mode with | .single => "single" | .multi => "multi"}-page HTML"
-      let (text', traverseState) ← traverse logError cfg text
+      let (text', traverseState) ←
+        withTimedBuildProgress cfg.verbose s!"{modeDescription} HTML traversal" <|
+          traverse logError cfg text
       let traverseState := patchBlueprintTraverseState traverseState
-      emitXrefsJson (cfg.destination / outDir) traverseState
-      emit logError cfg text' traverseState
+      withTimedBuildProgress cfg.verbose s!"writing {modeDescription} xrefs" <|
+        emitXrefsJson (cfg.destination / outDir) traverseState
+      withTimedBuildProgress cfg.verbose s!"emitting {modeDescription} HTML" <|
+        emit logError cfg text' traverseState
       for step in extraSteps do
         step mode logError cfg.toConfig traverseState text'
   | .delay f =>
-      let (text', traverseState) ← traverse logError cfg text
+      let (text', traverseState) ←
+        withTimedBuildProgress cfg.verbose s!"{modeDescription} HTML traversal" <|
+          traverse logError cfg text
       let traverseState := patchBlueprintTraverseState traverseState
-      emitXrefsJson (cfg.destination / outDir) traverseState
-      SavedState.mk text' traverseState |>.save f
+      withTimedBuildProgress cfg.verbose s!"writing {modeDescription} xrefs" <|
+        emitXrefsJson (cfg.destination / outDir) traverseState
+      withTimedBuildProgress cfg.verbose s!"saving {modeDescription} traversal state to {f}" <|
+        SavedState.mk text' traverseState |>.save f
   | .resumeFrom f =>
-      let { text, traverseState } ← SavedState.load f
+      let { text, traverseState } ←
+        withTimedBuildProgress cfg.verbose s!"loading {modeDescription} traversal state from {f}" <|
+          SavedState.load f
       let traverseState := patchBlueprintTraverseState traverseState
-      emit logError cfg text traverseState
+      withTimedBuildProgress cfg.verbose s!"emitting {modeDescription} HTML" <|
+        emit logError cfg text traverseState
       for step in extraSteps do
         step mode logError cfg.toConfig traverseState text
 
@@ -2338,10 +2558,9 @@ where
     let extraSteps := emitBuildMetadata buildMetadata :: extraSteps
 
     if cfg.emitTeX then
-      if cfg.verbose then
-        IO.println "Saving TeX"
-      emitTeX logError cfg.toConfig text
-      Informal.TeX.Cleanup.patchFile logError cfg.toConfig text
+      withTimedBuildProgress cfg.verbose "TeX emission" <| do
+        emitTeX logError cfg.toConfig text
+        Informal.TeX.Cleanup.patchFile logError cfg.toConfig text
 
     emitBlueprintHtml extraSteps cfg.emitHtmlSingle .single logError cfg text
       traverseHtmlSingle emitHtmlSingle
@@ -2349,9 +2568,8 @@ where
       traverseHtmlMulti emitHtmlMulti
 
     if let some wcFile := cfg.wordCount then
-      if cfg.verbose then
-        IO.println s!"Saving word counts to {wcFile}"
-      wordCount wcFile logError cfg.toConfig text
+      withTimedBuildProgress cfg.verbose s!"word count emission to {wcFile}" <|
+        wordCount wcFile logError cfg.toConfig text
     if pdfOptions.enabled then
       Informal.TeX.Pdf.compile logError pdfOptions cfg.toConfig
 

--- a/src/VersoBlueprint/PreviewManifest/Cli.lean
+++ b/src/VersoBlueprint/PreviewManifest/Cli.lean
@@ -155,7 +155,7 @@ def helpText : String := String.intercalate "\n" [
   "  --with-html-multi | --delay-html-multi <file> | --resume-html-multi <file> | --without-html-multi",
   "  --with-word-count <file> | --without-word-count",
   "  --draft",
-  "  --verbose",
+  "  --verbose                  Show phase timing and progress diagnostics.",
   "  --remote-config <file>"
 ]
 

--- a/src/VersoBlueprint/VbpMain.lean
+++ b/src/VersoBlueprint/VbpMain.lean
@@ -12,9 +12,12 @@ open System
 
 namespace VersoBlueprint.Vbp.Main
 
+private def buildUsageLine : String :=
+  "lake exe vbp build [--output <dir>] [--pdf] [--verbose] [--serve] [--port <n>]"
+
 private def mainCommandLines : List String := [
   "lake exe vbp discover",
-  "lake exe vbp build [--output <dir>] [--pdf] [--serve] [--port <n>]",
+  buildUsageLine,
   "lake exe vbp query [--site <dir>] <selector>",
   "lake exe vbp check [--site <dir>]"
 ]
@@ -22,9 +25,20 @@ private def mainCommandLines : List String := [
 private def defaultHelpLines : List String := [
   "build writes _out/site",
   "--pdf builds _out/site/pdf/main.pdf from the generated TeX",
+  "--verbose shows Blueprint generation phase progress during build",
   "query and check read _out/site",
   "--serve serves the generated html-multi directory after a successful build",
   "--serve --port <n> serves on a fixed port"
+]
+
+private def buildOptionLines : List String := [
+  "--output <dir>      Write generated output under <dir> instead of _out/site",
+  "--pdf               Build _out/site/pdf/main.pdf from the generated TeX",
+  "--pdf-engine <cmd>  Use <cmd> for PDF compilation",
+  "--pdf-runs <n>      Run the PDF engine <n> times",
+  "--verbose           Show Blueprint generation phase progress",
+  "--serve             Serve the generated html-multi directory after build",
+  "--port <n>          Serve on a fixed TCP port; requires --serve"
 ]
 
 private def indentHelpLine (line : String) : String :=
@@ -42,6 +56,16 @@ def helpText : String := String.intercalate "\n" <|
     "",
     "Defaults:"
   ] ++ defaultHelpLines.map indentHelpLine
+
+def buildHelpText : String := String.intercalate "\n" <|
+  [
+  "vbp build - build a Verso Blueprint site",
+  "",
+  "Usage:",
+  indentHelpLine buildUsageLine,
+  "",
+  "Options:"
+  ] ++ buildOptionLines.map indentHelpLine
 
 private def printJson (json : Json) : IO Unit :=
   IO.println json.compress
@@ -167,6 +191,7 @@ structure BuildOptions where
   pdf : Bool := false
   pdfEngine? : Option String := none
   pdfRuns? : Option Nat := none
+  verbose : Bool := false
   serve : Bool := false
   port? : Option Nat := none
 
@@ -220,6 +245,7 @@ private partial def parseBuildOptionsCore : List String → BuildOptions → Exc
         | [] => .error s!"missing value after {Informal.PreviewManifest.pdfRunsFlag}"
       else
         match arg, args with
+        | "--verbose", args => parseBuildOptionsCore args { opts with verbose := true }
         | "--serve", args => parseBuildOptionsCore args { opts with serve := true }
         | "--port", raw :: args =>
             match parseTcpPort raw with
@@ -283,9 +309,14 @@ The raw environment-wrapped Lean interpreter form does not load package native
 libraries such as MD4Lean. The `lake lean Foo.lean -- --run Foo.lean ...` form
 does, while still avoiding the generator executable build path.
 -/
-private def generatorRunArgs (generatorFile output : FilePath) : Array String :=
-  #["lean", generatorFile.toString, "--", "--run", generatorFile.toString,
-    "--output", output.toString]
+private def generatorRunArgs (generatorFile output : FilePath) (verbose : Bool) : Array String :=
+  let args :=
+    #["lean", generatorFile.toString, "--", "--run", generatorFile.toString,
+      "--output", output.toString]
+  if verbose then
+    args ++ #["--verbose"]
+  else
+    args
 
 private def pdfGeneratorArgs (opts : BuildOptions) : Array String :=
   let args := if opts.pdf then #[Informal.PreviewManifest.pdfFlag] else #[]
@@ -304,7 +335,7 @@ private def buildPlan (opts : BuildOptions) : IO (Except String BuildPlan) := do
       pure (.ok {
         packageName := info.packageName,
         generatorPrepareArgs := #["lean", info.generatorFile.toString],
-        generatorArgs := generatorRunArgs info.generatorFile opts.output ++ pdfGeneratorArgs opts
+        generatorArgs := generatorRunArgs info.generatorFile opts.output opts.verbose ++ pdfGeneratorArgs opts
       })
 
 private def serveScript : String := String.intercalate "\n" [
@@ -340,27 +371,32 @@ private def serve (output : FilePath) (port? : Option Nat) : IO UInt32 := do
     runAttached "python3" #["-c", serveScript, mode, toString port, htmlDir.toString]
 
 def build (args : List String) : IO UInt32 := do
-  match parseBuildOptions args {} with
-  | .error err =>
-      IO.eprintln err
-      pure 2
-  | .ok opts =>
-      match ← buildPlan opts with
+  match args with
+  | ["--help"] | ["-h"] | ["help"] =>
+      IO.println buildHelpText
+      pure 0
+  | _ =>
+      match parseBuildOptions args {} with
       | .error err =>
           IO.eprintln err
-          pure 1
-      | .ok plan =>
-          let code ← runBuildStages [
-            { stage := "package build", cmd := "lake", args := #["build", plan.packageName] },
-            { stage := "generator preparation", cmd := "lake", args := plan.generatorPrepareArgs },
-            { stage := "generator run", cmd := "lake", args := plan.generatorArgs }
-          ]
-          if code != 0 then
-            pure code
-          else if opts.serve then
-            serve opts.output opts.port?
-          else
-            pure 0
+          pure 2
+      | .ok opts =>
+          match ← buildPlan opts with
+          | .error err =>
+              IO.eprintln err
+              pure 1
+          | .ok plan =>
+              let code ← runBuildStages [
+                { stage := "package build", cmd := "lake", args := #["build", plan.packageName] },
+                { stage := "generator preparation", cmd := "lake", args := plan.generatorPrepareArgs },
+                { stage := "generator run", cmd := "lake", args := plan.generatorArgs }
+              ]
+              if code != 0 then
+                pure code
+              else if opts.serve then
+                serve opts.output opts.port?
+              else
+                pure 0
 
 def query (args : List String) : IO UInt32 := do
   match parseSiteOptions args {} with

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -280,11 +280,22 @@ private def jsonArrayHasNullField (values : Array Json) (field : String) : Bool 
       text.contains "selectors" &&
       text.contains "all <label>" &&
       text.contains "search <text>" &&
-      text.contains "lake exe vbp build [--output <dir>] [--pdf]" &&
+      text.contains "lake exe vbp build [--output <dir>] [--pdf] [--verbose]" &&
       text.contains "--pdf builds _out/site/pdf/main.pdf" &&
+      text.contains "--verbose shows Blueprint generation phase progress during build" &&
       text.contains "--serve --port <n>" &&
       text.contains "build writes _out/site" &&
       !text.contains "lake exe vbp query [--site <dir>] node <label>"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    let text := VersoBlueprint.Vbp.Main.buildHelpText
+    text.contains "lake exe vbp build [--output <dir>] [--pdf] [--verbose]" &&
+      text.contains "--verbose" &&
+      text.contains "Show Blueprint generation phase progress" &&
+      text.contains "--port <n>"
 
 /-- info: true -/
 #guard_msgs in
@@ -781,12 +792,14 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
 #eval
   show Bool from
     match VersoBlueprint.Vbp.Main.parseBuildOptions
-        ["--output", "_out/custom", "--pdf", "--pdf-engine", "xelatex", "--pdf-runs", "3"] {} with
+        ["--output", "_out/custom", "--pdf", "--pdf-engine", "xelatex", "--pdf-runs", "3",
+          "--verbose"] {} with
     | .ok opts =>
         opts.output.toString == "_out/custom" &&
           opts.pdf &&
           opts.pdfEngine? == some "xelatex" &&
-          opts.pdfRuns? == some 3
+          opts.pdfRuns? == some 3 &&
+          opts.verbose
     | .error _ => false
 
 /-- info: true -/

--- a/tests/harness/test_verso_blueprint_skill.py
+++ b/tests/harness/test_verso_blueprint_skill.py
@@ -22,7 +22,9 @@ class VersoBlueprintSkillTests(unittest.TestCase):
 
     def test_vbp_reference_documents_public_surface(self) -> None:
         text = (SKILL_ROOT / "references" / "vbp.md").read_text(encoding="utf-8")
-        self.assertIn("lake exe vbp build [--output <dir>] [--serve] [--port <n>]", text)
+        self.assertIn("lake exe vbp build [--output <dir>] [--pdf] [--verbose] [--serve] [--port <n>]", text)
+        self.assertIn("Pass `--pdf` to build `_out/site/pdf/main.pdf` from the generated TeX.", text)
+        self.assertIn("`build --verbose` passes `--verbose` through to the generator run", text)
         self.assertIn("lake exe vbp query [--site <dir>] <selector>", text)
         self.assertIn("lake lean <GeneratorMain>.lean", text)
         self.assertIn("lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean --output <output>", text)


### PR DESCRIPTION
## Summary
Backport #293 to `v4.30.0`.

## Primary Review
- Primary review: #293
- Keep review comments on #293 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.30.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- Resolved `src/VersoBlueprint/PreviewManifest.lean` against `v4.30.0`'s explicit `logError` callback API.
- No intentional user-visible release-specific changes.