### PR TITLE
chore: stop requiring v4.30 backports

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,4 +23,3 @@ This PR <short summary of the problem solved and useful outcome>.
 maintainer-visible changes. Avoid module-by-module implementation inventory.>
 
 Backport v4.31.0: pending
-Backport v4.30.0: pending

--- a/branch-policy.json
+++ b/branch-policy.json
@@ -2,8 +2,7 @@
   "version": 2,
   "default_dev_branch": "v4.32.0",
   "required_backport_branches": [
-    "v4.31.0",
-    "v4.30.0"
+    "v4.31.0"
   ],
   "release_targets": [
     {


### PR DESCRIPTION
This PR removes v4.30 from the required-backport policy before the release line is fully retired, allowing subsequent harness maintenance to require only the maintained v4.31 backport.

Backport v4.31.0: exempt: repository metadata only
Backport v4.30.0: exempt: repository metadata only