### PR TITLE
[backport v4.31.0] refactor: deduplicate work queue planning projection

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -283,17 +283,17 @@ methods on `Informal.PreviewManifest.File` rather than reimplementing filters:
 `findPrimaryQueryableEntry?`, `blockStatementEntries`,
 `findBlockEntriesByLabel`, `findPrimaryBlockEntry?`, `sourceDocument?`,
 `entriesWithSource`, `entriesForSourceDocument`, `ownerValues`, `tagValues`,
-`metadataEntries`, `actionableGraphNode?`, and `workQueueEntries`.
+`metadataEntries`, `actionableGraphNode?`, and `workQueueItems`.
 `metadataEntries` selects nodes with owner, tag, priority, or effort metadata.
-`workQueueEntries` selects nodes whose finalized graph status exposes an
-actionable statement or proof step; `actionableGraphNode?` returns that status
-record for clients that need the step and its statement/proof states. Finalized
-graph data is the generated planning source of truth: these helpers do not infer
-readiness from tags or other entry metadata, and return no work-queue item when
-no matching graph node is present. Use the queryable helpers for the same node
-selection as `lake exe vbp query`; use the block-only helpers when a consumer
-explicitly needs rendered block entries and should exclude source-backed
-bodyless external-markup nodes. Entry-level helpers
+`workQueueItems` pairs each selected entry with its actionable graph node and
+next step (`"statement"` or `"proof"`).
+`actionableGraphNode?` performs the corresponding lookup for one label.
+Finalized graph data is the generated planning source of truth: these helpers do
+not infer readiness from tags or other entry metadata, and return no work-queue
+item when no matching graph node is present. Use the queryable helpers for the
+same node selection as `lake exe vbp query`; use the block-only helpers when a
+consumer explicitly needs rendered block entries and should exclude
+source-backed bodyless external-markup nodes. Entry-level helpers
 `Entry.hasSourceDocument`, `Entry.matchesText`, and `Entry.matchesCode` provide
 the same source filtering and search predicates used by the `lake exe vbp query`
 interface.
@@ -308,10 +308,8 @@ def primaryNodeTitle?
 
 def workQueueNextSteps
     (manifest : Informal.PreviewManifest.File) : Array (String × String) :=
-  manifest.workQueueEntries.filterMap fun entry => do
-    let node ← manifest.actionableGraphNode? entry.label
-    let nextStep ← node.actionableStage?
-    pure (entry.authoredLabel, nextStep)
+  manifest.workQueueItems.map fun item =>
+    (item.entry.authoredLabel, item.nextStep)
 ```
 
 Generator-side Lean callers can configure source-backed external-source cache

--- a/skills/verso-blueprint/references/vbp.md
+++ b/skills/verso-blueprint/references/vbp.md
@@ -85,10 +85,10 @@ All query commands print compact JSON for agent consumption. The JSON shape is f
 - `used-by <label>`: reverse dependencies for one label.
 - `group <label>`: group metadata and sibling entries for one label, when present.
 - `owners` and `tags`: distinct values from statement-level block entries.
-- `work-queue`: statement-level entries with a graph-status-backed unblocked
-  next step; each row includes `nextStep`, `statementStatus`, and `proofStatus`.
-  Graph data is the generated planning source of truth, so no graph status means
-  no work-queue row.
+- `work-queue`: statement-level entries with a graph-status-backed actionable
+  next step; each row includes `nextStep` (`"statement"` or `"proof"`),
+  `statementStatus`, and `proofStatus`. Graph data is the generated planning
+  source of truth, so no graph status means no work-queue row.
 - `metadata`: statement-level entries with owner, tags, priority, or effort metadata.
 - `search <text>`: statement-level entries whose label, title, owner, tag, or parent title contains the text, case-insensitively.
 - `code <decl>`: statement-level entries with Lean preview keys containing the declaration text.

--- a/src/VersoBlueprint/Commands/Summary/Sections.lean
+++ b/src/VersoBlueprint/Commands/Summary/Sections.lean
@@ -27,6 +27,9 @@ open Verso Doc Html Genre Manual
 open Verso.Output.Html
 open Verso.Multi (AllRemotes)
 
+private def actionableEntryDescription : String :=
+  "Entries with an actionable next formalization step."
+
 private def summaryOverviewSection (data : Summary) (rows : SummaryRows) : Output.Html :=
   let showBlockers := rows.blockerCount > 0
   let showPendingInformal := !rows.pendingInformalRows.isEmpty
@@ -37,7 +40,7 @@ private def summaryOverviewSection (data : Summary) (rows : SummaryRows) : Outpu
         {{summaryCard
             "Ready now"
             (toString data.coverageSplit.readyToFormalize)
-            (Option.some "Entries whose next formalization step is currently unblocked.")}}
+            (Option.some actionableEntryDescription)}}
         {{summaryCard
             "Fully closed"
             (toString data.coverageSplit.fullyClosed)
@@ -327,7 +330,7 @@ private def summaryStructureSection (data : Summary) (rows : SummaryRows) : Outp
               (data.coverageSplit.readyToFormalize > 0)
               "Ready to formalize"
               (toString data.coverageSplit.readyToFormalize)
-              (Option.some "Entries whose next step is currently unblocked.")}}
+              (Option.some actionableEntryDescription)}}
           {{summaryOptionalCard
               (data.coverageSplit.formalizedWithoutAncestors > 0)
               "Formalized, ancestors open"

--- a/src/VersoBlueprint/Graph.lean
+++ b/src/VersoBlueprint/Graph.lean
@@ -273,7 +273,7 @@ structure NodeData where
   visual : NodeVisual
 deriving Inhabited, Repr, ToJson, FromJson, Quote
 
-/-- The next unblocked formalization stage represented by this finalized graph node. -/
+/-- The next actionable formalization stage represented by this finalized graph node. -/
 def NodeData.actionableStage? (node : NodeData) : Option String := do
   let kind ← node.kind
   actionableStageForStatuses? kind node.statementStatus node.proofStatus

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -1534,22 +1534,39 @@ def File.metadataEntries (file : File) : Array Entry :=
     entry.ownerDisplayName.isSome || entry.priority.isSome ||
       entry.effort.isSome || !entry.tags.isEmpty
 
-/-- First finalized graph node showing an unblocked next step for `label`. -/
-def File.actionableGraphNode? (file : File) (label : Name) : Option Informal.Graph.NodeData :=
+private def File.actionableGraphNodeWithStep? (file : File) (label : Name) :
+    Option (Informal.Graph.NodeData × String) :=
   file.graphs.findSome? fun graph =>
-    graph.nodes.find? fun node =>
-      node.label == label && node.actionableStage?.isSome
+    graph.nodes.findSome? fun node =>
+      if node.label == label then
+        node.actionableStage?.map fun nextStep => (node, nextStep)
+      else
+        none
+
+/-- First finalized graph node showing an actionable next step for `label`. -/
+def File.actionableGraphNode? (file : File) (label : Name) : Option Informal.Graph.NodeData :=
+  (file.actionableGraphNodeWithStep? label).map (·.1)
+
+/-- A queryable statement entry paired with its actionable finalized graph status. -/
+structure WorkQueueItem where
+  /-- Queryable statement-level manifest entry. -/
+  entry : Entry
+  /-- Matching finalized graph node whose status makes the entry actionable. -/
+  graphNode : Informal.Graph.NodeData
+  /-- Actionable formalization track, either `"statement"` or `"proof"`. -/
+  nextStep : String
 
 /--
-Queryable statement entries whose next formalization stage is unblocked.
+Queryable statement entries paired with their actionable finalized graph status.
 
 Finalized graph nodes are the generated planning source of truth. This query
 does not infer readiness from entry metadata; a manifest without matching graph
 nodes therefore has an empty work queue.
 -/
-def File.workQueueEntries (file : File) : Array Entry :=
-  file.queryableStatementEntries.filter fun entry =>
-    (file.actionableGraphNode? entry.label).isSome
+def File.workQueueItems (file : File) : Array WorkQueueItem :=
+  file.queryableStatementEntries.filterMap fun entry => do
+    let (graphNode, nextStep) ← file.actionableGraphNodeWithStep? entry.label
+    pure { entry, graphNode, nextStep }
 
 private def containsSearchText (text value : String) : Bool :=
   value.toLower.contains text

--- a/src/VersoBlueprint/Vbp.lean
+++ b/src/VersoBlueprint/Vbp.lean
@@ -19,6 +19,7 @@ abbrev RelatedEntry := Informal.PreviewManifest.RelatedEntry
 abbrev GroupRelation := Informal.PreviewManifest.GroupRelation
 abbrev RelationAxis := Informal.PreviewManifest.RelationAxis
 abbrev PreviewArtifactIndex := Informal.PreviewManifest.PreviewArtifactIndex
+abbrev WorkQueueItem := Informal.PreviewManifest.WorkQueueItem
 
 def defaultSite : FilePath := "_out" / "site"
 
@@ -131,15 +132,12 @@ private def entrySummaryFields (entry : Entry) : List (String × Json) := [
 private def entrySummaryJson (entry : Entry) : Json :=
   Json.mkObj (entrySummaryFields entry)
 
-private def workQueueEntryJson (manifest : ManifestFile) (entry : Entry) : Json :=
-  match manifest.actionableGraphNode? entry.label with
-  | none => entrySummaryJson entry
-  | some node =>
-      Json.mkObj <| entrySummaryFields entry ++ [
-        ("nextStep", optionStringJson node.actionableStage?),
-        ("statementStatus", Json.str node.statementStatus.toText),
-        ("proofStatus", Json.str node.proofStatus.toText)
-      ]
+private def workQueueItemJson (item : WorkQueueItem) : Json :=
+  Json.mkObj <| entrySummaryFields item.entry ++ [
+    ("nextStep", Json.str item.nextStep),
+    ("statementStatus", Json.str item.graphNode.statementStatus.toText),
+    ("proofStatus", Json.str item.graphNode.proofStatus.toText)
+  ]
 
 private def entryGroupJson (manifest : ManifestFile) (entry : Entry) : Json :=
   match manifest.groupForEntry? entry with
@@ -272,7 +270,7 @@ def queryJson (manifest : ManifestFile) (args : List String) : Except String Jso
       .ok <| responseJson [("tags", stringArrayJson manifest.tagValues)]
   | ["work-queue"] =>
       .ok <| responseJson [
-        ("entries", Json.arr (manifest.workQueueEntries.map (workQueueEntryJson manifest)))
+        ("entries", Json.arr (manifest.workQueueItems.map workQueueItemJson))
       ]
   | ["metadata"] =>
       .ok <| responseJson [

--- a/tests/VersoBlueprintTests/BlueprintSummaryStatus.lean
+++ b/tests/VersoBlueprintTests/BlueprintSummaryStatus.lean
@@ -45,6 +45,7 @@ private def mkLiterateCode (definedDefs : Array LiterateDef) (definedTheorems : 
   actionableStageForStatuses? .definition .ready .ready == some "statement" &&
     actionableStageForStatuses? .definition .blocked .incomplete == none &&
     actionableStageForStatuses? .theorem .ready .none == some "statement" &&
+    actionableStageForStatuses? .theorem .ready .incomplete == some "proof" &&
     actionableStageForStatuses? .theorem .formalized .ready == some "proof" &&
     actionableStageForStatuses? .theorem .blocked .incomplete == some "proof" &&
     actionableStageForStatuses? .theorem .formalized .formalized == none &&

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -417,7 +417,21 @@ private def jsonArrayHasNullField (values : Array Json) (field : String) : Bool 
     let items := sampleMetadataManifest.workQueueItems
     items.map (fun item => (item.entry.authoredLabel, item.nextStep)) ==
         #[("zeta_statement", "statement"), ("proof_statement", "proof")] &&
-      items.all fun item => item.graphNode.actionableStage? == some item.nextStep
+      items.all fun item =>
+        item.graphNode.label == item.entry.label &&
+          item.graphNode.actionableStage? == some item.nextStep
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    match
+      sampleMetadataManifest.actionableGraphNode? (label "proof_statement"),
+      sampleMetadataManifest.actionableGraphNode? (label "alpha_statement") with
+    | some proofNode, none =>
+        proofNode.label == label "proof_statement" &&
+          proofNode.actionableStage? == some "proof"
+    | _, _ => false
 
 private partial def freshVbpFixtureRoot : IO System.FilePath := do
   let suffix ← IO.rand 0 1000000000000

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -385,7 +385,7 @@ private def jsonArrayHasNullField (values : Array Json) (field : String) : Bool 
 #guard_msgs in
 #eval
   show Bool from
-    sampleManifest.graphs.isEmpty && sampleManifest.workQueueEntries.isEmpty
+    sampleManifest.graphs.isEmpty && sampleManifest.workQueueItems.isEmpty
 
 /-- info: true -/
 #guard_msgs in
@@ -407,10 +407,17 @@ private def jsonArrayHasNullField (values : Array Json) (field : String) : Bool 
           sampleMetadataManifest.ownerValues == #["Alpha", "Zed"] &&
           sampleMetadataManifest.tagValues == #["alpha", "beta", "zeta"] &&
           sampleMetadataManifest.metadataEntries.map (·.authoredLabel) ==
-            #["zeta_statement", "alpha_statement"] &&
-          sampleMetadataManifest.workQueueEntries.map (·.authoredLabel) ==
-            #["zeta_statement", "proof_statement"]
+            #["zeta_statement", "alpha_statement"]
     | _, _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    let items := sampleMetadataManifest.workQueueItems
+    items.map (fun item => (item.entry.authoredLabel, item.nextStep)) ==
+        #[("zeta_statement", "statement"), ("proof_statement", "proof")] &&
+      items.all fun item => item.graphNode.actionableStage? == some item.nextStep
 
 private partial def freshVbpFixtureRoot : IO System.FilePath := do
   let suffix ← IO.rand 0 1000000000000


### PR DESCRIPTION
## Summary
Backport #340 to `v4.31.0`.

## Primary Review
- Primary review: #340
- Keep review comments on #340 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.31.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.