### PR TITLE
fix: align summary and work queue readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ This uses the checked-in Lake manifest and writes the HTML site under
 `lake exe vbp build --serve`. After that, follow the template README to rename
 `ProjectTemplate` to your project name and replace the starter chapters.
 
+After building, query the generated planning data through `vbp` rather than
+reading generated JSON files directly:
+
+```bash
+lake exe vbp query work-queue
+lake exe vbp query metadata
+```
+
 ### See real examples
 
 For larger Blueprints in use, see [Reference Blueprints](#reference-blueprints).
@@ -294,7 +302,8 @@ contribute automatically to the reported progress state.
 
 ### Metadata export
 
-Blueprint can dump structured metadata for other tools, including the semantic
+For common label, dependency, planning, and metadata queries, use
+`lake exe vbp query`. Lower-level tools can also dump the complete semantic
 manifest, its schema, and the rendered-fragment cache
 (`blueprint-html-cache.json`) used by preview consumers. The cache includes the
 hover payloads needed by cached Lean fragments. These are command-line flags

--- a/doc/API.md
+++ b/doc/API.md
@@ -284,12 +284,14 @@ methods on `Informal.PreviewManifest.File` rather than reimplementing filters:
 `findPrimaryQueryableEntry?`, `blockStatementEntries`,
 `findBlockEntriesByLabel`, `findPrimaryBlockEntry?`, `sourceDocument?`,
 `entriesWithSource`, `entriesForSourceDocument`, `ownerValues`, `tagValues`,
-`metadataEntries`, and `workQueueEntries`. `metadataEntries` selects nodes with
-owner, tag, priority, or effort metadata. `workQueueEntries` selects nodes whose
-finalized graph status exposes an unblocked statement or proof step. Finalized
-graph data is the generated planning source of truth: the helper does not infer
-readiness from tags or other entry metadata, and returns an empty queue when no
-matching graph nodes are present. Use the queryable helpers for the same node
+`metadataEntries`, `actionableGraphNode?`, and `workQueueEntries`.
+`metadataEntries` selects nodes with owner, tag, priority, or effort metadata.
+`workQueueEntries` selects nodes whose finalized graph status exposes an
+actionable statement or proof step; `actionableGraphNode?` returns that status
+record for clients that need the step and its statement/proof states. Finalized
+graph data is the generated planning source of truth: these helpers do not infer
+readiness from tags or other entry metadata, and return no work-queue item when
+no matching graph node is present. Use the queryable helpers for the same node
 selection as `lake exe vbp query`; use the block-only helpers when a consumer
 explicitly needs rendered block entries and should exclude source-backed
 bodyless external-markup nodes. Entry-level helpers
@@ -305,9 +307,12 @@ def primaryNodeTitle?
     (label : String) : Option String :=
   (manifest.findPrimaryQueryableEntry? label).map (·.title)
 
-def workQueueLabels
-    (manifest : Informal.PreviewManifest.File) : Array String :=
-  manifest.workQueueEntries.map (·.authoredLabel)
+def workQueueNextSteps
+    (manifest : Informal.PreviewManifest.File) : Array (String × String) :=
+  manifest.workQueueEntries.filterMap fun entry => do
+    let node ← manifest.actionableGraphNode? entry.label
+    let nextStep ← node.actionableStage?
+    pure (entry.authoredLabel, nextStep)
 ```
 
 Generator-side Lean callers can configure source-backed external-markup cache

--- a/doc/API.md
+++ b/doc/API.md
@@ -284,10 +284,15 @@ methods on `Informal.PreviewManifest.File` rather than reimplementing filters:
 `findPrimaryQueryableEntry?`, `blockStatementEntries`,
 `findBlockEntriesByLabel`, `findPrimaryBlockEntry?`, `sourceDocument?`,
 `entriesWithSource`, `entriesForSourceDocument`, `ownerValues`, `tagValues`,
-and `workQueueEntries`. Use the queryable helpers for the same node selection
-as `lake exe vbp query`; use the block-only helpers when a consumer explicitly
-needs rendered block entries and should exclude source-backed bodyless
-external-markup nodes. Entry-level helpers
+`metadataEntries`, and `workQueueEntries`. `metadataEntries` selects nodes with
+owner, tag, priority, or effort metadata. `workQueueEntries` selects nodes whose
+finalized graph status exposes an unblocked statement or proof step. Finalized
+graph data is the generated planning source of truth: the helper does not infer
+readiness from tags or other entry metadata, and returns an empty queue when no
+matching graph nodes are present. Use the queryable helpers for the same node
+selection as `lake exe vbp query`; use the block-only helpers when a consumer
+explicitly needs rendered block entries and should exclude source-backed
+bodyless external-markup nodes. Entry-level helpers
 `Entry.hasSourceDocument`, `Entry.matchesText`, and `Entry.matchesCode` provide
 the same source filtering and search predicates used by the `lake exe vbp query`
 interface.

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -994,7 +994,8 @@ entries without knowing each traversal domain's raw JSON decoding details.
 
 Finished manifest files also own the reusable query helpers for downstream
 Lean clients. `Informal.PreviewManifest.File` provides block-entry filtering,
-primary label lookup, owner/tag/work-queue extraction, and entry search
+primary label lookup, owner/tag/metadata extraction, graph-status-backed work
+queues, and entry search
 predicates. `Informal.PreviewManifest.previewMetadataLosses` audits whether
 traversal-preview Lean metadata, including bodyless `(lean := ...)` payloads,
 survived manifest construction. Preview-data generation reports non-empty audit
@@ -1002,6 +1003,14 @@ results as warnings while traversal state is still available. Generated-data
 tools such as `VersoBlueprint.Vbp` operate after that boundary, so they validate
 manifest/cache consistency instead of reconstructing traversal-only audits;
 neither layer should own a parallel selector model.
+
+The semantic environment remains the build-time source of truth for authored
+nodes, dependencies, and Lean status. Once generation finishes, finalized graph
+data is the public planning projection of that state. Work-queue consumers read
+those graph statuses directly and must not reinterpret tags such as
+`formalized` or infer readiness from the presence of owner, priority, or effort
+metadata. If a generated manifest contains no matching graph node, the node has
+no generated planning status and is omitted from the work queue.
 
 ### Traversal Storage Roles
 

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -867,8 +867,8 @@ For routine project work, read the summary from top to bottom:
 
 1. Start with **Current blockers**. Missing external declarations and incomplete
    Lean declarations usually explain why apparently small tasks are not ready.
-2. Use **Ready next** for work that can start now and already unlocks downstream
-   entries.
+2. Use **Actionable priorities** for work that can start now and already
+   unlocks downstream entries.
 3. Check **Quick wins** when you want small high-priority tasks.
 4. Use **Dependency insights** and **Structure and coverage** when planning a
    larger batch of work or reviewing the shape of a Blueprint.

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -879,6 +879,9 @@ Some summary sections use deliberately practical project-management terms:
 
 - **Actionable** entries are not locally formalized yet, and their statement or
   proof status says there is work that can start now.
+- **Actionable priorities** are the actionable entries that also unlock
+  downstream work. The broader **Ready now** count, quick wins, and owner/tag
+  rollups still include actionable leaf entries with no dependents.
 - **Quick wins** are actionable entries marked with high priority and small
   effort metadata.
 - **Direct uses** count immediate statement or proof dependency edges into an

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -271,7 +271,7 @@ above until the semantics are clearer.
 2. keep the default summary focused on progress, blockers, and next ready work;
    move owner/tag rollups, dependency insights, and metadata audit to the
    maintainer view
-3. use compact status chips after the status source of truth is centralized
+3. use compact status chips in summary and work-queue rows
 4. revisit graph layout with a CSS-first page architecture so canvas sizing is
    less runtime-driven
 5. improve the default font family used by generated Blueprint output

--- a/skills/verso-blueprint/references/vbp.md
+++ b/skills/verso-blueprint/references/vbp.md
@@ -26,6 +26,7 @@ group <label>
 owners
 tags
 work-queue
+metadata
 search <text>
 code <decl>
 stats
@@ -84,7 +85,11 @@ All query commands print compact JSON for agent consumption. The JSON shape is f
 - `used-by <label>`: reverse dependencies for one label.
 - `group <label>`: group metadata and sibling entries for one label, when present.
 - `owners` and `tags`: distinct values from statement-level block entries.
-- `work-queue`: statement-level entries with owner, tags, priority, or effort metadata.
+- `work-queue`: statement-level entries with a graph-status-backed unblocked
+  next step; each row includes `nextStep`, `statementStatus`, and `proofStatus`.
+  Graph data is the generated planning source of truth, so no graph status means
+  no work-queue row.
+- `metadata`: statement-level entries with owner, tags, priority, or effort metadata.
 - `search <text>`: statement-level entries whose label, title, owner, tag, or parent title contains the text, case-insensitively.
 - `code <decl>`: statement-level entries with Lean preview keys containing the declaration text.
 - `stats`: counts of statement-level entries by kind, owner, and tag.

--- a/src/VersoBlueprint/Commands/Summary/Collect.lean
+++ b/src/VersoBlueprint/Commands/Summary/Collect.lean
@@ -78,20 +78,6 @@ partial def downstreamUseCount (reverseMap : NameMap (Array Name))
       let next := (reverseMap.getD label #[]).toList
       downstreamUseCount reverseMap (next ++ rest) (visited.insert label) (count + 1)
 
-private def actionableStage? (node : Data.Node)
-    (statementStatus : Informal.Graph.StatementStatus) (proofStatus : Informal.Graph.ProofStatus) : Option String :=
-  if node.kind.isTheoremLike then
-    if proofStatus == .ready || proofStatus == .incomplete then
-      some "proof"
-    else if statementStatus == .ready then
-      some "statement"
-    else
-      none
-  else if statementStatus == .ready then
-    some "statement"
-  else
-    none
-
 private def bumpEntryStatus (acc : EntryStatusCounts) (flags : EntryStatusFlags) : EntryStatusCounts :=
   {
     completed := acc.completed + (if flags.completed then 1 else 0)
@@ -278,7 +264,7 @@ private def priorityItem? (state : Environment.State) (external : Informal.Graph
   let statementStatus := Informal.Graph.statementStatus external state label node
   let proofStatus := Informal.Graph.proofStatus external state label node
   let localFormalized := Informal.Graph.nodeLocalFormalized external node
-  match actionableStage? node statementStatus proofStatus with
+  match Informal.Graph.actionableStageForStatuses? node.kind statementStatus proofStatus with
   | Option.none => Option.none
   | Option.some stage =>
     if localFormalized then
@@ -547,7 +533,7 @@ private def GroupHealthCounts.addEntry (counts : GroupHealthCounts)
   let proofStatus := Informal.Graph.proofStatus ctx.external ctx.state child node
   let readyNow :=
     !Informal.Graph.nodeLocalFormalized ctx.external node &&
-      (actionableStage? node statementStatus proofStatus).isSome
+      (Informal.Graph.actionableStageForStatuses? node.kind statementStatus proofStatus).isSome
   let blockedNow := !statusFlags.completed && !statusFlags.completedDepsNo && !readyNow
   let incompleteLeanNow :=
     Informal.Graph.nodeHasAssociatedCode node &&
@@ -597,18 +583,14 @@ private def collectGroupHealth (ctx : SummaryBuildContext) : List GroupHealthIte
 
 private def collectCoverageSplit (ctx : SummaryBuildContext) : CoverageSplit :=
   ctx.entries.foldl (init := ({} : CoverageSplit)) fun acc (label, node) =>
-    let hasStatement := node.statement.isSome
-    let hasCode := Informal.Graph.nodeHasAssociatedCode node
     let statusFlags := entryStatusFlags ctx.state ctx.external node
     let statementStatus := Informal.Graph.statementStatus ctx.external ctx.state label node
     let proofStatus := Informal.Graph.proofStatus ctx.external ctx.state label node
-    if hasStatement && !hasCode then
-      { acc with informalOnly := acc.informalOnly + 1 }
-    else if statusFlags.completed then
+    if statusFlags.completed then
       { acc with fullyClosed := acc.fullyClosed + 1 }
     else if statusFlags.completedDepsNo then
       { acc with formalizedWithoutAncestors := acc.formalizedWithoutAncestors + 1 }
-    else if (actionableStage? node statementStatus proofStatus).isSome then
+    else if (Informal.Graph.actionableStageForStatuses? node.kind statementStatus proofStatus).isSome then
       { acc with readyToFormalize := acc.readyToFormalize + 1 }
     else
       { acc with blockedOrIncomplete := acc.blockedOrIncomplete + 1 }

--- a/src/VersoBlueprint/Commands/Summary/Collect.lean
+++ b/src/VersoBlueprint/Commands/Summary/Collect.lean
@@ -258,7 +258,7 @@ private def metadataEntryItem (state : Environment.State) (label : Name) (node :
     leanObjects := nodeLeanObjects node
   }
 
-private def priorityItem? (state : Environment.State) (external : Informal.Graph.ExternalCodeStatus)
+private def mkActionableItem? (state : Environment.State) (external : Informal.Graph.ExternalCodeStatus)
     (usageMap : NameMap UsageCounts) (reverseMap : NameMap (Array Name))
     (label : Name) (node : Data.Node) : Option PriorityItem :=
   let statementStatus := Informal.Graph.statementStatus external state label node
@@ -272,33 +272,27 @@ private def priorityItem? (state : Environment.State) (external : Informal.Graph
     else
       let usage := usageMap.getD label {}
       let downstreamUses := downstreamUseCount reverseMap (reverseMap.getD label #[]).toList
-      if downstreamUses == 0 then
-        Option.none
-      else
-        Option.some {
-          label
-          kind := toString node.kind
-          stage
-          priority := node.priority
-          ownerDisplayName := ownerDisplayName state node
-          effort := node.effort
-          prUrl := node.prUrl
-          tags := node.tags.toList
-          statementStatus := Informal.Graph.StatementStatus.toText statementStatus
-          proofStatus := if node.kind.isTheoremLike then Informal.Graph.ProofStatus.toText proofStatus else ""
-          directUses := usage.directUses
-          downstreamUses
-          leanObjects := nodeLeanObjects node
-        }
+      Option.some {
+        label
+        kind := toString node.kind
+        stage
+        priority := node.priority
+        ownerDisplayName := ownerDisplayName state node
+        effort := node.effort
+        prUrl := node.prUrl
+        tags := node.tags.toList
+        statementStatus := Informal.Graph.StatementStatus.toText statementStatus
+        proofStatus := if node.kind.isTheoremLike then Informal.Graph.ProofStatus.toText proofStatus else ""
+        directUses := usage.directUses
+        downstreamUses
+        leanObjects := nodeLeanObjects node
+      }
 
 private def metadataIsQuickWin (priority effort : Option String) : Bool :=
   priority == some "high" && effort == some "small"
 
 private def priorityItemIsQuickWin (item : PriorityItem) : Bool :=
   metadataIsQuickWin item.priority item.effort
-
-private def nodeIsQuickWin (node : Data.Node) (actionable : Bool) : Bool :=
-  actionable && metadataIsQuickWin node.priority node.effort
 
 private def addParentTheoremLikeItem (groups : NameMap (List IndexItem)) (parent : Name) (item : IndexItem) :
     NameMap (List IndexItem) :=
@@ -331,9 +325,9 @@ private def mkSummaryBuildContext (state : Environment.State) : SummaryBuildCont
 private def SummaryBuildContext.downstreamUses (ctx : SummaryBuildContext) (label : Name) : Nat :=
   downstreamUseCount ctx.reverseMap (ctx.reverseMap.getD label #[]).toList
 
-private def SummaryBuildContext.priorityEntry? (ctx : SummaryBuildContext)
+private def SummaryBuildContext.actionableItem? (ctx : SummaryBuildContext)
     (label : Name) (node : Data.Node) : Option PriorityItem :=
-  priorityItem? ctx.state ctx.external ctx.usageMap ctx.reverseMap label node
+  mkActionableItem? ctx.state ctx.external ctx.usageMap ctx.reverseMap label node
 
 private def SummaryBuildContext.childEntries (ctx : SummaryBuildContext) (children : Array Name) :
     Array (Name × Data.Node) :=
@@ -488,9 +482,9 @@ private def collectTheoremLikeByParent (ctx : SummaryBuildContext) : List Parent
       let header := ctx.groupHeaders.getD parent parent.toString
       { parent, header, entries := items.reverse } :: acc
 
-private def collectPriorityItems (ctx : SummaryBuildContext) : List PriorityItem :=
+private def collectActionableItems (ctx : SummaryBuildContext) : List PriorityItem :=
   let items := ctx.entries.foldl (init := #[]) fun acc (label, node) =>
-    match ctx.priorityEntry? label node with
+    match ctx.actionableItem? label node with
     | none => acc
     | some item => acc.push item
   (sortPriorityItems items).toList
@@ -559,7 +553,7 @@ private def collectGroupHealth (ctx : SummaryBuildContext) : List GroupHealthIte
         counts.addEntry ctx child node
       let nextPriority? :=
         let candidates := childEntries.foldl (init := #[]) fun acc (child, node) =>
-          match ctx.priorityEntry? child node with
+          match ctx.actionableItem? child node with
           | none => acc
           | some item => acc.push item
         let sorted := sortPriorityItems candidates
@@ -670,8 +664,9 @@ private def collectOwnerRollups (ctx : SummaryBuildContext) : List OwnerRollupIt
     match node.owner with
     | none => acc
     | some owner =>
-      let actionable := (ctx.priorityEntry? label node).isSome
-      let quickWin := nodeIsQuickWin node actionable
+      let actionableItem? := ctx.actionableItem? label node
+      let actionable := actionableItem?.isSome
+      let quickWin := actionableItem?.map priorityItemIsQuickWin |>.getD false
       let linkedPr := node.prUrl.isSome
       let displayName := (ownerDisplayName ctx.state node).getD owner.toString
       let cur := acc.getD owner { owner, displayName }
@@ -686,8 +681,9 @@ private def collectOwnerRollups (ctx : SummaryBuildContext) : List OwnerRollupIt
 
 private def collectTagRollups (ctx : SummaryBuildContext) : List TagRollupItem :=
   let rollups := ctx.entries.foldl (init := ({} : Std.HashMap String TagRollupItem)) fun acc (label, node) =>
-    let actionable := (ctx.priorityEntry? label node).isSome
-    let quickWin := nodeIsQuickWin node actionable
+    let actionableItem? := ctx.actionableItem? label node
+    let actionable := actionableItem?.isSome
+    let quickWin := actionableItem?.map priorityItemIsQuickWin |>.getD false
     let linkedPr := node.prUrl.isSome
     node.tags.foldl (init := acc) fun acc tag =>
       let cur := acc.getD tag { tag }
@@ -710,13 +706,14 @@ def buildSummary : CoreM Summary := do
   let state := informalExt.getState env
   let ctx := mkSummaryBuildContext state
   let summary := collectSummaryOverview ctx
-  let topPriorities := collectPriorityItems ctx
+  let actionableItems := collectActionableItems ctx
+  let actionablePriorities := actionableItems.filter (·.downstreamUses > 0)
   let metadataAudit := collectMetadataAudit ctx
   return {
     summary with
       showDebugDiagnostics := showDebugDiagnostics
       theoremLikeByParent := collectTheoremLikeByParent ctx
-      topPriorities := topPriorities
+      actionablePriorities := actionablePriorities
       mostUsed := collectUsageItems ctx
       groupHealth := collectGroupHealth ctx
       coverageSplit := collectCoverageSplit ctx
@@ -726,7 +723,7 @@ def buildSummary : CoreM Summary := do
       noDependents := collectIndexItems ctx fun label _ =>
         (ctx.usageMap.getD label {}).directUses == 0
       proofDebtHotspots := collectProofDebtHotspots ctx
-      quickWins := topPriorities.filter priorityItemIsQuickWin
+      quickWins := actionableItems.filter priorityItemIsQuickWin
       ownerRollups := collectOwnerRollups ctx
       tagRollups := collectTagRollups ctx
       linkedPrs := metadataAudit.sortedLinkedPrs

--- a/src/VersoBlueprint/Commands/Summary/Data.lean
+++ b/src/VersoBlueprint/Commands/Summary/Data.lean
@@ -178,7 +178,7 @@ structure Summary where
   theoremLikeIndex : List IndexItem := []
   axiomIndex : List IndexItem := []
   theoremLikeByParent : List ParentTheoremGroup := []
-  topPriorities : List PriorityItem := []
+  actionablePriorities : List PriorityItem := []
   mostUsed : List UsageItem := []
   groupHealth : List GroupHealthItem := []
   coverageSplit : CoverageSplit := {}

--- a/src/VersoBlueprint/Commands/Summary/Data.lean
+++ b/src/VersoBlueprint/Commands/Summary/Data.lean
@@ -96,7 +96,6 @@ structure GroupHealthItem where
 deriving Inhabited, FromJson, ToJson, Quote
 
 structure CoverageSplit where
-  informalOnly : Nat := 0
   readyToFormalize : Nat := 0
   formalizedWithoutAncestors : Nat := 0
   fullyClosed : Nat := 0

--- a/src/VersoBlueprint/Commands/Summary/Html.lean
+++ b/src/VersoBlueprint/Commands/Summary/Html.lean
@@ -53,7 +53,7 @@ def Summary.previewLabels (data : Summary) : Array Name :=
     data.renderFailures.map (·.label) ++
     data.definitionIndex.map (·.label) ++
     data.theoremLikeIndex.map (·.label) ++
-    data.topPriorities.map (·.label) ++
+    data.actionablePriorities.map (·.label) ++
     data.quickWins.map (·.label) ++
     data.mostUsed.map (·.label) ++
     data.heaviestPrerequisites.map (·.label) ++
@@ -95,7 +95,7 @@ structure SummaryRows where
   sorryRows : Array Output.Html := #[]
   missingRows : Array Output.Html := #[]
   renderFailureRows : Array Output.Html := #[]
-  topPriorityRows : Array Output.Html := #[]
+  actionablePriorityRows : Array Output.Html := #[]
   quickWinRows : Array Output.Html := #[]
   statementUsedItems : Array UsageItem := #[]
   proofUsedItems : Array UsageItem := #[]
@@ -614,7 +614,7 @@ private def SummaryRows.withOverviewRows
   let pendingInformalRows := ctx.leanRows data.pendingInformalEntries
   let sorryRows ← data.sorryDetails.toArray.mapM ctx.sorryRow
   let missingRows := data.missingLeanDecls.toArray.map ctx.missingRow
-  let topPriorityRows := data.topPriorities.toArray.map ctx.priorityRow
+  let actionablePriorityRows := data.actionablePriorities.toArray.map ctx.priorityRow
   let quickWinRows := data.quickWins.toArray.map ctx.priorityRow
   let blockerCount := data.missingLeanDecls.length + data.sorryDetails.length
   let blockerRows := missingRows ++ sorryRows
@@ -623,7 +623,7 @@ private def SummaryRows.withOverviewRows
     pendingInformalRows
     sorryRows
     missingRows
-    topPriorityRows
+    actionablePriorityRows
     quickWinRows
     blockerCount
     blockerRows

--- a/src/VersoBlueprint/Commands/Summary/Sections.lean
+++ b/src/VersoBlueprint/Commands/Summary/Sections.lean
@@ -44,7 +44,7 @@ private def summaryOverviewSection (data : Summary) (rows : SummaryRows) : Outpu
             (Option.some "Local code and prerequisite closure are both complete.")}}
         {{summaryCard
             "Actionable priorities"
-            (toString data.topPriorities.length)
+            (toString data.actionablePriorities.length)
             (Option.some "Entries ready now and already unlocking downstream work.")}}
         {{summaryOptionalWarnCard
             showBlockers
@@ -66,9 +66,9 @@ private def summaryOverviewSection (data : Summary) (rows : SummaryRows) : Outpu
           {{<p class="bp_summary_empty">"No blueprint entries were registered in the current document."</p>}}
         else .empty}}
       {{summaryOptionalCappedDetailsList
-          (!rows.topPriorityRows.isEmpty)
-          s!"Actionable priorities ({data.topPriorities.length})"
-          rows.topPriorityRows
+          (!rows.actionablePriorityRows.isEmpty)
+          s!"Actionable priorities ({data.actionablePriorities.length})"
+          rows.actionablePriorityRows
           "priorities"
           "bp_summary_subsection"
           true}}

--- a/src/VersoBlueprint/Commands/Summary/Sections.lean
+++ b/src/VersoBlueprint/Commands/Summary/Sections.lean
@@ -67,7 +67,7 @@ private def summaryOverviewSection (data : Summary) (rows : SummaryRows) : Outpu
         else .empty}}
       {{summaryOptionalCappedDetailsList
           (!rows.topPriorityRows.isEmpty)
-          s!"Ready next ({data.topPriorities.length})"
+          s!"Actionable priorities ({data.topPriorities.length})"
           rows.topPriorityRows
           "priorities"
           "bp_summary_subsection"
@@ -307,7 +307,7 @@ private def summaryStructureSection (data : Summary) (rows : SummaryRows) : Outp
   let showNoDependents := !rows.noDependentRows.isEmpty
   let showProofDebtHotspots := !rows.proofDebtHotspotRows.isEmpty
   let showStructureCards :=
-    data.coverageSplit.informalOnly > 0 ||
+    data.informalOnlyEntries > 0 ||
     data.coverageSplit.readyToFormalize > 0 ||
     data.coverageSplit.formalizedWithoutAncestors > 0 ||
     data.coverageSplit.fullyClosed > 0 ||
@@ -319,9 +319,9 @@ private def summaryStructureSection (data : Summary) (rows : SummaryRows) : Outp
     summarySection "Structure and coverage" {{
         <div class="bp_summary_grid">
           {{summaryOptionalCard
-              (data.coverageSplit.informalOnly > 0)
+              (data.informalOnlyEntries > 0)
               "Informal-only"
-              (toString data.coverageSplit.informalOnly)
+              (toString data.informalOnlyEntries)
               (Option.some "Statements with no associated Lean code yet.")}}
           {{summaryOptionalCard
               (data.coverageSplit.readyToFormalize > 0)

--- a/src/VersoBlueprint/Graph.lean
+++ b/src/VersoBlueprint/Graph.lean
@@ -38,7 +38,12 @@ inductive ProofStatus where
   | formalizedWithAncestors
 deriving Inhabited, Repr, DecidableEq, ToJson, FromJson, Quote
 
-/-- The formalization track whose next step is currently unblocked. -/
+/--
+The formalization track whose next step is currently actionable.
+
+For theorem-like nodes, ready or incomplete proof work takes precedence over a
+ready statement. Other node kinds expose only a ready statement step.
+-/
 def actionableStageForStatuses? (kind : Data.NodeKind)
     (statementStatus : StatementStatus) (proofStatus : ProofStatus) : Option String :=
   if kind.isTheoremLike then

--- a/src/VersoBlueprint/Graph.lean
+++ b/src/VersoBlueprint/Graph.lean
@@ -38,6 +38,21 @@ inductive ProofStatus where
   | formalizedWithAncestors
 deriving Inhabited, Repr, DecidableEq, ToJson, FromJson, Quote
 
+/-- The formalization track whose next step is currently unblocked. -/
+def actionableStageForStatuses? (kind : Data.NodeKind)
+    (statementStatus : StatementStatus) (proofStatus : ProofStatus) : Option String :=
+  if kind.isTheoremLike then
+    if proofStatus == .ready || proofStatus == .incomplete then
+      some "proof"
+    else if statementStatus == .ready then
+      some "statement"
+    else
+      none
+  else if statementStatus == .ready then
+    some "statement"
+  else
+    none
+
 structure WarningFlags where
   unknownRef : Bool := false
   leanOnlyNoStatement : Bool := false
@@ -253,6 +268,11 @@ structure NodeData where
   warnings : WarningFlags := {}
   visual : NodeVisual
 deriving Inhabited, Repr, ToJson, FromJson, Quote
+
+/-- The next unblocked formalization stage represented by this finalized graph node. -/
+def NodeData.actionableStage? (node : NodeData) : Option String := do
+  let kind ← node.kind
+  actionableStageForStatuses? kind node.statementStatus node.proofStatus
 
 /--
 Public graph data shared by Lean, generated manifests, and browser runtime code.

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -1516,11 +1516,28 @@ def File.tagValues (file : File) : Array String :=
       entry.tags.foldl pushUniqueString tags
   tags.qsort (· < ·)
 
-/-- Queryable statement entries carrying work-queue metadata. -/
-def File.workQueueEntries (file : File) : Array Entry :=
+/-- Queryable statement entries carrying owner, tag, priority, or effort metadata. -/
+def File.metadataEntries (file : File) : Array Entry :=
   file.queryableStatementEntries.filter fun entry =>
     entry.ownerDisplayName.isSome || entry.priority.isSome ||
       entry.effort.isSome || !entry.tags.isEmpty
+
+/-- First finalized graph node showing an unblocked next step for `label`. -/
+def File.actionableGraphNode? (file : File) (label : Name) : Option Informal.Graph.NodeData :=
+  file.graphs.findSome? fun graph =>
+    graph.nodes.find? fun node =>
+      node.label == label && node.actionableStage?.isSome
+
+/--
+Queryable statement entries whose next formalization stage is unblocked.
+
+Finalized graph nodes are the generated planning source of truth. This query
+does not infer readiness from entry metadata; a manifest without matching graph
+nodes therefore has an empty work queue.
+-/
+def File.workQueueEntries (file : File) : Array Entry :=
+  file.queryableStatementEntries.filter fun entry =>
+    (file.actionableGraphNode? entry.label).isSome
 
 private def containsSearchText (text value : String) : Bool :=
   value.toLower.contains text

--- a/src/VersoBlueprint/Vbp.lean
+++ b/src/VersoBlueprint/Vbp.lean
@@ -37,6 +37,7 @@ def querySelectorLines : List String := [
   "owners",
   "tags",
   "work-queue",
+  "metadata",
   "search <text>",
   "code <decl>",
   "stats"
@@ -129,6 +130,16 @@ private def entrySummaryFields (entry : Entry) : List (String × Json) := [
 
 private def entrySummaryJson (entry : Entry) : Json :=
   Json.mkObj (entrySummaryFields entry)
+
+private def workQueueEntryJson (manifest : ManifestFile) (entry : Entry) : Json :=
+  match manifest.actionableGraphNode? entry.label with
+  | none => entrySummaryJson entry
+  | some node =>
+      Json.mkObj <| entrySummaryFields entry ++ [
+        ("nextStep", optionStringJson node.actionableStage?),
+        ("statementStatus", Json.str node.statementStatus.toText),
+        ("proofStatus", Json.str node.proofStatus.toText)
+      ]
 
 private def entryGroupJson (entry : Entry) : Json :=
   match entry.group with
@@ -259,7 +270,11 @@ def queryJson (manifest : ManifestFile) (args : List String) : Except String Jso
       .ok <| responseJson [("tags", stringArrayJson manifest.tagValues)]
   | ["work-queue"] =>
       .ok <| responseJson [
-        ("entries", Json.arr (manifest.workQueueEntries.map entrySummaryJson))
+        ("entries", Json.arr (manifest.workQueueEntries.map (workQueueEntryJson manifest)))
+      ]
+  | ["metadata"] =>
+      .ok <| responseJson [
+        ("entries", Json.arr (manifest.metadataEntries.map entrySummaryJson))
       ]
   | ["search", text] =>
       .ok <| responseJson [

--- a/tests/VersoBlueprintTests/BlueprintSummaryLinks/Shared.lean
+++ b/tests/VersoBlueprintTests/BlueprintSummaryLinks/Shared.lean
@@ -131,6 +131,10 @@ Definition 11.
 Definition 12.
 :::
 
+:::definition "def:triage.leaf" (parent := "triage.group") (owner := "bob") (tags := "critical, leaf-quick-win") (effort := "small") (priority := "high")
+Actionable leaf definition with no downstream users.
+:::
+
 :::theorem "thm:triage.main" (parent := "triage.group") (owner := "alice") (tags := "critical") (effort := "large")
 Depends on
 {uses "def:triage.01"}[],

--- a/tests/VersoBlueprintTests/BlueprintSummaryLinks/Triage.lean
+++ b/tests/VersoBlueprintTests/BlueprintSummaryLinks/Triage.lean
@@ -19,7 +19,7 @@ open Verso.VersoBlueprintTests.BlueprintSummaryLinks.Shared
     pure (
       hasSubstr out ">Overview</summary>" &&
       hasSubstr out "Dependency insights" &&
-      hasSummaryCardValue out "Ready now" "15" &&
+      hasSummaryCardValue out "Ready now" "16" &&
       hasSummaryCardValue out "Actionable priorities" "12" &&
       hasSummaryCardValue out "Statement-used entries" "12" &&
       hasSummaryCardValue out "Proof-used entries" "2" &&
@@ -32,7 +32,7 @@ open Verso.VersoBlueprintTests.BlueprintSummaryLinks.Shared
       hasSubstr out "Group health (1)" &&
       hasSubstr out "By parent groups (1)" &&
       hasSubstr out "Metadata" &&
-      hasSubstr out "Quick wins (1)" &&
+      hasSubstr out "Quick wins (2)" &&
       hasSubstr out "Owner rollups (2)" &&
       hasSubstr out "Tag rollups (" &&
       hasSubstr out "Linked PRs (2)" &&
@@ -47,16 +47,20 @@ open Verso.VersoBlueprintTests.BlueprintSummaryLinks.Shared
       hasSubstr out "Bob Example" &&
       hasSubstr out "https://example.com/pr/12" &&
       hasSubstr out "quick-win" &&
+      hasSubstr out "leaf-quick-win" &&
+      hasSubstr out "def:triage.leaf" &&
+      hasSubstr out "downstream unlocks: 0" &&
+      hasSummaryMetricBadge out "quick wins" "2" &&
       hasSubstr out "Structure and coverage" &&
       hasSubstr out "Heaviest prerequisites (" &&
       hasSubstr out "No prerequisites (" &&
       hasSubstr out "No dependents (" &&
       !hasSubstr out "Proof debt hotspots (0)" &&
       hasSubstr out "Next:" &&
-      hasSummaryMetricBadge out "total" "14" &&
+      hasSummaryMetricBadge out "total" "15" &&
       hasSummaryMetricBadge out "closed" "0" &&
       hasSummaryMetricBadge out "local-only" "0" &&
-      hasSummaryMetricBadge out "ready" "13" &&
+      hasSummaryMetricBadge out "ready" "14" &&
       hasSummaryMetricBadge out "blocked" "1" &&
       hasSummaryMetricBadge out "incomplete Lean" "0" &&
       hasSummaryMetricBadge out "unlock score" "14" &&

--- a/tests/VersoBlueprintTests/BlueprintSummaryLinks/Triage.lean
+++ b/tests/VersoBlueprintTests/BlueprintSummaryLinks/Triage.lean
@@ -19,10 +19,11 @@ open Verso.VersoBlueprintTests.BlueprintSummaryLinks.Shared
     pure (
       hasSubstr out ">Overview</summary>" &&
       hasSubstr out "Dependency insights" &&
+      hasSummaryCardValue out "Ready now" "15" &&
       hasSummaryCardValue out "Actionable priorities" "12" &&
       hasSummaryCardValue out "Statement-used entries" "12" &&
       hasSummaryCardValue out "Proof-used entries" "2" &&
-      hasSubstr out "Ready next (12)" &&
+      hasSubstr out "Actionable priorities (12)" &&
       hasSubstr out "Show all 2 more priorities" &&
       hasSubstr out "Most used in statements (12)" &&
       hasSubstr out "Show all 2 more statement-used entries" &&

--- a/tests/VersoBlueprintTests/BlueprintSummaryStatus.lean
+++ b/tests/VersoBlueprintTests/BlueprintSummaryStatus.lean
@@ -35,6 +35,24 @@ private def mkLiterateCode (definedDefs : Array LiterateDef) (definedTheorems : 
 /-- info: true -/
 #guard_msgs in
 #eval
+  let unknownKindNode : NodeData := {
+    label := `unknown_kind
+    title := "Unknown kind"
+    displayLabel := "Unknown kind"
+    statementStatus := .ready
+    visual := { fillcolor := "#ffffff" }
+  }
+  actionableStageForStatuses? .definition .ready .ready == some "statement" &&
+    actionableStageForStatuses? .definition .blocked .incomplete == none &&
+    actionableStageForStatuses? .theorem .ready .none == some "statement" &&
+    actionableStageForStatuses? .theorem .formalized .ready == some "proof" &&
+    actionableStageForStatuses? .theorem .blocked .incomplete == some "proof" &&
+    actionableStageForStatuses? .theorem .formalized .formalized == none &&
+    unknownKindNode.actionableStage?.isNone
+
+/-- info: true -/
+#guard_msgs in
+#eval
   let provedStatus := ProvedStatus.proved
   let stmtGap := ProvedStatus.ofRefCounts 1 0
   let proofGap := ProvedStatus.ofRefCounts 0 1

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -335,6 +335,14 @@ private def sampleMetadataManifest : ManifestFile := {
       title := "Alpha"
       ownerDisplayName := some "Alpha"
       tags := #["beta"]
+    },
+    {
+      key := "informal:proof_statement:statement"
+      targetKind := .block
+      label := label "proof_statement"
+      facet := .statement
+      kind := some .theorem
+      title := "Proof statement"
     }
   ]
   graphs := #[{
@@ -346,6 +354,7 @@ private def sampleMetadataManifest : ManifestFile := {
         displayLabel := "Zeta"
         kind := some .definition
         statementStatus := .ready
+        proofStatus := .ready
         visual := { fillcolor := "#ffffff" }
       },
       {
@@ -354,6 +363,15 @@ private def sampleMetadataManifest : ManifestFile := {
         displayLabel := "Alpha"
         kind := some .definition
         statementStatus := .blocked
+        visual := { fillcolor := "#ffffff" }
+      },
+      {
+        label := label "proof_statement"
+        title := "Proof statement"
+        displayLabel := "Proof statement"
+        kind := some .theorem
+        statementStatus := .formalized
+        proofStatus := .incomplete
         visual := { fillcolor := "#ffffff" }
       }
     ]
@@ -516,7 +534,7 @@ private def graphNodePreviewKeys
           sampleMetadataManifest.metadataEntries.map (·.authoredLabel) ==
             #["zeta_statement", "alpha_statement"] &&
           sampleMetadataManifest.workQueueEntries.map (·.authoredLabel) ==
-            #["zeta_statement"]
+            #["zeta_statement", "proof_statement"]
     | _, _ => false
 
 /-- info: true -/
@@ -611,10 +629,19 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
     | .ok json =>
         match jsonArrayField? json "entries" with
         | some entries =>
-            entries.size == 1 &&
-              jsonArrayHasStringField entries "label" "zeta_statement" &&
-              jsonArrayHasStringField entries "nextStep" "statement" &&
-              jsonArrayHasStringField entries "statementStatus" "ready to formalize"
+            match
+              entries.find? (fun entry => jsonStringField? entry "label" == some "zeta_statement"),
+              entries.find? (fun entry => jsonStringField? entry "label" == some "proof_statement") with
+            | some statementEntry, some proofEntry =>
+                entries.size == 2 &&
+                  jsonHasApiStability json &&
+                  jsonStringField? statementEntry "nextStep" == some "statement" &&
+                  jsonStringField? statementEntry "statementStatus" == some "ready to formalize" &&
+                  jsonStringField? statementEntry "proofStatus" == some "ready to formalize" &&
+                  jsonStringField? proofEntry "nextStep" == some "proof" &&
+                  jsonStringField? proofEntry "statementStatus" == some "formalized" &&
+                  jsonStringField? proofEntry "proofStatus" == some "Lean code incomplete"
+            | _, _ => false
         | none => false
     | .error _ => false
 

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -337,6 +337,27 @@ private def sampleMetadataManifest : ManifestFile := {
       tags := #["beta"]
     }
   ]
+  graphs := #[{
+    key := "metadata-status"
+    nodes := #[
+      {
+        label := label "zeta_statement"
+        title := "Zeta"
+        displayLabel := "Zeta"
+        kind := some .definition
+        statementStatus := .ready
+        visual := { fillcolor := "#ffffff" }
+      },
+      {
+        label := label "alpha_statement"
+        title := "Alpha"
+        displayLabel := "Alpha"
+        kind := some .definition
+        statementStatus := .blocked
+        visual := { fillcolor := "#ffffff" }
+      }
+    ]
+  }]
 }
 
 private def jsonField? (json : Json) (field : String) : Option Json :=
@@ -471,6 +492,12 @@ private def graphNodePreviewKeys
 #guard_msgs in
 #eval
   show Bool from
+    sampleManifest.graphs.isEmpty && sampleManifest.workQueueEntries.isEmpty
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
     match
       sampleExternalManifest.findPrimaryQueryableEntry? "external_bodyless",
       sampleManifest.findPrimaryQueryableEntry? "addition_assoc" with
@@ -486,8 +513,10 @@ private def graphNodePreviewKeys
           blockEntry.requiresRenderedBody &&
           sampleMetadataManifest.ownerValues == #["Alpha", "Zed"] &&
           sampleMetadataManifest.tagValues == #["alpha", "beta", "zeta"] &&
+          sampleMetadataManifest.metadataEntries.map (·.authoredLabel) ==
+            #["zeta_statement", "alpha_statement"] &&
           sampleMetadataManifest.workQueueEntries.map (·.authoredLabel) ==
-            #["zeta_statement", "alpha_statement"]
+            #["zeta_statement"]
     | _, _ => false
 
 /-- info: true -/
@@ -568,7 +597,38 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
             jsonHasApiStability json &&
               jsonArrayContainsString selectors "selectors" &&
               jsonArrayContainsString selectors "all <label>" &&
+              jsonArrayContainsString selectors "work-queue" &&
+              jsonArrayContainsString selectors "metadata" &&
               jsonArrayContainsString selectors "search <text>"
+        | none => false
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.queryJson sampleMetadataManifest ["work-queue"] with
+    | .ok json =>
+        match jsonArrayField? json "entries" with
+        | some entries =>
+            entries.size == 1 &&
+              jsonArrayHasStringField entries "label" "zeta_statement" &&
+              jsonArrayHasStringField entries "nextStep" "statement" &&
+              jsonArrayHasStringField entries "statementStatus" "ready to formalize"
+        | none => false
+    | .error _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match VersoBlueprint.Vbp.queryJson sampleMetadataManifest ["metadata"] with
+    | .ok json =>
+        match jsonArrayField? json "entries" with
+        | some entries =>
+            entries.size == 2 &&
+              jsonArrayHasStringField entries "label" "zeta_statement" &&
+              jsonArrayHasStringField entries "label" "alpha_statement"
         | none => false
     | .error _ => false
 


### PR DESCRIPTION
This PR makes the finalized Blueprint graph the shared source of planning status for the summary and `vbp query work-queue`, so both surfaces report the same actionable items while informal coverage remains a separate metric. It preserves metadata inventory under the explicit `metadata` selector and documents the graph-backed planning contract.

Backport v4.31.0: #336
