### PR TITLE
[backport v4.30.0] perf: normalize relation panel traversal caches

### DIFF
--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -1066,8 +1066,8 @@ the operational detail that is easier to read in prose.
 | `CitationPreviews` | runtime cache | `(citation label, citation style, locator kind, locator index)` -> `CitationPreviewData` | Bibliography hover payloads captured during citation traversal and rendered into preview data. |
 | `Bibliography` | semantic domain | citation label -> bibliography entry anchor ids | Linkable bibliography entry destinations. |
 | `CitationUsages` | accumulator | citation label -> `CitationUsageData` plus citation use-site ids | Backlink data accumulated from citation inlines, including rendered use-site destinations and human-readable location summaries. |
-| `RelatedPanelUsedByCache` | internal index | informal label -> precomputed reverse-dependency entries | Reverse-dependency rows grouped by target label so each rendered used-by panel avoids a full node scan. |
-| `RelatedPanelGroupMembersCache` | internal index | group label -> precomputed statement members | Group members collected once by parent label so each rendered group panel avoids a full node scan. |
+| `RelatedPanelUsedByCache` | internal index | informal label -> ordered reverse-dependency metadata keyed by source label | Compact reverse-dependency facts grouped by target label so each rendered used-by panel avoids a full node scan; canonical source-node data remains in `Nodes`. |
+| `RelatedPanelGroupMembersCache` | internal index | group label -> ordered statement labels | Group-member labels collected once by parent label so each rendered group panel avoids a full node scan; canonical member data remains in `Nodes`. |
 
 The auxiliary indexes above are normalized out of `Nodes` for different
 reasons:
@@ -1083,8 +1083,8 @@ reasons:
 | `ExternalDeclAnchors` | Informal block traversal for rendered external declarations | Informal block rendering plus summary/graph/code-summary links that jump to rendered external rows | Store only occurrence-specific row anchors keyed by `(informal label, canonical declaration)`. The same Lean declaration may be rendered under multiple Blueprint labels, and each rendered row needs its own destination. |
 | `CitationPreviews` | Citation inline traversal | `TraversalIndex.CitationPreviews.entries`, preview-manifest construction, and citation inline hovers via the shared lookup key | Store bibliography hover data once per rendered citation target and locator. Inline citations then carry a manifest key instead of owning page-local preview templates. |
 | `CitationUsages` | Citation inline traversal | `TraversalIndex.CitationUsages.hrefs`, `TraversalIndex.CitationUsages.data?`, and bibliography rendering | Accumulate bibliography backlinks by citation label. Each citation use contributes a rendered href plus a structured location summary, while bibliography entries remain the semantic/linkable destinations in `Bibliography`. |
-| `RelatedPanelUsedByCache` | `Informal.RelatedPanel.patchRelationCaches` after traversal | used-by relation-panel rendering | Precompute merged reverse-dependency entries once per target label, including statement/proof axes and non-default origin or intent metadata. |
-| `RelatedPanelGroupMembersCache` | `Informal.RelatedPanel.patchRelationCaches` after traversal | group relation-panel rendering | Precompute statement members once per parent label while leaving canonical node metadata in `Nodes`. |
+| `RelatedPanelUsedByCache` | `Informal.RelatedPanel.patchRelationCaches` after traversal | `TraversalIndex.RelatedPanelUsedByCache.data?` and used-by relation-panel rendering | Store only the source label plus merged statement/proof axes and origin or intent metadata. Resolve the source's canonical node data through `Nodes` instead of copying a full `BlockData` into every target cache. |
+| `RelatedPanelGroupMembersCache` | `Informal.RelatedPanel.patchRelationCaches` after traversal | `TraversalIndex.RelatedPanelGroupMembersCache.data?` and group relation-panel rendering | Store ordered statement labels once per parent label. Resolve canonical member data through `Nodes` instead of copying full statement records into the group cache. |
 
 In particular, the main Blueprint node index is now intentionally slimmer than
 the full `BlockData` payload used by block rendering. Code-specific

--- a/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
+++ b/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
@@ -216,7 +216,27 @@ private structure UsedByEntry where
   inProof : Bool := false
   origins : Array Data.UseOrigin := #[]
   intents : Array Data.UseIntent := #[]
-deriving FromJson, ToJson
+
+private def UsedByEntry.toCacheEntry (entry : UsedByEntry) :
+    Informal.TraversalIndex.RelatedPanelUsedByCache.Entry := {
+  sourceLabel := entry.source.label
+  inStatement := entry.inStatement
+  inProof := entry.inProof
+  origins := entry.origins
+  intents := entry.intents
+}
+
+private def UsedByEntry.ofCacheEntry?
+    (ctx : RelationContext)
+    (entry : Informal.TraversalIndex.RelatedPanelUsedByCache.Entry) : Option UsedByEntry := do
+  let source ← storedBlockByLabel? ctx entry.sourceLabel
+  return {
+    source
+    inStatement := entry.inStatement
+    inProof := entry.inProof
+    origins := entry.origins
+    intents := entry.intents
+  }
 
 private structure UsesEntry where
   label : Data.Label
@@ -257,16 +277,6 @@ private def addUsedByEntry
   else
     acc.push <| mergeUsedByEntry { source } useRef isProof
 
-private def cachedDomainData? [FromJson α]
-    (state : TraverseState) (domainName : Lean.Name) (label : Data.Label) : Option α := do
-  let obj ← state.getDomainObject? domainName label.toString
-  (fromJson? (α := α) obj.data).toOption
-
-private def saveCachedDomainData [ToJson α]
-    (state : TraverseState) (domainName : Lean.Name) (label : Data.Label) (data : α) :
-    TraverseState :=
-  state.saveDomainObjectData domainName label.toString (toJson data)
-
 private def addUsedByCacheEntry
     (cache : Data.LabelMap (Array UsedByEntry)) (source : BlockData)
     (useRef : Data.UseRef) (isProof : Bool) : Data.LabelMap (Array UsedByEntry) :=
@@ -294,13 +304,13 @@ private def buildUsedByCache (blocks : Array BlockData) :
     cache.insert label (sortUsedByEntries entries)
 
 private def buildGroupMembersCache (blocks : Array BlockData) :
-    Data.LabelMap (Array BlockData) :=
+    Data.LabelMap (Array Data.Label) :=
   blocks.foldl
-      (init := (Std.TreeMap.empty : Data.LabelMap (Array BlockData))) fun cache block =>
+      (init := (Std.TreeMap.empty : Data.LabelMap (Array Data.Label))) fun cache block =>
     match block.kind, block.parent with
     | .statement _, some parent =>
         let members := cache.find? parent |>.getD #[]
-        cache.insert parent (members.push block)
+        cache.insert parent (members.push block.label)
     | _, _ => cache
 
 /--
@@ -316,15 +326,15 @@ def patchRelationCaches (state : TraverseState) : TraverseState :=
   let groupMembersCache := buildGroupMembersCache blocks
   let state :=
     usedByCache.foldl (init := state) fun state label entries =>
-      saveCachedDomainData state Informal.TraversalIndex.RelatedPanelUsedByCache.domainName label entries
+      Informal.TraversalIndex.RelatedPanelUsedByCache.saveData state label
+        (entries.map fun entry => entry.toCacheEntry)
   groupMembersCache.foldl (init := state) fun state label entries =>
-    saveCachedDomainData state Informal.TraversalIndex.RelatedPanelGroupMembersCache.domainName label entries
+    Informal.TraversalIndex.RelatedPanelGroupMembersCache.saveData state label entries
 
 private def collectUsedByEntries
     (ctx : RelationContext) (target : Data.Label) : Array UsedByEntry :=
-  match cachedDomainData? (α := Array UsedByEntry) ctx.state
-      Informal.TraversalIndex.RelatedPanelUsedByCache.domainName target with
-  | some entries => entries
+  match Informal.TraversalIndex.RelatedPanelUsedByCache.data? ctx.state target with
+  | some entries => entries.filterMap (UsedByEntry.ofCacheEntry? ctx)
   | none =>
       sortUsedByEntries <| collectStoredBlocks ctx.state |>.foldl (init := #[]) fun acc source =>
         if source.label == target then
@@ -384,9 +394,9 @@ private def collectUsesEntries
 private def collectGroupEntries
     (ctx : RelationContext) (target : BlockData) (group : GroupRenderInfo) :
     Array BlockData :=
-  match cachedDomainData? (α := Array BlockData) ctx.state
-      Informal.TraversalIndex.RelatedPanelGroupMembersCache.domainName group.label with
-  | some entries => entries.filter (fun source => source.label != target.label)
+  match Informal.TraversalIndex.RelatedPanelGroupMembersCache.data? ctx.state group.label with
+  | some labels => labels.filterMap fun label =>
+      if label == target.label then none else storedBlockByLabel? ctx label
   | none =>
       collectStoredBlocks ctx.state |>.foldl (init := #[]) fun acc source =>
         if source.label == target.label then

--- a/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
+++ b/src/VersoBlueprint/Informal/Block/RelatedPanel.lean
@@ -7,7 +7,6 @@ Author: Emilio J. Gallego Arias
 import VersoManual
 import VersoBlueprint.Informal.Block.Model
 import VersoBlueprint.Informal.Block.Store
-import VersoBlueprint.Informal.Group
 import VersoBlueprint.Lib.HoverRender
 import VersoBlueprint.Lib.PreviewSource
 import VersoBlueprint.TraversalIndex

--- a/src/VersoBlueprint/TraversalIndex.lean
+++ b/src/VersoBlueprint/TraversalIndex.lean
@@ -546,15 +546,31 @@ end CitationUsages
 
 namespace RelatedPanelUsedByCache
 
+/-- Compact reverse-dependency metadata; canonical source-node data remains in `Nodes`. -/
+structure Entry where
+  sourceLabel : Data.Label
+  inStatement : Bool := false
+  inProof : Bool := false
+  origins : Array Data.UseOrigin := #[]
+  intents : Array Data.UseIntent := #[]
+deriving FromJson, ToJson
+
 def spec : StoreSpec := {
   name := `_versoBlueprintRelationUsedByCache
   kind := .internalIndex
   key := "informal label"
-  value := "precomputed reverse-dependency relation-panel entries"
+  value := "precomputed reverse-dependency metadata keyed by source label"
   summary := "Traversal-local render cache for Blueprint relation-panel reverse dependencies."
 }
 
 def domainName : Name := spec.name
+
+def data? (state : TraverseState) (label : Data.Label) : Option (Array Entry) :=
+  objectData? state domainName label.toString
+
+def saveData (state : TraverseState) (label : Data.Label) (entries : Array Entry) :
+    TraverseState :=
+  saveObjectData state domainName label.toString (toJson entries)
 
 end RelatedPanelUsedByCache
 
@@ -564,11 +580,18 @@ def spec : StoreSpec := {
   name := `_versoBlueprintRelationGroupMembersCache
   kind := .internalIndex
   key := "group label"
-  value := "precomputed group-member relation-panel entries"
+  value := "ordered statement-member labels"
   summary := "Traversal-local render cache for Blueprint relation-panel group membership."
 }
 
 def domainName : Name := spec.name
+
+def data? (state : TraverseState) (label : Data.Label) : Option (Array Data.Label) :=
+  objectData? state domainName label.toString
+
+def saveData (state : TraverseState) (label : Data.Label) (members : Array Data.Label) :
+    TraverseState :=
+  saveObjectData state domainName label.toString (toJson members)
 
 end RelatedPanelGroupMembersCache
 

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
@@ -26,21 +26,16 @@ private def sampleMissingPreviewPanelEntry : Informal.RelatedPanel.PanelEntry :=
   label := Lean.Name.mkSimple "missing.preview"
 }
 
-private def cachedRelationArraySize?
-    (state : Verso.Genre.Manual.TraverseState) (domainName label : Lean.Name) : Option Nat := do
-  let obj ← state.getDomainObject? domainName label.toString
-  match obj.data with
-  | .arr entries => some entries.size
-  | _ => none
-
 private def cachedStatement
-    (label : Lean.Name) (count : Nat) (statementUses : Array Informal.Data.UseRef := #[]) :
+    (label : Lean.Name) (count : Nat) (statementUses : Array Informal.Data.UseRef := #[])
+    (parent : Option Informal.Data.Parent := none) :
     Informal.StoredBlockData :=
   {
     kind := .statement .definition
     label
     count
     statementUses
+    parent
   }
 
 /-- info: true -/
@@ -77,20 +72,34 @@ private def cachedStatement
     let target := Lean.Name.mkSimple "cache.target"
     let source := Lean.Name.mkSimple "cache.source"
     let empty := Lean.Name.mkSimple "cache.empty"
+    let group := Lean.Name.mkSimple "cache.group"
     let targetData := cachedStatement target 0 #[{ label := target }]
-    let sourceData := cachedStatement source 1 #[{ label := target }]
+    let sourceData := cachedStatement source 1
+      #[{ label := target, origin := .automatic, intent := .auxiliary }] (some group)
     let emptyData := cachedStatement empty 2
     let state : Verso.Genre.Manual.TraverseState := .initialize {}
     let state := Informal.TraversalIndex.Nodes.saveData state target (Lean.toJson targetData)
     let state := Informal.TraversalIndex.Nodes.saveData state source (Lean.toJson sourceData)
     let state := Informal.TraversalIndex.Nodes.saveData state empty (Lean.toJson emptyData)
     let state := Informal.RelatedPanel.patchRelationCaches state
-    cachedRelationArraySize? state
-        Informal.TraversalIndex.RelatedPanelUsedByCache.domainName target == some 1 &&
-      cachedRelationArraySize? state
-        Informal.TraversalIndex.RelatedPanelUsedByCache.domainName source == some 0 &&
-      cachedRelationArraySize? state
-        Informal.TraversalIndex.RelatedPanelUsedByCache.domainName empty == some 0
+    let targetEntries := Informal.TraversalIndex.RelatedPanelUsedByCache.data? state target
+    let sourceEntries := Informal.TraversalIndex.RelatedPanelUsedByCache.data? state source
+    let emptyEntries := Informal.TraversalIndex.RelatedPanelUsedByCache.data? state empty
+    let groupMembers := Informal.TraversalIndex.RelatedPanelGroupMembersCache.data? state group
+    match targetEntries with
+    | some #[entry] =>
+        let rawEntry := Lean.toJson entry |>.compress
+        match entry.origins, entry.intents with
+        | #[.automatic], #[.auxiliary] =>
+            entry.sourceLabel == source &&
+              entry.inStatement && !entry.inProof &&
+              !hasSubstr rawEntry "\"count\"" &&
+              !hasSubstr rawEntry "\"statementUses\"" &&
+              sourceEntries.map Array.isEmpty == some true &&
+              emptyEntries.map Array.isEmpty == some true &&
+              groupMembers == some #[source]
+        | _, _ => false
+    | _ => false
 
 /-- info: true -/
 #guard_msgs in


### PR DESCRIPTION
## Summary
Backport #325 to `v4.30.0`.

## Primary Review
- Primary review: #325
- Keep review comments on #325 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.30.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.