### PR TITLE
[backport v4.30.0] chore: update to Lean v4.32.0

### DIFF
--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -298,9 +298,12 @@ That command rewrites the managed `lean-toolchain` files, rewrites the root
 package's direct `require verso` pin, refreshes the committed manifests for the
 root package, `project_template`, and
 `tests/test_blueprints/preview_runtime_showcase/`, and by default runs the same
-build/test validation pass that maintainers would otherwise do manually. Release
+build/test validation pass that maintainers would otherwise do manually. It
+also synchronizes the current release target's RC metadata for in-repo
+reference projects; external project RC overrides remain explicit. Release
 candidates use the official short RC name, for example `4.31-rc2`; the harness
 writes the corresponding Lean and `verso` tag ref, such as `v4.31.0-rc2`.
+The requested toolchain must belong to the checkout's current release line.
 Pass `--verso-ref <tag>` only when the Lean toolchain ref and upstream `verso`
 release tag need to differ.
 
@@ -323,8 +326,9 @@ Run this from the new local branch, for example `v4.31.0`. The command:
   line, the previous default-development branch becomes a required backport
   target, and the new release target is recorded
 - adds the new release target to in-repo CI fixtures such as
-  `project-template`; fixtures remain explicitly selectable for validation but
-  are not added to the public reference catalog
+  `project-template` and records their RC override while the root package is on
+  a release candidate; fixtures remain explicitly selectable for validation
+  but are not added to the public reference catalog
 
 For release candidates, use the official short RC name such as `4.31-rc2`.
 The branch name remains the stable release branch, for example `v4.31.0`, while
@@ -655,9 +659,10 @@ python3 -m scripts.blueprint_harness worktree-retire <name> --merged-pr <number>
   `VersoBlueprint` resolves to the checkout under test before running
   `lake update`
 - external reference repositories should commit `lake-manifest.json`; when that
-  tracked manifest is present, the harness updates only `VersoBlueprint` so
-  transitive dependencies such as `verso` stay pinned to the project's tested
-  revisions
+  tracked manifest is present, the harness runs a full update from those
+  committed pins, so fixed direct inputs remain pinned while the local
+  `VersoBlueprint` dependency and its transitive graph are refreshed
+- project and dependency `lean-toolchain` files are immutable harness inputs
 - the Python harness is maintainer tooling for those validations, not the main
   package-facing authoring interface
 
@@ -821,8 +826,10 @@ The harness is now project-driven rather than hardcoded to one project.
 - the harness currently rewrites the cloned `lakefile.lean` dependency line so
   external test projects exercise the local `VersoBlueprint` checkout instead
   of the committed upstream dependency
-- the external checkout's Lean release family must match its catalog target;
-  the harness rejects cross-release combinations before running `lake update`
+- the external project's top-level `lean-toolchain` selects its compiler; the
+  harness validates that it exactly matches the project target's final/RC
+  metadata and belongs to the same Lean release family as the VBP checkout, but
+  never promotes an RC project or rewrites dependency toolchains
 - the current local override injection expects a `lakefile.lean` project that
   declares `VersoBlueprint` from the official `leanprover/verso-blueprint` Git
   repository, and it tolerates different Git refs and URL spellings for that

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -415,17 +415,34 @@ def command_sync_root_lake(_: argparse.Namespace) -> int:
 def command_bump_toolchain(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
     require_checkout_role(layout.package_root, required_role="default_dev", operation="bump-toolchain")
+    requested_release_id = release_branch_from_lean_ref(args.toolchain)
+    checkout_release_id = active_release_branch(layout.package_root)
+    if requested_release_id != checkout_release_id:
+        raise SystemExit(
+            f"[blueprint-harness] refusing to bump `{checkout_release_id}` with toolchain `{args.toolchain}`; "
+            f"expected a toolchain on release line `{checkout_release_id}`"
+        )
+
     result = bump_toolchain_checkout(
         layout.package_root,
         args.toolchain,
         verso_ref=args.verso_ref,
         validate=not args.skip_validation,
     )
+    rc = release_candidate_name_or_none(result.lean_ref)
+    manifest_path = resolve_manifest_path(None, layout.package_root)
+    update_release_line_project_manifest(
+        manifest_path,
+        release_id=requested_release_id,
+        rc=rc,
+    )
     print(f"package_root={layout.package_root}")
     print(f"toolchain_ref={result.lean_ref}")
     print(f"toolchain_spec={result.toolchain_spec}")
     print(f"verso_ref={result.verso_ref}")
     print(f"verso_tag_oid={result.verso_tag_oid}")
+    print(f"rc={rc or ''}")
+    print(f"project_manifest={manifest_path}")
     print(f"validated={str(not args.skip_validation).lower()}")
     return 0
 
@@ -449,6 +466,7 @@ def update_release_line_project_manifest(
     manifest_path: Path,
     *,
     release_id: str,
+    rc: str | None,
 ) -> None:
     try:
         raw = load_json_object(manifest_path)
@@ -459,6 +477,7 @@ def update_release_line_project_manifest(
     if not isinstance(projects, list):
         raise SystemExit(f"[blueprint-harness] invalid project manifest `{manifest_path}`: expected `projects` list")
 
+    changed = False
     for project in projects:
         if not isinstance(project, dict):
             continue
@@ -471,13 +490,29 @@ def update_release_line_project_manifest(
                 f"[blueprint-harness] invalid project manifest `{manifest_path}`: "
                 f"in-repo project `{project.get('id', '<unknown>')}` has no `targets` list"
             )
-        if not any(
-            isinstance(target, dict) and release_branch_from_lean_ref(str(target.get("release", ""))) == release_id
-            for target in targets
-        ):
-            targets.append({"release": release_id})
+        matching_target = next(
+            (
+                target
+                for target in targets
+                if isinstance(target, dict)
+                and release_branch_from_lean_ref(str(target.get("release", ""))) == release_id
+            ),
+            None,
+        )
+        if matching_target is None:
+            matching_target = {"release": release_id}
+            targets.append(matching_target)
+            changed = True
+        if rc is None:
+            if "rc" in matching_target:
+                matching_target.pop("rc")
+                changed = True
+        elif matching_target.get("rc") != rc:
+            matching_target["rc"] = rc
+            changed = True
 
-    write_json(manifest_path, raw)
+    if changed:
+        write_json(manifest_path, raw)
 
 
 def upsert_release_target(
@@ -495,12 +530,25 @@ def upsert_release_target(
 
 def command_start_release_line(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
-    release_id = release_branch_from_lean_ref(args.toolchain)
+    requested_lean_ref = normalize_lean_release_ref(args.toolchain)
+    release_id = release_branch_from_lean_ref(requested_lean_ref)
     current_branch = current_branch_name(layout.package_root)
     if current_branch != release_id:
         raise SystemExit(
             f"[blueprint-harness] start-release-line must run from local branch `{release_id}`; "
             f"current branch is `{current_branch or '<detached>'}`"
+        )
+
+    requested_rc = release_candidate_name_or_none(requested_lean_ref)
+    requested_verso_ref = (
+        normalize_lean_release_ref(args.verso_ref)
+        if args.verso_ref is not None
+        else requested_lean_ref
+    )
+    if requested_rc is not None and release_branch_from_lean_ref(requested_verso_ref) != release_id:
+        raise SystemExit(
+            f"[blueprint-harness] release candidate `{requested_lean_ref}` expects a matching `verso` release line; "
+            f"got `{requested_verso_ref}`"
         )
 
     old_policy = load_branch_policy(layout.package_root)
@@ -518,11 +566,6 @@ def command_start_release_line(args: argparse.Namespace) -> int:
     release_toolchain = release_branch_from_lean_ref(result.lean_ref)
     release_verso_ref = release_branch_from_lean_ref(result.verso_ref)
     rc = release_candidate_name_or_none(result.lean_ref)
-    if rc is not None and release_verso_ref != release_id:
-        raise SystemExit(
-            f"[blueprint-harness] release candidate `{result.lean_ref}` expects a matching `verso` release line; "
-            f"got `{result.verso_ref}`"
-        )
 
     release_targets = upsert_release_target(
         old_policy.release_targets,
@@ -545,6 +588,7 @@ def command_start_release_line(args: argparse.Namespace) -> int:
     update_release_line_project_manifest(
         manifest_path,
         release_id=release_id,
+        rc=rc,
     )
 
     print(f"package_root={layout.package_root}")

--- a/scripts/blueprint_harness_project_commands.py
+++ b/scripts/blueprint_harness_project_commands.py
@@ -60,13 +60,22 @@ def _require_official_blueprint_git_dependency(project_dir: Path, *, action: str
     return lakefile, text, match
 
 
-def rewrite_local_blueprint_dependency(project_dir: Path, package_root: Path) -> Path:
+def rewrite_local_blueprint_dependency(
+    project_dir: Path,
+    package_root: Path,
+    *,
+    relative: bool = False,
+) -> Path:
     lakefile, text, match = _require_official_blueprint_git_dependency(
         project_dir,
         action="inject the local path override automatically",
     )
-    relative_path = os.path.relpath(package_root, start=project_dir)
-    replacement = f'{match.group("indent")}require VersoBlueprint from "{relative_path}"'
+    local_path = (
+        Path(os.path.relpath(package_root.resolve(), project_dir.resolve())).as_posix()
+        if relative
+        else str(package_root.resolve())
+    )
+    replacement = f'{match.group("indent")}require VersoBlueprint from "{local_path}"'
     rewritten = text[: match.start()] + replacement + text[match.end() :]
     rewritten = disable_header_linter_for_mathlib_blueprint_lakefile(rewritten)
     lakefile.write_text(rewritten, encoding="utf-8")
@@ -167,7 +176,12 @@ def run_project_lake_update(package_root: Path, project_dir: Path) -> list[str]:
     return command
 
 
-def maybe_rewrite_in_repo_blueprint_dependency(project_dir: Path, package_root: Path) -> tuple[Path | None, str | None]:
+def maybe_rewrite_in_repo_blueprint_dependency(
+    project_dir: Path,
+    package_root: Path,
+    *,
+    relative: bool = False,
+) -> tuple[Path | None, str | None]:
     lakefile = project_dir / "lakefile.lean"
     if not lakefile.exists():
         return None, None
@@ -178,7 +192,7 @@ def maybe_rewrite_in_repo_blueprint_dependency(project_dir: Path, package_root: 
     if "require VersoBlueprint from git" not in text:
         return None, None
 
-    rewrite_local_blueprint_dependency(project_dir, package_root)
+    rewrite_local_blueprint_dependency(project_dir, package_root, relative=relative)
     return lakefile, text
 
 
@@ -188,8 +202,13 @@ def maybe_in_repo_blueprint_dependency_override(
     package_root: Path,
     *,
     log: bool = False,
+    relative: bool = False,
 ):
-    rewritten_lakefile, original_lakefile_text = maybe_rewrite_in_repo_blueprint_dependency(project_dir, package_root)
+    rewritten_lakefile, original_lakefile_text = maybe_rewrite_in_repo_blueprint_dependency(
+        project_dir,
+        package_root,
+        relative=relative,
+    )
     if rewritten_lakefile is not None and log:
         print(f"[blueprint-harness] local package override: rewrote {rewritten_lakefile}")
     try:

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -107,6 +107,14 @@ def _short_reference_cache_ref(ref: str) -> str:
     return ref
 
 
+def selected_project_toolchain(project: HarnessProject) -> str | None:
+    if project.selected_rc is not None:
+        return release_candidate_ref(project.selected_rc)
+    if project.selected_release is not None:
+        return normalize_lean_release_ref(project.selected_release)
+    return None
+
+
 def reference_dependency_cache_key(project: HarnessProject) -> str:
     """Key dependency cache state for one external project source ref.
 

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -9,13 +9,14 @@ from pathlib import Path
 import tomllib
 
 from scripts.blueprint_harness_releases import (
-    lean_release_order_key,
-    lean_toolchain_spec,
     normalize_lean_release_ref,
     release_branch_from_lean_ref,
-    rewrite_lean_toolchain,
 )
-from scripts.blueprint_harness_projects import HarnessProject, reference_dependency_cache_key
+from scripts.blueprint_harness_projects import (
+    HarnessProject,
+    reference_dependency_cache_key,
+    selected_project_toolchain,
+)
 from scripts.blueprint_harness_project_commands import (
     discard_untracked_project_manifest,
     format_project_command,
@@ -73,28 +74,10 @@ class ReferenceProjectBumpResult:
 
 
 @dataclass(frozen=True)
-class ReferenceToolchainCandidate:
+class ReferenceToolchain:
     path: Path
     lean_ref: str
     release_branch: str
-    order_key: tuple[int, int, int, int]
-
-
-@dataclass(frozen=True)
-class ReferenceToolchainReconciliationResult:
-    selected_ref: str | None
-    release_branch: str | None
-    changed_paths: tuple[Path, ...]
-
-    @property
-    def changed(self) -> bool:
-        return bool(self.changed_paths)
-
-
-@dataclass(frozen=True)
-class ReferenceLakeUpdateResult:
-    command: list[str]
-    reconciliation: ReferenceToolchainReconciliationResult
 
 
 def output_dir_for(project: HarnessProject, output_root: Path) -> Path:
@@ -155,7 +138,7 @@ def lake_build_dir(project_dir: Path) -> Path:
     return project_dir / ".lake" / "build"
 
 
-def read_reference_toolchain_candidate(path: Path) -> ReferenceToolchainCandidate | None:
+def read_reference_toolchain(path: Path) -> ReferenceToolchain | None:
     if not path.exists():
         return None
     try:
@@ -163,72 +146,58 @@ def read_reference_toolchain_candidate(path: Path) -> ReferenceToolchainCandidat
     except SystemExit:
         return None
 
-    order_key = lean_release_order_key(lean_ref)
-    if order_key is None:
-        return None
-    return ReferenceToolchainCandidate(
+    return ReferenceToolchain(
         path=path,
         lean_ref=lean_ref,
         release_branch=release_branch_from_lean_ref(lean_ref),
-        order_key=order_key,
     )
 
 
-def reference_dependency_toolchain_paths(project_dir: Path) -> list[Path]:
-    packages = lake_packages_dir(project_dir)
-    if not packages.exists():
-        return []
-    return sorted(path / "lean-toolchain" for path in packages.iterdir() if (path / "lean-toolchain").exists())
+def validate_reference_toolchain_release_family(
+    package_root: Path,
+    project_dir: Path,
+    *,
+    expected_project_toolchain: str | None = None,
+) -> str | None:
+    """Reject cross-release checks without changing any checkout toolchain.
 
-
-def reconcile_reference_toolchains(package_root: Path, project_dir: Path) -> ReferenceToolchainReconciliationResult:
-    package_candidate = read_reference_toolchain_candidate(package_root / "lean-toolchain")
-    project_candidate = read_reference_toolchain_candidate(project_dir / "lean-toolchain")
-    if package_candidate is None or project_candidate is None:
-        return ReferenceToolchainReconciliationResult(
-            selected_ref=None,
-            release_branch=None,
-            changed_paths=(),
+    The external project owns the compiler used for its build. In particular,
+    an RC-pinned catalog project remains on that RC even when the selected
+    Verso Blueprint checkout has advanced to the final release. Dependency
+    toolchains are immutable inputs and are never inspected or rewritten.
+    """
+    package_toolchain = read_reference_toolchain(package_root / "lean-toolchain")
+    project_toolchain = read_reference_toolchain(project_dir / "lean-toolchain")
+    if expected_project_toolchain is None and (package_toolchain is None or project_toolchain is None):
+        return None
+    if package_toolchain is None:
+        raise SystemExit(
+            "[blueprint-harness] selected Verso Blueprint checkout has no valid `lean-toolchain`: "
+            f"{package_root / 'lean-toolchain'}"
         )
-    if package_candidate.release_branch != project_candidate.release_branch:
+    if project_toolchain is None:
+        raise SystemExit(
+            "[blueprint-harness] external reference project has no valid `lean-toolchain`: "
+            f"{project_dir / 'lean-toolchain'}"
+        )
+    if package_toolchain.release_branch != project_toolchain.release_branch:
         raise SystemExit(
             "[blueprint-harness] reference Blueprint release mismatch: "
-            f"project `{project_dir}` uses Lean `{project_candidate.lean_ref}` "
-            f"({project_candidate.release_branch}), but the selected Verso Blueprint checkout "
-            f"uses Lean `{package_candidate.lean_ref}` ({package_candidate.release_branch}). "
+            f"project `{project_dir}` uses Lean `{project_toolchain.lean_ref}` "
+            f"({project_toolchain.release_branch}), but the selected Verso Blueprint checkout "
+            f"uses Lean `{package_toolchain.lean_ref}` ({package_toolchain.release_branch}). "
             "Catalog each external Blueprint only under its current matching release."
         )
-
-    common_branch = package_candidate.release_branch
-    candidates = [package_candidate, project_candidate]
-    for path in reference_dependency_toolchain_paths(project_dir):
-        candidate = read_reference_toolchain_candidate(path)
-        if candidate is not None and candidate.release_branch == common_branch:
-            candidates.append(candidate)
-
-    selected = max(candidates, key=lambda candidate: candidate.order_key)
-    package_toolchain_path = package_candidate.path.resolve()
-    changed_paths: list[Path] = []
-    for candidate in candidates:
-        # The package checkout is the source for the run; reconcile only the
-        # disposable reference checkout files.
-        if candidate.path.resolve() == package_toolchain_path:
-            continue
-        if candidate.lean_ref == selected.lean_ref:
-            continue
-        rewrite_lean_toolchain(candidate.path, selected.lean_ref)
-        changed_paths.append(candidate.path)
-
-    if changed_paths:
-        print(
-            "[blueprint-harness] reconciled reference Lean toolchain to "
-            f"{lean_toolchain_spec(selected.lean_ref)} for {len(changed_paths)} file(s) sharing {common_branch}"
-        )
-    return ReferenceToolchainReconciliationResult(
-        selected_ref=selected.lean_ref,
-        release_branch=common_branch,
-        changed_paths=tuple(changed_paths),
-    )
+    if expected_project_toolchain is not None:
+        expected_ref = normalize_lean_release_ref(expected_project_toolchain)
+        if project_toolchain.lean_ref != expected_ref:
+            raise SystemExit(
+                "[blueprint-harness] reference Blueprint toolchain mismatch: "
+                f"catalog target expects Lean `{expected_ref}`, but project `{project_dir}` "
+                f"uses Lean `{project_toolchain.lean_ref}`. Update the external project ref "
+                "or keep its explicit project-target RC metadata."
+            )
+    return project_toolchain.lean_ref
 
 
 def validate_reference_package_mode(mode: str) -> str:
@@ -602,20 +571,18 @@ def run_reference_lake_update(
     package_root: Path,
     project_dir: Path,
     *,
-    reconcile_toolchains: bool = True,
-) -> ReferenceLakeUpdateResult:
-    reconciliation = (
-        reconcile_reference_toolchains(package_root, project_dir)
-        if reconcile_toolchains
-        else ReferenceToolchainReconciliationResult(
-            selected_ref=None,
-            release_branch=None,
-            changed_paths=(),
+    validate_toolchain_release: bool = True,
+    expected_project_toolchain: str | None = None,
+) -> list[str]:
+    if validate_toolchain_release:
+        validate_reference_toolchain_release_family(
+            package_root,
+            project_dir,
+            expected_project_toolchain=expected_project_toolchain,
         )
-    )
     command = project_lake_update_command(package_root, project_dir)
     run(command, cwd=project_dir)
-    return ReferenceLakeUpdateResult(command=command, reconciliation=reconciliation)
+    return command
 
 
 def project_checkout_pathspec(checkout_root: Path, project_dir: Path) -> str:
@@ -731,7 +698,11 @@ def bump_reference_project(
 
     project_dir = edit_dir / project.project_root
     _lakefile, previous_ref = rewrite_pinned_blueprint_dependency(project_dir, ref)
-    run_reference_lake_update(layout.package_root, project_dir)
+    run_reference_lake_update(
+        layout.package_root,
+        project_dir,
+        expected_project_toolchain=selected_project_toolchain(project),
+    )
 
     generated_output: Path | None = None
     command_output_root = output_root or (layout.artifact_root / "reference-blueprints-edit")
@@ -861,7 +832,11 @@ def sync_reference_cache_checkout(
     seed_lake_path_builds_from_dependency_cache(layout, project, project_dir)
     try:
         with local_blueprint_dependency_override(layout.package_root, project_dir, restore_lakefile=True):
-            run_reference_lake_update(layout.package_root, project_dir)
+            run_reference_lake_update(
+                layout.package_root,
+                project_dir,
+                expected_project_toolchain=selected_project_toolchain(project),
+            )
             seed_lake_path_builds_from_dependency_cache(layout, project, project_dir)
             if warm_build and project.build_command is not None:
                 command = lean_low_priority_command(layout.package_root, *project.build_command)
@@ -964,7 +939,7 @@ def generate_in_repo_command_project(
                 update_project=lambda: run_reference_lake_update(
                     layout.package_root,
                     project_dir,
-                    reconcile_toolchains=False,
+                    validate_toolchain_release=False,
                 ),
                 build_command=project.build_command,
                 generate_command=generate_command,
@@ -1009,7 +984,8 @@ def generate_git_project(
             run_reference_lake_update(
                 layout.package_root,
                 project_dir,
-                reconcile_toolchains=True,
+                validate_toolchain_release=True,
+                expected_project_toolchain=selected_project_toolchain(project),
             )
             seed_lake_path_builds_from_dependency_cache(layout, project, project_dir)
 

--- a/scripts/blueprint_harness_toolchains.py
+++ b/scripts/blueprint_harness_toolchains.py
@@ -112,7 +112,7 @@ def resolve_remote_verso_tag_oid(package_root: Path, ref: str) -> str | None:
 
 
 def refresh_managed_manifest(package_root: Path, project_dir: Path) -> None:
-    with maybe_in_repo_blueprint_dependency_override(project_dir, package_root):
+    with maybe_in_repo_blueprint_dependency_override(project_dir, package_root, relative=True):
         run(lean_low_priority_command(package_root, "lake", "update"), cwd=project_dir)
 
 

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -1151,6 +1151,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                     "operation": operation,
                 }
             ),
+            active_release_branch=lambda _package_root: "v4.29.0",
             bump_toolchain_checkout=lambda package_root, toolchain, *, verso_ref, validate: seen.update(
                 {
                     "package_root": package_root,
@@ -1165,6 +1166,14 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 verso_ref="v4.29.0",
                 verso_tag_oid="deadbeef",
             ),
+            resolve_manifest_path=lambda _path, _package_root: Path("/tmp/projects.json"),
+            update_release_line_project_manifest=lambda manifest_path, *, release_id, rc: seen.update(
+                {
+                    "manifest_path": manifest_path,
+                    "manifest_release_id": release_id,
+                    "manifest_rc": rc,
+                }
+            ),
         ):
             self.assertEqual(harness_mod.command_bump_toolchain(args), 0)
 
@@ -1175,6 +1184,86 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertEqual(seen["toolchain"], "4.29.0")
         self.assertEqual(seen["verso_ref"], None)
         self.assertTrue(seen["validate"])
+        self.assertEqual(seen["manifest_path"], Path("/tmp/projects.json"))
+        self.assertEqual(seen["manifest_release_id"], "v4.29.0")
+        self.assertIsNone(seen["manifest_rc"])
+
+    def test_bump_toolchain_rejects_a_different_release_line_before_mutation(self) -> None:
+        args = argparse.Namespace(toolchain="4.30-rc2", verso_ref=None, skip_validation=True)
+        layout = SimpleNamespace(package_root=Path("/tmp/package"))
+        called = False
+
+        def unexpected_bump(*_args, **_kwargs):
+            nonlocal called
+            called = True
+
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            require_checkout_role=lambda _checkout_root, *, required_role, operation: None,
+            active_release_branch=lambda _package_root: "v4.29.0",
+            bump_toolchain_checkout=unexpected_bump,
+        ):
+            with self.assertRaisesRegex(SystemExit, "expected a toolchain on release line `v4.29.0`"):
+                harness_mod.command_bump_toolchain(args)
+
+        self.assertFalse(called)
+
+    def test_update_release_line_project_manifest_tracks_in_repo_rc_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = Path(tmp) / "projects.json"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "version": 2,
+                        "projects": [
+                            {
+                                "id": "template",
+                                "source": {"kind": "in_repo_project"},
+                                "targets": [{"release": "v4.29.0"}],
+                            },
+                            {
+                                "id": "external",
+                                "source": {"kind": "git_checkout"},
+                                "targets": [{"release": "v4.30.0", "ref": "abc", "rc": "4.30-rc1"}],
+                            },
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            original_text = manifest_path.read_text(encoding="utf-8")
+
+            harness_mod.update_release_line_project_manifest(
+                manifest_path,
+                release_id="v4.29.0",
+                rc=None,
+            )
+            self.assertEqual(manifest_path.read_text(encoding="utf-8"), original_text)
+
+            harness_mod.update_release_line_project_manifest(
+                manifest_path,
+                release_id="v4.30.0",
+                rc="4.30-rc2",
+            )
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                manifest["projects"][0]["targets"],
+                [
+                    {"release": "v4.29.0"},
+                    {"release": "v4.30.0", "rc": "4.30-rc2"},
+                ],
+            )
+            self.assertEqual(manifest["projects"][1]["targets"][0]["rc"], "4.30-rc1")
+
+            harness_mod.update_release_line_project_manifest(
+                manifest_path,
+                release_id="v4.30.0",
+                rc=None,
+            )
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertNotIn("rc", manifest["projects"][0]["targets"][1])
+            self.assertEqual(manifest["projects"][1]["targets"][0]["rc"], "4.30-rc1")
 
     def test_start_release_line_updates_policy_and_in_repo_targets(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -1298,14 +1387,42 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
             self.assertNotIn("release_targets", manifest)
             self.assertEqual(
-                [target["release"] for target in manifest["projects"][0]["targets"]],
-                ["v4.29.0", "v4.30.0"],
+                manifest["projects"][0]["targets"],
+                [
+                    {"release": "v4.29.0"},
+                    {"release": "v4.30.0", "rc": "4.30-rc2"},
+                ],
             )
             self.assertEqual(
                 [target["release"] for target in manifest["projects"][1]["targets"]],
                 ["v4.29.0"],
             )
             self.assertIn("set-default-dev-branch v4.30.0", out.getvalue())
+
+    def test_start_release_line_rejects_mismatched_rc_verso_line_before_mutation(self) -> None:
+        args = argparse.Namespace(
+            toolchain="4.30-rc2",
+            verso_ref="v4.29.0",
+            deploy_pages=False,
+            skip_validation=True,
+        )
+        layout = SimpleNamespace(package_root=Path("/tmp/package"))
+        called = False
+
+        def unexpected_bump(*_args, **_kwargs):
+            nonlocal called
+            called = True
+
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            current_branch_name=lambda _checkout_root: "v4.30.0",
+            bump_toolchain_checkout=unexpected_bump,
+        ):
+            with self.assertRaisesRegex(SystemExit, "expects a matching `verso` release line"):
+                harness_mod.command_start_release_line(args)
+
+        self.assertFalse(called)
 
     def test_set_default_dev_branch_preserves_required_backports(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/harness/test_blueprint_harness_project_commands.py
+++ b/tests/harness/test_blueprint_harness_project_commands.py
@@ -62,6 +62,21 @@ class BlueprintHarnessProjectCommandTests(unittest.TestCase):
             self.assertIn('require VersoBlueprint from "', text)
             self.assertNotIn('from git "https://github.com/leanprover/verso-blueprint.git"', text)
 
+    def test_rewrite_local_blueprint_dependency_can_emit_a_portable_relative_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            package_root = Path(tmp) / "package"
+            project_dir = package_root / "project_template"
+            project_dir.mkdir(parents=True)
+            lakefile = project_dir / "lakefile.lean"
+            lakefile.write_text(f"{OFFICIAL_BLUEPRINT_REQUIRE}\n", encoding="utf-8")
+
+            rewrite_local_blueprint_dependency(project_dir, package_root, relative=True)
+
+            self.assertEqual(
+                lakefile.read_text(encoding="utf-8"),
+                'require VersoBlueprint from ".."',
+            )
+
     def test_rewrite_local_blueprint_dependency_disables_mathlib_header_linter(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             project_dir = Path(tmp)

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -34,14 +34,15 @@ from scripts.blueprint_harness_references import (
     default_reference_edit_base,
     generate_git_project,
     reference_submodule_update_command,
-    reconcile_reference_toolchains,
     require_reference_harness_layout,
+    run_reference_lake_update,
     seed_lake_path_builds_from_dependency_cache,
     seed_reference_edit_checkout_lake,
     seed_lake_packages_from_dependency_cache,
     store_lake_path_builds_in_dependency_cache,
     store_lake_packages_in_dependency_cache,
     update_git_checkout,
+    validate_reference_toolchain_release_family,
 )
 
 
@@ -1116,7 +1117,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             "chore/bump-verso-blueprint-9b50e39c1743",
         )
 
-    def test_reconcile_reference_toolchains_promotes_same_release_branch_to_newest_ref(self) -> None:
+    def test_validate_reference_toolchains_preserves_rc_project_and_dependencies(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             package_root = root / "pkg"
@@ -1131,32 +1132,27 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             (mathlib_dir / "lean-toolchain").write_text("leanprover/lean4:v4.30.0-rc2", encoding="utf-8")
             (other_dir / "lean-toolchain").write_text("leanprover/lean4:v4.29.0\n", encoding="utf-8")
 
-            result = reconcile_reference_toolchains(package_root, project_dir)
-
-            self.assertTrue(result.changed)
-            self.assertEqual(result.selected_ref, "v4.30.0")
-            self.assertEqual(result.release_branch, "v4.30.0")
-            self.assertEqual(
-                set(result.changed_paths),
-                {
-                    project_dir / "lean-toolchain",
-                    mathlib_dir / "lean-toolchain",
-                },
+            selected_ref = validate_reference_toolchain_release_family(
+                package_root,
+                project_dir,
+                expected_project_toolchain="4.30-rc1",
             )
+
+            self.assertEqual(selected_ref, "v4.30.0-rc1")
             self.assertEqual(
                 (project_dir / "lean-toolchain").read_text(encoding="utf-8"),
-                "leanprover/lean4:v4.30.0\n",
+                "leanprover/lean4:4.30-rc1\n",
             )
             self.assertEqual(
                 (mathlib_dir / "lean-toolchain").read_text(encoding="utf-8"),
-                "leanprover/lean4:v4.30.0",
+                "leanprover/lean4:v4.30.0-rc2",
             )
             self.assertEqual(
                 (other_dir / "lean-toolchain").read_text(encoding="utf-8"),
                 "leanprover/lean4:v4.29.0\n",
             )
 
-    def test_reconcile_reference_toolchains_rejects_different_release_branches(self) -> None:
+    def test_validate_reference_toolchains_rejects_different_release_branches(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             package_root = root / "pkg"
@@ -1172,7 +1168,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 SystemExit,
                 "reference Blueprint release mismatch.*Catalog each external Blueprint only under its current matching release",
             ):
-                reconcile_reference_toolchains(package_root, project_dir)
+                validate_reference_toolchain_release_family(package_root, project_dir)
 
             self.assertEqual(
                 (project_dir / "lean-toolchain").read_text(encoding="utf-8"),
@@ -1182,6 +1178,109 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 (mathlib_dir / "lean-toolchain").read_text(encoding="utf-8"),
                 "leanprover/lean4:v4.29.0\n",
             )
+
+    def test_reference_lake_update_rejects_missing_toolchain_before_update(self) -> None:
+        import scripts.blueprint_harness_references as refs_mod
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_root = root / "pkg"
+            project_dir = root / "external"
+            package_root.mkdir()
+            project_dir.mkdir()
+            (package_root / "lean-toolchain").write_text("leanprover/lean4:v4.30.0\n", encoding="utf-8")
+            update_called = False
+
+            original_run = refs_mod.run
+            try:
+                def unexpected_run(_command, *, cwd):
+                    nonlocal update_called
+                    update_called = True
+
+                refs_mod.run = unexpected_run
+                with self.assertRaisesRegex(SystemExit, "external reference project has no valid `lean-toolchain`"):
+                    run_reference_lake_update(
+                        package_root,
+                        project_dir,
+                        expected_project_toolchain="v4.30.0",
+                    )
+            finally:
+                refs_mod.run = original_run
+
+            self.assertFalse(update_called)
+
+    def test_reference_lake_update_rejects_catalog_toolchain_drift_before_update(self) -> None:
+        import scripts.blueprint_harness_references as refs_mod
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_root = root / "pkg"
+            project_dir = root / "external"
+            package_root.mkdir()
+            project_dir.mkdir()
+            (package_root / "lean-toolchain").write_text("leanprover/lean4:v4.30.0\n", encoding="utf-8")
+            (project_dir / "lean-toolchain").write_text("leanprover/lean4:v4.30.0-rc1\n", encoding="utf-8")
+            update_called = False
+
+            original_run = refs_mod.run
+            try:
+                def unexpected_run(_command, *, cwd):
+                    nonlocal update_called
+                    update_called = True
+
+                refs_mod.run = unexpected_run
+                with self.assertRaisesRegex(
+                    SystemExit,
+                    "catalog target expects Lean `v4.30.0`.*keep its explicit project-target RC metadata",
+                ):
+                    run_reference_lake_update(
+                        package_root,
+                        project_dir,
+                        expected_project_toolchain="v4.30.0",
+                    )
+            finally:
+                refs_mod.run = original_run
+
+            self.assertFalse(update_called)
+
+    def test_reference_lake_update_never_mutates_project_or_dependency_toolchains(self) -> None:
+        import scripts.blueprint_harness_references as refs_mod
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_root = root / "pkg"
+            project_dir = root / "external"
+            dependency_dir = project_dir / ".lake" / "packages" / "verso-slides"
+            package_root.mkdir()
+            dependency_dir.mkdir(parents=True)
+            (package_root / "lean-toolchain").write_text("leanprover/lean4:v4.30.0\n", encoding="utf-8")
+            (project_dir / "lean-toolchain").write_text("leanprover/lean4:v4.30.0-rc1\n", encoding="utf-8")
+            dependency_toolchain = dependency_dir / "lean-toolchain"
+            dependency_toolchain.write_text("leanprover/lean4:v4.30.0\n", encoding="utf-8")
+
+            original_run = refs_mod.run
+            original_update_command = refs_mod.project_lake_update_command
+            seen: dict[str, str] = {}
+
+            def fake_run(command, *, cwd):
+                self.assertEqual(command, ["lake", "update"])
+                self.assertEqual(cwd, project_dir)
+                seen["project"] = (project_dir / "lean-toolchain").read_text(encoding="utf-8")
+                seen["dependency"] = dependency_toolchain.read_text(encoding="utf-8")
+
+            try:
+                refs_mod.run = fake_run
+                refs_mod.project_lake_update_command = lambda _package_root, _project_dir: ["lake", "update"]
+                result = run_reference_lake_update(package_root, project_dir)
+            finally:
+                refs_mod.run = original_run
+                refs_mod.project_lake_update_command = original_update_command
+
+            self.assertEqual(seen["project"], "leanprover/lean4:v4.30.0-rc1\n")
+            self.assertEqual(seen["dependency"], "leanprover/lean4:v4.30.0\n")
+            self.assertEqual((project_dir / "lean-toolchain").read_text(encoding="utf-8"), seen["project"])
+            self.assertEqual(dependency_toolchain.read_text(encoding="utf-8"), "leanprover/lean4:v4.30.0\n")
+            self.assertEqual(result, ["lake", "update"])
 
     def test_reference_cache_checkout_uses_current_package_root_override(self) -> None:
         import scripts.blueprint_harness_project_commands as commands_mod


### PR DESCRIPTION
## Summary
Backport #319 to `v4.30.0`.

## Primary Review
- Primary review: #319
- Keep review comments on #319 unless this backport diverges materially.

## Scope
- Backport the default-development change onto `v4.30.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- The v4.32-only release-pin commit is provenance-only; v4.30 toolchain and package pins remain unchanged.
- Conflict resolution preserves the v4.30 API surface while applying the reviewed manifest-path behavior.