### PR TITLE
[backport v4.31.0] chore: simplify harness release maintenance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,4 +23,3 @@ This PR <short summary of the problem solved and useful outcome>.
 maintainer-visible changes. Avoid module-by-module implementation inventory.>
 
 Backport v4.31.0: pending
-Backport v4.30.0: pending

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,10 +82,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Install elan
-        run: |
-          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
       - name: Run Python harness tests
         run: python3 -m unittest discover -s tests/harness -p 'test_*.py'
       - name: Check Python harness syntax

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,8 +171,7 @@
     smaller test-blueprint fixture also exists
 - Default reference-project selection follows the active checkout release:
   - `v4.32.0`: `noperthedron`, `verso-flt`
-  - `v4.31.0`: no public reference project by default
-  - `v4.30.0`: `spherepackingblueprint`, `verso-carleson`
+  - `v4.31.0`: `spherepackingblueprint`, `verso-carleson`
 - Validation output lives under `_out/reference-blueprints/` in the root
   checkout and `_out/<worktree>/reference-blueprints/` in a linked worktree.
 - `project-template` is an explicitly selectable CI fixture for every

--- a/README.md
+++ b/README.md
@@ -369,9 +369,6 @@ Each external Blueprint is published only for its intended current release:
 Noperthedron and FLT on `v4.32.0`, and Sphere Packing and Carleson on
 `v4.31.0`. The in-repo starter template is a CI fixture rather than a public
 reference entry; it continues to validate every maintained release line.
-Release lines without a current external reference project, currently
-`v4.30.0`, remain CI-maintained without adding an empty public catalog section
-or deploying a legacy reference catalog.
 
 - [`ejgallego/verso-noperthedron`](https://github.com/ejgallego/verso-noperthedron),
   [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/noperthedron/)

--- a/branch-policy.json
+++ b/branch-policy.json
@@ -2,17 +2,9 @@
   "version": 2,
   "default_dev_branch": "v4.32.0",
   "required_backport_branches": [
-    "v4.31.0",
-    "v4.30.0"
+    "v4.31.0"
   ],
   "release_targets": [
-    {
-      "id": "v4.30.0",
-      "toolchain": "v4.30.0",
-      "verso_ref": "v4.30.0",
-      "branch": "v4.30.0",
-      "deploy_pages": false
-    },
     {
       "id": "v4.31.0",
       "toolchain": "v4.31.0",

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -26,9 +26,9 @@ This repository keeps local parallel work simple:
   default-dev slug with a release marker in front of it.
   Examples:
   - default-dev branch: `fix/backport-discipline`
-  - paired `v4.30.0` backport branch: `fix/backport-v430-backport-discipline`
+  - paired `v4.31.0` backport branch: `fix/backport-v431-backport-discipline`
   - default-dev docs branch: `docs/manual-cleanup`
-  - paired `v4.30.0` docs backport branch: `docs/backport-v430-manual-cleanup`
+  - paired `v4.31.0` docs backport branch: `docs/backport-v431-manual-cleanup`
 
 Prefer short, descriptive slugs over opaque branch names.
 
@@ -129,8 +129,8 @@ Do those upstream write actions only when they are explicitly requested.
   - use `python3 -m scripts.blueprint_harness prepare-backports` only when you
     need to refresh just the backport plan lines in an existing PR body
   - once it is ready for review, open the paired backport PRs
-  - use `python3 -m scripts.blueprint_harness prepare-backport-pr v4.30.0 --main-pr <pr>` to scaffold one paired backport PR branch name, title, and body
-  - apply the scaffolded release label, for example `backport-v4.30.0`, to the
+  - use `python3 -m scripts.blueprint_harness prepare-backport-pr v4.31.0 --main-pr <pr>` to scaffold one paired backport PR branch name, title, and body
+  - apply the scaffolded release label, for example `backport-v4.31.0`, to the
     paired backport PR
   - when several releases are required, use `python3 -m scripts.blueprint_harness prepare-backport-pr --all-required --main-pr <pr>` to emit one scaffold block per release, then let the agent apply the `git cherry-pick -x` series and resolve conflicts in each backport worktree
   - replace each `Backport ...: pending` line with `Backport ...: #<pr>`, or
@@ -144,9 +144,9 @@ Do those upstream write actions only when they are explicitly requested.
 - Record the pairing in the PR body using plain lines like:
 
 ```text
-Backport v4.30.0: pending
-Backport v4.30.0: #122
-Backport v4.30.0: exempt: docs-only change
+Backport v4.31.0: pending
+Backport v4.31.0: #122
+Backport v4.31.0: exempt: docs-only change
 ```
 
 See the repository PR template for the preferred structure.

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -248,6 +248,11 @@ The generated test-blueprint output has a browsable index:
 
 In a linked worktree, the same tree lives under `_out/<worktree>/test-blueprints/`.
 
+`python3 -m scripts.blueprint_test_blueprints list-json` reports the standalone
+fixture manifest without invoking Lean. Curated-document metadata comes from
+the Lean registry and is validated once, before `generate-test-blueprints.sh`
+starts rendering artifacts.
+
 ### Prepare or Land PRs
 
 Use the harness to generate public PR/backport scaffolds:
@@ -255,7 +260,7 @@ Use the harness to generate public PR/backport scaffolds:
 ```bash
 python3 -m scripts.blueprint_harness prepare-pr
 python3 -m scripts.blueprint_harness prepare-backports
-python3 -m scripts.blueprint_harness prepare-backport-pr v4.30.0 --main-pr <pr>
+python3 -m scripts.blueprint_harness prepare-backport-pr v4.31.0 --main-pr <pr>
 python3 -m scripts.blueprint_harness prepare-backport-pr --all-required --main-pr <pr>
 ```
 
@@ -265,7 +270,7 @@ check intentionally does not require patch-id equality, because release-line
 conflict resolution often changes the exact diff while preserving provenance.
 
 Each paired backport PR should carry the scaffolded release label, such as
-`backport-v4.30.0`, so release-specific queues remain visible when several
+`backport-v4.31.0`, so release-specific queues remain visible when several
 maintenance lines are active.
 
 Land reviewed local work from the clean root checkout:
@@ -346,11 +351,11 @@ policy metadata on each older release branch so the harness recognizes them as
 backport-only:
 
 ```bash
-python3 -m scripts.blueprint_harness set-default-dev-branch v4.31.0
+python3 -m scripts.blueprint_harness set-default-dev-branch v4.32.0
 ```
 
 Commit that metadata-only change separately on each older branch that still
-carries `branch-policy.json`, such as `v4.30.0`. Preserve their own Lean
+carries `branch-policy.json`, such as `v4.31.0`. Preserve their own Lean
 toolchain pins.
 
 To remove stale harness-managed reference caches and orphaned local clones:
@@ -384,23 +389,6 @@ locations used by the harness.
 
 It also prints the shared reference checkout cache root, dependency package
 cache root, and the current checkout's local clone root.
-
-To generate local test-blueprint fixtures, run:
-
-```bash
-./scripts/generate-test-blueprints.sh
-```
-
-By default that renders all local test-blueprint sites under the current
-checkout's worktree-aware `test-blueprints/` output root. Pass one or more
-slugs to render only a subset:
-
-```bash
-./scripts/generate-test-blueprints.sh state-showcase summary-blockers
-```
-
-Use `python3 -m scripts.blueprint_test_blueprints list-json` when you need the
-current slug list and metadata.
 
 ## Working from Linked Worktrees
 
@@ -456,15 +444,15 @@ python3 -m scripts.blueprint_harness prepare-backports
 Paste the emitted backport lines into the draft PR body. While the PR is still draft,
 each required line may remain:
 
-- `Backport v4.30.0: pending`
+- `Backport v4.31.0: pending`
 - or, for documentation and repository-metadata-only changes,
-  `Backport v4.30.0: exempt: <reason>`
+  `Backport v4.31.0: exempt: <reason>`
 
 Once the default-development PR is ready for review it must replace each `pending` line
 with either:
 
-- link the paired backport PR in the PR body with `Backport v4.30.0: #<pr>`
-- or record `Backport v4.30.0: exempt: <reason>` when every changed file is
+- link the paired backport PR in the PR body with `Backport v4.31.0: #<pr>`
+- or record `Backport v4.31.0: exempt: <reason>` when every changed file is
   documentation or repository metadata
 
 Keep code-bearing release lines structurally aligned even when compatibility or a
@@ -484,16 +472,16 @@ prefix and reuse the default-development slug with a release marker. For
 example:
 
 - default-development branch: `fix/backport-discipline`
-- paired `v4.30.0` branch: `fix/backport-v430-backport-discipline`
+- paired `v4.31.0` branch: `fix/backport-v431-backport-discipline`
 
 To keep paired backport PRs consistent, scaffold them with:
 
 ```bash
-python3 -m scripts.blueprint_harness prepare-backport-pr v4.30.0 --main-pr <pr>
+python3 -m scripts.blueprint_harness prepare-backport-pr v4.31.0 --main-pr <pr>
 ```
 
 That helper prints a standardized paired branch name, a title of the form
-`[backport v4.30.0] ...`, a `backport-v4.30.0` release label, and a PR body
+`[backport v4.31.0] ...`, a `backport-v4.31.0` release label, and a PR body
 that points back to the primary default-development review. By default the
 title after the backport prefix is read from the GitHub title of `--main-pr`,
 which keeps multi-commit backports from inheriting the last local commit
@@ -534,7 +522,7 @@ python3 -m scripts.blueprint_harness land-release feat/some-branch --cleanup
 ```
 
 `land-release` refuses to proceed unless the root checkout is on a clean,
-in-sync local release branch such as `v4.30.0`, and it only accepts
+in-sync local release branch such as `v4.32.0`, and it only accepts
 fast-forward source refs. With `--cleanup`, it also removes the source worktree
 and deletes the source branch when that can be done safely.
 
@@ -600,6 +588,10 @@ The local coordination layer is now machine-readable and untracked.
 - after a GitHub squash merge, pass `--merged-pr <number>` so `worktree-retire`
   can verify that the merged PR head SHA, head branch, and base branch match the
   local worktree before force-deleting the local branch
+- if an interrupted retirement removed the checkout directory but left Git's
+  worktree metadata behind, rerun it with `--merged-pr <number>`; the harness
+  verifies the merged PR, prunes the stale worktree entry, and finishes branch
+  and reference-cache cleanup
 - by default, each session should only retire or delete worktrees and branches
   it created or landed itself; broader cleanup should be explicit
 
@@ -662,7 +654,10 @@ python3 -m scripts.blueprint_harness worktree-retire <name> --merged-pr <number>
   tracked manifest is present, the harness runs a full update from those
   committed pins, so fixed direct inputs remain pinned while the local
   `VersoBlueprint` dependency and its transitive graph are refreshed
-- project and dependency `lean-toolchain` files are immutable harness inputs
+- the selected package and external project's `lean-toolchain` files are
+  immutable harness inputs; external-project flows reject missing toolchains,
+  cross-release pairs, and catalog/toolchain mismatches instead of rewriting
+  either file
 - the Python harness is maintainer tooling for those validations, not the main
   package-facing authoring interface
 
@@ -695,18 +690,24 @@ The repository includes these GitHub Actions workflows:
 - `.github/workflows/reference-blueprints-deploy.yml`
 
 `ci.yml` is the main verification workflow. It keeps the always-on checks for
-pull requests and pushes to release branches named like `v4.30.0`:
+pull requests and pushes to release branches named like `v4.32.0`:
 
 - `Blueprint Build`
 - `Blueprint Tests`
 - `Harness Tests`
+
+`Harness Tests` is intentionally Python-only: ordinary `unittest` discovery
+must not invoke Lean or Lake. `Blueprint Tests` owns explicit Lean execution
+smokes, while the Lean-backed curated-document registry is exercised and
+checked against the shared test-blueprint category/tag vocabulary by `Build
+Test Blueprints` before it generates the artifact catalog.
 
 On pull requests it also runs `Project Template Fresh Repo`, which materializes
 the in-repo template as a fresh standalone repository and smoke-tests the
 template-owned CI path.
 
 `reference-blueprints.yml` is the shared build workflow. On pull requests,
-pushes to release branches named like `v4.30.0`, and manual dispatch, it:
+pushes to release branches named like `v4.32.0`, and manual dispatch, it:
 
 - resolves the current branch's release target from `branch-policy.json`
 - builds only project targets for that release that set
@@ -725,7 +726,7 @@ pushes to release branches named like `v4.30.0`, and manual dispatch, it:
 
 `reference-blueprints-deploy.yml` is the deployment workflow. It runs after a
 successful `reference-blueprints.yml` run on a release branch named like
-`v4.30.0`, checks out the repository default-development branch as the source
+`v4.32.0`, checks out the repository default-development branch as the source
 of truth for deployment policy, resolves every release target with
 `deploy_pages: true`, selects project targets marked `publish_reference: true`,
 rebuilds those selected blueprints in isolation, and assembles one combined
@@ -836,9 +837,9 @@ The harness is now project-driven rather than hardcoded to one project.
   source
 - local worktree bookkeeping is intentionally not tracked in the repository
 
-For example, the release id may remain `v4.30.0` while a specific published
-project target records `"rc": "4.30-rc2"`. That row then builds with
-`leanprover/lean4:v4.30.0-rc2` and pins `verso` to `v4.30.0-rc2`, while another
+For example, the release id may remain `v4.32.0` while a specific published
+project target records `"rc": "4.32-rc1"`. That row then builds with
+`leanprover/lean4:v4.32.0-rc1` and pins `verso` to `v4.32.0-rc1`, while another
 project target on the same release id can use a different RC or the final
 release tag.
 
@@ -856,7 +857,7 @@ Minimal external catalog entry shape:
       },
       "targets": [
         {
-          "release": "v4.30.0",
+          "release": "v4.32.0",
           "ref": "0123456789abcdef0123456789abcdef01234567",
           "publish_reference": true
         }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -57,7 +57,7 @@ python3 -m scripts.blueprint_harness paths
 python3 -m scripts.blueprint_reference_harness projects
 python3 -m scripts.blueprint_reference_harness status
 python3 -m scripts.blueprint_reference_harness sync
-python3 -m scripts.blueprint_test_blueprints list-json
+python3 -m scripts.blueprint_test_blueprints list-json  # standalone fixtures only
 ```
 
 Reference blueprints and test blueprints are distinct artifact families:
@@ -156,12 +156,16 @@ lives in [`tests/harness/projects.json`](../tests/harness/projects.json). The
 current workflow and flag semantics live in
 [`doc/MAINTAINER_GUIDE.md`](../doc/MAINTAINER_GUIDE.md).
 
-The local HTML-producing test fixtures use a second metadata source:
+The local HTML-producing test fixtures use two metadata sources:
 
 - curated doc fixtures in
   [`tests/VersoBlueprintTests/TestBlueprintRegistry.lean`](../tests/VersoBlueprintTests/TestBlueprintRegistry.lean)
 - standalone test package fixtures in
   [`tests/harness/test_blueprints.json`](../tests/harness/test_blueprints.json)
+
+The Python `list` and `list-json` commands report only the standalone manifest
+and do not invoke Lean. Full test-blueprint generation reads and validates the
+curated Lean registry once before rendering either fixture family.
 
 ## Read Next
 

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -61,7 +61,10 @@ from scripts.blueprint_harness_worktrees import (
     GitWorktree,
     git_worktree_map,
     git_worktrees,
+    load_record,
+    metadata_path,
     normalize_priority,
+    ref_merged_into_base,
     resolve_worktree_name,
     sync_worktree_registry,
     update_worktree_record,
@@ -213,26 +216,49 @@ def worktree_merged_pr_validation_error(
     worktree: GitWorktree,
     base_ref: str,
 ) -> str | None:
+    actual_base_ref, error = worktree_merged_pr_base_ref(repo_root, pr_number, worktree)
+    if error is not None:
+        return error
+    assert actual_base_ref is not None
+    if branch_name_from_ref(actual_base_ref) != branch_name_from_ref(base_ref):
+        return (
+            f"GitHub PR #{pr_number} base `{branch_name_from_ref(actual_base_ref)}` "
+            f"does not match `{base_ref}`"
+        )
+    return None
+
+
+def worktree_merged_pr_base_ref(
+    repo_root: Path,
+    pr_number: int,
+    worktree: GitWorktree,
+) -> tuple[str | None, str | None]:
     payload = github_pr_view_json(
         repo_root,
         pr_number,
         ("state", "baseRefName", "headRefName", "headRefOid"),
     )
     if payload is None:
-        return f"unable to read GitHub PR #{pr_number}"
+        return None, f"unable to read GitHub PR #{pr_number}"
     state = payload.get("state")
     if state != "MERGED":
-        return f"GitHub PR #{pr_number} is not merged"
+        return None, f"GitHub PR #{pr_number} is not merged"
     base_ref_name = payload.get("baseRefName")
-    if base_ref_name != branch_name_from_ref(base_ref):
-        return f"GitHub PR #{pr_number} base `{base_ref_name}` does not match `{base_ref}`"
+    if not isinstance(base_ref_name, str) or not base_ref_name:
+        return None, f"GitHub PR #{pr_number} has no base branch"
     head_ref_oid = payload.get("headRefOid")
     if head_ref_oid != worktree.head:
-        return f"GitHub PR #{pr_number} head `{head_ref_oid}` does not match worktree head `{worktree.head}`"
+        return None, (
+            f"GitHub PR #{pr_number} head `{head_ref_oid}` "
+            f"does not match worktree head `{worktree.head}`"
+        )
     head_ref_name = payload.get("headRefName")
     if worktree.branch is not None and head_ref_name != worktree.branch:
-        return f"GitHub PR #{pr_number} head branch `{head_ref_name}` does not match `{worktree.branch}`"
-    return None
+        return None, (
+            f"GitHub PR #{pr_number} head branch `{head_ref_name}` "
+            f"does not match `{worktree.branch}`"
+        )
+    return f"origin/{base_ref_name}", None
 
 
 def resolve_main_pr_title(repo_root: Path, args: argparse.Namespace) -> str:
@@ -326,6 +352,10 @@ def resolve_create_worktree_base(layout, requested_base: str | None) -> str:
 
 def preferred_worktree_base_ref(path: Path) -> str:
     return preferred_release_ref(path)
+
+
+def worktree_path_exists(path: Path) -> bool:
+    return path.exists()
 
 
 def ref_merged_into_worktree_base(repo_root: Path, ref: str, worktree_path: Path) -> bool:
@@ -1128,17 +1158,15 @@ def command_worktree_retire(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
     release_branch = local_release_ref(layout.repo_root)
     name = resolve_worktree_name(layout.worktree_name, args.name)
-    records, _registry = worktree_record_map(layout.repo_root)
-    if name not in records:
-        raise SystemExit(f"[blueprint-harness] unknown worktree `{name}`")
-    record = records[name]
     worktrees = git_worktree_map(layout.repo_root)
     if name not in worktrees:
         raise SystemExit(f"[blueprint-harness] unknown worktree `{name}`")
     worktree = worktrees[name]
     path = worktree.path
     branch = worktree.branch
-    if record.locked:
+    path_exists = worktree_path_exists(path)
+    metadata = load_record(metadata_path(layout.repo_root, name))
+    if metadata is not None and metadata.locked:
         raise SystemExit(f"[blueprint-harness] worktree `{name}` is locked; unlock it before retiring")
     if worktree.root_checkout:
         raise SystemExit("[blueprint-harness] cannot retire the root checkout")
@@ -1146,13 +1174,34 @@ def command_worktree_retire(args: argparse.Namespace) -> int:
         raise SystemExit("[blueprint-harness] cannot retire the current active worktree from inside itself")
     if branch == release_branch:
         raise SystemExit(f"[blueprint-harness] cannot retire a linked worktree attached to `{release_branch}`")
-    merge_subject = branch or worktree.head
-    base_ref = preferred_worktree_base_ref(path)
-    merged_by_ancestry = ref_merged_into_worktree_base(layout.repo_root, merge_subject, path)
     merged_pr = getattr(args, "merged_pr", None)
     merge_mode = "ancestry"
     branch_delete_flag = "-d"
-    if not merged_by_ancestry:
+    merge_subject = branch or worktree.head
+    if path_exists:
+        records, _registry = worktree_record_map(layout.repo_root)
+        if name not in records:
+            raise SystemExit(f"[blueprint-harness] unknown worktree `{name}`")
+        if records[name].locked:
+            raise SystemExit(f"[blueprint-harness] worktree `{name}` is locked; unlock it before retiring")
+        base_ref = preferred_worktree_base_ref(path)
+        merged_by_ancestry = ref_merged_into_worktree_base(layout.repo_root, merge_subject, path)
+    else:
+        if merged_pr is None:
+            raise SystemExit(
+                f"[blueprint-harness] worktree `{name}` path is missing; "
+                "pass `--merged-pr <number>` to verify and finish a partial retirement"
+            )
+        base_ref, validation_error = worktree_merged_pr_base_ref(layout.repo_root, merged_pr, worktree)
+        if validation_error is not None:
+            raise SystemExit(f"[blueprint-harness] cannot retire worktree `{name}`: {validation_error}")
+        assert base_ref is not None
+        merged_by_ancestry = ref_merged_into_base(layout.repo_root, merge_subject, base_ref)
+        merge_mode = f"recovered-github-pr-{merged_pr}"
+        if not merged_by_ancestry:
+            branch_delete_flag = "-D"
+
+    if not merged_by_ancestry and path_exists:
         if merged_pr is not None:
             validation_error = worktree_merged_pr_validation_error(layout.repo_root, merged_pr, worktree, base_ref)
             if validation_error is None:
@@ -1170,20 +1219,8 @@ def command_worktree_retire(args: argparse.Namespace) -> int:
             raise SystemExit(
                 f"[blueprint-harness] branch `{branch}` is not merged into `{base_ref}`{squash_hint}"
             )
-    if not worktree_is_clean(path):
+    if path_exists and not worktree_is_clean(path):
         raise SystemExit(f"[blueprint-harness] worktree `{name}` has local modifications")
-
-    print(f"name={name}")
-    print(f"path={path}")
-    print(f"branch={branch or ''}")
-    print(f"head={worktree.head}")
-    print(f"merge_mode={merge_mode}")
-    if args.dry_run:
-        return 0
-
-    run(["git", "worktree", "remove", str(path)], cwd=layout.repo_root)
-    if branch is not None:
-        run(["git", "branch", branch_delete_flag, branch], cwd=layout.repo_root)
 
     manifest_path = resolve_manifest_path(None, layout.package_root)
     try:
@@ -1191,8 +1228,9 @@ def command_worktree_retire(args: argparse.Namespace) -> int:
     except (FileNotFoundError, ValueError) as err:
         raise SystemExit(f"[blueprint-harness] {err}") from err
     active_names = {
-        root_checkout_namespace(layout.repo_root) if worktree.root_checkout else worktree.name
-        for worktree in git_worktrees(layout.repo_root)
+        root_checkout_namespace(layout.repo_root) if candidate.root_checkout else candidate.name
+        for candidate in git_worktrees(layout.repo_root)
+        if candidate.name != name and candidate.path.exists()
     }
     cache_keys = reference_dependency_cache_keys(projects)
     removals = reference_prune_plan(
@@ -1202,6 +1240,22 @@ def command_worktree_retire(args: argparse.Namespace) -> int:
         layout.reference_project_root / "by-worktree",
         layout.reference_dependency_cache_root,
     )
+
+    print(f"name={name}")
+    print(f"path={path}")
+    print(f"branch={branch or ''}")
+    print(f"head={worktree.head}")
+    print(f"merge_mode={merge_mode}")
+    if args.dry_run:
+        return 0
+
+    if path_exists:
+        run(["git", "worktree", "remove", str(path)], cwd=layout.repo_root)
+    else:
+        run(["git", "worktree", "prune", "--expire", "now"], cwd=layout.repo_root)
+    sync_worktree_registry(layout.repo_root)
+    if branch is not None:
+        run(["git", "branch", branch_delete_flag, branch], cwd=layout.repo_root)
     for stale_path in removals:
         shutil.rmtree(stale_path)
     print(f"[blueprint-harness] retired worktree `{name}`")
@@ -1308,7 +1362,7 @@ def add_release_management_commands(subparsers) -> None:
     )
     bump_toolchain.add_argument(
         "toolchain",
-        help="Lean toolchain ref such as `v4.29.0`, `4.29.0`, `4.30-rc2`, or `leanprover/lean4:v4.30.0-rc2`.",
+        help="Lean toolchain ref such as `v4.32.0`, `4.33-rc1`, or `leanprover/lean4:v4.33.0-rc1`.",
     )
     bump_toolchain.add_argument(
         "--verso-ref",
@@ -1328,7 +1382,7 @@ def add_release_management_commands(subparsers) -> None:
     )
     start_release_line.add_argument(
         "toolchain",
-        help="Lean toolchain ref for the new line, such as `v4.30.0` or official RC name `4.30-rc2`.",
+        help="Lean toolchain ref for the new line, such as `v4.33.0` or official RC name `4.33-rc1`.",
     )
     start_release_line.add_argument(
         "--verso-ref",
@@ -1353,7 +1407,7 @@ def add_release_management_commands(subparsers) -> None:
     )
     set_default_dev_branch.add_argument(
         "branch",
-        help="New default development branch, such as `v4.30.0`.",
+        help="New default development branch, such as `v4.32.0`.",
     )
     set_default_dev_branch.set_defaults(func=command_set_default_dev_branch)
 

--- a/scripts/blueprint_harness_project_commands.py
+++ b/scripts/blueprint_harness_project_commands.py
@@ -18,9 +18,6 @@ from scripts.blueprint_harness_utils import (
 
 
 OFFICIAL_BLUEPRINT_REPOSITORY = "leanprover/verso-blueprint"
-OFFICIAL_BLUEPRINT_REQUIRE = (
-    f'require VersoBlueprint from git "https://github.com/{OFFICIAL_BLUEPRINT_REPOSITORY}"@"v4.31.0"'
-)
 OFFICIAL_BLUEPRINT_URL_PATTERNS = (
     rf"https://github\.com/{OFFICIAL_BLUEPRINT_REPOSITORY}(?:\.git)?",
     rf"git@github\.com:{OFFICIAL_BLUEPRINT_REPOSITORY}\.git",
@@ -28,7 +25,7 @@ OFFICIAL_BLUEPRINT_URL_PATTERNS = (
 )
 OFFICIAL_BLUEPRINT_SOURCE_DESCRIPTION = f"`{OFFICIAL_BLUEPRINT_REPOSITORY}`"
 OFFICIAL_BLUEPRINT_REQUIRE_PATTERN = re.compile(
-    r'^(?P<indent>\s*)require\s+VersoBlueprint\s+from\s+git\s+"(?P<url>[^"]+)"(?:\s*@\s*"(?P<ref>[^"]+)")?\s*$',
+    r'^(?P<indent>[ \t]*)require\s+VersoBlueprint\s+from\s+git\s+"(?P<url>[^"]+)"(?:\s*@\s*"(?P<ref>[^"]+)")?[ \t]*$',
     re.MULTILINE,
 )
 MATHLIB_STANDARD_LINTER_OPTION_PATTERN = re.compile(
@@ -161,12 +158,11 @@ def project_lake_update_command(package_root: Path, project_dir: Path) -> list[s
             "[blueprint-harness] committed lake-manifest.json detected; "
             "running full `lake update` from committed pins"
         )
-        return lean_low_priority_command(package_root, "lake", "update")
-
-    print(
-        "[blueprint-harness] no committed lake-manifest.json detected; "
-        "falling back to full `lake update`"
-    )
+    else:
+        print(
+            "[blueprint-harness] no committed lake-manifest.json detected; "
+            "falling back to full `lake update`"
+        )
     return lean_low_priority_command(package_root, "lake", "update")
 
 

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -107,12 +107,12 @@ def _short_reference_cache_ref(ref: str) -> str:
     return ref
 
 
-def selected_project_toolchain(project: HarnessProject) -> str | None:
+def selected_project_toolchain(project: HarnessProject) -> str:
     if project.selected_rc is not None:
         return release_candidate_ref(project.selected_rc)
     if project.selected_release is not None:
         return normalize_lean_release_ref(project.selected_release)
-    return None
+    raise ValueError(f"project `{project.project_id}` has no selected release target")
 
 
 def reference_dependency_cache_key(project: HarnessProject) -> str:

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -75,7 +75,6 @@ class ReferenceProjectBumpResult:
 
 @dataclass(frozen=True)
 class ReferenceToolchain:
-    path: Path
     lean_ref: str
     release_branch: str
 
@@ -147,18 +146,17 @@ def read_reference_toolchain(path: Path) -> ReferenceToolchain | None:
         return None
 
     return ReferenceToolchain(
-        path=path,
         lean_ref=lean_ref,
         release_branch=release_branch_from_lean_ref(lean_ref),
     )
 
 
-def validate_reference_toolchain_release_family(
+def validate_external_reference_toolchain(
     package_root: Path,
     project_dir: Path,
     *,
-    expected_project_toolchain: str | None = None,
-) -> str | None:
+    expected_project_toolchain: str,
+) -> str:
     """Reject cross-release checks without changing any checkout toolchain.
 
     The external project owns the compiler used for its build. In particular,
@@ -168,8 +166,6 @@ def validate_reference_toolchain_release_family(
     """
     package_toolchain = read_reference_toolchain(package_root / "lean-toolchain")
     project_toolchain = read_reference_toolchain(project_dir / "lean-toolchain")
-    if expected_project_toolchain is None and (package_toolchain is None or project_toolchain is None):
-        return None
     if package_toolchain is None:
         raise SystemExit(
             "[blueprint-harness] selected Verso Blueprint checkout has no valid `lean-toolchain`: "
@@ -188,15 +184,14 @@ def validate_reference_toolchain_release_family(
             f"uses Lean `{package_toolchain.lean_ref}` ({package_toolchain.release_branch}). "
             "Catalog each external Blueprint only under its current matching release."
         )
-    if expected_project_toolchain is not None:
-        expected_ref = normalize_lean_release_ref(expected_project_toolchain)
-        if project_toolchain.lean_ref != expected_ref:
-            raise SystemExit(
-                "[blueprint-harness] reference Blueprint toolchain mismatch: "
-                f"catalog target expects Lean `{expected_ref}`, but project `{project_dir}` "
-                f"uses Lean `{project_toolchain.lean_ref}`. Update the external project ref "
-                "or keep its explicit project-target RC metadata."
-            )
+    expected_ref = normalize_lean_release_ref(expected_project_toolchain)
+    if project_toolchain.lean_ref != expected_ref:
+        raise SystemExit(
+            "[blueprint-harness] reference Blueprint toolchain mismatch: "
+            f"catalog target expects Lean `{expected_ref}`, but project `{project_dir}` "
+            f"uses Lean `{project_toolchain.lean_ref}`. Update the external project ref "
+            "or keep its explicit project-target RC metadata."
+        )
     return project_toolchain.lean_ref
 
 
@@ -570,19 +565,24 @@ def prepare_reference_edit_checkout(
 def run_reference_lake_update(
     package_root: Path,
     project_dir: Path,
-    *,
-    validate_toolchain_release: bool = True,
-    expected_project_toolchain: str | None = None,
 ) -> list[str]:
-    if validate_toolchain_release:
-        validate_reference_toolchain_release_family(
-            package_root,
-            project_dir,
-            expected_project_toolchain=expected_project_toolchain,
-        )
     command = project_lake_update_command(package_root, project_dir)
     run(command, cwd=project_dir)
     return command
+
+
+def run_external_reference_lake_update(
+    package_root: Path,
+    project_dir: Path,
+    *,
+    expected_project_toolchain: str,
+) -> list[str]:
+    validate_external_reference_toolchain(
+        package_root,
+        project_dir,
+        expected_project_toolchain=expected_project_toolchain,
+    )
+    return run_reference_lake_update(package_root, project_dir)
 
 
 def project_checkout_pathspec(checkout_root: Path, project_dir: Path) -> str:
@@ -698,7 +698,7 @@ def bump_reference_project(
 
     project_dir = edit_dir / project.project_root
     _lakefile, previous_ref = rewrite_pinned_blueprint_dependency(project_dir, ref)
-    run_reference_lake_update(
+    run_external_reference_lake_update(
         layout.package_root,
         project_dir,
         expected_project_toolchain=selected_project_toolchain(project),
@@ -832,7 +832,7 @@ def sync_reference_cache_checkout(
     seed_lake_path_builds_from_dependency_cache(layout, project, project_dir)
     try:
         with local_blueprint_dependency_override(layout.package_root, project_dir, restore_lakefile=True):
-            run_reference_lake_update(
+            run_external_reference_lake_update(
                 layout.package_root,
                 project_dir,
                 expected_project_toolchain=selected_project_toolchain(project),
@@ -939,7 +939,6 @@ def generate_in_repo_command_project(
                 update_project=lambda: run_reference_lake_update(
                     layout.package_root,
                     project_dir,
-                    validate_toolchain_release=False,
                 ),
                 build_command=project.build_command,
                 generate_command=generate_command,
@@ -981,10 +980,9 @@ def generate_git_project(
         output_dir.mkdir(parents=True, exist_ok=True)
         bootstrap_reference_checkout(project_dir=project_dir)
         def update_reference_project() -> None:
-            run_reference_lake_update(
+            run_external_reference_lake_update(
                 layout.package_root,
                 project_dir,
-                validate_toolchain_release=True,
                 expected_project_toolchain=selected_project_toolchain(project),
             )
             seed_lake_path_builds_from_dependency_cache(layout, project, project_dir)

--- a/scripts/blueprint_harness_releases.py
+++ b/scripts/blueprint_harness_releases.py
@@ -24,7 +24,7 @@ def normalize_release_candidate_name(raw_ref: str) -> str:
     ref = clean_lean_ref(raw_ref)
     match = LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(ref)
     if match is None:
-        raise SystemExit("[blueprint-harness] expected an official Lean release candidate name like `4.30-rc2`")
+        raise SystemExit("[blueprint-harness] expected an official Lean release candidate name like `4.33-rc1`")
 
     major = match.group("major")
     minor = match.group("minor")
@@ -68,21 +68,6 @@ def release_branch_from_lean_ref(raw_ref: str) -> str:
         patch = match.group("patch") or "0"
         return f"v{match.group('major')}.{match.group('minor')}.{patch}"
     return ref
-
-
-def lean_release_order_key(raw_ref: str) -> tuple[int, int, int, int] | None:
-    ref = normalize_lean_release_ref(raw_ref)
-    if NUMERIC_LEAN_RELEASE_PATTERN.fullmatch(ref) is not None:
-        version = ref[1:] if ref.startswith("v") else ref
-        major, minor, patch = (int(part) for part in version.split("."))
-        return major, minor, patch, 1_000_000
-
-    match = LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(ref)
-    if match is None:
-        return None
-
-    patch = int(match.group("patch") or "0")
-    return int(match.group("major")), int(match.group("minor")), patch, int(match.group("rc"))
 
 
 def lean_toolchain_spec(lean_ref: str) -> str:

--- a/scripts/blueprint_harness_worktrees.py
+++ b/scripts/blueprint_harness_worktrees.py
@@ -329,7 +329,7 @@ def collect_worktree_facts(repo_root: Path, git_wt: GitWorktree) -> dict[str, ob
 def sync_worktree_registry(repo_root: Path) -> tuple[list[WorktreeRecord], Path]:
     now = utc_now()
     records: list[WorktreeRecord] = []
-    git_wt_list = git_worktrees(repo_root)
+    git_wt_list = [worktree for worktree in git_worktrees(repo_root) if worktree.path.exists()]
     active_names = {git_wt.name for git_wt in git_wt_list}
     for git_wt in git_wt_list:
         path = metadata_path(repo_root, git_wt.name)

--- a/scripts/blueprint_test_blueprints.py
+++ b/scripts/blueprint_test_blueprints.py
@@ -174,18 +174,39 @@ def load_test_blueprints_manifest(manifest_path: Path) -> list[StandaloneTestBlu
     return fixtures
 
 
-def list_curated_test_doc_slugs(package_root: Path) -> list[str]:
-    result = subprocess.run(
-        lean_low_priority_command(package_root, "lake", "exe", "blueprint-test-docs", "--list"),
-        cwd=package_root,
-        check=True,
-        text=True,
-        capture_output=True,
-    )
-    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+def validate_curated_test_doc_meta(
+    entries: list[dict[str, object]],
+    categories: tuple[str, ...],
+) -> list[dict[str, object]]:
+    if not entries:
+        raise ValueError("expected `blueprint-test-docs --list-json` to emit at least one entry")
+
+    seen_slugs: set[str] = set()
+    for index, entry in enumerate(entries, start=1):
+        context = f"blueprint-test-docs entry {index}"
+        slug = _require_string(entry, "slug", context=context)
+        if slug in seen_slugs:
+            raise ValueError(f"{context}: duplicate slug `{slug}`")
+        seen_slugs.add(slug)
+
+        _require_string(entry, "title", context=context)
+        category = _require_string(entry, "category", context=context)
+        if category not in categories:
+            raise ValueError(f"{context}: unknown category `{category}`")
+        _require_string(entry, "summary", context=context)
+        kind = _require_string(entry, "kind", context=context)
+        if kind != "curated_doc":
+            raise ValueError(f"{context}: expected kind `curated_doc`, got `{kind}`")
+        if not isinstance(entry.get("tags"), list):
+            raise ValueError(f"{context}: expected list field `tags`")
+        _optional_tags(entry, "tags", context=context)
+    return entries
 
 
-def list_curated_test_doc_meta(package_root: Path) -> list[dict[str, object]]:
+def list_curated_test_doc_meta(
+    package_root: Path,
+    categories: tuple[str, ...],
+) -> list[dict[str, object]]:
     result = subprocess.run(
         lean_low_priority_command(package_root, "lake", "exe", "blueprint-test-docs", "--list-json"),
         cwd=package_root,
@@ -196,22 +217,29 @@ def list_curated_test_doc_meta(package_root: Path) -> list[dict[str, object]]:
     data = json.loads(result.stdout)
     if not isinstance(data, list):
         raise ValueError("expected `blueprint-test-docs --list-json` to emit a JSON list")
-    return [entry for entry in data if isinstance(entry, dict)]
+    if not all(isinstance(entry, dict) for entry in data):
+        raise ValueError("expected every `blueprint-test-docs --list-json` entry to be an object")
+    entries: list[dict[str, object]] = data
+    return validate_curated_test_doc_meta(entries, categories)
 
 
-def test_blueprint_index_entries(
-    package_root: Path,
+def blueprint_meta_by_slug(
+    curated_entries: list[dict[str, object]],
     fixtures: list[StandaloneTestBlueprint],
-    selected_slugs: list[str],
-) -> list[dict[str, object]]:
+) -> dict[str, dict[str, object]]:
     meta_by_slug = {
         str(entry["slug"]): entry
-        for entry in list_curated_test_doc_meta(package_root)
+        for entry in curated_entries
         if isinstance(entry.get("slug"), str)
     }
     for fixture in fixtures:
+        if fixture.slug in meta_by_slug:
+            raise ValueError(
+                f"test blueprint slug `{fixture.slug}` is declared by both "
+                "the curated-document registry and the standalone fixture manifest"
+            )
         meta_by_slug[fixture.slug] = fixture.meta
-    return [meta_by_slug[slug] for slug in selected_slugs if slug in meta_by_slug]
+    return meta_by_slug
 
 
 def render_test_blueprint_tag_list(tags: object) -> str:
@@ -321,23 +349,28 @@ def write_test_blueprint_index(output_root: Path, category_order: tuple[str, ...
 
 
 def split_generation_targets(
-    package_root: Path,
+    curated_entries: list[dict[str, object]],
     fixtures: list[StandaloneTestBlueprint],
     requested_slugs: list[str],
 ) -> tuple[list[str], list[StandaloneTestBlueprint]]:
+    doc_slugs = [str(entry["slug"]) for entry in curated_entries]
     if not requested_slugs:
-        return list_curated_test_doc_slugs(package_root), fixtures
+        return doc_slugs, fixtures
 
+    doc_slug_set = set(doc_slugs)
     fixture_by_slug = {fixture.slug: fixture for fixture in fixtures}
-    doc_slugs: list[str] = []
+    selected_doc_slugs: list[str] = []
     standalone_fixtures: list[StandaloneTestBlueprint] = []
     for target in requested_slugs:
         fixture = fixture_by_slug.get(target)
-        if fixture is None:
-            doc_slugs.append(target)
-        else:
+        if fixture is not None:
             standalone_fixtures.append(fixture)
-    return doc_slugs, standalone_fixtures
+        elif target in doc_slug_set:
+            selected_doc_slugs.append(target)
+        else:
+            known = ", ".join(sorted({*doc_slug_set, *fixture_by_slug}))
+            raise ValueError(f"unknown test blueprint `{target}`; known fixtures: {known}")
+    return selected_doc_slugs, standalone_fixtures
 
 
 def prune_stale_test_blueprint_outputs(output_root: Path, expected_slugs: set[str]) -> None:
@@ -370,7 +403,9 @@ def generate_test_blueprint_outputs(
     output_root: Path,
     requested_slugs: list[str],
 ) -> None:
-    doc_slugs, standalone_fixtures = split_generation_targets(package_root, fixtures, requested_slugs)
+    curated_entries = list_curated_test_doc_meta(package_root, category_order)
+    meta_by_slug = blueprint_meta_by_slug(curated_entries, fixtures)
+    doc_slugs, standalone_fixtures = split_generation_targets(curated_entries, fixtures, requested_slugs)
     standalone_slugs = [fixture.slug for fixture in standalone_fixtures]
 
     if not requested_slugs:
@@ -386,7 +421,7 @@ def generate_test_blueprint_outputs(
     write_test_blueprint_index(
         output_root,
         category_order,
-        test_blueprint_index_entries(package_root, fixtures, selected_slugs),
+        [meta_by_slug[slug] for slug in selected_slugs],
     )
 
 

--- a/scripts/run-lean-tests.sh
+++ b/scripts/run-lean-tests.sh
@@ -6,3 +6,4 @@ package_root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$package_root"
 
 ./scripts/lean-low-priority lake test
+python3 tests/integration/check_lean_run_external_markup.py

--- a/tests/harness/project_fixtures.py
+++ b/tests/harness/project_fixtures.py
@@ -1,0 +1,3 @@
+TEST_OFFICIAL_BLUEPRINT_REQUIRE = (
+    'require VersoBlueprint from git "https://github.com/leanprover/verso-blueprint"@"test-ref"'
+)

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -10,9 +10,6 @@
       },
       "targets": [
         {
-          "release": "v4.30.0"
-        },
-        {
           "release": "v4.31.0"
         },
         {

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -1905,6 +1905,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 Path("/tmp/repo/.worktrees/registry.json"),
             ),
             git_worktree_map=lambda _repo_root: {"reference-edit": detached},
+            worktree_path_exists=lambda _path: True,
             preferred_worktree_base_ref=lambda _path: "origin/v4.29.0",
             ref_merged_into_worktree_base=lambda _repo_root, ref, _path: ref == "abc123",
             worktree_is_clean=lambda _path: True,
@@ -1914,6 +1915,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             load_project_catalog_manifest=lambda _manifest_path: SimpleNamespace(projects=()),
             git_worktrees=lambda _repo_root: [],
             reference_prune_plan=lambda *_args, **_kwargs: [],
+            sync_worktree_registry=lambda _repo_root: ([], Path("/tmp/registry.json")),
         ):
             self.assertEqual(harness_mod.command_worktree_retire(args), 0)
 
@@ -1937,6 +1939,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             root_checkout=False,
         )
         commands: list[list[str]] = []
+        sync_calls: list[Path] = []
         with patched_attrs(
             harness_mod,
             detect_harness_layout=lambda _start=None: layout,
@@ -1950,6 +1953,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 Path("/tmp/repo/.worktrees/registry.json"),
             ),
             git_worktree_map=lambda _repo_root: {"backport-demo": backport},
+            worktree_path_exists=lambda _path: True,
             preferred_worktree_base_ref=lambda _path: "origin/v4.28.0",
             ref_merged_into_worktree_base=lambda _repo_root, ref, _path: ref == "fix/backport-demo",
             worktree_is_clean=lambda _path: True,
@@ -1959,6 +1963,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             load_project_catalog_manifest=lambda _manifest_path: SimpleNamespace(projects=()),
             git_worktrees=lambda _repo_root: [],
             reference_prune_plan=lambda *_args, **_kwargs: [],
+            sync_worktree_registry=lambda repo_root: sync_calls.append(repo_root) or ([], Path("/tmp/registry.json")),
         ):
             self.assertEqual(harness_mod.command_worktree_retire(args), 0)
 
@@ -1969,6 +1974,152 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 ["git", "branch", "-d", backport.branch],
             ],
         )
+        self.assertEqual(sync_calls, [layout.repo_root])
+
+    def test_worktree_retire_validates_cleanup_inputs_before_removal(self) -> None:
+        args = argparse.Namespace(name="demo", dry_run=False)
+        layout = SimpleNamespace(
+            repo_root=Path("/tmp/repo"),
+            package_root=Path("/tmp/package"),
+            worktree_name=None,
+            reference_source_cache_root=Path("/tmp/cache"),
+            reference_dependency_cache_root=Path("/tmp/deps"),
+            reference_project_root=Path("/tmp/reference-root"),
+        )
+        demo = GitWorktree(
+            name="demo",
+            path=Path("/tmp/repo/.worktrees/demo"),
+            head="abc123",
+            branch="fix/demo",
+            root_checkout=False,
+        )
+        commands: list[list[str]] = []
+
+        def invalid_catalog(_manifest_path):
+            raise ValueError("invalid project catalog")
+
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            local_release_ref=lambda _repo_root: "v4.32.0",
+            git_worktree_map=lambda _repo_root: {"demo": demo},
+            worktree_path_exists=lambda _path: True,
+            worktree_record_map=lambda _repo_root: (
+                {"demo": SimpleNamespace(name="demo", locked=False)},
+                Path("/tmp/registry.json"),
+            ),
+            preferred_worktree_base_ref=lambda _path: "origin/v4.32.0",
+            ref_merged_into_worktree_base=lambda _repo_root, _ref, _path: True,
+            worktree_is_clean=lambda _path: True,
+            resolve_manifest_path=lambda _path_text, _package_root: Path("/tmp/projects.json"),
+            load_project_catalog_manifest=invalid_catalog,
+            run=lambda command, *, cwd: commands.append(command),
+        ):
+            with self.assertRaisesRegex(SystemExit, "invalid project catalog"):
+                harness_mod.command_worktree_retire(args)
+
+        self.assertEqual(commands, [])
+
+    def test_worktree_retire_recovers_when_git_still_records_a_missing_path(self) -> None:
+        args = argparse.Namespace(name="demo", dry_run=False, merged_pr=319)
+        layout = SimpleNamespace(
+            repo_root=Path("/tmp/repo"),
+            package_root=Path("/tmp/package"),
+            worktree_name=None,
+            reference_source_cache_root=Path("/tmp/cache"),
+            reference_dependency_cache_root=Path("/tmp/deps"),
+            reference_project_root=Path("/tmp/reference-root"),
+        )
+        stale = GitWorktree(
+            name="demo",
+            path=Path("/tmp/repo/.worktrees/missing-demo"),
+            head="abc123",
+            branch="fix/demo",
+            root_checkout=False,
+        )
+        commands: list[list[str]] = []
+        sync_calls: list[Path] = []
+
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            local_release_ref=lambda _repo_root: "v4.32.0",
+            git_worktree_map=lambda _repo_root: {"demo": stale},
+            worktree_path_exists=lambda _path: False,
+            load_record=lambda _path: SimpleNamespace(locked=False),
+            worktree_merged_pr_base_ref=lambda _repo_root, _pr, _worktree: ("origin/v4.32.0", None),
+            ref_merged_into_base=lambda _repo_root, _ref, _base_ref: False,
+            run=lambda command, *, cwd: commands.append(command),
+            sync_worktree_registry=lambda repo_root: sync_calls.append(repo_root) or ([], Path("/tmp/registry.json")),
+            resolve_manifest_path=lambda _path_text, _package_root: Path("/tmp/projects.json"),
+            load_project_catalog_manifest=lambda _manifest_path: SimpleNamespace(projects=()),
+            git_worktrees=lambda _repo_root: [],
+            reference_prune_plan=lambda *_args, **_kwargs: [],
+        ):
+            self.assertEqual(harness_mod.command_worktree_retire(args), 0)
+
+        self.assertEqual(
+            commands,
+            [
+                ["git", "worktree", "prune", "--expire", "now"],
+                ["git", "branch", "-D", "fix/demo"],
+            ],
+        )
+        self.assertEqual(sync_calls, [layout.repo_root])
+
+    def test_worktree_retire_requires_merged_pr_to_recover_a_missing_path(self) -> None:
+        args = argparse.Namespace(name="demo", dry_run=False, merged_pr=None)
+        layout = SimpleNamespace(
+            repo_root=Path("/tmp/repo"),
+            package_root=Path("/tmp/package"),
+            worktree_name=None,
+        )
+        stale = GitWorktree(
+            name="demo",
+            path=Path("/tmp/repo/.worktrees/missing-demo"),
+            head="abc123",
+            branch="fix/demo",
+            root_checkout=False,
+        )
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            local_release_ref=lambda _repo_root: "v4.32.0",
+            git_worktree_map=lambda _repo_root: {"demo": stale},
+            worktree_path_exists=lambda _path: False,
+            load_record=lambda _path: SimpleNamespace(locked=False),
+        ):
+            with self.assertRaisesRegex(SystemExit, "pass `--merged-pr <number>`"):
+                harness_mod.command_worktree_retire(args)
+
+    def test_worktree_retire_rejects_unverified_missing_path_recovery(self) -> None:
+        args = argparse.Namespace(name="demo", dry_run=False, merged_pr=319)
+        layout = SimpleNamespace(
+            repo_root=Path("/tmp/repo"),
+            package_root=Path("/tmp/package"),
+            worktree_name=None,
+        )
+        stale = GitWorktree(
+            name="demo",
+            path=Path("/tmp/repo/.worktrees/missing-demo"),
+            head="abc123",
+            branch="fix/demo",
+            root_checkout=False,
+        )
+        with patched_attrs(
+            harness_mod,
+            detect_harness_layout=lambda _start=None: layout,
+            local_release_ref=lambda _repo_root: "v4.32.0",
+            git_worktree_map=lambda _repo_root: {"demo": stale},
+            worktree_path_exists=lambda _path: False,
+            load_record=lambda _path: SimpleNamespace(locked=False),
+            worktree_merged_pr_base_ref=lambda _repo_root, _pr, _worktree: (
+                None,
+                "GitHub PR #319 head does not match worktree head",
+            ),
+        ):
+            with self.assertRaisesRegex(SystemExit, "head does not match worktree head"):
+                harness_mod.command_worktree_retire(args)
 
     def test_worktree_retire_accepts_verified_squash_merged_pr(self) -> None:
         args = argparse.Namespace(name="demo", dry_run=False, merged_pr=152)
@@ -2009,6 +2160,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 Path("/tmp/repo/.worktrees/registry.json"),
             ),
             git_worktree_map=lambda _repo_root: {"demo": demo},
+            worktree_path_exists=lambda _path: True,
             preferred_worktree_base_ref=lambda _path: "origin/v4.31.0",
             ref_merged_into_worktree_base=lambda _repo_root, _ref, _path: False,
             worktree_merged_pr_validation_error=fake_pr_validation,
@@ -2019,6 +2171,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             load_project_catalog_manifest=lambda _manifest_path: SimpleNamespace(projects=()),
             git_worktrees=lambda _repo_root: [],
             reference_prune_plan=lambda *_args, **_kwargs: [],
+            sync_worktree_registry=lambda _repo_root: ([], Path("/tmp/registry.json")),
         ):
             self.assertEqual(harness_mod.command_worktree_retire(args), 0)
 
@@ -2058,6 +2211,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 Path("/tmp/repo/.worktrees/registry.json"),
             ),
             git_worktree_map=lambda _repo_root: {"demo": demo},
+            worktree_path_exists=lambda _path: True,
             preferred_worktree_base_ref=lambda _path: "origin/v4.31.0",
             ref_merged_into_worktree_base=lambda _repo_root, _ref, _path: False,
             worktree_merged_pr_validation_error=lambda *_args: "GitHub PR #152 is not merged",
@@ -2093,6 +2247,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 Path("/tmp/repo/.worktrees/registry.json"),
             ),
             git_worktree_map=lambda _repo_root: {"demo": demo},
+            worktree_path_exists=lambda _path: True,
             preferred_worktree_base_ref=lambda _path: "origin/v4.31.0",
             ref_merged_into_worktree_base=lambda _repo_root, _ref, _path: False,
             local_release_ref=lambda _repo_root: "v4.31.0",
@@ -2129,6 +2284,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                     root_checkout=False,
                 )
             },
+            worktree_path_exists=lambda _path: True,
         ):
             with self.assertRaisesRegex(SystemExit, "is locked; unlock it before retiring"):
                 harness_mod.command_worktree_retire(args)

--- a/tests/harness/test_blueprint_harness_project_commands.py
+++ b/tests/harness/test_blueprint_harness_project_commands.py
@@ -6,7 +6,6 @@ import tempfile
 import unittest
 
 from scripts.blueprint_harness_project_commands import (
-    OFFICIAL_BLUEPRINT_REQUIRE,
     discard_untracked_project_manifest,
     project_lake_update_command,
     rewrite_local_blueprint_dependency,
@@ -14,6 +13,7 @@ from scripts.blueprint_harness_project_commands import (
     run_project_update_build_generate,
     tracked_project_manifest_path,
 )
+from tests.harness.project_fixtures import TEST_OFFICIAL_BLUEPRINT_REQUIRE
 
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
@@ -33,7 +33,7 @@ class BlueprintHarnessProjectCommandTests(unittest.TestCase):
                     [
                         "import Lake",
                         "open Lake DSL",
-                        OFFICIAL_BLUEPRINT_REQUIRE,
+                        TEST_OFFICIAL_BLUEPRINT_REQUIRE,
                         "",
                     ]
                 ),
@@ -44,7 +44,7 @@ class BlueprintHarnessProjectCommandTests(unittest.TestCase):
 
             self.assertEqual(result, lakefile)
             text = lakefile.read_text(encoding="utf-8")
-            self.assertNotIn(OFFICIAL_BLUEPRINT_REQUIRE, text)
+            self.assertNotIn(TEST_OFFICIAL_BLUEPRINT_REQUIRE, text)
             self.assertIn(f'require VersoBlueprint from "{PACKAGE_ROOT.resolve()}"', text)
 
     def test_rewrite_local_blueprint_dependency_accepts_official_repo_with_non_main_ref(self) -> None:
@@ -68,13 +68,13 @@ class BlueprintHarnessProjectCommandTests(unittest.TestCase):
             project_dir = package_root / "project_template"
             project_dir.mkdir(parents=True)
             lakefile = project_dir / "lakefile.lean"
-            lakefile.write_text(f"{OFFICIAL_BLUEPRINT_REQUIRE}\n", encoding="utf-8")
+            lakefile.write_text(f"{TEST_OFFICIAL_BLUEPRINT_REQUIRE}\n", encoding="utf-8")
 
             rewrite_local_blueprint_dependency(project_dir, package_root, relative=True)
 
             self.assertEqual(
                 lakefile.read_text(encoding="utf-8"),
-                'require VersoBlueprint from ".."',
+                'require VersoBlueprint from ".."\n',
             )
 
     def test_rewrite_local_blueprint_dependency_disables_mathlib_header_linter(self) -> None:
@@ -86,7 +86,7 @@ class BlueprintHarnessProjectCommandTests(unittest.TestCase):
                     [
                         "import Lake",
                         "open Lake DSL",
-                        OFFICIAL_BLUEPRINT_REQUIRE,
+                        TEST_OFFICIAL_BLUEPRINT_REQUIRE,
                         "",
                         "package Blueprint where",
                         "  leanOptions := #[",
@@ -112,7 +112,7 @@ class BlueprintHarnessProjectCommandTests(unittest.TestCase):
             lakefile.write_text(
                 "\n".join(
                     [
-                        OFFICIAL_BLUEPRINT_REQUIRE,
+                        TEST_OFFICIAL_BLUEPRINT_REQUIRE,
                         "package Blueprint where",
                         "  leanOptions := #[",
                         "    ⟨`weak.linter.style.header, false⟩,",

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -19,12 +19,10 @@ from scripts.blueprint_harness_projects import (
     reference_release_payload,
     resolve_projects_for_release,
     resolve_release_target,
+    selected_project_toolchain,
 )
 from scripts.blueprint_harness_branches import load_branch_policy
-from scripts.blueprint_harness_project_commands import (
-    OFFICIAL_BLUEPRINT_REQUIRE,
-    tracked_project_manifest_path,
-)
+from scripts.blueprint_harness_project_commands import tracked_project_manifest_path
 from scripts.blueprint_harness_releases import release_candidate_ref
 from scripts.blueprint_harness_references import (
     bootstrap_reference_checkout,
@@ -35,15 +33,16 @@ from scripts.blueprint_harness_references import (
     generate_git_project,
     reference_submodule_update_command,
     require_reference_harness_layout,
-    run_reference_lake_update,
+    run_external_reference_lake_update,
     seed_lake_path_builds_from_dependency_cache,
     seed_reference_edit_checkout_lake,
     seed_lake_packages_from_dependency_cache,
     store_lake_path_builds_in_dependency_cache,
     store_lake_packages_in_dependency_cache,
     update_git_checkout,
-    validate_reference_toolchain_release_family,
+    validate_external_reference_toolchain,
 )
+from tests.harness.project_fixtures import TEST_OFFICIAL_BLUEPRINT_REQUIRE
 
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
@@ -135,6 +134,11 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             ],
         )
         self.assertEqual(catalog.release_targets, branch_policy.release_targets)
+        self.assertEqual(branch_policy.required_backport_branches, ("v4.31.0",))
+        self.assertEqual(
+            [target.release_id for target in branch_policy.release_targets],
+            ["v4.31.0", "v4.32.0"],
+        )
         self.assertTrue(projects[0].in_repo_project)
         self.assertTrue(projects[0].in_repo_command_project)
         self.assertEqual(projects[0].project_root, "project_template")
@@ -158,7 +162,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertIsNotNone(default_template_target)
         self.assertFalse(default_template_target.publish_reference)
         self.assertFalse(any(target.publish_reference for target in projects[0].targets))
-        self.assertFalse(catalog.release_target("v4.30.0").deploy_pages)
+        self.assertTrue(catalog.release_target("v4.31.0").deploy_pages)
         self.assertEqual(current_release.release_toolchain, current_release.toolchain)
         self.assertEqual(current_release.release_verso_ref, current_release.verso_ref)
         if current_release.deploy_pages:
@@ -200,6 +204,16 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertIsNone(projects[4].targets[0].rc)
         self.assertIsNone(projects[4].build_command)
         self.assertEqual(projects[4].generate_command, VBP_BUILD_OUTPUT_COMMAND)
+
+    def test_selected_project_toolchain_requires_resolved_release_metadata(self) -> None:
+        catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
+        noperthedron = resolve_projects_for_release(catalog, "v4.32.0", ["noperthedron"])[0]
+        spherepacking = resolve_projects_for_release(catalog, "v4.31.0", ["spherepackingblueprint"])[0]
+
+        self.assertEqual(selected_project_toolchain(noperthedron), "v4.32.0-rc1")
+        self.assertEqual(selected_project_toolchain(spherepacking), "v4.31.0")
+        with self.assertRaisesRegex(ValueError, "has no selected release target"):
+            selected_project_toolchain(catalog.projects[1])
 
     def test_project_catalog_requires_json_object(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -519,7 +533,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
 
     def test_reference_pages_workflow_stages_every_manifest_project(self) -> None:
         catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
-        release = resolve_release_target(catalog, "v4.30.0", PACKAGE_ROOT)
+        release = resolve_release_target(catalog, "v4.32.0", PACKAGE_ROOT)
         projects = resolve_projects_for_release(catalog, release.release_id, None)
         matrix = reference_build_matrix(projects, release)
         workflow_text = (PACKAGE_ROOT / ".github" / "workflows" / "reference-blueprints.yml").read_text(
@@ -891,7 +905,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(projects[0].generate_command, VBP_BUILD_OUTPUT_COMMAND)
 
     def test_resolve_projects_for_release_filters_to_matching_targets(self) -> None:
-        self.assert_resolved_projects_match_manifest("v4.30.0")
+        self.assert_resolved_projects_match_manifest("v4.31.0")
 
     def test_resolve_projects_for_default_release_uses_matching_targets(self) -> None:
         self.assert_resolved_projects_match_manifest(load_branch_policy(PACKAGE_ROOT).default_dev_branch)
@@ -1132,7 +1146,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             (mathlib_dir / "lean-toolchain").write_text("leanprover/lean4:v4.30.0-rc2", encoding="utf-8")
             (other_dir / "lean-toolchain").write_text("leanprover/lean4:v4.29.0\n", encoding="utf-8")
 
-            selected_ref = validate_reference_toolchain_release_family(
+            selected_ref = validate_external_reference_toolchain(
                 package_root,
                 project_dir,
                 expected_project_toolchain="4.30-rc1",
@@ -1168,7 +1182,11 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 SystemExit,
                 "reference Blueprint release mismatch.*Catalog each external Blueprint only under its current matching release",
             ):
-                validate_reference_toolchain_release_family(package_root, project_dir)
+                validate_external_reference_toolchain(
+                    package_root,
+                    project_dir,
+                    expected_project_toolchain="v4.29.0",
+                )
 
             self.assertEqual(
                 (project_dir / "lean-toolchain").read_text(encoding="utf-8"),
@@ -1199,7 +1217,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
 
                 refs_mod.run = unexpected_run
                 with self.assertRaisesRegex(SystemExit, "external reference project has no valid `lean-toolchain`"):
-                    run_reference_lake_update(
+                    run_external_reference_lake_update(
                         package_root,
                         project_dir,
                         expected_project_toolchain="v4.30.0",
@@ -1233,7 +1251,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                     SystemExit,
                     "catalog target expects Lean `v4.30.0`.*keep its explicit project-target RC metadata",
                 ):
-                    run_reference_lake_update(
+                    run_external_reference_lake_update(
                         package_root,
                         project_dir,
                         expected_project_toolchain="v4.30.0",
@@ -1271,7 +1289,11 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             try:
                 refs_mod.run = fake_run
                 refs_mod.project_lake_update_command = lambda _package_root, _project_dir: ["lake", "update"]
-                result = run_reference_lake_update(package_root, project_dir)
+                result = run_external_reference_lake_update(
+                    package_root,
+                    project_dir,
+                    expected_project_toolchain="v4.30.0-rc1",
+                )
             finally:
                 refs_mod.run = original_run
                 refs_mod.project_lake_update_command = original_update_command
@@ -1300,6 +1322,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             panel_regression_script=None,
             browser_tests_path=None,
             description=None,
+            selected_release="v4.30.0",
         )
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -1308,7 +1331,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             project_dir.mkdir(parents=True)
             (cache_dir / ".git").mkdir()
             lakefile = project_dir / "lakefile.lean"
-            lakefile.write_text(OFFICIAL_BLUEPRINT_REQUIRE + "\n", encoding="utf-8")
+            lakefile.write_text(TEST_OFFICIAL_BLUEPRINT_REQUIRE + "\n", encoding="utf-8")
             layout = SimpleNamespace(
                 package_root=root / "worktree",
                 repo_root=root / "root",
@@ -1323,6 +1346,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 "update_git_checkout": refs_mod.update_git_checkout,
                 "bootstrap_reference_checkout": refs_mod.bootstrap_reference_checkout,
                 "project_lake_update_command": refs_mod.project_lake_update_command,
+                "validate_external_reference_toolchain": refs_mod.validate_external_reference_toolchain,
                 "run": refs_mod.run,
             }
             seen: dict[str, object] = {}
@@ -1336,6 +1360,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
 
                 commands_mod.rewrite_local_blueprint_dependency = fake_rewrite
                 refs_mod.project_lake_update_command = lambda _package_root, _project_dir: ["lake", "update"]
+                refs_mod.validate_external_reference_toolchain = lambda *_args, **_kwargs: "v4.30.0"
                 refs_mod.run = lambda _command, *, cwd: None
 
                 refs_mod.sync_reference_cache_checkout(layout, project, warm_build=False)
@@ -1347,7 +1372,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                         setattr(refs_mod, name, value)
 
             self.assertEqual(seen["package_root"], layout.package_root)
-            self.assertEqual(lakefile.read_text(encoding="utf-8"), OFFICIAL_BLUEPRINT_REQUIRE + "\n")
+            self.assertEqual(lakefile.read_text(encoding="utf-8"), TEST_OFFICIAL_BLUEPRINT_REQUIRE + "\n")
 
     def test_reference_cache_checkout_rewrites_override_to_absolute_linked_worktree_path(self) -> None:
         import scripts.blueprint_harness_references as refs_mod
@@ -1366,6 +1391,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             panel_regression_script=None,
             browser_tests_path=None,
             description=None,
+            selected_release="v4.30.0",
         )
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -1375,7 +1401,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             cache_dir.mkdir(parents=True)
             (cache_dir / ".git").mkdir()
             lakefile = cache_dir / "lakefile.lean"
-            lakefile.write_text(OFFICIAL_BLUEPRINT_REQUIRE + "\n", encoding="utf-8")
+            lakefile.write_text(TEST_OFFICIAL_BLUEPRINT_REQUIRE + "\n", encoding="utf-8")
             package_root.mkdir(parents=True)
             layout = SimpleNamespace(
                 package_root=package_root,
@@ -1388,6 +1414,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 "update_git_checkout": refs_mod.update_git_checkout,
                 "bootstrap_reference_checkout": refs_mod.bootstrap_reference_checkout,
                 "project_lake_update_command": refs_mod.project_lake_update_command,
+                "validate_external_reference_toolchain": refs_mod.validate_external_reference_toolchain,
                 "run": refs_mod.run,
             }
             seen: dict[str, str] = {}
@@ -1402,6 +1429,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 refs_mod.update_git_checkout = lambda _project, _cache_dir: None
                 refs_mod.bootstrap_reference_checkout = lambda *, project_dir: None
                 refs_mod.project_lake_update_command = lambda _package_root, _project_dir: ["lake", "update"]
+                refs_mod.validate_external_reference_toolchain = lambda *_args, **_kwargs: "v4.30.0"
                 refs_mod.run = fake_run
 
                 refs_mod.sync_reference_cache_checkout(layout, project, warm_build=False)
@@ -1411,7 +1439,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
 
             self.assertIn(f'require VersoBlueprint from "{package_root.resolve()}"', seen["lakefile_during_update"])
             self.assertNotIn("../../../docs-431-reference-catalog", seen["lakefile_during_update"])
-            self.assertEqual(lakefile.read_text(encoding="utf-8"), OFFICIAL_BLUEPRINT_REQUIRE + "\n")
+            self.assertEqual(lakefile.read_text(encoding="utf-8"), TEST_OFFICIAL_BLUEPRINT_REQUIRE + "\n")
 
     def test_reference_cache_warm_build_failure_reports_recovery_hints(self) -> None:
         import scripts.blueprint_harness_references as refs_mod
@@ -1430,6 +1458,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             panel_regression_script=None,
             browser_tests_path=None,
             description=None,
+            selected_release="v4.30.0",
         )
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -1439,7 +1468,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             project_dir.mkdir(parents=True)
             (cache_dir / ".git").mkdir()
             lakefile = project_dir / "lakefile.lean"
-            lakefile.write_text(OFFICIAL_BLUEPRINT_REQUIRE + "\n", encoding="utf-8")
+            lakefile.write_text(TEST_OFFICIAL_BLUEPRINT_REQUIRE + "\n", encoding="utf-8")
             layout = SimpleNamespace(
                 package_root=root / "worktree",
                 repo_root=root / "root",
@@ -1453,6 +1482,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 "update_git_checkout": refs_mod.update_git_checkout,
                 "bootstrap_reference_checkout": refs_mod.bootstrap_reference_checkout,
                 "project_lake_update_command": refs_mod.project_lake_update_command,
+                "validate_external_reference_toolchain": refs_mod.validate_external_reference_toolchain,
                 "run": refs_mod.run,
                 "run_with_heartbeat": refs_mod.run_with_heartbeat,
             }
@@ -1469,6 +1499,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 refs_mod.update_git_checkout = lambda _project, _cache_dir: None
                 refs_mod.bootstrap_reference_checkout = lambda *, project_dir: None
                 refs_mod.project_lake_update_command = lambda _package_root, _project_dir: ["lake", "update"]
+                refs_mod.validate_external_reference_toolchain = lambda *_args, **_kwargs: "v4.30.0"
                 refs_mod.run = fake_run
                 refs_mod.run_with_heartbeat = fake_run_with_heartbeat
 
@@ -1486,7 +1517,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             self.assertIn("incompatible `.olean` header", message)
             self.assertIn("create-worktree <name> --lightweight", message)
             self.assertIn("blueprint_reference_harness prune --dry-run", message)
-            self.assertEqual(lakefile.read_text(encoding="utf-8"), OFFICIAL_BLUEPRINT_REQUIRE + "\n")
+            self.assertEqual(lakefile.read_text(encoding="utf-8"), TEST_OFFICIAL_BLUEPRINT_REQUIRE + "\n")
 
     def test_child_manifests_inherit_verso_and_subverso_from_root_without_mathlib(self) -> None:
         root_manifest_path = PACKAGE_ROOT / "lake-manifest.json"
@@ -1694,6 +1725,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             panel_regression_script=None,
             browser_tests_path=None,
             description=None,
+            selected_release="v4.30.0",
         )
 
         with tempfile.TemporaryDirectory() as tmp:
@@ -1734,6 +1766,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 "sync_reference_cache_checkout": refs_mod.sync_reference_cache_checkout,
                 "sync_reference_local_checkout": refs_mod.sync_reference_local_checkout,
                 "project_lake_update_command": refs_mod.project_lake_update_command,
+                "validate_external_reference_toolchain": refs_mod.validate_external_reference_toolchain,
                 "run": refs_mod.run,
             }
             commands: list[list[str]] = []
@@ -1756,6 +1789,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                     lambda _project_dir, _package_root: local_dir / "lakefile.lean"
                 )
                 refs_mod.project_lake_update_command = lambda _package_root, _project_dir: ["lake", "update", "VersoBlueprint"]
+                refs_mod.validate_external_reference_toolchain = lambda *_args, **_kwargs: "v4.30.0"
                 refs_mod.run = lambda command, *, cwd: commands.append(command)
                 commands_mod.run = lambda command, *, cwd: commands.append(command)
                 commands_mod.run_with_heartbeat = lambda command, *, cwd, label: commands.append(command)
@@ -1917,6 +1951,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             panel_regression_script=None,
             browser_tests_path=None,
             description=None,
+            selected_release="v4.30.0",
         )
         layout = SimpleNamespace(
             package_root=Path("/tmp/package"),
@@ -1931,6 +1966,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             "git_checkout_is_clean": refs_mod.git_checkout_is_clean,
             "rewrite_pinned_blueprint_dependency": refs_mod.rewrite_pinned_blueprint_dependency,
             "project_lake_update_command": refs_mod.project_lake_update_command,
+            "validate_external_reference_toolchain": refs_mod.validate_external_reference_toolchain,
             "run": refs_mod.run,
             "git_has_tracked_changes": refs_mod.git_has_tracked_changes,
             "commit_project_tracked_changes": refs_mod.commit_project_tracked_changes,
@@ -1950,6 +1986,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 "old-ref",
             )
             refs_mod.project_lake_update_command = lambda _package_root, _project_dir: ["lake", "update", "VersoBlueprint"]
+            refs_mod.validate_external_reference_toolchain = lambda *_args, **_kwargs: "v4.30.0"
             refs_mod.run = lambda command, *, cwd: commands.append(command)
             refs_mod.git_has_tracked_changes = lambda _checkout_root, _pathspec: True
 
@@ -2003,6 +2040,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             panel_regression_script=None,
             browser_tests_path=None,
             description=None,
+            selected_release="v4.30.0",
         )
 
         with tempfile.TemporaryDirectory() as tmp:
@@ -2021,6 +2059,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 "git_checkout_is_clean": refs_mod.git_checkout_is_clean,
                 "rewrite_pinned_blueprint_dependency": refs_mod.rewrite_pinned_blueprint_dependency,
                 "project_lake_update_command": refs_mod.project_lake_update_command,
+                "validate_external_reference_toolchain": refs_mod.validate_external_reference_toolchain,
                 "run": refs_mod.run,
                 "run_with_heartbeat": refs_mod.run_with_heartbeat,
                 "git_has_tracked_changes": refs_mod.git_has_tracked_changes,
@@ -2038,6 +2077,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                     "old-ref",
                 )
                 refs_mod.project_lake_update_command = lambda _package_root, _project_dir: ["lake", "update", "VersoBlueprint"]
+                refs_mod.validate_external_reference_toolchain = lambda *_args, **_kwargs: "v4.30.0"
                 refs_mod.run = lambda command, *, cwd: commands.append(command)
                 refs_mod.run_with_heartbeat = lambda command, *, cwd, label: commands.append(command)
                 refs_mod.git_has_tracked_changes = lambda _checkout_root, _pathspec: False

--- a/tests/harness/test_blueprint_harness_releases.py
+++ b/tests/harness/test_blueprint_harness_releases.py
@@ -28,21 +28,6 @@ class BlueprintHarnessReleaseHelperTests(unittest.TestCase):
         self.assertEqual(releases_mod.normalize_lean_release_ref(SAMPLE_NEXT_RC), SAMPLE_NEXT_RC_REF)
         self.assertEqual(releases_mod.release_branch_from_lean_ref(lean_toolchain(SAMPLE_NEXT_RC_REF)), SAMPLE_NEXT_RELEASE)
 
-    def test_lean_release_order_key_orders_release_candidates_before_final_release(self) -> None:
-        self.assertLess(
-            releases_mod.lean_release_order_key("v4.30.0-rc1"),
-            releases_mod.lean_release_order_key(SAMPLE_NEXT_RC_REF),
-        )
-        self.assertLess(
-            releases_mod.lean_release_order_key(SAMPLE_NEXT_RC_REF),
-            releases_mod.lean_release_order_key(SAMPLE_NEXT_RELEASE),
-        )
-        self.assertEqual(
-            releases_mod.lean_release_order_key("v4.30-rc2"),
-            releases_mod.lean_release_order_key(SAMPLE_NEXT_RC_REF),
-        )
-        self.assertIsNone(releases_mod.lean_release_order_key("nightly-testing"))
-
     def test_rewrite_lean_toolchain_preserves_existing_final_newline_style(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/harness/test_blueprint_harness_worktrees.py
+++ b/tests/harness/test_blueprint_harness_worktrees.py
@@ -112,6 +112,64 @@ branch refs/heads/feat/demo
             self.assertEqual(by_name["demo"].main_ahead, 1)
             self.assertEqual(by_name["demo"].main_behind, 2)
 
+    def test_sync_worktree_registry_ignores_missing_git_worktree_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            stale_dir = repo_root / ".worktrees" / "stale"
+            subprocess_text = f"""
+worktree {repo_root}
+HEAD abc
+branch refs/heads/v4.32.0
+
+worktree {stale_dir}
+HEAD def
+branch refs/heads/feat/stale
+"""
+            stale_metadata = metadata_path(repo_root, "stale")
+            stale_metadata.parent.mkdir(parents=True)
+            stale_metadata.write_text(
+                json.dumps({"version": 1, "name": "stale", "status": "merged"}) + "\n",
+                encoding="utf-8",
+            )
+
+            import scripts.blueprint_harness_worktrees as worktrees_mod
+
+            originals = {
+                "git_worktrees": worktrees_mod.git_worktrees,
+                "collect_worktree_facts": worktrees_mod.collect_worktree_facts,
+            }
+            seen: list[str] = []
+            try:
+                worktrees_mod.git_worktrees = lambda _repo_root: parse_git_worktree_porcelain(subprocess_text, repo_root)
+
+                def fake_facts(_repo_root, git_wt):
+                    seen.append(git_wt.name)
+                    return {
+                        "dirty": False,
+                        "tracked_changes": 0,
+                        "untracked_changes": 0,
+                        "base_ref": "origin/v4.32.0",
+                        "merged_into_main": True,
+                        "main_ahead": 0,
+                        "main_behind": 0,
+                        "upstream": "origin/v4.32.0",
+                        "upstream_ahead": 0,
+                        "upstream_behind": 0,
+                        "last_commit": "abc",
+                        "last_commit_at": "2026-07-15T00:00:00Z",
+                        "last_commit_subject": "root",
+                    }
+
+                worktrees_mod.collect_worktree_facts = fake_facts
+                records, _registry = sync_worktree_registry(repo_root)
+            finally:
+                for name, value in originals.items():
+                    setattr(worktrees_mod, name, value)
+
+            self.assertEqual(seen, [ROOT_WORKTREE_NAME])
+            self.assertEqual([record.name for record in records], [ROOT_WORKTREE_NAME])
+            self.assertFalse(stale_metadata.exists())
+
     def test_sync_worktree_registry_preserves_created_at_and_refreshes_canonical_fields(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)

--- a/tests/harness/test_blueprint_test_blueprints.py
+++ b/tests/harness/test_blueprint_test_blueprints.py
@@ -2,20 +2,20 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-import subprocess
 import tempfile
 import unittest
 
 from scripts.blueprint_test_blueprints import (
-    TAG_PATTERN,
     StandaloneTestBlueprint,
     default_test_blueprint_manifest,
     find_test_blueprint,
     generate_test_blueprint_outputs,
+    blueprint_meta_by_slug,
     load_test_blueprint_categories,
     load_test_blueprints_manifest,
     render_test_blueprint_index_html,
     split_generation_targets,
+    validate_curated_test_doc_meta,
     validate_test_blueprint_outputs,
     write_test_blueprint_index,
 )
@@ -167,25 +167,45 @@ class StandaloneTestBlueprintTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "invalid tag"):
                 load_test_blueprints_manifest(manifest)
 
-    def test_curated_docs_follow_shared_category_vocabulary(self) -> None:
+    def test_curated_doc_metadata_uses_the_shared_catalog_vocabulary(self) -> None:
         manifest = default_test_blueprint_manifest(PACKAGE_ROOT)
-        categories = set(load_test_blueprint_categories(manifest))
-        result = subprocess.run(
-            ["./scripts/lean-low-priority", "lake", "exe", "blueprint-test-docs", "--list-json"],
-            cwd=PACKAGE_ROOT,
-            check=True,
-            text=True,
-            capture_output=True,
+        categories = load_test_blueprint_categories(manifest)
+        entries = [
+            {
+                "slug": "demo",
+                "title": "Demo",
+                "category": "Runtime",
+                "summary": "Demo entry",
+                "tags": ["preview", "runtime"],
+                "kind": "curated_doc",
+            }
+        ]
+
+        self.assertEqual(validate_curated_test_doc_meta(entries, categories), entries)
+
+    def test_curated_doc_metadata_rejects_invalid_catalog_fields(self) -> None:
+        categories = ("Runtime",)
+        valid = {
+            "slug": "demo",
+            "title": "Demo",
+            "category": "Runtime",
+            "summary": "Demo entry",
+            "tags": ["preview", "runtime"],
+            "kind": "curated_doc",
+        }
+        invalid_entries = (
+            ({**valid, "title": ""}, "expected non-empty string field `title`"),
+            ({**valid, "category": "Unknown"}, "unknown category"),
+            ({**valid, "summary": None}, "expected non-empty string field `summary`"),
+            ({**valid, "kind": "standalone_project"}, "expected kind `curated_doc`"),
+            ({**valid, "tags": ["not valid"]}, "invalid tag"),
+            ({**valid, "tags": ["preview", "preview"]}, "duplicate values"),
         )
-        entries = json.loads(result.stdout)
-        self.assertTrue(entries)
-        for entry in entries:
-            self.assertIn(entry["category"], categories)
-            self.assertEqual(entry["kind"], "curated_doc")
-            self.assertIsInstance(entry.get("tags"), list)
-            self.assertTrue(all(isinstance(tag, str) and tag for tag in entry["tags"]))
-            self.assertEqual(len(entry["tags"]), len(set(entry["tags"])))
-            self.assertTrue(all(TAG_PATTERN.fullmatch(tag) for tag in entry["tags"]))
+
+        for entry, message in invalid_entries:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    validate_curated_test_doc_meta([entry], categories)
 
     def test_meta_uses_unified_shape(self) -> None:
         fixture = StandaloneTestBlueprint(
@@ -298,13 +318,49 @@ class StandaloneTestBlueprintTests(unittest.TestCase):
             browser_tests_path=None,
         )
         doc_slugs, fixtures = split_generation_targets(
-            PACKAGE_ROOT,
+            [
+                {
+                    "slug": "summary-doc",
+                    "title": "Summary",
+                    "category": "Runtime",
+                    "summary": "Summary fixture",
+                    "tags": [],
+                    "kind": "curated_doc",
+                }
+            ],
             [fixture],
             ["summary-doc", "runtime-showcase"],
         )
 
         self.assertEqual(doc_slugs, ["summary-doc"])
         self.assertEqual([entry.slug for entry in fixtures], ["runtime-showcase"])
+
+    def test_test_blueprint_catalog_rejects_cross_catalog_slug_collisions(self) -> None:
+        fixture = StandaloneTestBlueprint(
+            slug="shared",
+            title="Standalone",
+            category="Runtime",
+            summary="Standalone fixture",
+            tags=(),
+            project_root="tests/test_blueprints/shared",
+            build_command=None,
+            generate_command=VBP_BUILD_OUTPUT_COMMAND,
+            panel_regression_script=None,
+            browser_tests_path=None,
+        )
+        curated = [
+            {
+                "slug": "shared",
+                "title": "Curated",
+                "category": "Runtime",
+                "summary": "Curated fixture",
+                "tags": [],
+                "kind": "curated_doc",
+            }
+        ]
+
+        with self.assertRaisesRegex(ValueError, "declared by both"):
+            blueprint_meta_by_slug(curated, [fixture])
 
     def test_generate_test_blueprint_outputs_prunes_only_full_generation(self) -> None:
         fixture = StandaloneTestBlueprint(
@@ -320,31 +376,33 @@ class StandaloneTestBlueprintTests(unittest.TestCase):
             browser_tests_path=None,
         )
         originals = {
-            "list_curated_test_doc_slugs": test_blueprints_mod.list_curated_test_doc_slugs,
+            "list_curated_test_doc_meta": test_blueprints_mod.list_curated_test_doc_meta,
             "generate_curated_test_doc": test_blueprints_mod.generate_curated_test_doc,
             "generate_standalone_test_blueprint": test_blueprints_mod.generate_standalone_test_blueprint,
-            "test_blueprint_index_entries": test_blueprints_mod.test_blueprint_index_entries,
         }
         generated: list[tuple[str, str]] = []
+        metadata_calls: list[Path] = []
         try:
-            test_blueprints_mod.list_curated_test_doc_slugs = lambda _package_root: ["summary-doc"]
+            def fake_curated_meta(package_root, _categories):
+                metadata_calls.append(package_root)
+                return [
+                    {
+                        "slug": "summary-doc",
+                        "title": "summary-doc",
+                        "category": "Runtime",
+                        "summary": "summary",
+                        "tags": [],
+                        "kind": "curated_doc",
+                    }
+                ]
+
+            test_blueprints_mod.list_curated_test_doc_meta = fake_curated_meta
             test_blueprints_mod.generate_curated_test_doc = (
                 lambda _package_root, slug, _output_dir: generated.append(("doc", slug))
             )
             test_blueprints_mod.generate_standalone_test_blueprint = (
                 lambda _package_root, standalone, _output_dir: generated.append(("standalone", standalone.slug))
             )
-            test_blueprints_mod.test_blueprint_index_entries = lambda _package_root, _fixtures, selected: [
-                {
-                    "slug": slug,
-                    "title": slug,
-                    "category": "Runtime",
-                    "summary": "summary",
-                    "tags": [],
-                    "kind": "curated_doc",
-                }
-                for slug in selected
-            ]
 
             with tempfile.TemporaryDirectory() as tmp:
                 output_root = Path(tmp) / "test-blueprints"
@@ -358,6 +416,7 @@ class StandaloneTestBlueprintTests(unittest.TestCase):
                 )
 
                 self.assertFalse((output_root / "stale-fixture").exists())
+                self.assertEqual(metadata_calls, [PACKAGE_ROOT])
                 self.assertEqual(generated, [("doc", "summary-doc"), ("standalone", "runtime-showcase")])
                 html = (output_root / "index.html").read_text(encoding="utf-8")
                 self.assertIn("./summary-doc/html-multi/", html)

--- a/tests/harness/test_harness_entrypoints.py
+++ b/tests/harness/test_harness_entrypoints.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import json
 from pathlib import Path
 import subprocess
 import sys
-import tempfile
 import unittest
 
 
@@ -61,30 +59,6 @@ class HarnessEntrypointSmokeTests(unittest.TestCase):
         result = self.run_command([sys.executable, "-m", "scripts.blueprint_test_blueprints", "list"])
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertEqual(result.stdout.strip(), "preview_runtime_showcase")
-
-    def test_external_markup_generator_supports_lake_lean_run(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            output = Path(tmp) / "site"
-            result = self.run_command(
-                [
-                    "./scripts/lean-low-priority",
-                    "lake",
-                    "lean",
-                    "tests/LeanRunExternalMarkupMain.lean",
-                    "--",
-                    "--run",
-                    "tests/LeanRunExternalMarkupMain.lean",
-                    "--output",
-                    str(output),
-                ]
-            )
-            self.assertEqual(result.returncode, 0, msg=result.stderr)
-            cache_path = output / "html-multi" / "-verso-data" / "blueprint-html-cache.json"
-            cache = json.loads(cache_path.read_text(encoding="utf-8"))
-            html = "\n".join(entry["html"] for entry in cache["entries"])
-            self.assertIn("bp_external_markdown_body", html)
-            self.assertIn("<h1>Markdown witness</h1>", html)
-            self.assertIn("&lt;span&gt;raw HTML stays text&lt;/span&gt;", html)
 
     def test_generate_reference_wrapper_help(self) -> None:
         result = self.run_command(["bash", "scripts/generate-reference-blueprints.sh", "--help"])

--- a/tests/integration/check_lean_run_external_markup.py
+++ b/tests/integration/check_lean_run_external_markup.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        output = Path(tmp) / "site"
+        subprocess.run(
+            [
+                "./scripts/lean-low-priority",
+                "lake",
+                "lean",
+                "tests/LeanRunExternalMarkupMain.lean",
+                "--",
+                "--run",
+                "tests/LeanRunExternalMarkupMain.lean",
+                "--output",
+                str(output),
+            ],
+            cwd=PACKAGE_ROOT,
+            check=True,
+        )
+        cache_path = output / "html-multi" / "-verso-data" / "blueprint-html-cache.json"
+        cache = json.loads(cache_path.read_text(encoding="utf-8"))
+        html = "\n".join(entry["html"] for entry in cache["entries"])
+        expected_fragments = (
+            "bp_external_markdown_body",
+            "<h1>Markdown witness</h1>",
+            "&lt;span&gt;raw HTML stays text&lt;/span&gt;",
+        )
+        missing = [fragment for fragment in expected_fragments if fragment not in html]
+        if missing:
+            raise SystemExit(f"missing rendered external-markup fragments: {', '.join(missing)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Backport #333 to `v4.31.0`.

## Primary Review
- Primary review: #333
- Keep review comments on #333 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.31.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- Also applies prerequisite #334's policy/template alignment: `v4.30.0` is removed from required backports because the `v4.31.0` base did not contain that default-development-only metadata change.