### PR TITLE
test: harden preview reference finalization

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -171,7 +171,7 @@ In practice:
 
 Generator-side data flow is source-to-traversal-to-public JSON. During Manual
 traversal, Blueprint records preview identities, rendered bodies, Lean-code
-associations, citations, graph data, and external-source witnesses in traversal
+associations, citations, graph data, and external-markup witnesses in traversal
 state and traversal domains. `Informal.PreviewManifest.buildPreviewDataFiles`
 then normalizes those phase-local records into the semantic manifest and the
 rendered-fragment cache. Generated ESM APIs load those two files; they do not
@@ -305,7 +305,7 @@ def workQueueLabels
   manifest.workQueueEntries.map (·.authoredLabel)
 ```
 
-Generator-side Lean callers can configure source-backed external-source cache
+Generator-side Lean callers can configure source-backed external-markup cache
 fragments with `Informal.ExternalMarkupRender.Config`. The
 default mode, `.markdown`, renders selected Markdown slots through MD4Lean with
 raw HTML disabled and falls back to escaped source if MD4Lean cannot render the

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -995,8 +995,10 @@ primary label lookup, owner/tag/work-queue extraction, and entry search
 predicates. `Informal.PreviewManifest.previewMetadataLosses` audits whether
 traversal-preview Lean metadata, including bodyless `(lean := ...)` payloads,
 survived manifest construction. Preview-data generation reports non-empty audit
-results as warnings, while `VersoBlueprint.Vbp` formats those results as JSON
-for stricter review workflows; neither should own a parallel selector model.
+results as warnings while traversal state is still available. Generated-data
+tools such as `VersoBlueprint.Vbp` operate after that boundary, so they validate
+manifest/cache consistency instead of reconstructing traversal-only audits;
+neither layer should own a parallel selector model.
 
 ### Traversal Storage Roles
 

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -1184,7 +1184,7 @@ end HtmlCache
 structure Files where
   /--
   Semantic preview data. This is the public source of truth for labels, hrefs,
-  relationship topology, Lean-code associations, external-source metadata, and
+  relationship topology, Lean-code associations, external-markup metadata, and
   other facts that generated consumers need.
   -/
   manifest : File := {}
@@ -1288,7 +1288,16 @@ private def graphFinalizePreviewReferences
       variants := graph.variants.map (graphVariantFinalizePreviewReferences index)
   }
 
-private def File.finalizePreviewReferences (file : File) (htmlCache : HtmlCache.File) : File :=
+/--
+Finalize traversal-derived preview references against the manifest/cache pair.
+
+Generated relation, group, Lean-code, and graph preview references are only
+advertised when the target key has both a semantic manifest entry and a rendered
+fragment cache body. Relations and graph nodes that fail that join remain
+present but lose their `previewKey`; Lean-code keys and graph-variant mappings
+are removed so generated JSON does not point at an unavailable preview body.
+-/
+def File.finalizePreviewReferences (file : File) (htmlCache : HtmlCache.File) : File :=
   let index := PreviewArtifactIndex.ofFiles file htmlCache
   {
     file with
@@ -2336,7 +2345,7 @@ completed Manual traversal state.
 
 This is the traversal-to-public-data boundary: traversal domains may contain
 semantic payloads that are not visible as rendered page bodies, such as bodyless
-external-source directives carrying Lean preview keys. Preserve those facts in
+external-markup directives carrying Lean preview keys. Preserve those facts in
 the manifest, and keep rendered fragments in the HTML cache.
 -/
 def buildPreviewDataFiles

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -195,6 +195,119 @@ private def sampleGraphReferenceCache : HtmlCacheFile := {
   ]
 }
 
+private def sampleUnfinalizedReferenceManifest : ManifestFile := {
+  previews := #[
+    {
+      key := "informal:reference_source:statement"
+      targetKind := .block
+      label := label "reference_source"
+      facet := .statement
+      kind := some .theorem
+      title := "Reference source"
+      leanCodePreviewKeys := #[
+        "lean:Valid",
+        "lean:MissingManifest",
+        "lean:MissingCache"
+      ]
+      uses := #[
+        related "valid_target" "Valid target" "informal:valid_target:statement",
+        related "cache_only_target" "Cache-only target" "informal:cache_only_target:statement",
+        related "missing_cache_target" "Missing-cache target" "informal:missing_cache_target:statement"
+      ]
+      usedBy := #[
+        related "valid_target" "Valid target" "informal:valid_target:statement",
+        related "cache_only_target" "Cache-only target" "informal:cache_only_target:statement",
+        related "missing_cache_target" "Missing-cache target" "informal:missing_cache_target:statement"
+      ]
+      group := some {
+        label := label "reference_group"
+        title := "Reference group"
+        declared := true
+        entries := #[
+          related "valid_target" "Valid target" "informal:valid_target:statement",
+          related "cache_only_target" "Cache-only target" "informal:cache_only_target:statement",
+          related "missing_cache_target" "Missing-cache target" "informal:missing_cache_target:statement"
+        ]
+      }
+    },
+    {
+      key := "informal:valid_target:statement"
+      targetKind := .block
+      label := label "valid_target"
+      facet := .statement
+      kind := some .definition
+      title := "Valid target"
+    },
+    {
+      key := "informal:missing_cache_target:statement"
+      targetKind := .block
+      label := label "missing_cache_target"
+      facet := .statement
+      kind := some .definition
+      title := "Missing-cache target"
+    },
+    {
+      key := "lean:Valid"
+      targetKind := .leanDecl
+      label := label "Valid"
+      facet := .statement
+      title := "Valid"
+    },
+    {
+      key := "lean:MissingCache"
+      targetKind := .leanDecl
+      label := label "MissingCache"
+      facet := .statement
+      title := "MissingCache"
+    }
+  ]
+  graphs := #[{
+    key := "reference-finalization"
+    nodes := #[
+      {
+        label := label "valid_target"
+        title := "Valid target"
+        displayLabel := "Valid target"
+        previewKey := Informal.PreviewKey.ofString? "informal:valid_target:statement"
+        visual := { fillcolor := "#ffffff" }
+      },
+      {
+        label := label "cache_only_target"
+        title := "Cache-only target"
+        displayLabel := "Cache-only target"
+        previewKey := Informal.PreviewKey.ofString? "informal:cache_only_target:statement"
+        visual := { fillcolor := "#ffffff" }
+      },
+      {
+        label := label "missing_cache_target"
+        title := "Missing-cache target"
+        displayLabel := "Missing-cache target"
+        previewKey := Informal.PreviewKey.ofString? "informal:missing_cache_target:statement"
+        visual := { fillcolor := "#ffffff" }
+      }
+    ]
+    variants := #[{
+      key := "full"
+      label := "Full"
+      dot := "digraph {}"
+      previewKeyByNodeId := #[
+        ("valid-node", "informal:valid_target:statement"),
+        ("cache-only-node", "informal:cache_only_target:statement"),
+        ("missing-cache-node", "informal:missing_cache_target:statement")
+      ]
+    }]
+  }]
+}
+
+private def sampleUnfinalizedReferenceCache : HtmlCacheFile := {
+  entries := #[
+    { key := "informal:reference_source:statement", html := "<div>reference source</div>" },
+    { key := "informal:valid_target:statement", html := "<div>valid target</div>" },
+    { key := "informal:cache_only_target:statement", html := "<div>cache only target</div>" },
+    { key := "lean:Valid", html := "<pre>Valid</pre>" }
+  ]
+}
+
 private def sampleCache : HtmlCacheFile := {
   entries := #[
     { key := "informal:addition_spec:statement", html := "<div>addition spec</div>" },
@@ -269,6 +382,18 @@ private def jsonArrayHasStringField (values : Array Json) (field expected : Stri
 
 private def jsonArrayHasNullField (values : Array Json) (field : String) : Bool :=
   values.any (fun json => jsonNullField json field)
+
+private def previewKeyValue? (key? : Option Informal.PreviewKey) : Option String :=
+  key?.map (·.value)
+
+private def relatedPreviewKeys (entries : Array RelatedEntry) : Array (String × Option String) :=
+  entries.map fun entry =>
+    (Informal.PreviewManifest.labelString entry.label, previewKeyValue? entry.previewKey)
+
+private def graphNodePreviewKeys
+    (nodes : Array Informal.Graph.NodeData) : Array (String × Option String) :=
+  nodes.map fun node =>
+    (Informal.PreviewManifest.labelString node.label, previewKeyValue? node.previewKey)
 
 /-- info: true -/
 #guard_msgs in
@@ -349,6 +474,36 @@ private def jsonArrayHasNullField (values : Array Json) (field : String) : Bool 
           sampleMetadataManifest.tagValues == #["alpha", "beta", "zeta"] &&
           sampleMetadataManifest.workQueueEntries.map (·.authoredLabel) ==
             #["zeta_statement", "alpha_statement"]
+    | _, _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    let finalized :=
+      sampleUnfinalizedReferenceManifest.finalizePreviewReferences sampleUnfinalizedReferenceCache
+    match finalized.findEntry? "informal:reference_source:statement",
+        finalized.graphs.find? (fun graph => graph.key == "reference-finalization") with
+    | some source, some graph =>
+        let expectedRelatedKeys := #[
+          ("valid_target", some "informal:valid_target:statement"),
+          ("cache_only_target", none),
+          ("missing_cache_target", none)
+        ]
+        let groupKeys :=
+          match source.group with
+          | some group => relatedPreviewKeys group.entries
+          | none => #[]
+        let variantKeys :=
+          match graph.variants[0]? with
+          | some variant => variant.previewKeyByNodeId
+          | none => #[]
+        source.leanCodePreviewKeys == #["lean:Valid"] &&
+          relatedPreviewKeys source.uses == expectedRelatedKeys &&
+          relatedPreviewKeys source.usedBy == expectedRelatedKeys &&
+          groupKeys == expectedRelatedKeys &&
+          graphNodePreviewKeys graph.nodes == expectedRelatedKeys &&
+          variantKeys == #[("valid-node", "informal:valid_target:statement")]
     | _, _ => false
 
 private partial def freshVbpFixtureRoot : IO System.FilePath := do


### PR DESCRIPTION
This PR hardens the manifest/cache join that controls which generated preview references are advertised. It adds regression coverage for relation, group, Lean-code, graph-node, and graph-variant references, and documents the finalization boundary and current external-markup terminology.

Backport v4.31.0: exempt: regression coverage and terminology clarification only
Backport v4.30.0: exempt: regression coverage and terminology clarification only
