### PR TITLE
fix: validate manifest group identity fields

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -352,10 +352,10 @@ clients can use `PreviewManifest.File.groupForEntry?` when they need the current
 entry filtered out of the member list.
 
 Relation entries in `uses`, `usedBy`, and top-level `groups[*].entries` carry
-their own `previewKey` field. That field is either a non-empty key that resolves through
-both the manifest and rendered-fragment cache, or `null` when the related node
-has no manifest/cache-backed preview in the generated artifact set. Fresh
-generated data does not use an empty string as a no-preview sentinel.
+their own `previewKey` field. That field is either a non-empty key that resolves
+through both the manifest and rendered-fragment cache, or `null` when the
+related node has no manifest/cache-backed preview in the generated artifact
+set. Fresh generated data does not use an empty string as a no-preview sentinel.
 
 Use `Informal.PreviewManifest.previewMetadataLosses state manifest` to audit
 whether traversal-preview metadata survived manifest construction. A non-empty

--- a/doc/API.md
+++ b/doc/API.md
@@ -344,9 +344,13 @@ Manifest entries serialize several label-like fields with distinct roles:
   should prefer it when presenting or round-tripping labels that contain
   punctuation.
 
-Group membership is normalized: a block entry's optional `parent` names one
-record in the manifest's top-level `groups` array. Each group stores its
-traversal-ordered statement members once. Browser clients can join these records
+Group membership is normalized: an informal block or source-backed
+external-markup entry's optional `parent` names one record in the manifest's
+top-level `groups` array. Each group stores its traversal-ordered statement
+members once. Group labels are unique, each member label belongs to at most one
+group, and participating manifest entries must agree with the catalog on group
+ownership and `parentTitle`. Both `vbp check` and the browser manifest loader
+reject incomplete or inconsistent joins. Browser clients can join these records
 with `loadGroup(entry.parent)` or enumerate them with `loadGroups()`; Lean
 clients can use `PreviewManifest.File.groupForEntry?` when they need the current
 entry filtered out of the member list.

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -652,7 +652,9 @@ optional `parent` label and a resolved `parentTitle` display convenience, while
 the top-level `groups` catalog stores each group's declaration state and
 traversal-ordered statement members once. Lean and browser consumers join
 through the parent label instead of copying the same sibling array into every
-preview entry.
+preview entry. The generated-data checker and browser loader enforce the join in
+both directions, including unique ownership and agreement between the catalog
+title and each entry's `parentTitle` convenience field.
 
 Consumers should join the two files by preview key at the last responsible
 moment. A renderer may use the manifest entry to decide what the object means

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -647,11 +647,12 @@ rendered-fragment cache stores opaque HTML bodies keyed by preview keys for
 entries that have generated preview bodies, plus the Verso hover payloads
 needed by those bodies.
 
-Group membership is normalized inside the manifest itself. Entries carry only
-their optional `parent` label, while the top-level `groups` catalog stores each
-group's title, declaration state, and traversal-ordered statement members once.
-Lean and browser consumers join through the parent label instead of copying the
-same sibling array into every preview entry.
+Group membership is normalized inside the manifest itself. Entries carry their
+optional `parent` label and a resolved `parentTitle` display convenience, while
+the top-level `groups` catalog stores each group's declaration state and
+traversal-ordered statement members once. Lean and browser consumers join
+through the parent label instead of copying the same sibling array into every
+preview entry.
 
 Consumers should join the two files by preview key at the last responsible
 moment. A renderer may use the manifest entry to decide what the object means

--- a/src/VersoBlueprint/Commands/preview-runtime-data.mjs
+++ b/src/VersoBlueprint/Commands/preview-runtime-data.mjs
@@ -672,6 +672,7 @@ import { resolveSourceMetadata } from "./preview-runtime-source-metadata.mjs";
       throw new Error("Blueprint manifest is missing groups array");
     }
     const groupsByLabel = new Map();
+    const memberGroupsByLabel = new Map();
     groups.forEach(function (group, index) {
       if (!group || typeof group !== "object" || Array.isArray(group)) {
         throw new Error("Blueprint manifest group " + index + " must be an object");
@@ -686,9 +687,109 @@ import { resolveSourceMetadata } from "./preview-runtime-source-metadata.mjs";
       if (groupsByLabel.has(label)) {
         throw new Error("Blueprint manifest contains duplicate group " + label);
       }
+      const title = typeof group.title === "string" ? group.title.trim() : "";
+      if (!title) {
+        throw new Error("Blueprint manifest group " + label + " is missing title");
+      }
+      const memberLabels = new Set();
+      group.entries.forEach(function (member, memberIndex) {
+        if (!member || typeof member !== "object" || Array.isArray(member)) {
+          throw new Error(
+            "Blueprint manifest group " + label + " member " + memberIndex + " must be an object"
+          );
+        }
+        const memberLabel = typeof member.label === "string" ? member.label.trim() : "";
+        if (!memberLabel) {
+          throw new Error(
+            "Blueprint manifest group " + label + " member " + memberIndex + " is missing label"
+          );
+        }
+        if (memberLabels.has(memberLabel)) {
+          throw new Error(
+            "Blueprint manifest contains duplicate member " + memberLabel + " in group " + label
+          );
+        }
+        memberLabels.add(memberLabel);
+        if (memberGroupsByLabel.has(memberLabel)) {
+          throw new Error(
+            "Blueprint manifest member " + memberLabel + " belongs to multiple groups: " +
+              memberGroupsByLabel.get(memberLabel) + " and " + label
+          );
+        }
+        memberGroupsByLabel.set(memberLabel, label);
+      });
       groupsByLabel.set(label, group);
     });
-    return { groups: groups, groupsByLabel: groupsByLabel };
+    return {
+      groups: groups,
+      groupsByLabel: groupsByLabel,
+      memberGroupsByLabel: memberGroupsByLabel
+    };
+  }
+
+  function validateBlueprintGroupJoins(previews, groupData) {
+    const matchedMembers = new Set();
+    previews.forEach(function (entry) {
+      if (!entry || (entry.targetKind !== "block" && entry.targetKind !== "externalMarkup")) {
+        return;
+      }
+      const label = typeof entry.label === "string" ? entry.label.trim() : "";
+      if (!label) {
+        throw new Error("Blueprint manifest entry " + entry.key + " is missing label");
+      }
+      const hasParent = entry.parent !== null && typeof entry.parent !== "undefined";
+      const parent = typeof entry.parent === "string" ? entry.parent.trim() : "";
+      if (hasParent && !parent) {
+        throw new Error("Blueprint manifest entry " + entry.key + " has invalid parent");
+      }
+      if (!hasParent) {
+        if (entry.parentTitle !== null && typeof entry.parentTitle !== "undefined") {
+          throw new Error(
+            "Blueprint manifest entry " + entry.key + " has parentTitle without parent"
+          );
+        }
+        if (groupData.memberGroupsByLabel.has(label)) {
+          throw new Error(
+            "Blueprint manifest entry " + entry.key +
+              " has no parent but is listed in group " + groupData.memberGroupsByLabel.get(label)
+          );
+        }
+        return;
+      }
+      const group = groupData.groupsByLabel.get(parent);
+      if (!group) {
+        throw new Error(
+          "Blueprint manifest entry " + entry.key + " references missing group " + parent
+        );
+      }
+      if (entry.parentTitle !== group.title) {
+        throw new Error(
+          "Blueprint manifest entry " + entry.key +
+            " has inconsistent parentTitle for group " + parent
+        );
+      }
+      const memberGroup = groupData.memberGroupsByLabel.get(label);
+      if (!memberGroup) {
+        throw new Error(
+          "Blueprint manifest entry " + entry.key + " is missing from group " + parent
+        );
+      }
+      if (memberGroup !== parent) {
+        throw new Error(
+          "Blueprint manifest entry " + entry.key + " belongs to group " + memberGroup +
+            " but references " + parent
+        );
+      }
+      matchedMembers.add(label);
+    });
+    groupData.memberGroupsByLabel.forEach(function (group, member) {
+      if (!matchedMembers.has(member)) {
+        throw new Error(
+          "Blueprint manifest group " + group + " member " + member +
+            " has no matching manifest entry"
+        );
+      }
+    });
   }
 
   export function decodeBlueprintSourceDocuments(data) {
@@ -725,6 +826,7 @@ import { resolveSourceMetadata } from "./preview-runtime-source-metadata.mjs";
   export function decodeBlueprintManifestFile(data, previews) {
     const previewMap = previews instanceof Map ? previews : decodeBlueprintManifest(data);
     const groupData = decodeBlueprintGroups(data);
+    validateBlueprintGroupJoins(previewMap, groupData);
     const sourceData = decodeBlueprintSourceDocuments(data);
     return {
       previews: previewMap,

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -1231,18 +1231,20 @@ def File.findEntry? (file : File) (key : String) : Option Entry :=
 def Index.findGroup? (index : Index) (label : Name) : Option GroupRelation :=
   index.groupsByLabel.get? label
 
-def File.findGroup? (file : File) (label : Name) : Option GroupRelation :=
-  file.index.findGroup? label
+private def GroupRelation.withoutMember (group : GroupRelation) (label : Name) : GroupRelation :=
+  { group with entries := group.entries.filter (fun member => member.label != label) }
 
 /-- Group metadata for an entry, with the current node removed from the member list. -/
 def Index.groupForEntry? (index : Index) (entry : Entry) : Option GroupRelation := do
   let parent ← entry.parent
   let group ← index.findGroup? parent
-  pure { group with entries := group.entries.filter (fun member => member.label != entry.label) }
+  pure (group.withoutMember entry.label)
 
 /-- Group metadata for an entry, with the current node removed from the member list. -/
-def File.groupForEntry? (file : File) (entry : Entry) : Option GroupRelation :=
-  file.index.groupForEntry? entry
+def File.groupForEntry? (file : File) (entry : Entry) : Option GroupRelation := do
+  let parent ← entry.parent
+  let group ← file.groups.find? (fun group => group.label == parent)
+  pure (group.withoutMember entry.label)
 
 /--
 Indexes over the generated manifest/cache pair used to decide whether a

--- a/src/VersoBlueprint/Vbp.lean
+++ b/src/VersoBlueprint/Vbp.lean
@@ -379,13 +379,14 @@ private def checkGraphPreviewKeys
 private def checkManifestGroupIntegrity
     (manifest : ManifestFile) (errors : Array String) : Array String := Id.run do
   let mut errors := errors
-  let mut groupLabels : NameSet := {}
+  let mut groupsByLabel : NameMap GroupRelation := {}
+  let mut memberGroups : NameMap Name := {}
   for group in manifest.groups do
-    if groupLabels.contains group.label then
+    if groupsByLabel.contains group.label then
       errors := errors.push
         s!"duplicate manifest group label: {Informal.PreviewManifest.labelString group.label}"
     else
-      groupLabels := groupLabels.insert group.label
+      groupsByLabel := groupsByLabel.insert group.label group
     let mut memberLabels : NameSet := {}
     for member in group.entries do
       if memberLabels.contains member.label then
@@ -394,14 +395,57 @@ private def checkManifestGroupIntegrity
             s!"in manifest group {Informal.PreviewManifest.labelString group.label}"
       else
         memberLabels := memberLabels.insert member.label
+      match memberGroups.get? member.label with
+      | some previousGroup =>
+          if previousGroup != group.label then
+            errors := errors.push <|
+              s!"manifest member {Informal.PreviewManifest.labelString member.label} " ++
+                s!"belongs to multiple groups: " ++
+                s!"{Informal.PreviewManifest.labelString previousGroup} and " ++
+                Informal.PreviewManifest.labelString group.label
+      | none =>
+          memberGroups := memberGroups.insert member.label group.label
+  let mut matchedMembers : NameSet := {}
   for entry in manifest.previews do
+    if entry.targetKind != .block && entry.targetKind != .externalMarkup then
+      continue
     match entry.parent with
+    | none =>
+        if entry.parentTitle.isSome then
+          errors := errors.push s!"entry {entry.key} has parentTitle without parent"
+        if let some group := memberGroups.get? entry.label then
+          errors := errors.push <|
+            s!"entry {entry.key} has no parent but is listed in manifest group: " ++
+              Informal.PreviewManifest.labelString group
     | some parent =>
-        unless groupLabels.contains parent do
+        match groupsByLabel.get? parent with
+        | none =>
           errors := errors.push <|
             s!"entry {entry.key} references missing manifest group: " ++
               Informal.PreviewManifest.labelString parent
-    | none => pure ()
+        | some group =>
+            if entry.parentTitle != some group.title then
+              errors := errors.push <|
+                s!"entry {entry.key} has inconsistent parentTitle for manifest group: " ++
+                  Informal.PreviewManifest.labelString parent
+        match memberGroups.get? entry.label with
+        | none =>
+            errors := errors.push <|
+              s!"entry {entry.key} is missing from manifest group: " ++
+                Informal.PreviewManifest.labelString parent
+        | some memberGroup =>
+            if memberGroup == parent then
+              matchedMembers := matchedMembers.insert entry.label
+            else
+              errors := errors.push <|
+                s!"entry {entry.key} belongs to manifest group " ++
+                  s!"{Informal.PreviewManifest.labelString memberGroup} but references " ++
+                  Informal.PreviewManifest.labelString parent
+  for (member, group) in memberGroups.toArray do
+    unless matchedMembers.contains member do
+      errors := errors.push <|
+        s!"manifest group {Informal.PreviewManifest.labelString group} member " ++
+          s!"{Informal.PreviewManifest.labelString member} has no matching manifest entry"
   return errors
 
 def checkGeneratedData (manifest : ManifestFile) (htmlCache : HtmlCacheFile) : Array String :=

--- a/src/VersoBlueprint/Vbp.lean
+++ b/src/VersoBlueprint/Vbp.lean
@@ -179,14 +179,15 @@ private def entryResponseJson (manifest : ManifestFile) (entry : Entry) : Json :
   responseJson (entryDetailFields entry (manifest.groupForEntry? entry))
 
 private def entryAllJson (manifest : ManifestFile) (label : String) (entry : Entry) : Json :=
+  let group? := manifest.groupForEntry? entry
   responseJson [
     ("label", Json.str label),
-    ("node", entryJson entry (manifest.groupForEntry? entry)),
+    ("node", entryJson entry group?),
     ("statementUses", Json.arr (entry.statementUses.map useRefJson)),
     ("proofUses", Json.arr (entry.proofUses.map useRefJson)),
     ("uses", Json.arr (entry.uses.map relatedEntryJson)),
     ("usedBy", Json.arr (entry.usedBy.map relatedEntryJson)),
-    ("group", entryGroupJson manifest entry)
+    ("group", group?.map groupRelationJson |>.getD Json.null)
   ]
 
 private def incrementCount (counts : Array (String × Nat)) (key : String) : Array (String × Nat) :=
@@ -375,6 +376,34 @@ private def checkGraphPreviewKeys
     (fun errors variant => checkGraphVariantPreviewKeys index graph.key variant errors)
     errors
 
+private def checkManifestGroupIntegrity
+    (manifest : ManifestFile) (errors : Array String) : Array String := Id.run do
+  let mut errors := errors
+  let mut groupLabels : NameSet := {}
+  for group in manifest.groups do
+    if groupLabels.contains group.label then
+      errors := errors.push
+        s!"duplicate manifest group label: {Informal.PreviewManifest.labelString group.label}"
+    else
+      groupLabels := groupLabels.insert group.label
+    let mut memberLabels : NameSet := {}
+    for member in group.entries do
+      if memberLabels.contains member.label then
+        errors := errors.push <|
+          s!"duplicate member {Informal.PreviewManifest.labelString member.label} " ++
+            s!"in manifest group {Informal.PreviewManifest.labelString group.label}"
+      else
+        memberLabels := memberLabels.insert member.label
+  for entry in manifest.previews do
+    match entry.parent with
+    | some parent =>
+        unless groupLabels.contains parent do
+          errors := errors.push <|
+            s!"entry {entry.key} references missing manifest group: " ++
+              Informal.PreviewManifest.labelString parent
+    | none => pure ()
+  return errors
+
 def checkGeneratedData (manifest : ManifestFile) (htmlCache : HtmlCacheFile) : Array String :=
   let index := Informal.PreviewManifest.PreviewArtifactIndex.ofFiles manifest htmlCache
   let errors := manifest.previews.foldl
@@ -402,6 +431,7 @@ def checkGeneratedData (manifest : ManifestFile) (htmlCache : HtmlCacheFile) : A
         s!"group {Informal.PreviewManifest.labelString group.label}"
         group.entries errors)
     errors
+  let errors := checkManifestGroupIntegrity manifest errors
   manifest.graphs.foldl (fun errors graph => checkGraphPreviewKeys index graph errors) errors
 
 def checkJsonFromErrors

--- a/src/VersoBlueprint/Vbp.lean
+++ b/src/VersoBlueprint/Vbp.lean
@@ -382,6 +382,11 @@ private def checkManifestGroupIntegrity
   let mut groupsByLabel : NameMap GroupRelation := {}
   let mut memberGroups : NameMap Name := {}
   for group in manifest.groups do
+    if group.label == .anonymous then
+      errors := errors.push "manifest group has empty label"
+    if group.title.trimAscii.toString.isEmpty then
+      errors := errors.push <|
+        s!"manifest group {Informal.PreviewManifest.labelString group.label} has empty title"
     if groupsByLabel.contains group.label then
       errors := errors.push
         s!"duplicate manifest group label: {Informal.PreviewManifest.labelString group.label}"
@@ -389,6 +394,11 @@ private def checkManifestGroupIntegrity
       groupsByLabel := groupsByLabel.insert group.label group
     let mut memberLabels : NameSet := {}
     for member in group.entries do
+      if member.label == .anonymous then
+        errors := errors.push <|
+          s!"manifest group {Informal.PreviewManifest.labelString group.label} " ++
+            "has member with empty label"
+        continue
       if memberLabels.contains member.label then
         errors := errors.push <|
           s!"duplicate member {Informal.PreviewManifest.labelString member.label} " ++
@@ -409,6 +419,9 @@ private def checkManifestGroupIntegrity
   for entry in manifest.previews do
     if entry.targetKind != .block && entry.targetKind != .externalMarkup then
       continue
+    if entry.label == .anonymous then
+      errors := errors.push s!"entry {entry.key} is missing label"
+      continue
     match entry.parent with
     | none =>
         if entry.parentTitle.isSome then
@@ -418,6 +431,9 @@ private def checkManifestGroupIntegrity
             s!"entry {entry.key} has no parent but is listed in manifest group: " ++
               Informal.PreviewManifest.labelString group
     | some parent =>
+        if parent == .anonymous then
+          errors := errors.push s!"entry {entry.key} has invalid parent"
+          continue
         match groupsByLabel.get? parent with
         | none =>
           errors := errors.push <|

--- a/src/VersoBlueprint/blueprint-api-types.mjs
+++ b/src/VersoBlueprint/blueprint-api-types.mjs
@@ -255,12 +255,13 @@
 
 /**
  * Shared group relation metadata from the manifest's top-level group catalog.
+ * Group labels are unique, and each member label belongs to at most one group.
  *
  * @typedef {Object} BlueprintGroupRelation
  * @property {string} label Canonical group label.
  * @property {string} title Resolved display title for the group.
  * @property {boolean} declared Whether the group was explicitly declared.
- * @property {BlueprintRelatedEntry[]} entries Traversal-ordered statement members in the group.
+ * @property {BlueprintRelatedEntry[]} entries Traversal-ordered statement members that join to matching block or external-markup manifest entries.
  */
 
 /**
@@ -274,8 +275,8 @@
  * @property {string} authoredLabel Authored/display label without Lean pretty-name quoting.
  * @property {string} [facet] Rendered facet such as `statement` or `proof`.
  * @property {string} [href] Link to the canonical generated node.
- * @property {string | null} parent Parent group label, used to join against the shared group catalog.
- * @property {string | null} parentTitle Resolved display title for the parent group.
+ * @property {string | null} parent Parent group label, used by block and external-markup entries to join against the shared group catalog.
+ * @property {string | null} parentTitle Resolved display title for the parent group; when `parent` is present, this agrees with the catalog title.
  * @property {BlueprintSourceLocationResult} sourceLocation Original source location lookup result for this entry.
  * @property {BlueprintExternalMarkup[]} [externalMarkup] Attached external source snippets.
  * @property {BlueprintSourceRef[]} [sources] Original source refs for this entry.

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -165,6 +165,25 @@ private def sampleGroupCache : HtmlCacheFile := {
   ]
 }
 
+private def sampleExternalGroupManifest : ManifestFile := {
+  sampleGroupManifest with
+    previews := sampleGroupManifest.previews.map fun entry =>
+      if entry.label == label "group_member" then
+        {
+          entry with
+            key := Informal.PreviewManifest.externalMarkupEntryKey entry.label
+            targetKind := .externalMarkup
+        }
+      else
+        entry
+}
+
+private def sampleExternalGroupCache : HtmlCacheFile := {
+  entries := #[
+    { key := "informal:group_peer:statement", html := "<div>group peer</div>" }
+  ]
+}
+
 private def sampleSemanticOnlyExternalManifest : ManifestFile := {
   previews := #[
     {
@@ -977,6 +996,13 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
 #guard_msgs in
 #eval
   show Bool from
+    VersoBlueprint.Vbp.checkGeneratedData
+      sampleExternalGroupManifest sampleExternalGroupCache |>.isEmpty
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
     let orphanedManifest := { sampleGroupManifest with groups := #[] }
     let group := sampleGroupManifest.groups[0]!
     let duplicateGroupManifest := {
@@ -1031,6 +1057,39 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
           else
             entry
     }
+    let emptyGroupLabelManifest := {
+      sampleGroupManifest with groups := #[{ group with label := .anonymous }]
+    }
+    let emptyGroupTitleManifest := {
+      sampleGroupManifest with groups := #[{ group with title := "  " }]
+    }
+    let emptyMemberLabelManifest := {
+      sampleGroupManifest with
+        groups := #[{
+          group with
+            entries := group.entries.map fun member =>
+              if member.label == firstMember.label then
+                { member with label := .anonymous }
+              else
+                member
+        }]
+    }
+    let emptyEntryLabelManifest := {
+      sampleGroupManifest with
+        previews := sampleGroupManifest.previews.map fun entry =>
+          if entry.label == label "group_member" then
+            { entry with label := .anonymous }
+          else
+            entry
+    }
+    let invalidParentManifest := {
+      sampleGroupManifest with
+        previews := sampleGroupManifest.previews.map fun entry =>
+          if entry.label == label "group_member" then
+            { entry with parent := some .anonymous }
+          else
+            entry
+    }
     let orphanErrors :=
       VersoBlueprint.Vbp.checkGeneratedData orphanedManifest sampleGroupCache
     let duplicateGroupErrors :=
@@ -1049,6 +1108,16 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
       VersoBlueprint.Vbp.checkGeneratedData mismatchedTitleManifest sampleGroupCache
     let unparentedMemberErrors :=
       VersoBlueprint.Vbp.checkGeneratedData unparentedMemberManifest sampleGroupCache
+    let emptyGroupLabelErrors :=
+      VersoBlueprint.Vbp.checkGeneratedData emptyGroupLabelManifest sampleGroupCache
+    let emptyGroupTitleErrors :=
+      VersoBlueprint.Vbp.checkGeneratedData emptyGroupTitleManifest sampleGroupCache
+    let emptyMemberLabelErrors :=
+      VersoBlueprint.Vbp.checkGeneratedData emptyMemberLabelManifest sampleGroupCache
+    let emptyEntryLabelErrors :=
+      VersoBlueprint.Vbp.checkGeneratedData emptyEntryLabelManifest sampleGroupCache
+    let invalidParentErrors :=
+      VersoBlueprint.Vbp.checkGeneratedData invalidParentManifest sampleGroupCache
     orphanErrors.any (fun err =>
       err == "entry informal:group_member:statement references missing manifest group: sample_group") &&
       duplicateGroupErrors.any (fun err =>
@@ -1070,7 +1139,12 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
           "entry informal:group_member:statement has inconsistent parentTitle for manifest group: sample_group") &&
       unparentedMemberErrors.any (fun err =>
         err ==
-          "entry informal:group_member:statement has no parent but is listed in manifest group: sample_group")
+          "entry informal:group_member:statement has no parent but is listed in manifest group: sample_group") &&
+      emptyGroupLabelErrors.any (· == "manifest group has empty label") &&
+      emptyGroupTitleErrors.any (· == "manifest group sample_group has empty title") &&
+      emptyMemberLabelErrors.any (· == "manifest group sample_group has member with empty label") &&
+      emptyEntryLabelErrors.any (· == "entry informal:group_member:statement is missing label") &&
+      invalidParentErrors.any (· == "entry informal:group_member:statement has invalid parent")
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -987,18 +987,90 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
       sampleGroupManifest with
         groups := #[{ group with entries := group.entries.push firstMember }]
     }
+    let secondGroup := {
+      group with
+        label := label "second_group"
+        title := "Second group"
+        entries := #[firstMember]
+    }
+    let crossGroupMemberManifest := {
+      sampleGroupManifest with groups := sampleGroupManifest.groups.push secondGroup
+    }
+    let missingMemberManifest := {
+      sampleGroupManifest with
+        groups := #[{
+          group with entries := group.entries.filter (·.label != label "group_member")
+        }]
+    }
+    let orphanMemberManifest := {
+      sampleGroupManifest with
+        previews := sampleGroupManifest.previews.filter (·.label != label "group_peer")
+    }
+    let mismatchedParentManifest := {
+      sampleGroupManifest with
+        previews := sampleGroupManifest.previews.map fun entry =>
+          if entry.label == label "group_member" then
+            { entry with parent := some (label "second_group"), parentTitle := some "Second group" }
+          else
+            entry
+        groups := sampleGroupManifest.groups.push { secondGroup with entries := #[] }
+    }
+    let mismatchedTitleManifest := {
+      sampleGroupManifest with
+        previews := sampleGroupManifest.previews.map fun entry =>
+          if entry.label == label "group_member" then
+            { entry with parentTitle := some "Stale group title" }
+          else
+            entry
+    }
+    let unparentedMemberManifest := {
+      sampleGroupManifest with
+        previews := sampleGroupManifest.previews.map fun entry =>
+          if entry.label == label "group_member" then
+            { entry with parent := none, parentTitle := none }
+          else
+            entry
+    }
     let orphanErrors :=
       VersoBlueprint.Vbp.checkGeneratedData orphanedManifest sampleGroupCache
     let duplicateGroupErrors :=
       VersoBlueprint.Vbp.checkGeneratedData duplicateGroupManifest sampleGroupCache
     let duplicateMemberErrors :=
       VersoBlueprint.Vbp.checkGeneratedData duplicateMemberManifest sampleGroupCache
+    let crossGroupMemberErrors :=
+      VersoBlueprint.Vbp.checkGeneratedData crossGroupMemberManifest sampleGroupCache
+    let missingMemberErrors :=
+      VersoBlueprint.Vbp.checkGeneratedData missingMemberManifest sampleGroupCache
+    let orphanMemberErrors :=
+      VersoBlueprint.Vbp.checkGeneratedData orphanMemberManifest sampleGroupCache
+    let mismatchedParentErrors :=
+      VersoBlueprint.Vbp.checkGeneratedData mismatchedParentManifest sampleGroupCache
+    let mismatchedTitleErrors :=
+      VersoBlueprint.Vbp.checkGeneratedData mismatchedTitleManifest sampleGroupCache
+    let unparentedMemberErrors :=
+      VersoBlueprint.Vbp.checkGeneratedData unparentedMemberManifest sampleGroupCache
     orphanErrors.any (fun err =>
       err == "entry informal:group_member:statement references missing manifest group: sample_group") &&
       duplicateGroupErrors.any (fun err =>
         err == "duplicate manifest group label: sample_group") &&
       duplicateMemberErrors.any (fun err =>
-        err == "duplicate member group_member in manifest group sample_group")
+        err == "duplicate member group_member in manifest group sample_group") &&
+      crossGroupMemberErrors.any (fun err =>
+        err ==
+          "manifest member group_member belongs to multiple groups: sample_group and second_group") &&
+      missingMemberErrors.any (fun err =>
+        err == "entry informal:group_member:statement is missing from manifest group: sample_group") &&
+      orphanMemberErrors.any (fun err =>
+        err == "manifest group sample_group member group_peer has no matching manifest entry") &&
+      mismatchedParentErrors.any (fun err =>
+        err ==
+          "entry informal:group_member:statement belongs to manifest group sample_group but references second_group") &&
+      mismatchedTitleErrors.any (fun err =>
+        err ==
+          "entry informal:group_member:statement has inconsistent parentTitle for manifest group: sample_group") &&
+      unparentedMemberErrors.any (fun err =>
+        err ==
+          "entry informal:group_member:statement has no parent but is listed in manifest group: sample_group")
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -124,6 +124,47 @@ private def sampleEmptyRelationCache : HtmlCacheFile := {
   ]
 }
 
+private def sampleGroupManifest : ManifestFile := {
+  previews := #[
+    {
+      key := "informal:group_member:statement"
+      targetKind := .block
+      label := label "group_member"
+      facet := .statement
+      kind := some .theorem
+      title := "Group member"
+      parent := some (label "sample_group")
+      parentTitle := some "Sample group"
+    },
+    {
+      key := "informal:group_peer:statement"
+      targetKind := .block
+      label := label "group_peer"
+      facet := .statement
+      kind := some .theorem
+      title := "Group peer"
+      parent := some (label "sample_group")
+      parentTitle := some "Sample group"
+    }
+  ]
+  groups := #[{
+    label := label "sample_group"
+    title := "Sample group"
+    declared := true
+    entries := #[
+      relatedWithoutPreview "group_member" "Group member",
+      relatedWithoutPreview "group_peer" "Group peer"
+    ]
+  }]
+}
+
+private def sampleGroupCache : HtmlCacheFile := {
+  entries := #[
+    { key := "informal:group_member:statement", html := "<div>group member</div>" },
+    { key := "informal:group_peer:statement", html := "<div>group peer</div>" }
+  ]
+}
+
 private def sampleSemanticOnlyExternalManifest : ManifestFile := {
   previews := #[
     {
@@ -925,6 +966,39 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
 #eval
   show Bool from
     VersoBlueprint.Vbp.checkGeneratedData sampleEmptyRelationManifest sampleEmptyRelationCache |>.isEmpty
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    VersoBlueprint.Vbp.checkGeneratedData sampleGroupManifest sampleGroupCache |>.isEmpty
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    let orphanedManifest := { sampleGroupManifest with groups := #[] }
+    let group := sampleGroupManifest.groups[0]!
+    let duplicateGroupManifest := {
+      sampleGroupManifest with groups := sampleGroupManifest.groups.push group
+    }
+    let firstMember := group.entries[0]!
+    let duplicateMemberManifest := {
+      sampleGroupManifest with
+        groups := #[{ group with entries := group.entries.push firstMember }]
+    }
+    let orphanErrors :=
+      VersoBlueprint.Vbp.checkGeneratedData orphanedManifest sampleGroupCache
+    let duplicateGroupErrors :=
+      VersoBlueprint.Vbp.checkGeneratedData duplicateGroupManifest sampleGroupCache
+    let duplicateMemberErrors :=
+      VersoBlueprint.Vbp.checkGeneratedData duplicateMemberManifest sampleGroupCache
+    orphanErrors.any (fun err =>
+      err == "entry informal:group_member:statement references missing manifest group: sample_group") &&
+      duplicateGroupErrors.any (fun err =>
+        err == "duplicate manifest group label: sample_group") &&
+      duplicateMemberErrors.any (fun err =>
+        err == "duplicate member group_member in manifest group sample_group")
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -1244,19 +1244,69 @@ class TestPreviewRuntimeRegressions:
                         groupCount: groups.length
                     };
                 }
-                const duplicateGroup = {
-                    label: "duplicate_group",
-                    title: "Duplicate group",
+                const sourceLocation = {
+                    ok: false,
+                    location: null,
+                    error: "source location unavailable"
+                };
+                const member = {
+                    label: "group_member",
+                    title: "Group member",
+                    href: null,
+                    previewKey: null,
+                    axes: []
+                };
+                const entry = {
+                    key: "informal:group_member:statement",
+                    targetKind: "block",
+                    label: "group_member",
+                    facet: "statement",
+                    title: "Group member",
+                    sourceLocation,
+                    parent: "sample_group",
+                    parentTitle: "Sample group"
+                };
+                const group = {
+                    label: "sample_group",
+                    title: "Sample group",
+                    declared: true,
+                    entries: [member]
+                };
+                const secondGroup = {
+                    label: "second_group",
+                    title: "Second group",
                     declared: true,
                     entries: []
                 };
+                function manifest(previews, groups) {
+                    return { previews, groups, graphs: [] };
+                }
+                const valid = manifest([entry], [group]);
+                const duplicateMemberGroup = {
+                    ...group,
+                    entries: [member, member]
+                };
+                const crossGroup = {
+                    ...secondGroup,
+                    entries: [member]
+                };
                 return {
                     missing: await loadStatus({ previews: [], graphs: [] }),
-                    duplicate: await loadStatus({
-                        previews: [],
-                        groups: [duplicateGroup, duplicateGroup],
-                        graphs: []
-                    })
+                    valid: await loadStatus(valid),
+                    duplicate: await loadStatus(manifest([], [group, group])),
+                    duplicateMember: await loadStatus(manifest([], [duplicateMemberGroup])),
+                    crossGroupMember: await loadStatus(manifest([], [group, crossGroup])),
+                    missingMember: await loadStatus(manifest([entry], [{ ...group, entries: [] }])),
+                    orphanMember: await loadStatus(manifest([], [group])),
+                    mismatchedParent: await loadStatus(manifest([
+                        { ...entry, parent: "second_group", parentTitle: "Second group" }
+                    ], [group, secondGroup])),
+                    mismatchedTitle: await loadStatus(manifest([
+                        { ...entry, parentTitle: "Stale group title" }
+                    ], [group])),
+                    unparentedMember: await loadStatus(manifest([
+                        { ...entry, parent: null, parentTitle: null }
+                    ], [group]))
                 };
                 """
             )
@@ -1265,9 +1315,41 @@ class TestPreviewRuntimeRegressions:
         assert result["missing"]["state"] == "error"
         assert result["missing"]["groupCount"] == 0
         assert "missing groups array" in result["missing"]["message"]
+        assert result["valid"]["state"] == "ready"
+        assert result["valid"]["groupCount"] == 1
         assert result["duplicate"]["state"] == "error"
         assert result["duplicate"]["groupCount"] == 0
-        assert "duplicate group duplicate_group" in result["duplicate"]["message"]
+        assert "duplicate group sample_group" in result["duplicate"]["message"]
+        assert (
+            "duplicate member group_member in group sample_group"
+            in result["duplicateMember"]["message"]
+        )
+        assert (
+            "member group_member belongs to multiple groups"
+            in result["crossGroupMember"]["message"]
+        )
+        assert (
+            "entry informal:group_member:statement is missing from group sample_group"
+            in result["missingMember"]["message"]
+        )
+        assert (
+            "group sample_group member group_member has no matching manifest entry"
+            in result["orphanMember"]["message"]
+        )
+        assert (
+            "entry informal:group_member:statement belongs to group "
+            "sample_group but references second_group"
+            in result["mismatchedParent"]["message"]
+        )
+        assert (
+            "entry informal:group_member:statement has inconsistent parentTitle"
+            in result["mismatchedTitle"]["message"]
+        )
+        assert (
+            "entry informal:group_member:statement has no parent but is listed in "
+            "group sample_group"
+            in result["unparentedMember"]["message"]
+        )
 
     def test_render_node_external_markup_diagnostics(self, server: str, page: Page):
         errors = record_runtime_errors(page)

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -1290,24 +1290,44 @@ class TestPreviewRuntimeRegressions:
                     ...secondGroup,
                     entries: [member]
                 };
-                return {
-                    missing: await loadStatus({ previews: [], graphs: [] }),
-                    valid: await loadStatus(valid),
-                    duplicate: await loadStatus(manifest([], [group, group])),
-                    duplicateMember: await loadStatus(manifest([], [duplicateMemberGroup])),
-                    crossGroupMember: await loadStatus(manifest([], [group, crossGroup])),
-                    missingMember: await loadStatus(manifest([entry], [{ ...group, entries: [] }])),
-                    orphanMember: await loadStatus(manifest([], [group])),
-                    mismatchedParent: await loadStatus(manifest([
+                const payloads = {
+                    missing: { previews: [], graphs: [] },
+                    valid,
+                    validExternal: manifest([
+                        {
+                            ...entry,
+                            key: "externalMarkup:group_member",
+                            targetKind: "externalMarkup"
+                        }
+                    ], [group]),
+                    duplicate: manifest([], [group, group]),
+                    duplicateMember: manifest([], [duplicateMemberGroup]),
+                    crossGroupMember: manifest([], [group, crossGroup]),
+                    missingMember: manifest([entry], [{ ...group, entries: [] }]),
+                    orphanMember: manifest([], [group]),
+                    mismatchedParent: manifest([
                         { ...entry, parent: "second_group", parentTitle: "Second group" }
-                    ], [group, secondGroup])),
-                    mismatchedTitle: await loadStatus(manifest([
+                    ], [group, secondGroup]),
+                    mismatchedTitle: manifest([
                         { ...entry, parentTitle: "Stale group title" }
-                    ], [group])),
-                    unparentedMember: await loadStatus(manifest([
+                    ], [group]),
+                    unparentedMember: manifest([
                         { ...entry, parent: null, parentTitle: null }
-                    ], [group]))
+                    ], [group]),
+                    emptyGroupLabel: manifest([entry], [{ ...group, label: " " }]),
+                    emptyGroupTitle: manifest([entry], [{ ...group, title: " " }]),
+                    emptyMemberLabel: manifest([entry], [{
+                        ...group,
+                        entries: [{ ...member, label: " " }]
+                    }]),
+                    emptyEntryLabel: manifest([{ ...entry, label: " " }], [group]),
+                    invalidParent: manifest([{ ...entry, parent: " " }], [group])
                 };
+                const statuses = {};
+                for (const [name, payload] of Object.entries(payloads)) {
+                    statuses[name] = await loadStatus(payload);
+                }
+                return statuses;
                 """
             )
         )
@@ -1317,6 +1337,8 @@ class TestPreviewRuntimeRegressions:
         assert "missing groups array" in result["missing"]["message"]
         assert result["valid"]["state"] == "ready"
         assert result["valid"]["groupCount"] == 1
+        assert result["validExternal"]["state"] == "ready"
+        assert result["validExternal"]["groupCount"] == 1
         assert result["duplicate"]["state"] == "error"
         assert result["duplicate"]["groupCount"] == 0
         assert "duplicate group sample_group" in result["duplicate"]["message"]
@@ -1349,6 +1371,17 @@ class TestPreviewRuntimeRegressions:
             "entry informal:group_member:statement has no parent but is listed in "
             "group sample_group"
             in result["unparentedMember"]["message"]
+        )
+        assert "missing label" in result["emptyGroupLabel"]["message"]
+        assert "missing title" in result["emptyGroupTitle"]["message"]
+        assert "member 0 is missing label" in result["emptyMemberLabel"]["message"]
+        assert (
+            "entry informal:group_member:statement is missing label"
+            in result["emptyEntryLabel"]["message"]
+        )
+        assert (
+            "entry informal:group_member:statement has invalid parent"
+            in result["invalidParent"]["message"]
         )
 
     def test_render_node_external_markup_diagnostics(self, server: str, page: Page):

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -1219,6 +1219,56 @@ class TestPreviewRuntimeRegressions:
         assert result["manifestSize"] == 0
         assert "missing sourceLocation" in result["message"]
 
+    def test_public_data_api_rejects_invalid_group_catalogs(
+        self, server: str, page: Page
+    ):
+        page.goto(f"{server}/Custom-Render-Client/")
+
+        result = page.evaluate(
+            blueprint_render_api_script(
+                """
+                const { createPreviewData } = await import(api.dataApiModuleUrl());
+                async function loadStatus(payload) {
+                    const data = createPreviewData({
+                        fetchJson(url) {
+                            if (url.endsWith("blueprint-manifest.json")) {
+                                return Promise.resolve(payload);
+                            }
+                            throw new Error("Unexpected custom loader URL: " + url);
+                        }
+                    });
+                    const groups = await data.loadGroups();
+                    return {
+                        state: data.readManifestStatus().state,
+                        message: data.readManifestStatus().lastError,
+                        groupCount: groups.length
+                    };
+                }
+                const duplicateGroup = {
+                    label: "duplicate_group",
+                    title: "Duplicate group",
+                    declared: true,
+                    entries: []
+                };
+                return {
+                    missing: await loadStatus({ previews: [], graphs: [] }),
+                    duplicate: await loadStatus({
+                        previews: [],
+                        groups: [duplicateGroup, duplicateGroup],
+                        graphs: []
+                    })
+                };
+                """
+            )
+        )
+
+        assert result["missing"]["state"] == "error"
+        assert result["missing"]["groupCount"] == 0
+        assert "missing groups array" in result["missing"]["message"]
+        assert result["duplicate"]["state"] == "error"
+        assert result["duplicate"]["groupCount"] == 0
+        assert "duplicate group duplicate_group" in result["duplicate"]["message"]
+
     def test_render_node_external_markup_diagnostics(self, server: str, page: Page):
         errors = record_runtime_errors(page)
         page.goto(f"{server}/Custom-Render-Client/")


### PR DESCRIPTION
This PR validates the normalized manifest group catalog as a complete bidirectional join, so Lean and browser consumers reject duplicate, orphaned, missing, or stale group metadata consistently while group lookups avoid rebuilding transient manifest indexes.

Standard generation derives manifest entries and the shared group catalog from the same traversal state. These checks therefore audit persisted or externally modified artifacts at their Lean and browser loading boundaries; they are not a repair step in the normal generation pipeline.

Backport v4.32.0: #363