### PR TITLE
[backport v4.31.0] feat: show verbose preview entry counts

### DIFF
--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -213,6 +213,9 @@ python3 -m scripts.blueprint_reference_harness generate --project noperthedron
 python3 -m scripts.blueprint_reference_harness validate --project project-template --run-lean-tests
 ```
 
+Pass `--verbose` to `generate` or `validate` when you want each Blueprint
+generator to print its own progress diagnostics during HTML emission.
+
 When editing an external reference repository, use an editable clone rather
 than the disposable validation clones:
 

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -44,6 +44,22 @@ GITHUB_SUBMODULE_URL_REWRITE_ARGS = (
 REFERENCE_HARNESS_CONFIG = "verso-harness.toml"
 
 
+def command_with_verbose(command: tuple[str, ...]) -> tuple[str, ...]:
+    if "--verbose" in command:
+        return command
+    return (*command, "--verbose")
+
+
+def reference_generation_command(
+    command: tuple[str, ...],
+    *,
+    verbose: bool,
+) -> tuple[str, ...]:
+    if verbose:
+        command = command_with_verbose(command)
+    return command
+
+
 @dataclass(frozen=True)
 class ReferenceProjectBumpResult:
     edit_dir: Path
@@ -920,7 +936,14 @@ def sync_reference_local_checkout(
     return local_dir
 
 
-def generate_in_repo_command_project(layout, output_root: Path, project: HarnessProject, *, skip_build: bool) -> None:
+def generate_in_repo_command_project(
+    layout,
+    output_root: Path,
+    project: HarnessProject,
+    *,
+    skip_build: bool,
+    verbose: bool = False,
+) -> None:
     project_dir = layout.package_root / project.project_root
     if not project_dir.exists():
         raise SystemExit(f"[blueprint-harness] missing in-repo project root for `{project.project_id}`: {project_dir}")
@@ -932,6 +955,7 @@ def generate_in_repo_command_project(layout, output_root: Path, project: Harness
     original_manifest = snapshot_tracked_project_manifest(project_dir)
     try:
         with maybe_in_repo_blueprint_dependency_override(project_dir, layout.package_root, log=True):
+            generate_command = reference_generation_command(project.generate_command or (), verbose=verbose)
             run_project_update_build_generate(
                 layout.package_root,
                 project_dir,
@@ -941,7 +965,7 @@ def generate_in_repo_command_project(layout, output_root: Path, project: Harness
                     reconcile_toolchains=False,
                 ),
                 build_command=project.build_command,
-                generate_command=project.generate_command or (),
+                generate_command=generate_command,
                 format_command=lambda command: format_project_command(
                     command,
                     reference_command_placeholders(
@@ -966,6 +990,7 @@ def generate_git_project(
     *,
     skip_build: bool,
     package_mode: str = REFERENCE_PACKAGE_MODE_COPY,
+    verbose: bool = False,
 ) -> None:
     package_mode = validate_reference_package_mode(package_mode)
     rebuild_and_log_embedded_asset_owners(layout.package_root)
@@ -987,12 +1012,13 @@ def generate_git_project(
             seed_lake_path_builds_from_dependency_cache(layout, project, project_dir)
 
         with local_blueprint_dependency_override(layout.package_root, project_dir, restore_lakefile=False, log=True):
+            generate_command = reference_generation_command(project.generate_command or (), verbose=verbose)
             run_project_update_build_generate(
                 layout.package_root,
                 project_dir,
                 update_project=update_reference_project,
                 build_command=project.build_command,
-                generate_command=project.generate_command or (),
+                generate_command=generate_command,
                 format_command=lambda command: format_project_command(
                     command,
                     reference_command_placeholders(

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -53,6 +53,7 @@ from scripts.blueprint_harness_references import (
     generate_git_project,
     output_dir_for,
     prepare_reference_edit_checkout,
+    reference_generation_command,
     ref_is_commit_hash,
     reference_dependency_cache_keys,
     reference_prune_plan,
@@ -121,6 +122,14 @@ def add_reference_package_mode_argument(parser: argparse.ArgumentParser) -> None
             "How external reference projects receive warmed `.lake/packages` trees. "
             "`copy` keeps the local default; `move` avoids duplicate package trees and is intended for CI."
         ),
+    )
+
+
+def add_generation_verbose_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Pass `--verbose` to Blueprint generator commands.",
     )
 
 
@@ -615,7 +624,29 @@ def build_in_repo_projects(package_root: Path, projects: list[HarnessProject]) -
         run(lean_low_priority_command(package_root, "lake", "build", *targets), cwd=package_root)
 
 
-def render_in_repo_projects(package_root: Path, output_root: Path, projects: list[HarnessProject], serial: bool) -> None:
+def reference_executable_args(
+    package_root: Path,
+    project: HarnessProject,
+    output_dir: Path,
+    *,
+    verbose: bool,
+) -> list[str]:
+    args = [
+        str(ensure_prebuilt_executable(package_root, project.generator or project.project_id)),
+        "--output",
+        str(output_dir),
+    ]
+    return list(reference_generation_command(tuple(args), verbose=verbose))
+
+
+def render_in_repo_projects(
+    package_root: Path,
+    output_root: Path,
+    projects: list[HarnessProject],
+    serial: bool,
+    *,
+    verbose: bool = False,
+) -> None:
     output_root.mkdir(parents=True, exist_ok=True)
     if serial:
         for project in projects:
@@ -623,9 +654,7 @@ def render_in_repo_projects(package_root: Path, output_root: Path, projects: lis
             run(
                 lean_low_priority_command(
                     package_root,
-                    str(ensure_prebuilt_executable(package_root, project.generator or project.project_id)),
-                    "--output",
-                    str(output_dir),
+                    *reference_executable_args(package_root, project, output_dir, verbose=verbose),
                 ),
                 cwd=package_root,
             )
@@ -638,9 +667,7 @@ def render_in_repo_projects(package_root: Path, output_root: Path, projects: lis
             output_dir.mkdir(parents=True, exist_ok=True)
             command = lean_low_priority_command(
                 package_root,
-                str(ensure_prebuilt_executable(package_root, project.generator or project.project_id)),
-                "--output",
-                str(output_dir),
+                *reference_executable_args(package_root, project, output_dir, verbose=verbose),
             )
             print(f"[blueprint-reference-harness] launching {project.project_id} -> {output_dir}", flush=True)
             procs.append((project.project_id, subprocess.Popen(command, cwd=package_root)))
@@ -668,6 +695,7 @@ def generate_projects(
     serial: bool,
     allow_local_build: bool,
     reference_package_mode: str = REFERENCE_PACKAGE_MODE_COPY,
+    verbose: bool = False,
 ) -> None:
     in_repo_projects = [project for project in projects if project.in_repo_project]
     in_repo_target_projects = [project for project in in_repo_projects if project.in_repo_target_project]
@@ -692,7 +720,7 @@ def generate_projects(
         elif not skip_build and not use_local_build:
             for project in in_repo_target_projects:
                 ensure_prebuilt_executable(layout.package_root, project.generator or project.project_id)
-        render_in_repo_projects(layout.package_root, output_root, in_repo_target_projects, serial)
+        render_in_repo_projects(layout.package_root, output_root, in_repo_target_projects, serial, verbose=verbose)
 
     if in_repo_command_projects:
         print(f"[blueprint-reference-harness] package root: {layout.package_root}")
@@ -702,7 +730,13 @@ def generate_projects(
             print(f"[blueprint-reference-harness] output root: {output_root}")
         for project in in_repo_command_projects:
             print(f"[blueprint-reference-harness] in-repo project: {project.project_id} ({project.project_root})")
-            generate_in_repo_command_project(layout, output_root, project, skip_build=skip_build)
+            generate_in_repo_command_project(
+                layout,
+                output_root,
+                project,
+                skip_build=skip_build,
+                verbose=verbose,
+            )
 
     for project in git_projects:
         print(f"[blueprint-reference-harness] reference checkout: {project.project_id}")
@@ -712,6 +746,7 @@ def generate_projects(
             project,
             skip_build=skip_build,
             package_mode=reference_package_mode,
+            verbose=verbose,
         )
 
 
@@ -730,6 +765,7 @@ def command_generate(args: argparse.Namespace) -> int:
         serial=args.serial,
         allow_local_build=args.allow_local_build,
         reference_package_mode=getattr(args, "reference_package_mode", REFERENCE_PACKAGE_MODE_COPY),
+        verbose=getattr(args, "verbose", False),
     )
 
     print(f"[blueprint-reference-harness] project manifest: {manifest_path}")
@@ -817,6 +853,7 @@ def command_validate(args: argparse.Namespace) -> int:
             serial=args.serial,
             allow_local_build=args.allow_local_build,
             reference_package_mode=getattr(args, "reference_package_mode", REFERENCE_PACKAGE_MODE_COPY),
+            verbose=getattr(args, "verbose", False),
         )
     except SystemExit as err:
         failures.append(StepFailure("generate projects", str(err)))
@@ -1086,6 +1123,7 @@ def add_generation_commands(subparsers) -> None:
         action="store_true",
         help="Skip project builds and only run already-built or command-only generation steps.",
     )
+    add_generation_verbose_argument(generate)
     add_allow_unsafe_root_release_argument(generate)
     add_serial_argument(generate)
     add_allow_local_build_argument(
@@ -1119,6 +1157,7 @@ def add_generation_commands(subparsers) -> None:
         help="Skip configured Playwright browser regression suites.",
     )
     add_allow_unsafe_root_release_argument(validate)
+    add_generation_verbose_argument(validate)
     add_serial_argument(validate)
     validate.add_argument(
         "--pytest-arg",

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -207,6 +207,15 @@ private def logBuildProgress (verbose : Bool) (message : String) : IO Unit := do
   if verbose then
     writeBuildProgress message
 
+private def storedEntryCountText (count : Nat) : String :=
+  if count == 1 then
+    "1 stored entry"
+  else
+    s!"{count} stored entries"
+
+private def logBuildProgressItemCount (verbose : Bool) (label : String) (count : Nat) : IO Unit :=
+  logBuildProgress verbose s!"{label}: {storedEntryCountText count}"
+
 private def withTimedBuildProgress
     {m : Type → Type} [Monad m] [MonadLiftT BaseIO m] [MonadLiftT IO m] {α : Type}
     (verbose : Bool) (label : String) (action : m α) : m α := do
@@ -2048,12 +2057,15 @@ private def buildTraversalEntries
     (impls : ExtensionImpls)
     (logError : String → IO Unit)
     (state : TraverseState)
-    (hoverState : Verso.Code.Hover.State Output.Html) :
+    (hoverState : Verso.Code.Hover.State Output.Html)
+    (verbose : Bool := false) :
     IO (Array Entry × Array HtmlCache.Entry × Verso.Code.Hover.State Output.Html) := do
   let mut entries := #[]
   let mut htmlEntries := #[]
   let mut hoverState := hoverState
-  for decoded in Informal.PreviewSource.traversalStoredEntries state do
+  let decodedEntries := Informal.PreviewSource.traversalStoredEntries state
+  logBuildProgressItemCount verbose "traversal preview entries" decodedEntries.size
+  for decoded in decodedEntries do
     match decoded with
     | .error err =>
       logError s!"Blueprint manifest: malformed preview entry {err.canonicalName}: {err.message}"
@@ -2080,11 +2092,14 @@ private def buildExternalMarkupEntries
     (logError : String → IO Unit)
     (state : TraverseState)
     (previewBackedEntries : Array Entry)
-    (renderConfig : Informal.ExternalMarkupRender.Config := {}) :
+    (renderConfig : Informal.ExternalMarkupRender.Config := {})
+    (verbose : Bool := false) :
     IO (Array Entry × Array HtmlCache.Entry) := do
   let mut entries := #[]
   let mut htmlEntries := #[]
-  for decoded in Informal.TraversalIndex.ExternalMarkup.entries state do
+  let decodedEntries := Informal.TraversalIndex.ExternalMarkup.entries state
+  logBuildProgressItemCount verbose "external markup manifest entries" decodedEntries.size
+  for decoded in decodedEntries do
     match decoded with
     | .error err =>
       logError s!"Blueprint manifest: malformed external-markup entry {err.canonicalName}: {err.message}"
@@ -2191,8 +2206,8 @@ private def buildLeanCodeEntries
       let decodedEntries := Informal.TraversalIndex.LeanCodePreviews.entries state
       let decodeFinish ← IO.monoMsNow
       logBuildProgress true <|
-        s!"Lean code preview entries decoded in {elapsedMsText (decodeFinish - decodeStart)} " ++
-        s!"({decodedEntries.size} stored entries)"
+        s!"Lean code preview entries: {storedEntryCountText decodedEntries.size}; " ++
+        s!"decoded in {elapsedMsText (decodeFinish - decodeStart)}"
       pure decodedEntries
     else
       pure <| Informal.TraversalIndex.LeanCodePreviews.entries state
@@ -2348,10 +2363,10 @@ def buildPreviewDataFiles
   let hoverState := HtmlCache.initialHoverState
   let (traversalPreviews, traversalHtml, hoverState) ←
     withTimedBuildProgress verbose "building traversal preview entries" <|
-      buildTraversalEntries impls logError state hoverState
+      buildTraversalEntries impls logError state hoverState (verbose := verbose)
   let (externalMarkupPreviews, externalMarkupHtml) ←
     withTimedBuildProgress verbose "building external markup manifest entries" <|
-      buildExternalMarkupEntries logError state traversalPreviews externalMarkupConfig
+      buildExternalMarkupEntries logError state traversalPreviews externalMarkupConfig (verbose := verbose)
   let (leanCodePreviews, leanCodeHtml, hoverState) ←
     withTimedBuildProgress verbose "building Lean code preview entries" <|
       buildLeanCodeEntries impls logError state hoverState (verbose := verbose)

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -158,6 +158,13 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertEqual(parser.parse_args(["generate", "--reference-package-mode", "move"]).reference_package_mode, "move")
         self.assertEqual(parser.parse_args(["validate", "--reference-package-mode", "move"]).reference_package_mode, "move")
 
+    def test_reference_generation_commands_parse_verbose(self) -> None:
+        parser = reference_harness_mod.build_parser()
+        self.assertFalse(parser.parse_args(["generate"]).verbose)
+        self.assertTrue(parser.parse_args(["generate", "--verbose"]).verbose)
+        self.assertFalse(parser.parse_args(["validate"]).verbose)
+        self.assertTrue(parser.parse_args(["validate", "--verbose"]).verbose)
+
     def test_reference_projects_parses_release_filter(self) -> None:
         parser = reference_harness_mod.build_parser()
         args = parser.parse_args(["projects", "--release", "v4.29.0"])
@@ -1936,7 +1943,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         with patched_attrs(
             reference_harness_mod,
             ensure_prebuilt_executable=lambda _package_root, _exe_name: Path("/tmp/demo"),
-            render_in_repo_projects=lambda _package_root, _output_root, _projects, _serial: None,
+            render_in_repo_projects=lambda _package_root, _output_root, _projects, _serial, *, verbose=False: None,
         ):
             generate_projects(
                 layout,

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -1589,7 +1589,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 commands_mod.run = lambda command, *, cwd: commands.append(command)
                 commands_mod.run_with_heartbeat = lambda command, *, cwd, label: commands.append(command)
 
-                generate_git_project(layout, output_root, project, skip_build=False)
+                generate_git_project(layout, output_root, project, skip_build=False, verbose=True)
             finally:
                 for name, value in originals.items():
                     if name == "command_rewrite_local_blueprint_dependency":
@@ -1609,7 +1609,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertTrue(
             any(
                 command[1:]
-                == [*VBP_BUILD_COMMAND, "--output", str(output_root / "external-blueprint")]
+                == [*VBP_BUILD_COMMAND, "--output", str(output_root / "external-blueprint"), "--verbose"]
                 for command in commands
             )
         )


### PR DESCRIPTION
## Summary
Backport #299 to `v4.31.0`.

## Primary Review
- Primary review: #299
- Keep review comments on #299 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.31.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- Conflict resolution kept the release-line reference harness API and did not pull in unrelated newer `--pdf` harness plumbing.