### PR TITLE
[backport v4.31.0] fix: harden reference blueprint publication

### DIFF
--- a/.github/workflows/reference-blueprints-deploy.yml
+++ b/.github/workflows/reference-blueprints-deploy.yml
@@ -16,12 +16,10 @@ permissions:
   id-token: write
 
 concurrency:
-  group: >-
-    ${{
-      github.event_name == 'workflow_dispatch'
-      && format('{0}-reference-blueprints-pages-dispatch-{1}', github.repository, github.ref_name)
-      || format('{0}-reference-blueprints-pages-release-{1}', github.repository, github.event.workflow_run.head_branch)
-    }}
+  # Every trigger assembles and replaces the same combined Pages site. Keep a
+  # single repository-wide deployment in flight so paired release completions
+  # coalesce instead of rebuilding and racing the full catalog independently.
+  group: ${{ github.repository }}-reference-blueprints-pages
   cancel-in-progress: true
 
 jobs:
@@ -65,11 +63,7 @@ jobs:
           echo "project_id=${{ matrix.project_id }}"
           echo "hash=${{ matrix.hash }}"
           echo "reference_cache_key=${{ matrix.reference_cache_key }}"
-      - name: Match reference target toolchain
-        if: ${{ matrix.rc != '' }}
-        run: printf 'leanprover/lean4:${{ matrix.toolchain }}\n' > lean-toolchain
-      - name: Report disk usage before cache restore
-        run: ./scripts/report-ci-disk-usage.sh "before cache restore" --reference-cache-key "${{ matrix.reference_cache_key }}" --artifact-path "${{ matrix.artifact_path }}"
+          echo "publish_pdf=${{ matrix.publish_pdf }}"
       - name: Write deploy project manifest
         env:
           BP_PROJECT_ID: ${{ matrix.project_id }}
@@ -85,11 +79,45 @@ jobs:
           manifest = json.loads(os.environ["BP_DEPLOY_PROJECT_MANIFEST"])
           path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
           PY
+      - name: Create exact reference artifact identity
+        id: artifact-identity
+        run: |
+          python3 scripts/reference_artifact_identity.py create \
+            --manifest _out/deploy-projects/${{ matrix.project_id }}.json \
+            --release-id ${{ matrix.release_id }} \
+            --project-id ${{ matrix.project_id }} \
+            --generator-revision "$(git rev-parse HEAD)" \
+            --output _out/deploy-projects/${{ matrix.project_id }}.identity.json \
+            --github-output >> "$GITHUB_OUTPUT"
+      - name: Report disk usage before cache restore
+        run: ./scripts/report-ci-disk-usage.sh "before cache restore" --reference-cache-key "${{ matrix.reference_cache_key }}" --artifact-path "${{ matrix.artifact_path }}"
+      - name: Restore exact generated reference site
+        id: generated-site-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ matrix.artifact_path }}
+          key: ${{ runner.os }}-reference-site-v1-${{ steps.artifact-identity.outputs.sha256 }}
+      - name: Match reference target toolchain
+        if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' && matrix.rc != '' }}
+        run: printf 'leanprover/lean4:${{ matrix.toolchain }}\n' > lean-toolchain
       - name: Install elan
+        if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' }}
         run: |
           curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+      - name: Install PDF toolchain
+        if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' && matrix.publish_pdf }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            python3-pygments \
+            texlive-fonts-extra \
+            texlive-fonts-recommended \
+            texlive-latex-extra \
+            texlive-luatex \
+            texlive-plain-generic
       - name: Restore Lake package cache
+        if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache@v5
         with:
           path: |
@@ -100,6 +128,7 @@ jobs:
             ${{ runner.os }}-reference-deploy-lake-packages-v2-${{ matrix.toolchain }}-
             ${{ runner.os }}-reference-deploy-lake-packages-v2-
       - name: Restore Lake dependency build cache
+        if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache@v5
         with:
           path: |
@@ -110,9 +139,10 @@ jobs:
             ${{ runner.os }}-reference-deploy-lake-deps-${{ matrix.toolchain }}-
             ${{ runner.os }}-reference-deploy-lake-deps-
       - name: Report disk usage after Lake cache restore
+        if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' }}
         run: ./scripts/report-ci-disk-usage.sh "after Lake cache restore" --reference-cache-key "${{ matrix.reference_cache_key }}" --artifact-path "${{ matrix.artifact_path }}"
       - name: Restore external reference dependency cache
-        if: ${{ matrix.reference_cache_key != '' }}
+        if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' && matrix.reference_cache_key != '' }}
         uses: actions/cache@v5
         with:
           path: |
@@ -122,13 +152,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-reference-deploy-deps-v2-${{ matrix.project_id }}-
       - name: Report disk usage after reference cache restore
+        if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' }}
         run: ./scripts/report-ci-disk-usage.sh "after reference cache restore" --reference-cache-key "${{ matrix.reference_cache_key }}" --artifact-path "${{ matrix.artifact_path }}"
       - name: Show tool versions
+        if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' }}
         run: |
           lean --version
           lake --version
+          if [ "${{ matrix.publish_pdf }}" = "true" ]; then
+            lualatex --version | head -n 1
+          fi
           python3 --version
       - name: Generate release reference blueprints
+        if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' }}
         run: |
           python3 -m scripts.blueprint_reference_harness generate \
             --manifest _out/deploy-projects/${{ matrix.project_id }}.json \
@@ -142,6 +178,23 @@ jobs:
       - name: Report disk usage after reference generation
         if: ${{ always() }}
         run: ./scripts/report-ci-disk-usage.sh "after reference generation" --reference-cache-key "${{ matrix.reference_cache_key }}" --artifact-path "${{ matrix.artifact_path }}"
+      - name: Install exact reference artifact identity
+        if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' }}
+        run: |
+          python3 scripts/reference_artifact_identity.py install \
+            --identity _out/deploy-projects/${{ matrix.project_id }}.identity.json \
+            --artifact-root ${{ matrix.artifact_path }}
+      - name: Validate exact reference artifact identity
+        run: |
+          python3 scripts/reference_artifact_identity.py validate \
+            --identity _out/deploy-projects/${{ matrix.project_id }}.identity.json \
+            --artifact-root ${{ matrix.artifact_path }}
+      - name: Save exact generated reference site
+        if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ matrix.artifact_path }}
+          key: ${{ runner.os }}-reference-site-v1-${{ steps.artifact-identity.outputs.sha256 }}
       - name: Upload release reference artifact
         uses: actions/upload-artifact@v7
         with:
@@ -204,6 +257,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.repository.default_branch }}
+          fetch-depth: 0
       - name: Show deploy release summary
         run: |
           echo "manifest_path=${{ needs.resolve-deploy-releases.outputs.manifest_path }}"
@@ -225,8 +279,18 @@ jobs:
         with:
           pattern: reference-blueprints-release-*
           path: _out/reference-artifact-downloads
+      - name: Resolve expected reference artifact identities
+        env:
+          BP_DEPLOY_PROJECT_MATRIX: ${{ needs.resolve-deploy-releases.outputs.deployable_project_matrix }}
+        run: |
+          python3 scripts/reference_artifact_identity.py expected-matrix \
+            --matrix-json "$BP_DEPLOY_PROJECT_MATRIX" \
+            --repo-root . \
+            --output _out/expected-reference-artifacts.json
       - name: Stage release reference artifacts
-        run: python3 ./scripts/stage_reference_deploy_artifacts.py
+        run: |
+          python3 ./scripts/stage_reference_deploy_artifacts.py \
+            --expected-identities _out/expected-reference-artifacts.json
       - name: Download test blueprints artifact
         uses: actions/download-artifact@v7
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,12 +169,12 @@
     reference-blueprint catalog instead
   - for UI review on a real deliverable, prefer reference blueprints even if a
     smaller test-blueprint fixture also exists
-- Default validation-catalog output on the current `v4.32.0` line in the root
-  checkout:
-  - `_out/reference-blueprints/{noperthedron,verso-flt}/`
-- Default validation-catalog output on the current `v4.32.0` line in a linked
-  worktree:
-  - `_out/<worktree>/reference-blueprints/{noperthedron,verso-flt}/`
+- Default reference-project selection follows the active checkout release:
+  - `v4.32.0`: `noperthedron`, `verso-flt`
+  - `v4.31.0`: no public reference project by default
+  - `v4.30.0`: `spherepackingblueprint`, `verso-carleson`
+- Validation output lives under `_out/reference-blueprints/` in the root
+  checkout and `_out/<worktree>/reference-blueprints/` in a linked worktree.
 - `project-template` is an explicitly selectable CI fixture for every
   maintained release, not a default or published reference-catalog entry.
 - Default test-blueprint output in the root checkout:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,8 +85,9 @@
 ## Release Status
 
 - The code is near release.
-- The reference blueprints now live in their own repositories:
-  `ejgallego/verso-noperthedron` and `ejgallego/verso-sphere-packing`.
+- The external reference blueprints live in their own repositories:
+  `ejgallego/verso-noperthedron`, `ejgallego/verso-sphere-packing`,
+  `ejgallego/verso-flt`, and `ejgallego/verso-carleson`.
 - A smaller starter example, a reusable template, and `lake exe bp new` are
   planned but not landed yet.
 - End-user docs should treat `lake exe vbp build` as the preferred Blueprint
@@ -168,10 +169,14 @@
     reference-blueprint catalog instead
   - for UI review on a real deliverable, prefer reference blueprints even if a
     smaller test-blueprint fixture also exists
-- Default validation-catalog output in the root checkout:
-  - `_out/reference-blueprints/{project-template,noperthedron,spherepackingblueprint}/`
-- Default validation-catalog output in a linked worktree:
-  - `_out/<worktree>/reference-blueprints/{project-template,noperthedron,spherepackingblueprint}/`
+- Default validation-catalog output on the current `v4.32.0` line in the root
+  checkout:
+  - `_out/reference-blueprints/{noperthedron,verso-flt}/`
+- Default validation-catalog output on the current `v4.32.0` line in a linked
+  worktree:
+  - `_out/<worktree>/reference-blueprints/{noperthedron,verso-flt}/`
+- `project-template` is an explicitly selectable CI fixture for every
+  maintained release, not a default or published reference-catalog entry.
 - Default test-blueprint output in the root checkout:
   - `_out/test-blueprints/{<slug>,preview_runtime_showcase,state-showcase}/`
 - Default test-blueprint output in a linked worktree:

--- a/README.md
+++ b/README.md
@@ -367,12 +367,11 @@ you want to enable it.
 The repository also tracks a current, release-versioned reference catalog.
 Each external Blueprint is published only for its intended current release:
 Noperthedron and FLT on `v4.32.0`, and Sphere Packing and Carleson on
-`v4.30.0`. The in-repo starter template continues to validate maintained
-release lines.
+`v4.30.0`. The in-repo starter template is a CI fixture rather than a public
+reference entry; it continues to validate every maintained release line.
+Release lines without a current external reference project, currently
+`v4.31.0`, remain CI-maintained without adding an empty public catalog section.
 
-- [project_template/](./project_template/), the in-repo starter template,
-  [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/project-template/)
-  and [rendered site for v4.31.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.31.0/project-template/)
 - [`ejgallego/verso-noperthedron`](https://github.com/ejgallego/verso-noperthedron),
   [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/noperthedron/)
 - [`ejgallego/verso-sphere-packing`](https://github.com/ejgallego/verso-sphere-packing),

--- a/branch-policy.json
+++ b/branch-policy.json
@@ -18,7 +18,7 @@
       "toolchain": "v4.31.0",
       "verso_ref": "v4.31.0",
       "branch": "v4.31.0",
-      "deploy_pages": true
+      "deploy_pages": false
     },
     {
       "id": "v4.32.0",

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -322,8 +322,9 @@ Run this from the new local branch, for example `v4.31.0`. The command:
 - updates `branch-policy.json` so the new branch is the default-development
   line, the previous default-development branch becomes a required backport
   target, and the new release target is recorded
-- enables the in-repo reference projects, currently `project-template`, on the
-  new release target
+- adds the new release target to in-repo CI fixtures such as
+  `project-template`; fixtures remain explicitly selectable for validation but
+  are not added to the public reference catalog
 
 For release candidates, use the official short RC name such as `4.31-rc2`.
 The branch name remains the stable release branch, for example `v4.31.0`, while
@@ -732,6 +733,23 @@ default-development catalog and passes it to the release-branch harness with
 so two projects in the same release line can deploy against different release
 candidate tags when needed.
 
+All runs of the deploy workflow share one repository-wide concurrency group
+because every run replaces the same combined Pages site. A deploy matrix entry
+first computes an exact generated-site identity from the release id, project
+id, complete generated one-project manifest, and checked-out release-branch
+commit. The workflow restores only the cache key for that exact identity; it
+does not use prefix or stale fallback keys. On a cache miss, normal generation
+runs and installs the identity metadata before saving the generated site. On a
+cache hit, toolchain installation, dependency restoration, external checkout,
+and generation are skipped.
+
+Before assembling Pages, the staging job independently recomputes the expected
+identities from the current catalog and fetched release-branch heads. It rejects
+missing, unexpected, tampered, or non-matching artifacts and removes the
+identity metadata from the public site. This permits a trusted last-known-good
+generated site to cover a temporary upstream outage only while every relevant
+pin and generator revision remains exactly unchanged.
+
 The current published project/release split is intentionally not duplicated
 here. Read `tests/harness/projects.json`; every project target marked
 `publish_reference: true` is part of the deployed catalog for that target's
@@ -836,18 +854,17 @@ Minimal external catalog entry shape:
           "publish_reference": true
         }
       ],
-      "build_command": ["lake", "build", "SomeUserProject"],
-      "generate_command": ["lake", "lean", "SomeUserProjectMain.lean", "--", "--run", "SomeUserProjectMain.lean", "--output", "{output_dir}"],
+      "generate_command": ["lake", "exe", "vbp", "build", "--output", "{output_dir}"],
       "site_subdir": "html-multi"
     }
   ]
 }
 ```
 
-The `lake lean <file> -- --run <file>` form is intentionally the catalog default
-for reference projects. It still requires the imported Lean modules to have been
-built first, but it avoids Lake's executable build path and the transitive native
-compilation cost that can dominate Mathlib-heavy projects.
+`lake exe vbp build --output <dir>` is the catalog default for external
+Blueprint projects. The project-owned `vbp` configuration is the source of
+truth for its generation instructions; the harness must not replace it with a
+guessed generator entry point or a separate broad build command.
 
 That override policy is now the default maintainer behavior: the external
 projects keep their committed dependency pointed at an approved upstream repo,

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -547,7 +547,13 @@ def release_target_manifest_entry(target: HarnessReleaseTarget) -> dict[str, obj
     }
 
 
-def project_manifest_entry(project: HarnessProject) -> dict[str, object]:
+def command_with_pdf(command: tuple[str, ...]) -> tuple[str, ...]:
+    if "--pdf" in command:
+        return command
+    return (*command, "--pdf")
+
+
+def project_manifest_entry(project: HarnessProject, *, include_pdf: bool = False) -> dict[str, object]:
     if project.selected_release is None:
         raise ValueError(f"project `{project.project_id}` is missing selected release metadata")
 
@@ -579,7 +585,12 @@ def project_manifest_entry(project: HarnessProject) -> dict[str, object]:
     if project.build_command is not None:
         entry["build_command"] = list(project.build_command)
     if project.generate_command is not None:
-        entry["generate_command"] = list(project.generate_command)
+        generate_command = project.generate_command
+        if include_pdf:
+            generate_command = command_with_pdf(generate_command)
+        entry["generate_command"] = list(generate_command)
+    elif include_pdf:
+        raise ValueError(f"project `{project.project_id}` needs a `generate_command` to publish PDF output")
     validation: dict[str, object] = {}
     if project.panel_regression_script is not None:
         validation["panel_regression_script"] = project.panel_regression_script
@@ -590,17 +601,24 @@ def project_manifest_entry(project: HarnessProject) -> dict[str, object]:
     return entry
 
 
-def deploy_project_manifest(target: HarnessReleaseTarget, project: HarnessProject) -> dict[str, object]:
+def deploy_project_manifest(
+    target: HarnessReleaseTarget,
+    project: HarnessProject,
+    *,
+    include_pdf: bool = True,
+) -> dict[str, object]:
     return {
         "version": 2,
         "release_targets": [release_target_manifest_entry(target)],
-        "projects": [project_manifest_entry(project)],
+        "projects": [project_manifest_entry(project, include_pdf=include_pdf)],
     }
 
 
 def deploy_matrix_from_controller_catalog(
     controller_catalog: HarnessProjectCatalog,
     deployable_targets: tuple[HarnessReleaseTarget, ...],
+    *,
+    pdf_release_id: str | None = None,
 ) -> dict[str, list[dict[str, object]]]:
     include: list[dict[str, object]] = []
     for target in deployable_targets:
@@ -612,6 +630,7 @@ def deploy_matrix_from_controller_catalog(
             )
         for project in controller_projects:
             fields = reference_project_target_fields(project, target)
+            publish_pdf = target.release_id == pdf_release_id
             include.append(
                 {
                     "release_id": target.release_id,
@@ -625,7 +644,8 @@ def deploy_matrix_from_controller_catalog(
                     "reference_cache_key": fields["reference_cache_key"],
                     "artifact_name": deploy_project_artifact_name(project),
                     "artifact_path": deploy_project_artifact_path(project),
-                    "project_manifest": deploy_project_manifest(target, project),
+                    "publish_pdf": publish_pdf,
+                    "project_manifest": deploy_project_manifest(target, project, include_pdf=publish_pdf),
                 }
             )
     return {"include": include}

--- a/scripts/emit_reference_deploy_matrix.py
+++ b/scripts/emit_reference_deploy_matrix.py
@@ -10,6 +10,7 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.blueprint_harness_paths import detect_harness_layout
+from scripts.blueprint_harness_branches import load_branch_policy
 from scripts.blueprint_harness_projects import (
     deploy_matrix_from_controller_catalog,
     load_project_catalog,
@@ -43,7 +44,12 @@ def payload(args: argparse.Namespace) -> dict[str, object]:
         for target in catalog.release_targets
         if target.deploy_pages
     )
-    matrix = deploy_matrix_from_controller_catalog(catalog, deployable_targets)
+    policy = load_branch_policy(layout.package_root)
+    matrix = deploy_matrix_from_controller_catalog(
+        catalog,
+        deployable_targets,
+        pdf_release_id=policy.default_dev_branch,
+    )
     deployable_release_count = len({entry["release_id"] for entry in matrix["include"]})
     return {
         "manifest_path": str(manifest_path),

--- a/scripts/reference_artifact_identity.py
+++ b/scripts/reference_artifact_identity.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+
+
+IDENTITY_VERSION = 1
+IDENTITY_FILENAME = "reference-blueprint-artifact.json"
+REVISION_RE = re.compile(r"[0-9a-f]{40,64}")
+
+
+def load_json_object(path: Path) -> dict[str, object]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as err:
+        raise ValueError(f"could not read JSON object `{path}`: {err}") from err
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object in `{path}`")
+    return value
+
+
+def canonical_sha256(value: object) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def artifact_identity(
+    project_manifest: dict[str, object],
+    *,
+    release_id: str,
+    project_id: str,
+    generator_revision: str,
+) -> dict[str, object]:
+    if not release_id or not project_id:
+        raise ValueError("artifact identity requires non-empty release and project ids")
+    if REVISION_RE.fullmatch(generator_revision) is None:
+        raise ValueError(f"invalid generator revision `{generator_revision}`")
+
+    projects = project_manifest.get("projects")
+    if not isinstance(projects, list) or len(projects) != 1 or not isinstance(projects[0], dict):
+        raise ValueError("artifact project manifest must contain exactly one project")
+    if projects[0].get("id") != project_id:
+        raise ValueError(
+            f"artifact project id `{project_id}` does not match manifest project `{projects[0].get('id')}`"
+        )
+
+    targets = projects[0].get("targets")
+    if not isinstance(targets, list) or len(targets) != 1 or not isinstance(targets[0], dict):
+        raise ValueError("artifact project manifest must contain exactly one project target")
+    if targets[0].get("release") != release_id:
+        raise ValueError(
+            f"artifact release `{release_id}` does not match manifest target `{targets[0].get('release')}`"
+        )
+
+    return {
+        "version": IDENTITY_VERSION,
+        "release_id": release_id,
+        "project_id": project_id,
+        "generator_revision": generator_revision,
+        "project_manifest": project_manifest,
+    }
+
+
+def identity_envelope(identity: dict[str, object]) -> dict[str, object]:
+    return {
+        "sha256": canonical_sha256(identity),
+        "identity": identity,
+    }
+
+
+def validate_identity_envelope(value: dict[str, object], *, context: str) -> dict[str, object]:
+    if set(value) != {"identity", "sha256"}:
+        raise ValueError(f"{context}: expected exactly `identity` and `sha256` fields")
+    identity = value.get("identity")
+    digest = value.get("sha256")
+    if not isinstance(identity, dict) or not isinstance(digest, str):
+        raise ValueError(f"{context}: expected `identity` object and `sha256` string")
+    actual = canonical_sha256(identity)
+    if digest != actual:
+        raise ValueError(f"{context}: identity digest mismatch: expected `{digest}`, computed `{actual}`")
+
+    release_id = identity.get("release_id")
+    project_id = identity.get("project_id")
+    generator_revision = identity.get("generator_revision")
+    project_manifest = identity.get("project_manifest")
+    if not isinstance(release_id, str) or not isinstance(project_id, str):
+        raise ValueError(f"{context}: identity release and project ids must be strings")
+    if not isinstance(generator_revision, str) or not isinstance(project_manifest, dict):
+        raise ValueError(f"{context}: identity generator revision and project manifest are invalid")
+    try:
+        validated = artifact_identity(
+            project_manifest,
+            release_id=release_id,
+            project_id=project_id,
+            generator_revision=generator_revision,
+        )
+    except ValueError as err:
+        raise ValueError(f"{context}: {err}") from err
+    if identity != validated:
+        raise ValueError(f"{context}: identity contains unexpected or inconsistent fields")
+    return value
+
+
+def write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def install_identity(identity_path: Path, artifact_root: Path) -> Path:
+    expected = validate_identity_envelope(load_json_object(identity_path), context=str(identity_path))
+    artifact_root.mkdir(parents=True, exist_ok=True)
+    destination = artifact_root / IDENTITY_FILENAME
+    write_json(destination, expected)
+    return destination
+
+
+def validate_artifact_identity(identity_path: Path, artifact_root: Path) -> None:
+    expected = validate_identity_envelope(load_json_object(identity_path), context=str(identity_path))
+    metadata_path = artifact_root / IDENTITY_FILENAME
+    actual = validate_identity_envelope(load_json_object(metadata_path), context=str(metadata_path))
+    if actual != expected:
+        raise ValueError(f"artifact `{artifact_root}` identity does not match the current catalog and generator")
+
+
+def resolve_branch_revision(repo_root: Path, branch: str) -> str:
+    candidates = (f"refs/remotes/origin/{branch}", f"refs/heads/{branch}", branch)
+    for candidate in candidates:
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", candidate],
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        revision = result.stdout.strip()
+        if result.returncode == 0 and REVISION_RE.fullmatch(revision) is not None:
+            return revision
+    raise ValueError(f"could not resolve generator revision for release branch `{branch}`")
+
+
+def expected_identities_from_matrix(matrix: dict[str, object], repo_root: Path) -> dict[str, object]:
+    include = matrix.get("include")
+    if not isinstance(include, list):
+        raise ValueError("deploy matrix must contain an `include` list")
+
+    artifacts: dict[str, object] = {}
+    revisions: dict[str, str] = {}
+    for index, entry in enumerate(include):
+        if not isinstance(entry, dict):
+            raise ValueError(f"deploy matrix entry #{index} must be an object")
+        required = ("artifact_name", "release_id", "project_id", "branch", "project_manifest")
+        if any(key not in entry for key in required):
+            raise ValueError(f"deploy matrix entry #{index} is missing artifact identity fields")
+        artifact_name = entry["artifact_name"]
+        release_id = entry["release_id"]
+        project_id = entry["project_id"]
+        branch = entry["branch"]
+        project_manifest = entry["project_manifest"]
+        if not all(isinstance(value, str) for value in (artifact_name, release_id, project_id, branch)):
+            raise ValueError(f"deploy matrix entry #{index} has non-string identity fields")
+        if not isinstance(project_manifest, dict):
+            raise ValueError(f"deploy matrix entry #{index} has invalid project manifest")
+        if artifact_name in artifacts:
+            raise ValueError(f"duplicate deploy artifact name `{artifact_name}`")
+        if branch not in revisions:
+            revisions[branch] = resolve_branch_revision(repo_root, branch)
+        revision = revisions[branch]
+        identity = artifact_identity(
+            project_manifest,
+            release_id=release_id,
+            project_id=project_id,
+            generator_revision=revision,
+        )
+        artifacts[artifact_name] = identity_envelope(identity)
+    return {"version": IDENTITY_VERSION, "artifacts": artifacts}
+
+
+def command_create(args: argparse.Namespace) -> int:
+    project_manifest = load_json_object(Path(args.manifest))
+    envelope = identity_envelope(
+        artifact_identity(
+            project_manifest,
+            release_id=args.release_id,
+            project_id=args.project_id,
+            generator_revision=args.generator_revision,
+        )
+    )
+    write_json(Path(args.output), envelope)
+    if args.github_output:
+        print(f"sha256={envelope['sha256']}")
+    return 0
+
+
+def command_install(args: argparse.Namespace) -> int:
+    install_identity(Path(args.identity), Path(args.artifact_root))
+    return 0
+
+
+def command_validate(args: argparse.Namespace) -> int:
+    validate_artifact_identity(Path(args.identity), Path(args.artifact_root))
+    return 0
+
+
+def command_expected_matrix(args: argparse.Namespace) -> int:
+    try:
+        matrix = json.loads(args.matrix_json)
+    except json.JSONDecodeError as err:
+        raise ValueError(f"invalid deploy matrix JSON: {err}") from err
+    if not isinstance(matrix, dict):
+        raise ValueError("deploy matrix JSON must be an object")
+    expected = expected_identities_from_matrix(matrix, Path(args.repo_root))
+    write_json(Path(args.output), expected)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Create and validate exact reference artifact identities.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    create = subparsers.add_parser("create")
+    create.add_argument("--manifest", required=True)
+    create.add_argument("--release-id", required=True)
+    create.add_argument("--project-id", required=True)
+    create.add_argument("--generator-revision", required=True)
+    create.add_argument("--output", required=True)
+    create.add_argument("--github-output", action="store_true")
+    create.set_defaults(func=command_create)
+
+    install = subparsers.add_parser("install")
+    install.add_argument("--identity", required=True)
+    install.add_argument("--artifact-root", required=True)
+    install.set_defaults(func=command_install)
+
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("--identity", required=True)
+    validate.add_argument("--artifact-root", required=True)
+    validate.set_defaults(func=command_validate)
+
+    expected = subparsers.add_parser("expected-matrix")
+    expected.add_argument("--matrix-json", required=True)
+    expected.add_argument("--repo-root", default=".")
+    expected.add_argument("--output", required=True)
+    expected.set_defaults(func=command_expected_matrix)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        return args.func(args)
+    except ValueError as err:
+        raise SystemExit(str(err)) from err
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/stage_reference_deploy_artifacts.py
+++ b/scripts/stage_reference_deploy_artifacts.py
@@ -10,6 +10,12 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.blueprint_harness_projects import DEPLOY_PROJECT_ARTIFACT_SEPARATOR
+from scripts.reference_artifact_identity import (
+    IDENTITY_FILENAME,
+    IDENTITY_VERSION,
+    load_json_object,
+    validate_identity_envelope,
+)
 
 
 ARTIFACT_PREFIX = "reference-blueprints-release-"
@@ -28,6 +34,11 @@ def parse_args() -> argparse.Namespace:
         "--output-root",
         default="_out/reference-blueprints",
         help="Directory where the combined reference blueprint tree should be rebuilt.",
+    )
+    parser.add_argument(
+        "--expected-identities",
+        default="_out/expected-reference-artifacts.json",
+        help="Exact artifact identities generated from the current deploy matrix and release branch heads.",
     )
     return parser.parse_args()
 
@@ -56,35 +67,83 @@ def resolve_artifact_project_root(artifact_dir: Path, release_id: str, project_i
     )
 
 
-def stage_artifacts(artifacts_root: Path, output_root: Path) -> None:
+def load_expected_identities(path: Path) -> dict[str, dict[str, object]]:
+    value = load_json_object(path)
+    if value.get("version") != IDENTITY_VERSION:
+        raise SystemExit(f"unsupported expected reference artifact identity version in `{path}`")
+    artifacts = value.get("artifacts")
+    if not isinstance(artifacts, dict):
+        raise SystemExit(f"expected reference artifact identities in `{path}` must contain an `artifacts` object")
+
+    expected: dict[str, dict[str, object]] = {}
+    for artifact_name, envelope in artifacts.items():
+        if not isinstance(artifact_name, str) or not isinstance(envelope, dict):
+            raise SystemExit(f"invalid expected reference artifact identity in `{path}`")
+        try:
+            expected[artifact_name] = validate_identity_envelope(
+                envelope,
+                context=f"expected artifact `{artifact_name}`",
+            )
+        except ValueError as err:
+            raise SystemExit(str(err)) from err
+    if not expected:
+        raise SystemExit(f"expected reference artifact identity set in `{path}` is empty")
+    return expected
+
+
+def stage_artifacts(artifacts_root: Path, output_root: Path, expected_identities_path: Path) -> None:
     if not artifacts_root.exists():
         raise SystemExit(f"missing downloaded reference artifact root: {artifacts_root}")
+
+    expected = load_expected_identities(expected_identities_path)
+    validated: list[tuple[str, str, Path]] = []
+    found: set[str] = set()
+    for artifact_dir in sorted(path for path in artifacts_root.iterdir() if path.is_dir()):
+        parsed = parse_artifact_name(artifact_dir.name)
+        if parsed is None:
+            continue
+        if artifact_dir.name not in expected:
+            raise SystemExit(f"unexpected deploy reference artifact: {artifact_dir.name}")
+        release_id, project_id = parsed
+        source_root = resolve_artifact_project_root(artifact_dir, release_id, project_id)
+        metadata_path = source_root / IDENTITY_FILENAME
+        try:
+            actual = validate_identity_envelope(
+                load_json_object(metadata_path),
+                context=f"artifact `{artifact_dir.name}`",
+            )
+        except ValueError as err:
+            raise SystemExit(str(err)) from err
+        if actual != expected[artifact_dir.name]:
+            raise SystemExit(
+                f"artifact `{artifact_dir.name}` identity does not match the current catalog and release branch"
+            )
+        identity = actual["identity"]
+        if identity["release_id"] != release_id or identity["project_id"] != project_id:
+            raise SystemExit(f"artifact `{artifact_dir.name}` identity does not match its artifact name")
+        validated.append((release_id, project_id, source_root))
+        found.add(artifact_dir.name)
+
+    missing = sorted(set(expected) - found)
+    if missing:
+        raise SystemExit(f"missing deploy reference artifacts: {', '.join(missing)}")
 
     if output_root.exists():
         shutil.rmtree(output_root)
     output_root.mkdir(parents=True, exist_ok=True)
 
-    staged = False
-    for artifact_dir in sorted(path for path in artifacts_root.iterdir() if path.is_dir()):
-        parsed = parse_artifact_name(artifact_dir.name)
-        if parsed is None:
-            continue
-        release_id, project_id = parsed
-        source_root = resolve_artifact_project_root(artifact_dir, release_id, project_id)
+    for release_id, project_id, source_root in validated:
         destination = output_root / release_id / project_id
         destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(source_root, destination)
-        staged = True
-
-    if not staged:
-        raise SystemExit(f"no deploy reference artifacts found under {artifacts_root}")
+        shutil.copytree(source_root, destination, ignore=shutil.ignore_patterns(IDENTITY_FILENAME))
 
 
 def main() -> int:
     args = parse_args()
     artifacts_root = Path(args.artifacts_root).resolve()
     output_root = Path(args.output_root).resolve()
-    stage_artifacts(artifacts_root, output_root)
+    expected_identities_path = Path(args.expected_identities).resolve()
+    stage_artifacts(artifacts_root, output_root, expected_identities_path)
     return 0
 
 

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -13,12 +13,10 @@
           "release": "v4.30.0"
         },
         {
-          "release": "v4.31.0",
-          "publish_reference": true
+          "release": "v4.31.0"
         },
         {
-          "release": "v4.32.0",
-          "publish_reference": true
+          "release": "v4.32.0"
         }
       ],
       "build_command": ["lake", "build", "ProjectTemplate"],

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -155,7 +155,9 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual([target.release for target in projects[0].targets], expected_template_targets)
         default_template_target = projects[0].target_for_release(branch_policy.default_dev_branch)
         self.assertIsNotNone(default_template_target)
-        self.assertTrue(default_template_target.publish_reference)
+        self.assertFalse(default_template_target.publish_reference)
+        self.assertFalse(any(target.publish_reference for target in projects[0].targets))
+        self.assertFalse(catalog.release_target("v4.31.0").deploy_pages)
         self.assertEqual(current_release.release_toolchain, current_release.toolchain)
         self.assertEqual(current_release.release_verso_ref, current_release.verso_ref)
         if current_release.deploy_pages:
@@ -535,6 +537,34 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertIn("reference-deps-v2-${{ matrix.reference_cache_key }}", workflow_text)
         self.assertIn(".worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/path-builds", deploy_workflow_text)
         self.assertIn("reference-deploy-deps-v2-${{ matrix.reference_cache_key }}", deploy_workflow_text)
+        self.assertIn(
+            "group: ${{ github.repository }}-reference-blueprints-pages",
+            deploy_workflow_text,
+        )
+        self.assertNotIn("reference-blueprints-pages-release-", deploy_workflow_text)
+        self.assertNotIn("reference-blueprints-pages-dispatch-", deploy_workflow_text)
+        self.assertIn("Install PDF toolchain", deploy_workflow_text)
+        self.assertIn(
+            "if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' && matrix.publish_pdf }}",
+            deploy_workflow_text,
+        )
+        self.assertIn("publish_pdf=${{ matrix.publish_pdf }}", deploy_workflow_text)
+        self.assertIn("Generate release reference blueprints", deploy_workflow_text)
+        self.assertIn("lualatex --version", deploy_workflow_text)
+        self.assertIn("texlive-fonts-extra", deploy_workflow_text)
+        self.assertIn("texlive-plain-generic", deploy_workflow_text)
+        self.assertIn("uses: actions/cache/restore@v5", deploy_workflow_text)
+        self.assertIn("uses: actions/cache/save@v5", deploy_workflow_text)
+        self.assertIn(
+            "reference-site-v1-${{ steps.artifact-identity.outputs.sha256 }}",
+            deploy_workflow_text,
+        )
+        self.assertIn("reference_artifact_identity.py create", deploy_workflow_text)
+        self.assertIn("reference_artifact_identity.py install", deploy_workflow_text)
+        self.assertIn("reference_artifact_identity.py validate", deploy_workflow_text)
+        self.assertIn("reference_artifact_identity.py expected-matrix", deploy_workflow_text)
+        self.assertIn("--expected-identities _out/expected-reference-artifacts.json", deploy_workflow_text)
+        self.assertIn("steps.generated-site-cache.outputs.cache-hit != 'true'", deploy_workflow_text)
 
         for entry in matrix["include"]:
             self.assertEqual(entry["artifact_name"], f"reference-blueprints-{entry['project_id']}")
@@ -728,6 +758,51 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(matrix_by_project["new-release-second-project"]["rc"], "4.29-rc2")
         self.assertEqual(matrix_by_project["new-release-second-project"]["toolchain"], "v4.29.0-rc2")
         self.assertEqual(matrix_by_project["new-release-second-project"]["verso_ref"], "v4.29.0-rc2")
+
+    def test_default_deploy_matrix_publishes_pdfs_only_for_default_dev_release(self) -> None:
+        catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
+        branch_policy = load_branch_policy(PACKAGE_ROOT)
+        deployable_targets = tuple(target for target in catalog.release_targets if target.deploy_pages)
+
+        matrix = deploy_matrix_from_controller_catalog(
+            catalog,
+            deployable_targets,
+            pdf_release_id=branch_policy.default_dev_branch,
+        )
+
+        rows = {
+            (entry["release_id"], entry["project_id"]): entry
+            for entry in matrix["include"]
+        }
+        self.assertEqual(
+            set(rows),
+            {
+                ("v4.30.0", "spherepackingblueprint"),
+                ("v4.30.0", "verso-carleson"),
+                ("v4.32.0", "noperthedron"),
+                ("v4.32.0", "verso-flt"),
+            },
+        )
+        self.assertFalse(rows[("v4.30.0", "spherepackingblueprint")]["publish_pdf"])
+        self.assertFalse(rows[("v4.30.0", "verso-carleson")]["publish_pdf"])
+        self.assertNotIn(
+            "--pdf",
+            rows[("v4.30.0", "spherepackingblueprint")]["project_manifest"]["projects"][0]["generate_command"],
+        )
+        self.assertNotIn(
+            "--pdf",
+            rows[("v4.30.0", "verso-carleson")]["project_manifest"]["projects"][0]["generate_command"],
+        )
+
+        current_release_projects = [
+            entry
+            for (release_id, _project_id), entry in rows.items()
+            if release_id == branch_policy.default_dev_branch
+        ]
+        self.assertTrue(current_release_projects)
+        for entry in current_release_projects:
+            self.assertTrue(entry["publish_pdf"])
+            self.assertIn("--pdf", entry["project_manifest"]["projects"][0]["generate_command"])
 
     def test_git_checkout_project_is_supported(self) -> None:
         manifest_data = {

--- a/tests/harness/test_prepare_reference_blueprints_pages.py
+++ b/tests/harness/test_prepare_reference_blueprints_pages.py
@@ -271,6 +271,9 @@ class PrepareReferenceBlueprintPagesTests(unittest.TestCase):
                 if target.publish_reference:
                     self.assertIn(f"reference-blueprints/{target.release}/{project.project_id}/", readme)
 
+        self.assertNotIn("reference-blueprints/v4.31.0/project-template/", readme)
+        self.assertNotIn("reference-blueprints/v4.32.0/project-template/", readme)
+
     def test_project_template_readme_does_not_link_unpublished_render(self) -> None:
         readme = (PACKAGE_ROOT / "project_template" / "README.md").read_text(encoding="utf-8")
 

--- a/tests/harness/test_reference_artifact_identity.py
+++ b/tests/harness/test_reference_artifact_identity.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from scripts.reference_artifact_identity import (
+    IDENTITY_FILENAME,
+    artifact_identity,
+    expected_identities_from_matrix,
+    identity_envelope,
+    install_identity,
+    validate_artifact_identity,
+    validate_identity_envelope,
+    write_json,
+)
+
+
+REVISION_A = "a" * 40
+REVISION_B = "b" * 40
+
+
+def project_manifest(release_id: str, project_id: str, *, ref: str = "source-ref") -> dict[str, object]:
+    return {
+        "version": 2,
+        "release_targets": [
+            {
+                "id": release_id,
+                "toolchain": release_id,
+                "verso_ref": release_id,
+                "branch": release_id,
+                "deploy_pages": True,
+            }
+        ],
+        "projects": [
+            {
+                "id": project_id,
+                "source": {
+                    "kind": "git_checkout",
+                    "repository": f"https://example.com/{project_id}.git",
+                    "project_root": ".",
+                },
+                "targets": [{"release": release_id, "ref": ref}],
+                "generate_command": ["lake", "exe", "vbp", "build", "--output", "{output_dir}"],
+            }
+        ],
+    }
+
+
+def envelope(release_id: str, project_id: str, revision: str = REVISION_A) -> dict[str, object]:
+    return identity_envelope(
+        artifact_identity(
+            project_manifest(release_id, project_id),
+            release_id=release_id,
+            project_id=project_id,
+            generator_revision=revision,
+        )
+    )
+
+
+class ReferenceArtifactIdentityTests(unittest.TestCase):
+    def test_identity_digest_is_deterministic_and_tracks_exact_inputs(self) -> None:
+        first = envelope("v4.32.0", "verso-flt")
+        second = envelope("v4.32.0", "verso-flt")
+        changed_revision = envelope("v4.32.0", "verso-flt", REVISION_B)
+        changed_manifest = identity_envelope(
+            artifact_identity(
+                project_manifest("v4.32.0", "verso-flt", ref="other-source-ref"),
+                release_id="v4.32.0",
+                project_id="verso-flt",
+                generator_revision=REVISION_A,
+            )
+        )
+
+        self.assertEqual(first, second)
+        self.assertNotEqual(first["sha256"], changed_revision["sha256"])
+        self.assertNotEqual(first["sha256"], changed_manifest["sha256"])
+
+    def test_identity_rejects_manifest_target_mismatches(self) -> None:
+        manifest = project_manifest("v4.32.0", "verso-flt")
+
+        with self.assertRaisesRegex(ValueError, "does not match manifest project"):
+            artifact_identity(
+                manifest,
+                release_id="v4.32.0",
+                project_id="noperthedron",
+                generator_revision=REVISION_A,
+            )
+        with self.assertRaisesRegex(ValueError, "does not match manifest target"):
+            artifact_identity(
+                manifest,
+                release_id="v4.30.0",
+                project_id="verso-flt",
+                generator_revision=REVISION_A,
+            )
+
+    def test_identity_rejects_digest_tampering_and_extra_fields(self) -> None:
+        tampered = envelope("v4.32.0", "verso-flt")
+        tampered["sha256"] = "0" * 64
+        with self.assertRaisesRegex(ValueError, "identity digest mismatch"):
+            validate_identity_envelope(tampered, context="test artifact")
+
+        extra = envelope("v4.32.0", "verso-flt")
+        extra["unexpected"] = True
+        with self.assertRaisesRegex(ValueError, "expected exactly"):
+            validate_identity_envelope(extra, context="test artifact")
+
+    def test_installed_identity_validates_only_against_an_exact_match(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            artifact_root = root / "site"
+            artifact_root.mkdir()
+            expected_path = root / "expected.json"
+            stale_path = root / "stale.json"
+            write_json(expected_path, envelope("v4.32.0", "verso-flt"))
+            write_json(stale_path, envelope("v4.32.0", "verso-flt", REVISION_B))
+
+            installed = install_identity(expected_path, artifact_root)
+            validate_artifact_identity(expected_path, artifact_root)
+
+            self.assertEqual(installed, artifact_root / IDENTITY_FILENAME)
+            with self.assertRaisesRegex(ValueError, "does not match"):
+                validate_artifact_identity(stale_path, artifact_root)
+
+    def test_expected_matrix_uses_each_release_branch_revision_once(self) -> None:
+        matrix = {
+            "include": [
+                {
+                    "artifact_name": "reference-blueprints-release-v4.32.0__project__verso-flt",
+                    "release_id": "v4.32.0",
+                    "project_id": "verso-flt",
+                    "branch": "v4.32.0",
+                    "project_manifest": project_manifest("v4.32.0", "verso-flt"),
+                },
+                {
+                    "artifact_name": "reference-blueprints-release-v4.32.0__project__noperthedron",
+                    "release_id": "v4.32.0",
+                    "project_id": "noperthedron",
+                    "branch": "v4.32.0",
+                    "project_manifest": project_manifest("v4.32.0", "noperthedron"),
+                },
+            ]
+        }
+
+        with patch(
+            "scripts.reference_artifact_identity.resolve_branch_revision",
+            return_value=REVISION_A,
+        ) as resolve:
+            expected = expected_identities_from_matrix(matrix, Path("."))
+
+        resolve.assert_called_once_with(Path("."), "v4.32.0")
+        self.assertEqual(expected["version"], 1)
+        self.assertEqual(
+            set(expected["artifacts"]),
+            {
+                "reference-blueprints-release-v4.32.0__project__verso-flt",
+                "reference-blueprints-release-v4.32.0__project__noperthedron",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/harness/test_stage_reference_deploy_artifacts.py
+++ b/tests/harness/test_stage_reference_deploy_artifacts.py
@@ -6,12 +6,42 @@ import sys
 import tempfile
 import unittest
 
+from scripts.reference_artifact_identity import (
+    IDENTITY_FILENAME,
+    artifact_identity,
+    identity_envelope,
+    write_json,
+)
+
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+REVISION_A = "a" * 40
+REVISION_B = "b" * 40
+
+
+def artifact_envelope(release_id: str, project_id: str, revision: str = REVISION_A) -> dict[str, object]:
+    manifest = {
+        "version": 2,
+        "release_targets": [{"id": release_id}],
+        "projects": [{"id": project_id, "targets": [{"release": release_id}]}],
+    }
+    return identity_envelope(
+        artifact_identity(
+            manifest,
+            release_id=release_id,
+            project_id=project_id,
+            generator_revision=revision,
+        )
+    )
 
 
 class StageReferenceDeployArtifactsTests(unittest.TestCase):
-    def run_helper(self, artifacts_root: Path, output_root: Path) -> subprocess.CompletedProcess[str]:
+    def run_helper(
+        self,
+        artifacts_root: Path,
+        output_root: Path,
+        expected_identities: Path,
+    ) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             [
                 sys.executable,
@@ -20,6 +50,8 @@ class StageReferenceDeployArtifactsTests(unittest.TestCase):
                 str(artifacts_root),
                 "--output-root",
                 str(output_root),
+                "--expected-identities",
+                str(expected_identities),
             ],
             cwd=PACKAGE_ROOT,
             text=True,
@@ -32,10 +64,13 @@ class StageReferenceDeployArtifactsTests(unittest.TestCase):
             tmp_path = Path(tmp)
             artifacts_root = tmp_path / "reference-artifact-downloads"
             output_root = tmp_path / "reference-blueprints"
+            expected_path = tmp_path / "expected.json"
 
             direct = artifacts_root / "reference-blueprints-release-v4.28.0__project__project-template"
             (direct / "html-multi").mkdir(parents=True)
             (direct / "html-multi" / "index.html").write_text("project template v4.28.0", encoding="utf-8")
+            direct_identity = artifact_envelope("v4.28.0", "project-template")
+            write_json(direct / IDENTITY_FILENAME, direct_identity)
 
             nested = artifacts_root / "reference-blueprints-release-v4.29.0__project__noperthedron"
             (nested / "noperthedron" / "html-multi").mkdir(parents=True)
@@ -43,8 +78,20 @@ class StageReferenceDeployArtifactsTests(unittest.TestCase):
                 "noperthedron v4.29.0",
                 encoding="utf-8",
             )
+            nested_identity = artifact_envelope("v4.29.0", "noperthedron")
+            write_json(nested / "noperthedron" / IDENTITY_FILENAME, nested_identity)
+            write_json(
+                expected_path,
+                {
+                    "version": 1,
+                    "artifacts": {
+                        direct.name: direct_identity,
+                        nested.name: nested_identity,
+                    },
+                },
+            )
 
-            result = self.run_helper(artifacts_root, output_root)
+            result = self.run_helper(artifacts_root, output_root, expected_path)
             self.assertEqual(result.returncode, 0, msg=result.stderr)
 
             self.assertEqual(
@@ -59,6 +106,52 @@ class StageReferenceDeployArtifactsTests(unittest.TestCase):
                 ),
                 "noperthedron v4.29.0",
             )
+            self.assertFalse((output_root / "v4.28.0" / "project-template" / IDENTITY_FILENAME).exists())
+            self.assertFalse((output_root / "v4.29.0" / "noperthedron" / IDENTITY_FILENAME).exists())
+
+    def test_stage_artifacts_rejects_stale_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            artifacts_root = root / "artifacts"
+            output_root = root / "output"
+            expected_path = root / "expected.json"
+            artifact = artifacts_root / "reference-blueprints-release-v4.32.0__project__verso-flt"
+            (artifact / "html-multi").mkdir(parents=True)
+            write_json(artifact / IDENTITY_FILENAME, artifact_envelope("v4.32.0", "verso-flt", REVISION_A))
+            write_json(
+                expected_path,
+                {"version": 1, "artifacts": {artifact.name: artifact_envelope("v4.32.0", "verso-flt", REVISION_B)}},
+            )
+
+            result = self.run_helper(artifacts_root, output_root, expected_path)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("does not match the current catalog and release branch", result.stderr)
+
+    def test_stage_artifacts_rejects_missing_and_unexpected_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            artifacts_root = root / "artifacts"
+            output_root = root / "output"
+            expected_path = root / "expected.json"
+            expected_name = "reference-blueprints-release-v4.32.0__project__verso-flt"
+            write_json(
+                expected_path,
+                {"version": 1, "artifacts": {expected_name: artifact_envelope("v4.32.0", "verso-flt")}},
+            )
+            artifacts_root.mkdir()
+
+            missing = self.run_helper(artifacts_root, output_root, expected_path)
+            self.assertNotEqual(missing.returncode, 0)
+            self.assertIn("missing deploy reference artifacts", missing.stderr)
+
+            unexpected = artifacts_root / "reference-blueprints-release-v4.30.0__project__verso-carleson"
+            (unexpected / "html-multi").mkdir(parents=True)
+            write_json(unexpected / IDENTITY_FILENAME, artifact_envelope("v4.30.0", "verso-carleson"))
+
+            extra = self.run_helper(artifacts_root, output_root, expected_path)
+            self.assertNotEqual(extra.returncode, 0)
+            self.assertIn("unexpected deploy reference artifact", extra.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Backport #320 to `v4.31.0`.

## Primary Review
- Primary review: #320
- Keep review comments on #320 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.31.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- Retain the release branch's existing near-release maintainer guidance.
- Add the deploy matrix's `publish_pdf`/manifest plumbing already present on v4.32, because the older branch lacked that prerequisite and the shared hardened workflow consumes it.
- No project pins or intended release selections change.