### PR TITLE
[backport v4.30.0] fix: report malformed graph cache entries

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -375,11 +375,17 @@ def graphForRenderedBlock
     (semantic : Informal.Graph.GraphData) : Informal.Graph.GraphData :=
   Informal.GraphApi.finalDataForBlock state blockId semantic
 
-def allRenderedGraphs
+def allRenderedGraphEntries
     (state : Verso.Genre.Manual.TraverseState) :
-    Array Informal.Graph.GraphData :=
-  Informal.GraphApi.cachedData state
+    Array (Except Informal.TraversalIndex.DecodeError
+      (Informal.TraversalIndex.StoredEntry Informal.Graph.GraphData)) :=
+  Informal.GraphApi.cachedEntries state
 ```
+
+`cachedEntries` preserves malformed traversal-cache records as `DecodeError`
+values and successful records as canonical-name/data pairs, so callers can
+report corruption instead of silently omitting graphs. The generated-manifest
+path reports those errors and continues with valid graph entries.
 
 Generated `blueprint-manifest.json` includes a `graphs` array. Each entry
 contains `schemaVersion`, `nodes`, `edges`, and `groups`, with status enums,

--- a/src/VersoBlueprint/GraphApi.lean
+++ b/src/VersoBlueprint/GraphApi.lean
@@ -153,7 +153,7 @@ def finalDataForBlockWithOptions
 Store graph block data during traversal.
 
 The cached payload deliberately remains semantic data plus the stable block key;
-call `cachedData` after traversal finishes to read the public, finalized form.
+call `cachedEntries` after traversal finishes to read the public, finalized form.
 -/
 def saveData
     (state : TraverseState)
@@ -168,13 +168,22 @@ def saveData
     |> (fun state => Informal.TraversalIndex.Graphs.saveData state key cached)
 
 /--
-Read every traversal-cached graph and finalize it for public manifest/API use.
+Decode every traversal-cached graph and finalize valid entries for public
+manifest/API use while preserving malformed-entry diagnostics.
 
 Call this only with the completed traversal state for the document/site being
-emitted.
+emitted. The consumer owns error reporting because it defines the generation
+boundary and its diagnostic context.
 -/
-def cachedData (state : TraverseState) : Array Informal.Graph.GraphData :=
-  Informal.TraversalIndex.Graphs.allData state |>.map fun cached =>
-    finalDataWithVariants state cached.data cached.options
+def cachedEntries (state : TraverseState) :
+    Array (Except Informal.TraversalIndex.DecodeError
+      (Informal.TraversalIndex.StoredEntry Informal.Graph.GraphData)) :=
+  Informal.TraversalIndex.Graphs.entries state |>.map fun
+    | .error err => .error err
+    | .ok stored =>
+        .ok {
+          canonicalName := stored.canonicalName
+          data := finalDataWithVariants state stored.data.data stored.data.options
+        }
 
 end Informal.GraphApi

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -2378,7 +2378,14 @@ def buildPreviewDataFiles
       let htmlEntries :=
         (traversalHtml ++ externalMarkupHtml ++ leanCodeHtml ++ citationHtml).qsort
           (fun a b => a.key < b.key)
-      let graphs := Informal.GraphApi.cachedData state
+      let mut graphEntries := #[]
+      for decoded in Informal.GraphApi.cachedEntries state do
+        match decoded with
+        | .error err =>
+            logError s!"Blueprint manifest: malformed graph entry {err.canonicalName}: {err.message}"
+        | .ok stored =>
+            graphEntries := graphEntries.push stored.data
+      let graphs := graphEntries.qsort (fun a b => a.key < b.key)
       pure (previews, htmlEntries, graphs)
   let htmlCache : HtmlCache.File := {
     entries := htmlEntries

--- a/src/VersoBlueprint/TraversalIndex.lean
+++ b/src/VersoBlueprint/TraversalIndex.lean
@@ -353,9 +353,6 @@ def entries (state : TraverseState) :
     Array (Except DecodeError (StoredEntry Informal.Graph.CachedGraphData)) :=
   decodeStoreEntries state domainName
 
-def allData (state : TraverseState) : Array Informal.Graph.CachedGraphData :=
-  entries state |>.filterMap (·.toOption.map (·.data)) |>.qsort (fun a b => a.data.key < b.data.key)
-
 end Graphs
 
 namespace TraversalPreviews

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
@@ -176,4 +176,23 @@ Base statement for graph preview mode option coverage.
       !hasSubstr out "dotByDirection"
     )
 
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (_, state) ← renderManualDocHtmlStringAndState manualImpls previewWiringDoc
+    let malformedKey := "graph:malformed"
+    let state :=
+      Informal.TraversalIndex.Graphs.saveId state malformedKey default
+        |>.saveDomainObjectData
+          Informal.TraversalIndex.Graphs.domainName malformedKey (Lean.Json.str "malformed")
+    let errors ← IO.mkRef #[]
+    let files ← Informal.PreviewManifest.buildPreviewDataFiles manualImpls
+      (fun msg => errors.modify (·.push msg)) state
+    let errors ← errors.get
+    pure <|
+      !files.manifest.graphs.isEmpty &&
+        errors.any fun msg =>
+          hasSubstr msg "Blueprint manifest: malformed graph entry graph:malformed:"
+
 end Verso.VersoBlueprintTests.BlueprintPreviewWiring.Graph


### PR DESCRIPTION
## Summary
Backport #308 to `v4.30.0`.

## Primary Review
- Primary review: #308
- Keep review comments on #308 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.30.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.
