### PR TITLE
fix: keep reference builds current and OLean-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,10 +364,11 @@ you want to enable it.
 
 ## Reference Blueprints
 
-The repository also tracks a release-versioned reference catalog. On the
-current `v4.32.0` line, the in-repo starter template is the active reference
-target. External blueprints keep their last published release links until their
-upstream repositories have been updated and validated for the new Lean release.
+The repository also tracks a current, release-versioned reference catalog.
+Each external Blueprint is published only for its intended current release:
+Noperthedron and FLT on `v4.32.0`, and Sphere Packing and Carleson on
+`v4.30.0`. The in-repo starter template continues to validate maintained
+release lines.
 
 - [project_template/](./project_template/), the in-repo starter template,
   [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/project-template/)

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -794,11 +794,12 @@ The harness is now project-driven rather than hardcoded to one project.
 - keep each external Blueprint on its one intended current release target;
   move that target when the project advances instead of retaining published
   legacy targets for older releases
-- prefer `lake exe vbp build` for package-local generation, or a build command
-  that targets only the Lean library or formalization artifacts needed by the
-  document followed by
+- prefer `lake exe vbp build` for package-local generation; if the harness must
+  drive an external project explicitly, build only the generator module's OLean
+  dependency closure with `lake build +<GeneratorModule>:olean`, followed by
   `lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean ...` when the
-  harness must drive an external project explicitly
+  harness must drive an external project explicitly; do not use Lake's default
+  `leanArts` facet because it also emits C
 - the harness currently rewrites the cloned `lakefile.lean` dependency line so
   external test projects exercise the local `VersoBlueprint` checkout instead
   of the committed upstream dependency

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -795,8 +795,8 @@ The harness is now project-driven rather than hardcoded to one project.
   move that target when the project advances instead of retaining published
   legacy targets for older releases
 - prefer `lake exe vbp build` for package-local generation; if the harness must
-  drive an external project explicitly, build only the generator module's OLean
-  dependency closure with `lake build +<GeneratorModule>:olean`, followed by
+  drive an external project explicitly, build only the Blueprint library's OLean
+  dependency closure with `lake build +<BlueprintLibrary>:olean`, followed by
   `lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean ...` when the
   harness must drive an external project explicitly; do not use Lake's default
   `leanArts` facet because it also emits C

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -791,6 +791,9 @@ The harness is now project-driven rather than hardcoded to one project.
   generation commands needed after checkout
 - each project target owns its release ref, optional RC metadata, and
   `publish_reference: true` marker for the release-facing published catalog
+- keep each external Blueprint on its one intended current release target;
+  move that target when the project advances instead of retaining published
+  legacy targets for older releases
 - prefer `lake exe vbp build` for package-local generation, or a build command
   that targets only the Lean library or formalization artifacts needed by the
   document followed by
@@ -799,6 +802,8 @@ The harness is now project-driven rather than hardcoded to one project.
 - the harness currently rewrites the cloned `lakefile.lean` dependency line so
   external test projects exercise the local `VersoBlueprint` checkout instead
   of the committed upstream dependency
+- the external checkout's Lean release family must match its catalog target;
+  the harness rejects cross-release combinations before running `lake update`
 - the current local override injection expects a `lakefile.lean` project that
   declares `VersoBlueprint` from the official `leanprover/verso-blueprint` Git
   repository, and it tolerates different Git refs and URL spellings for that

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -1159,13 +1159,13 @@ lake exe vbp build
 lake exe vbp build --serve
 ```
 
-It builds the generator module's OLean dependency closure, prepares and runs
+It builds the Blueprint library's OLean dependency closure, prepares and runs
 the generator, and optionally serves the result. When a maintainer harness or
 advanced CI job must drive those stages explicitly, the equivalent lower-level
 shape is:
 
 ```bash
-lake build +<GeneratorModule>:olean
+lake build +<BlueprintLibrary>:olean
 lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean --output _out/site
 ```
 

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -1159,14 +1159,19 @@ lake exe vbp build
 lake exe vbp build --serve
 ```
 
-It performs the package build, generator preparation, generator run, and
-optional local serving. When a maintainer harness or advanced CI job must drive
-those stages explicitly, the equivalent lower-level shape is:
+It builds the generator module's OLean dependency closure, prepares and runs
+the generator, and optionally serves the result. When a maintainer harness or
+advanced CI job must drive those stages explicitly, the equivalent lower-level
+shape is:
 
 ```bash
-lake build <library-or-formalization-target>
+lake build +<GeneratorModule>:olean
 lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean --output _out/site
 ```
+
+Keep the explicit `:olean` facet. The default `leanArts` facet also emits C and
+can accidentally turn a Blueprint generation run into a native dependency
+build.
 
 The project helper can emit TeX and compile a PDF in the same run:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,7 +7,7 @@ For package-facing usage, use `lake exe vbp build` or the project's Blueprint
 generator entry point, not the Python harness here. CI and Mathlib-heavy
 projects can run
 `lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean --output ...`
-after building `+<GeneratorModule>:olean`. Keep the explicit OLean facet so
+after building `+<BlueprintLibrary>:olean`. Keep the explicit OLean facet so
 generation cannot trigger native C builds of Mathlib dependencies. Start with the top-level
 [`README.md`](../README.md) and [`doc/MANUAL.md`](../doc/MANUAL.md).
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,7 +7,8 @@ For package-facing usage, use `lake exe vbp build` or the project's Blueprint
 generator entry point, not the Python harness here. CI and Mathlib-heavy
 projects can run
 `lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean --output ...`
-after building the needed Lean library artifacts. Start with the top-level
+after building `+<GeneratorModule>:olean`. Keep the explicit OLean facet so
+generation cannot trigger native C builds of Mathlib dependencies. Start with the top-level
 [`README.md`](../README.md) and [`doc/MANUAL.md`](../doc/MANUAL.md).
 
 For repository maintenance, the canonical workflow document is

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -194,10 +194,12 @@ def reconcile_reference_toolchains(package_root: Path, project_dir: Path) -> Ref
             changed_paths=(),
         )
     if package_candidate.release_branch != project_candidate.release_branch:
-        return ReferenceToolchainReconciliationResult(
-            selected_ref=None,
-            release_branch=None,
-            changed_paths=(),
+        raise SystemExit(
+            "[blueprint-harness] reference Blueprint release mismatch: "
+            f"project `{project_dir}` uses Lean `{project_candidate.lean_ref}` "
+            f"({project_candidate.release_branch}), but the selected Verso Blueprint checkout "
+            f"uses Lean `{package_candidate.lean_ref}` ({package_candidate.release_branch}). "
+            "Catalog each external Blueprint only under its current matching release."
         )
 
     common_branch = package_candidate.release_branch

--- a/scripts/blueprint_harness_utils.py
+++ b/scripts/blueprint_harness_utils.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 import shutil
 import re
+import signal
 import subprocess
 import sys
 import time
@@ -90,6 +91,35 @@ def timed_step(label: str):
         print(f"[blueprint-harness] finished {label} in {elapsed}", flush=True)
 
 
+def spawn_managed_process(command: list[str], *, cwd: Path) -> subprocess.Popen[bytes]:
+    return subprocess.Popen(command, cwd=cwd, start_new_session=os.name == "posix")
+
+
+def terminate_managed_process(proc: subprocess.Popen[bytes], *, timeout_seconds: int = 5) -> None:
+    if proc.poll() is not None:
+        return
+    if os.name == "posix":
+        try:
+            os.killpg(proc.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+    else:
+        proc.terminate()
+    try:
+        proc.wait(timeout=timeout_seconds)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    if os.name == "posix":
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+    else:
+        proc.kill()
+    proc.wait()
+
+
 def run_with_heartbeat(
     command: list[str],
     *,
@@ -100,7 +130,7 @@ def run_with_heartbeat(
     print(f"[blueprint-harness] $ {format_command(command)}")
     with timed_step(label):
         start = time.monotonic()
-        proc = subprocess.Popen(command, cwd=cwd)
+        proc = spawn_managed_process(command, cwd=cwd)
         try:
             while True:
                 try:
@@ -115,9 +145,7 @@ def run_with_heartbeat(
             if returncode != 0:
                 raise subprocess.CalledProcessError(returncode, command)
         except BaseException:
-            if proc.poll() is None:
-                proc.kill()
-                proc.wait()
+            terminate_managed_process(proc)
             raise
 
 

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -68,6 +68,8 @@ from scripts.blueprint_harness_utils import (
     print_failure_summary,
     run,
     run_capturing_failure,
+    spawn_managed_process,
+    terminate_managed_process,
 )
 from scripts.blueprint_harness_validation import SiteValidationCheck, run_site_validation_checks
 from scripts.blueprint_harness_worktrees import git_worktrees, rev_list_counts, worktree_is_clean
@@ -672,7 +674,7 @@ def render_in_repo_projects(
                 *reference_executable_args(package_root, project, output_dir, pdf=pdf, verbose=verbose),
             )
             print(f"[blueprint-reference-harness] launching {project.project_id} -> {output_dir}", flush=True)
-            procs.append((project.project_id, subprocess.Popen(command, cwd=package_root)))
+            procs.append((project.project_id, spawn_managed_process(command, cwd=package_root)))
 
         failures: list[str] = []
         for project_id, proc in procs:
@@ -684,8 +686,7 @@ def render_in_repo_projects(
             raise SystemExit(f"[blueprint-reference-harness] project render failed: {', '.join(failures)}")
     finally:
         for _, proc in procs:
-            if proc.poll() is None:
-                proc.kill()
+            terminate_managed_process(proc)
 
 
 def generate_projects(

--- a/skills/verso-blueprint/references/vbp.md
+++ b/skills/verso-blueprint/references/vbp.md
@@ -45,11 +45,11 @@ Defaults:
 `discover` reports the Lake-backed package, generator entry point, generator module, generator source file, and default output paths. Fields ending in `Guess`, such as `topLevelBlueprintModuleGuess` and `chapterCandidateGuesses`, are convention-based hints for agents and may be null or incomplete. The JSON includes `"apiStability":"unstable"` and a `discoveryErrors` array. When Lake workspace discovery fails or no generator entry point can be found, package and generator fields are null and `discoveryErrors` explains why.
 
 `build` discovers the generator entry point directly, builds only the
-generator module's OLean dependency closure, prepares/elaborates the generator
+Blueprint library's OLean dependency closure, prepares/elaborates the generator
 file with Lake, then runs the generator through Lean's interpreter:
 
 ```bash
-lake build +<GeneratorModule>:olean
+lake build +<BlueprintLibrary>:olean
 lake lean <GeneratorMain>.lean
 lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean --output <output>
 ```
@@ -96,7 +96,7 @@ The command exits nonzero when generated data is missing, malformed, or internal
 For older projects, inspect the generator entry point, then use:
 
 ```bash
-lake build +<GeneratorModule>:olean
+lake build +<BlueprintLibrary>:olean
 lake lean <GeneratorMain>.lean
 lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean --output _out/site
 lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean --dump-manifest

--- a/skills/verso-blueprint/references/vbp.md
+++ b/skills/verso-blueprint/references/vbp.md
@@ -44,12 +44,19 @@ Defaults:
 
 `discover` reports the Lake-backed package, generator entry point, generator module, generator source file, and default output paths. Fields ending in `Guess`, such as `topLevelBlueprintModuleGuess` and `chapterCandidateGuesses`, are convention-based hints for agents and may be null or incomplete. The JSON includes `"apiStability":"unstable"` and a `discoveryErrors` array. When Lake workspace discovery fails or no generator entry point can be found, package and generator fields are null and `discoveryErrors` explains why.
 
-`build` discovers the generator entry point directly, runs `lake build <package>`, prepares/elaborates the generator file with Lake so imported OLeans are materialized, then runs the generator through Lean's interpreter:
+`build` discovers the generator entry point directly, builds only the
+generator module's OLean dependency closure, prepares/elaborates the generator
+file with Lake, then runs the generator through Lean's interpreter:
 
 ```bash
+lake build +<GeneratorModule>:olean
 lake lean <GeneratorMain>.lean
 lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean --output <output>
 ```
+
+The explicit `:olean` facet is important for Mathlib consumers: Lake's default
+`leanArts` facet also emits C and can otherwise trigger an unintended native
+dependency rebuild.
 
 `build --verbose` passes `--verbose` through to the generator run, enabling Blueprint generation phase progress after the Lake package build completes.
 
@@ -89,7 +96,7 @@ The command exits nonzero when generated data is missing, malformed, or internal
 For older projects, inspect the generator entry point, then use:
 
 ```bash
-lake build <library-or-formalization-target>
+lake build +<GeneratorModule>:olean
 lake lean <GeneratorMain>.lean
 lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean --output _out/site
 lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean --dump-manifest

--- a/src/VersoBlueprint/VbpMain.lean
+++ b/src/VersoBlueprint/VbpMain.lean
@@ -85,12 +85,12 @@ def generatorModuleFromFile (path : FilePath) : String :=
       text
   text.replace "/" "."
 
-/-- Build only the generator module's OLean dependency closure.
+/-- Build only the Blueprint library's OLean dependency closure.
 
 The default `leanArts` facet also emits C, which can turn a Blueprint build in
 a Mathlib consumer into an accidental native rebuild of Mathlib. -/
-def generatorOLeanTarget (generatorModule : String) : String :=
-  s!"+{generatorModule}:olean"
+def packageOLeanTarget (packageName : String) : String :=
+  s!"+{packageName}:olean"
 
 structure ProjectInfo where
   packageName : String
@@ -249,7 +249,7 @@ structure BuildOptions where
   port? : Option Nat := none
 
 structure BuildPlan where
-  generatorOLeanTarget : String
+  packageOLeanTarget : String
   generatorPrepareArgs : Array String
   generatorArgs : Array String
 
@@ -386,7 +386,7 @@ private def buildPlan (opts : BuildOptions) : IO (Except String BuildPlan) := do
   | .error err => pure (.error err)
   | .ok info =>
       pure (.ok {
-        generatorOLeanTarget := generatorOLeanTarget info.generatorModule,
+        packageOLeanTarget := packageOLeanTarget info.packageName,
         generatorPrepareArgs := #["lean", info.generatorFile.toString],
         generatorArgs := generatorRunArgs info.generatorFile opts.output opts.verbose ++ pdfGeneratorArgs opts
       })
@@ -440,7 +440,7 @@ def build (args : List String) : IO UInt32 := do
               pure 1
           | .ok plan =>
               let code ← runBuildStages [
-                { stage := "generator OLean build", cmd := "lake", args := #["build", plan.generatorOLeanTarget] },
+                { stage := "package OLean build", cmd := "lake", args := #["build", plan.packageOLeanTarget] },
                 { stage := "generator preparation", cmd := "lake", args := plan.generatorPrepareArgs },
                 { stage := "generator run", cmd := "lake", args := plan.generatorArgs }
               ]

--- a/src/VersoBlueprint/VbpMain.lean
+++ b/src/VersoBlueprint/VbpMain.lean
@@ -85,6 +85,13 @@ def generatorModuleFromFile (path : FilePath) : String :=
       text
   text.replace "/" "."
 
+/-- Build only the generator module's OLean dependency closure.
+
+The default `leanArts` facet also emits C, which can turn a Blueprint build in
+a Mathlib consumer into an accidental native rebuild of Mathlib. -/
+def generatorOLeanTarget (generatorModule : String) : String :=
+  s!"+{generatorModule}:olean"
+
 structure ProjectInfo where
   packageName : String
   generatorFile : FilePath
@@ -242,7 +249,7 @@ structure BuildOptions where
   port? : Option Nat := none
 
 structure BuildPlan where
-  packageName : String
+  generatorOLeanTarget : String
   generatorPrepareArgs : Array String
   generatorArgs : Array String
 
@@ -379,7 +386,7 @@ private def buildPlan (opts : BuildOptions) : IO (Except String BuildPlan) := do
   | .error err => pure (.error err)
   | .ok info =>
       pure (.ok {
-        packageName := info.packageName,
+        generatorOLeanTarget := generatorOLeanTarget info.generatorModule,
         generatorPrepareArgs := #["lean", info.generatorFile.toString],
         generatorArgs := generatorRunArgs info.generatorFile opts.output opts.verbose ++ pdfGeneratorArgs opts
       })
@@ -433,7 +440,7 @@ def build (args : List String) : IO UInt32 := do
               pure 1
           | .ok plan =>
               let code ← runBuildStages [
-                { stage := "package build", cmd := "lake", args := #["build", plan.packageName] },
+                { stage := "generator OLean build", cmd := "lake", args := #["build", plan.generatorOLeanTarget] },
                 { stage := "generator preparation", cmd := "lake", args := plan.generatorPrepareArgs },
                 { stage := "generator run", cmd := "lake", args := plan.generatorArgs }
               ]

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -433,8 +433,8 @@ private def graphNodePreviewKeys
       VersoBlueprint.Vbp.Main.generatorModuleFromFile
           (System.FilePath.mk "Blueprint" / "Main.lean") ==
         "Blueprint.Main" &&
-      VersoBlueprint.Vbp.Main.generatorOLeanTarget "Main" == "+Main:olean" &&
-      VersoBlueprint.Vbp.Main.generatorOLeanTarget "Blueprint.Main" == "+Blueprint.Main:olean"
+      VersoBlueprint.Vbp.Main.packageOLeanTarget "ProjectTemplate" == "+ProjectTemplate:olean" &&
+      VersoBlueprint.Vbp.Main.packageOLeanTarget "Contents" == "+Contents:olean"
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -432,7 +432,9 @@ private def graphNodePreviewKeys
         "ProjectTemplateMain" &&
       VersoBlueprint.Vbp.Main.generatorModuleFromFile
           (System.FilePath.mk "Blueprint" / "Main.lean") ==
-        "Blueprint.Main"
+        "Blueprint.Main" &&
+      VersoBlueprint.Vbp.Main.generatorOLeanTarget "Main" == "+Main:olean" &&
+      VersoBlueprint.Vbp.Main.generatorOLeanTarget "Blueprint.Main" == "+Blueprint.Main:olean"
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -50,8 +50,7 @@
           "rc": "4.32-rc1"
         }
       ],
-      "build_command": ["lake", "build", "Contents"],
-      "generate_command": ["lake", "lean", "Main.lean", "--", "--run", "Main.lean", "--output", "{output_dir}"],
+      "generate_command": ["lake", "exe", "vbp", "build", "--output", "{output_dir}"],
       "site_subdir": "html-multi"
     },
     {
@@ -69,17 +68,7 @@
           "publish_reference": true
         }
       ],
-      "build_command": ["bash", "scripts/ci-reference-build.sh"],
-      "generate_command": [
-        "lake",
-        "lean",
-        "SpherePackingBlueprintMain.lean",
-        "--",
-        "--run",
-        "SpherePackingBlueprintMain.lean",
-        "--output",
-        "{output_dir}"
-      ],
+      "generate_command": ["lake", "exe", "vbp", "build", "--output", "{output_dir}"],
       "site_subdir": "html-multi"
     },
     {
@@ -98,17 +87,7 @@
           "rc": "4.32-rc1"
         }
       ],
-      "build_command": ["lake", "build", "FLTBlueprint"],
-      "generate_command": [
-        "lake",
-        "lean",
-        "FLTBlueprintMain.lean",
-        "--",
-        "--run",
-        "FLTBlueprintMain.lean",
-        "--output",
-        "{output_dir}"
-      ],
+      "generate_command": ["lake", "exe", "vbp", "build", "--output", "{output_dir}"],
       "site_subdir": "html-multi"
     },
     {
@@ -127,17 +106,7 @@
           "publish_reference": true
         }
       ],
-      "build_command": ["lake", "build", "CarlesonBlueprint"],
-      "generate_command": [
-        "lake",
-        "lean",
-        "BlueprintMain.lean",
-        "--",
-        "--run",
-        "BlueprintMain.lean",
-        "--output",
-        "{output_dir}"
-      ],
+      "generate_command": ["lake", "exe", "vbp", "build", "--output", "{output_dir}"],
       "site_subdir": "html-multi"
     }
   ]

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -45,7 +45,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "3de67591d70fe602651703d8779e24e1f54f3878",
+          "ref": "ad062f0d06b891fa53db1cfcdc7e39be05c39204",
           "publish_reference": true,
           "rc": "4.32-rc1"
         }
@@ -65,7 +65,7 @@
       "targets": [
         {
           "release": "v4.30.0",
-          "ref": "406882e214dfd36614e8681c0406394857fd0af5",
+          "ref": "75cb2fb052fd37a851b6e5d2f89e80c80d5dece3",
           "publish_reference": true
         }
       ],
@@ -93,7 +93,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "675805c5b382b6f6a0ddcaf5f82ffa0dd8870d53",
+          "ref": "3a249321ef38b74fe89b61cbfcde01fae2dc69a7",
           "publish_reference": true,
           "rc": "4.32-rc1"
         }
@@ -122,7 +122,7 @@
       "targets": [
         {
           "release": "v4.30.0",
-          "ref": "fc70036bd3333b3ec8595d067c9b3f960938b78a",
+          "ref": "9c5052bbdac3f3bcecdf988b53e1a1fa10c84f6b",
           "rc": "4.30-rc2",
           "publish_reference": true
         }

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -184,11 +184,8 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             projects[1], expected_external_releases[projects[1].project_id], publish_reference=True
         )
         self.assertEqual(projects[1].targets[0].rc, "4.32-rc1")
-        self.assertEqual(projects[1].build_command, ("lake", "build", "Contents"))
-        self.assertEqual(
-            projects[1].generate_command,
-            ("lake", "lean", "Main.lean", "--", "--run", "Main.lean", "--output", "{output_dir}"),
-        )
+        self.assertIsNone(projects[1].build_command)
+        self.assertEqual(projects[1].generate_command, VBP_BUILD_OUTPUT_COMMAND)
         self.assertEqual(projects[1].browser_tests_path, None)
         self.assertEqual(projects[1].panel_regression_script, None)
         self.assertEqual(projects[2].repository, "https://github.com/ejgallego/verso-sphere-packing.git")
@@ -196,22 +193,22 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             projects[2], expected_external_releases[projects[2].project_id], publish_reference=True
         )
         self.assertIsNone(projects[2].targets[0].rc)
-        self.assertEqual(projects[2].build_command, ("bash", "scripts/ci-reference-build.sh"))
+        self.assertIsNone(projects[2].build_command)
+        self.assertEqual(projects[2].generate_command, VBP_BUILD_OUTPUT_COMMAND)
         self.assertEqual(projects[3].repository, "https://github.com/ejgallego/verso-flt.git")
         self.assert_single_current_release_target(
             projects[3], expected_external_releases[projects[3].project_id], publish_reference=True
         )
         self.assertEqual(projects[3].targets[0].rc, "4.32-rc1")
+        self.assertIsNone(projects[3].build_command)
+        self.assertEqual(projects[3].generate_command, VBP_BUILD_OUTPUT_COMMAND)
         self.assertEqual(projects[4].repository, "https://github.com/ejgallego/verso-carleson.git")
         self.assert_single_current_release_target(
             projects[4], expected_external_releases[projects[4].project_id], publish_reference=True
         )
         self.assertIsNotNone(projects[4].targets[0].rc)
-        self.assertEqual(projects[4].build_command, ("lake", "build", "CarlesonBlueprint"))
-        self.assertEqual(
-            projects[4].generate_command,
-            ("lake", "lean", "BlueprintMain.lean", "--", "--run", "BlueprintMain.lean", "--output", "{output_dir}"),
-        )
+        self.assertIsNone(projects[4].build_command)
+        self.assertEqual(projects[4].generate_command, VBP_BUILD_OUTPUT_COMMAND)
 
     def test_project_catalog_requires_json_object(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -1152,7 +1152,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 "leanprover/lean4:v4.29.0\n",
             )
 
-    def test_reconcile_reference_toolchains_leaves_different_release_branches_alone(self) -> None:
+    def test_reconcile_reference_toolchains_rejects_different_release_branches(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             package_root = root / "pkg"
@@ -1164,12 +1164,12 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             (project_dir / "lean-toolchain").write_text("leanprover/lean4:v4.29.0\n", encoding="utf-8")
             (mathlib_dir / "lean-toolchain").write_text("leanprover/lean4:v4.29.0\n", encoding="utf-8")
 
-            result = reconcile_reference_toolchains(package_root, project_dir)
+            with self.assertRaisesRegex(
+                SystemExit,
+                "reference Blueprint release mismatch.*Catalog each external Blueprint only under its current matching release",
+            ):
+                reconcile_reference_toolchains(package_root, project_dir)
 
-            self.assertFalse(result.changed)
-            self.assertIsNone(result.selected_ref)
-            self.assertIsNone(result.release_branch)
-            self.assertEqual(result.changed_paths, ())
             self.assertEqual(
                 (project_dir / "lean-toolchain").read_text(encoding="utf-8"),
                 "leanprover/lean4:v4.29.0\n",

--- a/tests/harness/test_blueprint_harness_utils.py
+++ b/tests/harness/test_blueprint_harness_utils.py
@@ -1,6 +1,7 @@
 import contextlib
 import io
 import os
+import signal
 import subprocess
 import tempfile
 import time
@@ -137,12 +138,40 @@ class TestBlueprintHarnessUtils(unittest.TestCase):
         ):
             run_with_heartbeat(["slow"], cwd=Path("/tmp"), label="external build")
 
-        popen_mock.assert_called_once_with(["slow"], cwd=Path("/tmp"))
+        popen_mock.assert_called_once_with(["slow"], cwd=Path("/tmp"), start_new_session=os.name == "posix")
         output = out.getvalue()
         self.assertIn("[blueprint-harness] $ slow", output)
         self.assertIn("[blueprint-harness] starting external build", output)
         self.assertIn("[blueprint-harness] still running external build after 1m01s", output)
         self.assertIn("[blueprint-harness] finished external build in 1m02s", output)
+
+    @unittest.skipUnless(os.name == "posix", "process-group cleanup is POSIX-specific")
+    def test_run_with_heartbeat_terminates_the_whole_process_group_on_interrupt(self) -> None:
+        class FakeProcess:
+            pid = 4242
+
+            def __init__(self) -> None:
+                self.cleanup_waits: list[int | None] = []
+
+            def wait(self, timeout: int | None = None) -> int:
+                if timeout == 60:
+                    raise KeyboardInterrupt
+                self.cleanup_waits.append(timeout)
+                return -signal.SIGTERM
+
+            def poll(self) -> None:
+                return None
+
+        fake_process = FakeProcess()
+        with (
+            patch("scripts.blueprint_harness_utils.subprocess.Popen", return_value=fake_process),
+            patch("scripts.blueprint_harness_utils.os.killpg") as killpg_mock,
+            self.assertRaises(KeyboardInterrupt),
+        ):
+            run_with_heartbeat(["slow"], cwd=Path("/tmp"), label="external build")
+
+        killpg_mock.assert_called_once_with(fake_process.pid, signal.SIGTERM)
+        self.assertEqual(fake_process.cleanup_waits, [5])
 
     def test_refresh_embedded_asset_owner_mtimes_touches_owner_when_asset_is_newer(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
This PR refreshes the reference Blueprint catalog while ensuring each external project is built only on its intended current release.

- Pins Noperthedron and FLT to v4.32, and Sphere Packing and Carleson to v4.30.
- Rejects cross-release wrapper/toolchain combinations before running lake update.
- Routes external generation through `lake exe vbp build`.
- Makes `vbp build` request only `+<BlueprintLibrary>:olean`, avoiding Lake's C-emitting `leanArts` facet.
- Terminates the whole harness process group on interruption so Lake workers cannot continue in the background.

Backport v4.31.0: #318
Backport v4.30.0: #317