### PR TITLE
[backport v4.30.0] chore: move current reference Blueprints to v4.31

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,19 +366,20 @@ you want to enable it.
 The repository also tracks a current, release-versioned reference catalog.
 Each external Blueprint is published only for its intended current release:
 Noperthedron and FLT on `v4.32.0`, and Sphere Packing and Carleson on
-`v4.30.0`. The in-repo starter template is a CI fixture rather than a public
+`v4.31.0`. The in-repo starter template is a CI fixture rather than a public
 reference entry; it continues to validate every maintained release line.
 Release lines without a current external reference project, currently
-`v4.31.0`, remain CI-maintained without adding an empty public catalog section.
+`v4.30.0`, remain CI-maintained without adding an empty public catalog section
+or deploying a legacy reference catalog.
 
 - [`ejgallego/verso-noperthedron`](https://github.com/ejgallego/verso-noperthedron),
   [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/noperthedron/)
 - [`ejgallego/verso-sphere-packing`](https://github.com/ejgallego/verso-sphere-packing),
-  [rendered site for v4.30.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.30.0/spherepackingblueprint/)
+  [rendered site for v4.31.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.31.0/spherepackingblueprint/)
 - [`ejgallego/verso-flt`](https://github.com/ejgallego/verso-flt),
   [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/verso-flt/)
 - [`ejgallego/verso-carleson`](https://github.com/ejgallego/verso-carleson),
-  [rendered site for v4.30.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.30.0/verso-carleson/)
+  [rendered site for v4.31.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.31.0/verso-carleson/)
 
 ## Rendered Test Blueprints
 

--- a/branch-policy.json
+++ b/branch-policy.json
@@ -11,14 +11,14 @@
       "toolchain": "v4.30.0",
       "verso_ref": "v4.30.0",
       "branch": "v4.30.0",
-      "deploy_pages": true
+      "deploy_pages": false
     },
     {
       "id": "v4.31.0",
       "toolchain": "v4.31.0",
       "verso_ref": "v4.31.0",
       "branch": "v4.31.0",
-      "deploy_pages": false
+      "deploy_pages": true
     },
     {
       "id": "v4.32.0",

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -61,8 +61,8 @@
       },
       "targets": [
         {
-          "release": "v4.30.0",
-          "ref": "75cb2fb052fd37a851b6e5d2f89e80c80d5dece3",
+          "release": "v4.31.0",
+          "ref": "4cbb43d6401ff2ca8d4495b82fea99df59b633bd",
           "publish_reference": true
         }
       ],
@@ -80,7 +80,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "3a249321ef38b74fe89b61cbfcde01fae2dc69a7",
+          "ref": "1695b7cb937a8022dacd2742b969a272b7d57d1e",
           "publish_reference": true,
           "rc": "4.32-rc1"
         }
@@ -98,9 +98,8 @@
       },
       "targets": [
         {
-          "release": "v4.30.0",
-          "ref": "9c5052bbdac3f3bcecdf988b53e1a1fa10c84f6b",
-          "rc": "4.30-rc2",
+          "release": "v4.31.0",
+          "ref": "5b34f5d43ba50bca0680b2c139b2b994857902f4",
           "publish_reference": true
         }
       ],

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -158,16 +158,16 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertIsNotNone(default_template_target)
         self.assertFalse(default_template_target.publish_reference)
         self.assertFalse(any(target.publish_reference for target in projects[0].targets))
-        self.assertFalse(catalog.release_target("v4.31.0").deploy_pages)
+        self.assertFalse(catalog.release_target("v4.30.0").deploy_pages)
         self.assertEqual(current_release.release_toolchain, current_release.toolchain)
         self.assertEqual(current_release.release_verso_ref, current_release.verso_ref)
         if current_release.deploy_pages:
             self.assertTrue(resolve_projects_for_release(catalog, current_release.release_id, None))
         expected_external_releases = {
             "noperthedron": "v4.32.0",
-            "spherepackingblueprint": "v4.30.0",
+            "spherepackingblueprint": "v4.31.0",
             "verso-flt": "v4.32.0",
-            "verso-carleson": "v4.30.0",
+            "verso-carleson": "v4.31.0",
         }
         self.assertTrue(projects[1].git_checkout)
         self.assertEqual(projects[1].repository, "https://github.com/ejgallego/verso-noperthedron.git")
@@ -197,7 +197,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assert_single_current_release_target(
             projects[4], expected_external_releases[projects[4].project_id], publish_reference=True
         )
-        self.assertIsNotNone(projects[4].targets[0].rc)
+        self.assertIsNone(projects[4].targets[0].rc)
         self.assertIsNone(projects[4].build_command)
         self.assertEqual(projects[4].generate_command, VBP_BUILD_OUTPUT_COMMAND)
 
@@ -778,21 +778,21 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(
             set(rows),
             {
-                ("v4.30.0", "spherepackingblueprint"),
-                ("v4.30.0", "verso-carleson"),
+                ("v4.31.0", "spherepackingblueprint"),
+                ("v4.31.0", "verso-carleson"),
                 ("v4.32.0", "noperthedron"),
                 ("v4.32.0", "verso-flt"),
             },
         )
-        self.assertFalse(rows[("v4.30.0", "spherepackingblueprint")]["publish_pdf"])
-        self.assertFalse(rows[("v4.30.0", "verso-carleson")]["publish_pdf"])
+        self.assertFalse(rows[("v4.31.0", "spherepackingblueprint")]["publish_pdf"])
+        self.assertFalse(rows[("v4.31.0", "verso-carleson")]["publish_pdf"])
         self.assertNotIn(
             "--pdf",
-            rows[("v4.30.0", "spherepackingblueprint")]["project_manifest"]["projects"][0]["generate_command"],
+            rows[("v4.31.0", "spherepackingblueprint")]["project_manifest"]["projects"][0]["generate_command"],
         )
         self.assertNotIn(
             "--pdf",
-            rows[("v4.30.0", "verso-carleson")]["project_manifest"]["projects"][0]["generate_command"],
+            rows[("v4.31.0", "verso-carleson")]["project_manifest"]["projects"][0]["generate_command"],
         )
 
         current_release_projects = [


### PR DESCRIPTION
## Summary

Backport #330 to `v4.30.0`.

## Primary Review

- Primary review: #330
- Keep review comments on #330 unless this backport diverges materially.

## Scope

- Backport the already-reviewed default-development change onto `v4.30.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta

- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.
