### PR TITLE
[backport v4.31.0] perf: reuse manifest relation indexes

### DIFF
--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -366,7 +366,7 @@ which is deliberately narrower than the graft manifest/cache context: it only
 packages the live traversal state. Forward dependencies resolve through the
 canonical node index, while precomputed traversal indexes provide group members
 and reverse dependencies without rescanning every stored informal block for
-each rendered panel.
+each rendered panel, manifest entry, or same-document graft.
 
 ### Browser Rendering Path Inventory
 
@@ -1081,8 +1081,8 @@ the operational detail that is easier to read in prose.
 | `CitationPreviews` | runtime cache | `(citation label, citation style, locator kind, locator index)` -> `CitationPreviewData` | Bibliography hover payloads captured during citation traversal and rendered into preview data. |
 | `Bibliography` | semantic domain | citation label -> bibliography entry anchor ids | Linkable bibliography entry destinations. |
 | `CitationUsages` | accumulator | citation label -> `CitationUsageData` plus citation use-site ids | Backlink data accumulated from citation inlines, including rendered use-site destinations and human-readable location summaries. |
-| `RelatedPanelUsedByCache` | internal index | informal label -> ordered reverse-dependency metadata keyed by source label | Compact reverse-dependency facts grouped by target label so each rendered used-by panel avoids a full node scan; canonical source-node data remains in `Nodes`. |
-| `RelatedPanelGroupMembersCache` | internal index | group label -> ordered statement labels | Group-member labels collected once by parent label so each rendered group panel avoids a full node scan; canonical member data remains in `Nodes`. |
+| `RelatedPanelUsedByCache` | internal index | informal label -> ordered reverse-dependency metadata keyed by source label | Compact reverse-dependency facts grouped by target label so used-by panels and manifest entries avoid a full node scan; canonical source-node data remains in `Nodes`. |
+| `RelatedPanelGroupMembersCache` | internal index | group label -> ordered statement labels | Group-member labels collected once by parent label so group panels and same-document grafts avoid a full node scan; canonical member data remains in `Nodes`. |
 
 The auxiliary indexes above are normalized out of `Nodes` for different
 reasons:
@@ -1098,8 +1098,8 @@ reasons:
 | `ExternalDeclAnchors` | Informal block traversal for rendered external declarations | Informal block rendering plus summary/graph/code-summary links that jump to rendered external rows | Store only occurrence-specific row anchors keyed by `(informal label, canonical declaration)`. The same Lean declaration may be rendered under multiple Blueprint labels, and each rendered row needs its own destination. |
 | `CitationPreviews` | Citation inline traversal | `TraversalIndex.CitationPreviews.entries`, preview-manifest construction, and citation inline hovers via the shared lookup key | Store bibliography hover data once per rendered citation target and locator. Inline citations then carry a manifest key instead of owning page-local preview templates. |
 | `CitationUsages` | Citation inline traversal | `TraversalIndex.CitationUsages.hrefs`, `TraversalIndex.CitationUsages.data?`, and bibliography rendering | Accumulate bibliography backlinks by citation label. Each citation use contributes a rendered href plus a structured location summary, while bibliography entries remain the semantic/linkable destinations in `Bibliography`. |
-| `RelatedPanelUsedByCache` | `Informal.RelatedPanel.patchRelationCaches` after traversal | `TraversalIndex.RelatedPanelUsedByCache.data?` and used-by relation-panel rendering | Store only the source label plus merged statement/proof axes and origin or intent metadata. Resolve the source's canonical node data through `Nodes` instead of copying a full `BlockData` into every target cache. |
-| `RelatedPanelGroupMembersCache` | `Informal.RelatedPanel.patchRelationCaches` after traversal | `TraversalIndex.RelatedPanelGroupMembersCache.data?` and group relation-panel rendering | Store ordered statement labels once per parent label. Resolve canonical member data through `Nodes` instead of copying full statement records into the group cache. |
+| `RelatedPanelUsedByCache` | `Informal.RelatedPanel.patchRelationCaches` after traversal | `TraversalIndex.RelatedPanelUsedByCache.data?`, used-by relation-panel rendering, and preview-manifest construction | Store only the source label plus merged statement/proof axes and origin or intent metadata. Resolve the source's canonical node data through `Nodes` instead of copying a full `BlockData` into every target cache. |
+| `RelatedPanelGroupMembersCache` | `Informal.RelatedPanel.patchRelationCaches` after traversal | `TraversalIndex.RelatedPanelGroupMembersCache.data?`, group relation-panel rendering, and same-document graft construction | Store ordered statement labels once per parent label. Resolve canonical member data through `Nodes` instead of copying full statement records into the group cache. |
 
 In particular, the main Blueprint node index is now intentionally slimmer than
 the full `BlockData` payload used by block rendering. Code-specific

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -2006,19 +2006,32 @@ private def buildUsesRelations
   labels.map fun label =>
     relatedEntryForLabel state label (relatedAxes blockData label)
 
+/--
+Read the reverse-dependency index installed after normal HTML traversal.
+The fallback keeps direct `buildPreviewDataFiles` callers with an unpatched
+traversal state correct.
+-/
 private def buildUsedByRelations
     (state : TraverseState)
-    (storedBlocks : Array Informal.BlockData)
     (blockData : Informal.BlockData) : Array RelatedEntry :=
-  storedBlocks.filterMap fun source =>
-    if source.label == blockData.label then
-      none
-    else
-      let axes := relatedAxes source blockData.label
-      if axes.isEmpty then
-        none
-      else
+  match Informal.TraversalIndex.RelatedPanelUsedByCache.data? state blockData.label with
+  | some cachedEntries =>
+      cachedEntries.filterMap fun cached => do
+        let source ← blockInfo? state cached.sourceLabel
+        let axes : Array RelationAxis :=
+          if cached.inStatement then #[.statement] else #[]
+        let axes := if cached.inProof then axes.push .proof else axes
         some <| relatedEntryForBlock state source axes
+  | none =>
+      Informal.collectStoredBlocks state |>.filterMap fun source =>
+        if source.label == blockData.label then
+          none
+        else
+          let axes := relatedAxes source blockData.label
+          if axes.isEmpty then
+            none
+          else
+            some <| relatedEntryForBlock state source axes
 
 private def groupRelationHeader
     (state : TraverseState)
@@ -2053,14 +2066,27 @@ private def buildGroupRelations (state : TraverseState) : Array GroupRelation :=
         groups := groups.push { label := parent, title, declared, entries := #[member] }
   return groups
 
-/-- Resolve traversal-backed group metadata for one entry without storing it per entry. -/
+/--
+Resolve traversal-backed group metadata for one entry without storing it per
+entry. Normal HTML generation uses the cached member index; direct callers with
+an unpatched traversal state retain the full-store fallback.
+-/
 def groupRelationForEntry? (state : TraverseState) (entry : Entry) : Option GroupRelation := do
   let parent ← entry.parent
-  let entries := Informal.collectStoredBlocks state |>.filterMap fun blockData =>
-    if statementGroupParent? blockData == some parent && blockData.label != entry.label then
-      some <| relatedEntryForBlock state blockData
-    else
-      none
+  let entries :=
+    match Informal.TraversalIndex.RelatedPanelGroupMembersCache.data? state parent with
+    | some labels =>
+        labels.filterMap fun label =>
+          if label == entry.label then
+            none
+          else
+            (blockInfo? state label).map (relatedEntryForBlock state)
+    | none =>
+        Informal.collectStoredBlocks state |>.filterMap fun blockData =>
+          if statementGroupParent? blockData == some parent && blockData.label != entry.label then
+            some <| relatedEntryForBlock state blockData
+          else
+            none
   let (title, declared) := groupRelationHeader state parent
   pure { label := parent, title, declared, entries }
 
@@ -2087,7 +2113,6 @@ private def blockSemanticManifestEntry
   let blockData? := blockInfo? state preview.label
   let headingParts? := blockHeadingParts? state preview.label preview.facet blockData?
   let codeData := blockCodeData? state preview.label preview blockData?
-  let storedBlocks := Informal.collectStoredBlocks state
   {
     key
     targetKind
@@ -2108,7 +2133,7 @@ private def blockSemanticManifestEntry
     externalMarkup := externalMarkup?.getD (externalMarkupArray state preview.label)
     sources := sourceRefsForBlockLabel state preview.label
     uses := blockData?.map (buildUsesRelations state ·) |>.getD #[]
-    usedBy := blockData?.map (buildUsedByRelations state storedBlocks ·) |>.getD #[]
+    usedBy := blockData?.map (buildUsedByRelations state ·) |>.getD #[]
     ownerDisplayName := blockData?.bind (·.ownerDisplayName)
     tags := blockData?.map (·.tags) |>.getD #[]
     priority := blockData?.bind (·.priority)
@@ -2496,6 +2521,7 @@ private def dumpManifest
   let (_text, traverseState) ←
     ReaderT.run (Verso.Genre.Manual.traverseHtmlMulti traverseCfg text) extensionImpls
       |>.run (callbackLogger logError)
+  let traverseState := Informal.RelatedPanel.patchRelationCaches traverseState
   let files ← buildPreviewDataFiles extensionImpls logError traverseState externalMarkupConfig
     (verbose := cfg.verbose)
   let logger := callbackLogger logError
@@ -2524,6 +2550,7 @@ private def dumpHtmlCache
   let (_text, traverseState) ←
     ReaderT.run (Verso.Genre.Manual.traverseHtmlMulti traverseCfg text) extensionImpls
       |>.run (callbackLogger logError)
+  let traverseState := Informal.RelatedPanel.patchRelationCaches traverseState
   let files ← buildPreviewDataFiles extensionImpls logError traverseState externalMarkupConfig
     (verbose := cfg.verbose)
   let logger := callbackLogger logError

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
@@ -86,6 +86,15 @@ private def cachedStatement
     let sourceEntries := Informal.TraversalIndex.RelatedPanelUsedByCache.data? state source
     let emptyEntries := Informal.TraversalIndex.RelatedPanelUsedByCache.data? state empty
     let groupMembers := Informal.TraversalIndex.RelatedPanelGroupMembersCache.data? state group
+    let sourceWithoutRelations := cachedStatement source 1
+    let cacheOnlyState :=
+      Informal.TraversalIndex.Nodes.saveData state source (Lean.toJson sourceWithoutRelations)
+    let targetPreview := Informal.PreviewCache.Entry.ofBlocks target .statement #[]
+    let targetManifestEntry :=
+      Informal.PreviewManifest.blockEntryOfTraversalPreview cacheOnlyState targetPreview
+    let groupedTargetEntry := { targetManifestEntry with parent := some group }
+    let cachedGroup? :=
+      Informal.PreviewManifest.groupRelationForEntry? cacheOnlyState groupedTargetEntry
     match targetEntries with
     | some #[entry] =>
         let rawEntry := Lean.toJson entry |>.compress
@@ -97,7 +106,10 @@ private def cachedStatement
               !hasSubstr rawEntry "\"statementUses\"" &&
               sourceEntries.map Array.isEmpty == some true &&
               emptyEntries.map Array.isEmpty == some true &&
-              groupMembers == some #[source]
+              groupMembers == some #[source] &&
+              targetManifestEntry.usedBy.map (·.label) == #[source] &&
+              targetManifestEntry.usedBy.map (·.axes) == #[#[.statement]] &&
+              cachedGroup?.map (fun relation => relation.entries.map (·.label)) == some #[source]
         | _, _ => false
     | _ => false
 


### PR DESCRIPTION
## Summary
Backport #343 to `v4.31.0`.

## Primary Review
- Primary review: #343
- Keep review comments on #343 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.31.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.