### PR TITLE
[backport v4.30.0] fix: require code-bearing backports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,9 +65,16 @@
   default-development PR ready for review, replace every pending backport line
   with either `Backport <release>: #<pr>` or
   `Backport <release>: exempt: <reason>`.
+- Use exemptions only when every changed file is documentation or repository
+  metadata. Source, scripts, tests, templates, package configuration, and
+  runtime assets require paired backports so later backports do not accumulate
+  avoidable structural conflicts.
 - For changes that need paired backports, open the paired backport PRs before
   the default-development PR leaves draft, then wait for the paired-backport CI
   check to pass before merging.
+- `prepare-backport-pr --main-pr <pr>` derives the source branch and commit
+  series from the PR, including after merge. Use `--source-branch` only as an
+  explicit fallback when GitHub metadata is unavailable.
 - Do not hand-roll PR descriptions from local status notes or validation
   transcripts. Keep routine validation details in local/final reports unless
   they change review risk or CI cannot show them.

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -105,6 +105,10 @@ Do those upstream write actions only when they are explicitly requested.
 - Non-draft PRs targeting the default-development branch must replace each
   `pending` entry with a paired backport PR number or an explicit exemption
   reason.
+- Exemptions are limited to changes whose files are all documentation or
+  repository metadata. Source, scripts, tests, templates, package
+  configuration, and runtime assets require paired backports so maintenance
+  lines remain structurally aligned for future cherry-picks.
 - Backported default-development PRs should normally be landed with a merge
   commit rather than squash or rebase, so the source commits recorded by
   `git cherry-pick -x` remain present in default-dev history.
@@ -129,8 +133,9 @@ Do those upstream write actions only when they are explicitly requested.
   - apply the scaffolded release label, for example `backport-v4.30.0`, to the
     paired backport PR
   - when several releases are required, use `python3 -m scripts.blueprint_harness prepare-backport-pr --all-required --main-pr <pr>` to emit one scaffold block per release, then let the agent apply the `git cherry-pick -x` series and resolve conflicts in each backport worktree
-  - replace each `Backport ...: pending` line with `Backport ...: #<pr>` or
-    `Backport ...: exempt: <reason>`
+  - replace each `Backport ...: pending` line with `Backport ...: #<pr>`, or
+    use `Backport ...: exempt: <reason>` only for documentation/metadata-only
+    changes
   - wait for CI on the default-development PR and required paired PRs before
     merging the default-development PR
 - Keep review comments and design discussion on the default-dev PR unless the

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -452,13 +452,22 @@ Paste the emitted backport lines into the draft PR body. While the PR is still d
 each required line may remain:
 
 - `Backport v4.30.0: pending`
-- or `Backport v4.30.0: exempt: <reason>`
+- or, for documentation and repository-metadata-only changes,
+  `Backport v4.30.0: exempt: <reason>`
 
 Once the default-development PR is ready for review it must replace each `pending` line
 with either:
 
 - link the paired backport PR in the PR body with `Backport v4.30.0: #<pr>`
-- or record `Backport v4.30.0: exempt: <reason>`
+- or record `Backport v4.30.0: exempt: <reason>` when every changed file is
+  documentation or repository metadata
+
+Keep code-bearing release lines structurally aligned even when compatibility or a
+reported maintenance-line regression is not the motivation. Changes to source,
+scripts, tests, templates, package configuration, and runtime assets require paired
+backports because skipping them makes later cherry-picks harder. The paired-backport
+check reads the PR file list and rejects exemptions for those paths; an exemption
+reason by itself is not sufficient.
 
 Use the default-development PR as the main review surface. The paired backport
 PR is primarily a maintenance-line artifact for CI, merge state, and any
@@ -480,8 +489,14 @@ python3 -m scripts.blueprint_harness prepare-backport-pr v4.30.0 --main-pr <pr>
 
 That helper prints a standardized paired branch name, a title of the form
 `[backport v4.30.0] ...`, a `backport-v4.30.0` release label, and a PR body
-that points back to the primary
-default-development review.
+that points back to the primary default-development review. By default the
+title after the backport prefix is read from the GitHub title of `--main-pr`,
+which keeps multi-commit backports from inheriting the last local commit
+subject. The source branch and exact commit series also come from `--main-pr`,
+so the command remains correct after the default-development PR merges. Use
+`--main-title '<type>: <subject>'` or `--source-branch <branch>` only when the
+GitHub lookup is not available or you intentionally need to override that PR
+metadata.
 
 When several backport releases are required, use:
 

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from scripts.blueprint_harness_backports import backport_exemption_violations
 from scripts.blueprint_harness_branches import (
     BranchPolicyReleaseTarget,
     CHECKOUT_ROLE_CHOICES,
@@ -174,6 +175,31 @@ def github_pr_view_json(repo_root: Path, pr_number: int, fields: tuple[str, ...]
     return payload if isinstance(payload, dict) else None
 
 
+def github_pr_title(repo_root: Path, pr_number: int) -> str | None:
+    payload = github_pr_view_json(repo_root, pr_number, ("title",))
+    if payload is None:
+        return None
+    title = payload.get("title") if isinstance(payload, dict) else None
+    return title if isinstance(title, str) and title.strip() else None
+
+
+def github_pr_backport_source(repo_root: Path, pr_number: int) -> tuple[str, list[str]] | None:
+    payload = github_pr_view_json(repo_root, pr_number, ("headRefName", "commits"))
+    if payload is None:
+        return None
+    head_ref = payload.get("headRefName")
+    commits = payload.get("commits")
+    if not isinstance(head_ref, str) or not head_ref.strip() or not isinstance(commits, list):
+        return None
+    commit_oids: list[str] = []
+    for commit in commits:
+        oid = commit.get("oid") if isinstance(commit, dict) else None
+        if not isinstance(oid, str) or not oid.strip():
+            return None
+        commit_oids.append(oid)
+    return head_ref, commit_oids
+
+
 def branch_name_from_ref(ref: str) -> str:
     for prefix in ("refs/remotes/origin/", "refs/heads/", "origin/"):
         if ref.startswith(prefix):
@@ -209,6 +235,18 @@ def worktree_merged_pr_validation_error(
     return None
 
 
+def resolve_main_pr_title(repo_root: Path, args: argparse.Namespace) -> str:
+    if args.main_title is not None:
+        return validate_public_pr_title(args.main_title)
+    title = github_pr_title(repo_root, args.main_pr)
+    if title is None:
+        raise SystemExit(
+            "[blueprint-harness] unable to read the default-development PR title from GitHub; "
+            "pass `--main-title '<type>: <subject>'` explicitly."
+        )
+    return validate_public_pr_title(title)
+
+
 def validate_public_pr_title(title: str) -> str:
     normalized = title.strip()
     if normalized != title or not normalized:
@@ -237,6 +275,29 @@ def source_commit_series(repo_root: Path, source_branch: str) -> list[str]:
         capture_output=True,
     )
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def source_changed_files(repo_root: Path, source_branch: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", f"{preferred_release_ref(repo_root)}...{source_branch}"],
+        cwd=repo_root,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def resolve_backport_source(repo_root: Path, args: argparse.Namespace) -> tuple[str, list[str]]:
+    if args.source_branch is not None:
+        return args.source_branch, source_commit_series(repo_root, args.source_branch)
+    source = github_pr_backport_source(repo_root, args.main_pr)
+    if source is None:
+        raise SystemExit(
+            "[blueprint-harness] unable to read the default-development PR head and commits from GitHub; "
+            "pass `--source-branch <branch>` explicitly."
+        )
+    return source
 
 
 def resolve_create_worktree_base(layout, requested_base: str | None) -> str:
@@ -653,6 +714,8 @@ def print_public_pr_message_scaffold(
     print("- Follow Lean upstream title style: `<type>: <subject>`, without type scopes such as `feat(entry): ...`.")
     print("- Do not add generator or tool prefixes such as `[codex]` to the public PR title.")
     print("- Do not add routine validation transcripts to the PR body; CI is the default validation record.")
+    if any(": exempt:" in line for line in backport_lines):
+        print("- Use backport exemptions only for documentation and repository metadata changes; CI checks the PR file list.")
     print()
     print("## PR Title")
     print(title)
@@ -825,6 +888,13 @@ def command_prepare_pr(args: argparse.Namespace) -> int:
     source_branch = args.source_branch or current_branch_name(layout.package_root)
     if not source_branch:
         raise SystemExit("[blueprint-harness] unable to determine a source branch; pass `--source-branch` explicitly")
+    if exemptions:
+        violations = backport_exemption_violations(source_changed_files(layout.package_root, source_branch))
+        if violations:
+            raise SystemExit(
+                "[blueprint-harness] backport exemptions are limited to documentation and repository metadata; "
+                "paired backports are required for: " + ", ".join(violations)
+            )
 
     title = validate_public_pr_title(args.title or current_commit_subject(layout.package_root))
     print_public_pr_message_scaffold(
@@ -842,12 +912,8 @@ def command_prepare_backport_pr(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
     require_checkout_role(layout.package_root, required_role="default_dev", operation="prepare-backport-pr")
     targets = prepare_backport_targets(layout, args)
-    source_branch = args.source_branch or current_branch_name(layout.package_root)
-    if not source_branch:
-        raise SystemExit("[blueprint-harness] unable to determine a source branch; pass `--source-branch` explicitly")
-
-    main_title = validate_public_pr_title(args.main_title or current_commit_subject(layout.package_root))
-    source_commits = source_commit_series(layout.package_root, source_branch)
+    main_title = resolve_main_pr_title(layout.package_root, args)
+    source_branch, source_commits = resolve_backport_source(layout.package_root, args)
     default_dev = default_dev_branch(layout.package_root)
 
     for index, backport_release in enumerate(targets):
@@ -1268,7 +1334,7 @@ def add_pr_preparation_commands(subparsers) -> None:
         "--exempt",
         action="append",
         default=None,
-        help="Pre-fill one required branch as `exempt: <reason>` using `--exempt <branch>=<reason>`. Repeat as needed.",
+        help="Pre-fill one documentation/metadata-only exemption using `--exempt <branch>=<reason>`. Repeat as needed.",
     )
     prepare_backports.set_defaults(func=command_prepare_backports)
 
@@ -1301,7 +1367,7 @@ def add_pr_preparation_commands(subparsers) -> None:
         "--exempt",
         action="append",
         default=None,
-        help="Pre-fill one required backport branch as `exempt: <reason>`. Repeat as needed.",
+        help="Pre-fill one documentation/metadata-only backport exemption. Repeat as needed.",
     )
     prepare_pr.set_defaults(func=command_prepare_pr)
 
@@ -1333,7 +1399,7 @@ def add_pr_preparation_commands(subparsers) -> None:
     prepare_backport_pr.add_argument(
         "--source-branch",
         default=None,
-        help="Override the default-development branch name. Defaults to the current branch.",
+        help="Override the source branch. Defaults to the head branch and commit series of `--main-pr`.",
     )
     prepare_backport_pr.set_defaults(func=command_prepare_backport_pr)
 

--- a/scripts/blueprint_harness_backports.py
+++ b/scripts/blueprint_harness_backports.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+EXEMPT_FILE_NAMES = frozenset(
+    {
+        ".gitattributes",
+        ".gitignore",
+        "branch-policy.json",
+        "LICENSE",
+    }
+)
+EXEMPT_PATH_PREFIXES = (".github/", "doc/", "LICENSES/")
+
+
+def backport_exemption_violations(paths: Iterable[str]) -> tuple[str, ...]:
+    """Return changed paths that require release-line backports."""
+    violations: list[str] = []
+    for raw_path in paths:
+        path = raw_path.removeprefix("./")
+        exempt = (
+            path.endswith(".md")
+            or path in EXEMPT_FILE_NAMES
+            or path.startswith(EXEMPT_PATH_PREFIXES)
+        )
+        if not exempt:
+            violations.append(path)
+    return tuple(violations)

--- a/scripts/check_backport_pr.py
+++ b/scripts/check_backport_pr.py
@@ -16,6 +16,7 @@ if str(Path(__file__).resolve().parents[1]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.blueprint_harness_branches import load_branch_policy
+from scripts.blueprint_harness_backports import backport_exemption_violations
 
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
@@ -111,6 +112,24 @@ class GitHubApi:
 
     def commit_diff(self, sha: str) -> str:
         return self.get_text(f"/repos/{self.repo_full_name}/commits/{sha}", accept="application/vnd.github.diff")
+
+    def pull_request_files(self, number: int) -> list[str]:
+        files: list[str] = []
+        page = 1
+        while True:
+            data = self.get_json(f"/repos/{self.repo_full_name}/pulls/{number}/files?per_page=100&page={page}")
+            if not isinstance(data, list):
+                raise BackportCheckError(f"Unexpected file payload for PR #{number}")
+            if not data:
+                return files
+            for item in data:
+                filename = item.get("filename") if isinstance(item, dict) else None
+                if not isinstance(filename, str) or not filename:
+                    raise BackportCheckError(f"Unexpected file payload shape for PR #{number}")
+                files.append(filename)
+            if len(data) < 100:
+                return files
+            page += 1
 
 
 def parse_args() -> argparse.Namespace:
@@ -303,6 +322,22 @@ def verify_backport_pr(
     verify_backport_commit_series(api, source_pr_number, entry.pr_number)
 
 
+def verify_backport_exemptions(
+    api: GitHubApi,
+    source_pr_number: int,
+    entries: dict[str, BackportEntry],
+) -> None:
+    exempt_branches = [entry.branch for entry in entries.values() if entry.exempt_reason is not None]
+    if not exempt_branches:
+        return
+    violations = backport_exemption_violations(api.pull_request_files(source_pr_number))
+    if violations:
+        raise BackportCheckError(
+            "backport exemptions are limited to documentation and repository metadata changes; "
+            "paired backports are required for " + ", ".join(violations)
+        )
+
+
 def event_pull_request(event: dict[str, Any]) -> dict[str, Any]:
     pull_request = event.get("pull_request")
     if not isinstance(pull_request, dict):
@@ -334,6 +369,25 @@ def run(event_path: str | None, token: str | None) -> int:
     draft = bool(pull_request.get("draft"))
     body = str(pull_request.get("body") or "")
     entries = validate_backport_entries(body, policy.required_backport_branches, allow_pending=draft)
+    entries_to_verify = [entries[branch] for branch in policy.required_backport_branches if entries[branch].pr_number is not None]
+    exemptions_to_verify = [entries[branch] for branch in policy.required_backport_branches if entries[branch].exempt_reason is not None]
+    needs_api = bool(exemptions_to_verify or (not draft and entries_to_verify))
+    if needs_api:
+        repository = event.get("repository")
+        if not isinstance(repository, dict) or not isinstance(repository.get("full_name"), str):
+            raise BackportCheckError("event payload is missing repository.full_name")
+        source_pr_number_raw = pull_request.get("number", event.get("number"))
+        try:
+            source_pr_number = int(source_pr_number_raw)
+        except (TypeError, ValueError) as err:
+            raise BackportCheckError("event payload is missing the default-development PR number") from err
+        if not token:
+            raise BackportCheckError("missing GitHub token; pass --token or set GITHUB_TOKEN")
+        api = GitHubApi(repository["full_name"], token)
+        verify_backport_exemptions(api, source_pr_number, entries)
+    else:
+        source_pr_number = 0
+        api = None
     if draft:
         print("[backport-check] draft PR; enforcing declared backport plan only")
         for branch in policy.required_backport_branches:
@@ -349,22 +403,6 @@ def run(event_path: str | None, token: str | None) -> int:
                     "paired PR structure will be verified after ready for review"
                 )
         return 0
-
-    repository = event.get("repository")
-    if not isinstance(repository, dict) or not isinstance(repository.get("full_name"), str):
-        raise BackportCheckError("event payload is missing repository.full_name")
-    entries_to_verify = [entries[branch] for branch in policy.required_backport_branches if entries[branch].pr_number is not None]
-    if entries_to_verify:
-        source_pr_number_raw = pull_request.get("number", event.get("number"))
-        try:
-            source_pr_number = int(source_pr_number_raw)
-        except (TypeError, ValueError) as err:
-            raise BackportCheckError("event payload is missing the default-development PR number") from err
-    else:
-        source_pr_number = 0
-    if entries_to_verify and not token:
-        raise BackportCheckError("missing GitHub token; pass --token or set GITHUB_TOKEN")
-    api = GitHubApi(repository["full_name"], token) if entries_to_verify else None
 
     for branch in policy.required_backport_branches:
         entry = entries[branch]

--- a/tests/harness/test_backport_pr_check.py
+++ b/tests/harness/test_backport_pr_check.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import tempfile
 import unittest
+from unittest.mock import patch
 from pathlib import Path
 
 from scripts.blueprint_harness_branches import load_branch_policy
@@ -22,10 +23,12 @@ class FakeGitHubApi:
         pull_requests: dict[int, dict[str, object]] | None = None,
         pull_request_commits: dict[int, list[backport_mod.PullRequestCommit]] | None = None,
         commit_diffs: dict[str, str] | None = None,
+        pull_request_files: dict[int, list[str]] | None = None,
     ) -> None:
         self._pull_requests = pull_requests or {}
         self._pull_request_commits = pull_request_commits or {}
         self._commit_diffs = commit_diffs or {}
+        self._pull_request_files = pull_request_files or {}
 
     def pull_request(self, number: int) -> dict[str, object]:
         return self._pull_requests[number]
@@ -35,6 +38,9 @@ class FakeGitHubApi:
 
     def commit_diff(self, sha: str) -> str:
         return self._commit_diffs[sha]
+
+    def pull_request_files(self, number: int) -> list[str]:
+        return self._pull_request_files[number]
 
 
 def diff_for(line: str) -> str:
@@ -54,6 +60,7 @@ def write_pull_request_event(path: Path, *, draft: bool, body: str) -> None:
             {
                 "repository": {"full_name": "leanprover/verso-blueprint"},
                 "pull_request": {
+                    "number": 11,
                     "base": {"ref": DEFAULT_DEV_RELEASE},
                     "draft": draft,
                     "body": body,
@@ -212,11 +219,41 @@ Backport v4.26.0: exempt: no longer maintained
             with self.assertRaisesRegex(backport_mod.BackportCheckError, "pending backport entries are not allowed"):
                 backport_mod.run(str(event_path), token=None)
 
-    def test_run_accepts_ready_default_dev_prs_with_only_exemptions_and_no_token(self) -> None:
+    def test_run_accepts_ready_docs_only_exemptions(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             event_path = Path(tmp) / "event.json"
-            write_pull_request_event(event_path, draft=False, body=required_backport_body("exempt: docs-only change"))
-            self.assertEqual(backport_mod.run(str(event_path), token=None), 0)
+            write_pull_request_event(
+                event_path,
+                draft=False,
+                body=required_backport_body("exempt: docs-only change"),
+            )
+            api = FakeGitHubApi(pull_request_files={11: ["doc/API.md", "README.md"]})
+            with patch.object(backport_mod, "GitHubApi", return_value=api):
+                self.assertEqual(backport_mod.run(str(event_path), token="token"), 0)
+
+    def test_run_rejects_source_change_exemptions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            event_path = Path(tmp) / "event.json"
+            write_pull_request_event(
+                event_path,
+                draft=False,
+                body=required_backport_body("exempt: no reported release-line regression"),
+            )
+            api = FakeGitHubApi(pull_request_files={11: ["src/VersoBlueprint/GraphApi.lean", "doc/API.md"]})
+            with patch.object(backport_mod, "GitHubApi", return_value=api):
+                with self.assertRaisesRegex(backport_mod.BackportCheckError, "paired backports are required"):
+                    backport_mod.run(str(event_path), token="token")
+
+    def test_run_requires_token_to_validate_exemptions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            event_path = Path(tmp) / "event.json"
+            write_pull_request_event(
+                event_path,
+                draft=False,
+                body=required_backport_body("exempt: docs-only change"),
+            )
+            with self.assertRaisesRegex(backport_mod.BackportCheckError, "missing GitHub token"):
+                backport_mod.run(str(event_path), token=None)
 
 
 if __name__ == "__main__":

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import tempfile
 from types import SimpleNamespace
 import unittest
+from unittest.mock import patch
 
 import scripts.blueprint_harness as harness_mod
 import scripts.blueprint_reference_harness as reference_harness_mod
@@ -587,6 +588,56 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             with self.assertRaisesRegex(SystemExit, "without type scopes"):
                 harness_mod.command_prepare_pr(args)
 
+    def test_prepare_pr_rejects_source_change_exemptions(self) -> None:
+        args = argparse.Namespace(
+            title="fix: report malformed graph cache entries",
+            summary=None,
+            change=None,
+            source_branch="fix/traversal-decode-errors",
+            exempt=["v4.28.0=no reported release-line regression"],
+        )
+        layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            load_branch_policy=lambda _checkout_root: SimpleNamespace(
+                default_dev_branch="v4.29.0",
+                required_backport_branches=("v4.28.0",),
+            ),
+            require_checkout_role=lambda *_args, **_kwargs: None,
+            source_changed_files=lambda _repo_root, _source_branch: [
+                "src/VersoBlueprint/GraphApi.lean",
+                "doc/API.md",
+            ],
+        ):
+            with self.assertRaisesRegex(SystemExit, "paired backports are required for: src/VersoBlueprint/GraphApi.lean"):
+                harness_mod.command_prepare_pr(args)
+
+    def test_prepare_pr_accepts_documentation_only_exemptions(self) -> None:
+        args = argparse.Namespace(
+            title="doc: clarify backport policy",
+            summary=None,
+            change=None,
+            source_branch="doc/backport-policy",
+            exempt=["v4.28.0=documentation-only change"],
+        )
+        layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
+        out = io.StringIO()
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            load_branch_policy=lambda _checkout_root: SimpleNamespace(
+                default_dev_branch="v4.29.0",
+                required_backport_branches=("v4.28.0",),
+            ),
+            require_checkout_role=lambda *_args, **_kwargs: None,
+            source_changed_files=lambda _repo_root, _source_branch: ["doc/MAINTAINER_GUIDE.md"],
+        ):
+            with redirect_stdout(out):
+                self.assertEqual(harness_mod.command_prepare_pr(args), 0)
+
+        self.assertIn("Backport v4.28.0: exempt: documentation-only change", out.getvalue())
+
     def test_prepare_pr_allows_squash_when_all_backports_are_exempt(self) -> None:
         out = io.StringIO()
         with redirect_stdout(out):
@@ -651,6 +702,104 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertIn("## PR Body", output)
         self.assertIn("Primary review: #11", output)
         self.assertIn("Keep review comments on #11 unless this backport diverges materially.", output)
+
+    def test_prepare_backport_pr_defaults_to_github_pr_title(self) -> None:
+        args = argparse.Namespace(
+            release="v4.28.0",
+            all_required=False,
+            main_pr=11,
+            main_title=None,
+            source_branch="feat/multi-commit-branch",
+        )
+        layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
+        out = io.StringIO()
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            load_branch_policy=lambda _checkout_root: SimpleNamespace(
+                default_dev_branch="v4.29.0",
+                required_backport_branches=("v4.28.0",),
+            ),
+            default_dev_branch=lambda _checkout_root: "v4.29.0",
+            require_checkout_role=lambda *_args, **_kwargs: None,
+            source_commit_series=lambda _repo_root, _source_branch: ["abc123", "def456"],
+            github_pr_title=lambda _repo_root, _main_pr: "feat: branch-level render API cleanup",
+            current_commit_subject=lambda _checkout_root: "fix: support release-line highlight patches",
+        ):
+            with redirect_stdout(out):
+                self.assertEqual(harness_mod.command_prepare_backport_pr(args), 0)
+
+        output = out.getvalue()
+        self.assertIn("paired_title=[backport v4.28.0] feat: branch-level render API cleanup", output)
+        self.assertIn("## PR Title\n[backport v4.28.0] feat: branch-level render API cleanup", output)
+        self.assertNotIn("fix: support release-line highlight patches", output)
+
+    def test_prepare_backport_pr_defaults_source_to_main_pr(self) -> None:
+        args = argparse.Namespace(
+            release="v4.28.0",
+            all_required=False,
+            main_pr=11,
+            main_title="fix: report malformed graph cache entries",
+            source_branch=None,
+        )
+        layout = SimpleNamespace(package_root=Path("/tmp/worktree"))
+        out = io.StringIO()
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            load_branch_policy=lambda _checkout_root: SimpleNamespace(
+                default_dev_branch="v4.29.0",
+                required_backport_branches=("v4.28.0",),
+            ),
+            default_dev_branch=lambda _checkout_root: "v4.29.0",
+            require_checkout_role=lambda *_args, **_kwargs: None,
+            github_pr_backport_source=lambda _repo_root, _main_pr: (
+                "fix/traversal-decode-errors",
+                ["abc123"],
+            ),
+        ):
+            with redirect_stdout(out):
+                self.assertEqual(harness_mod.command_prepare_backport_pr(args), 0)
+
+        output = out.getvalue()
+        self.assertIn("source_branch=fix/traversal-decode-errors", output)
+        self.assertIn("source_commits=abc123", output)
+        self.assertIn("paired_branch=fix/backport-v428-traversal-decode-errors", output)
+
+    def test_github_pr_backport_source_reads_head_and_commits(self) -> None:
+        with patched_attrs(
+            harness_mod,
+            github_pr_view_json=lambda _repo_root, _pr_number, _fields: {
+                "headRefName": "fix/traversal-decode-errors",
+                "commits": [{"oid": "abc123"}, {"oid": "def456"}],
+            },
+        ):
+            source = harness_mod.github_pr_backport_source(Path("/tmp/worktree"), 11)
+
+        self.assertEqual(source, ("fix/traversal-decode-errors", ["abc123", "def456"]))
+
+    def test_github_pr_title_reads_public_title(self) -> None:
+        with patch(
+            "scripts.blueprint_harness.subprocess.run",
+            return_value=SimpleNamespace(returncode=0, stdout='{"title":"doc: clarify API"}'),
+        ) as run_mock:
+            title = harness_mod.github_pr_title(Path("/tmp/worktree"), 11)
+
+        self.assertEqual(title, "doc: clarify API")
+        run_mock.assert_called_once_with(
+            ["gh", "pr", "view", "11", "--repo", "leanprover/verso-blueprint", "--json", "title"],
+            cwd=Path("/tmp/worktree"),
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_github_pr_title_returns_none_for_lookup_failure(self) -> None:
+        with patch(
+            "scripts.blueprint_harness.subprocess.run",
+            return_value=SimpleNamespace(returncode=1, stdout=""),
+        ):
+            self.assertIsNone(harness_mod.github_pr_title(Path("/tmp/worktree"), 11))
 
     def test_worktree_merged_pr_validation_accepts_matching_metadata(self) -> None:
         worktree = GitWorktree(


### PR DESCRIPTION
## Summary
Backport #311 to `v4.30.0`.

## Primary Review
- Primary review: #311
- Keep review comments on #311 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.30.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- Preserve the existing `v4.30.0` patch-identity verification alongside the new exemption file-list check.
- Include the PR title/source lookup helpers that were already present on newer release lines and are required by the post-merge scaffold fix.
