### PR TITLE
feat: compose editable external Blueprints

### DIFF
--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -36,8 +36,9 @@ modules are the canonical source for flags, path resolution, and orchestration:
 
 - `blueprint_harness` handles worktrees, branch/release checks, PR scaffolds,
   landing, toolchain bumps, and local coordination
-- `blueprint_reference_harness` handles reference-project generation,
-  validation, status, sync, editable checkouts, pin bumps, and pruning
+- `blueprint_reference_harness` composes editable user-provided Blueprints and
+  handles reference-project generation, validation, status, sync, editable
+  checkouts, pin bumps, and pruning
 - `blueprint_test_blueprints` handles local test-blueprint listing,
   generation, and validation
 
@@ -214,6 +215,29 @@ CLI help for the full flag surface:
 python3 -m scripts.blueprint_reference_harness generate --project noperthedron
 python3 -m scripts.blueprint_reference_harness validate --project project-template --run-lean-tests
 ```
+
+To work on this package together with an editable user-provided Blueprint,
+compose the external checkout directly rather than registering it in the
+reference catalog:
+
+```bash
+python3 -m scripts.blueprint_reference_harness compose /path/to/source-checkout \
+  --project-root blueprint \
+  --id local-blueprint
+```
+
+The command builds the editable source against the current `VersoBlueprint`
+checkout, writes `_out/.../reference-blueprints/local-blueprint/`, and runs
+`vbp check`. Each run replaces that generated output so removed pages cannot
+survive from an older composition. It temporarily overrides either an official
+Git dependency or a relative `verso-blueprint` path and restores the source
+checkout's lakefile and manifest afterwards. When the composed Lake graph
+contains Mathlib, the harness runs `lake exe cache get` before the build;
+composing a Blueprint must reuse Mathlib's cache rather than compiling Mathlib.
+
+`compose` is intentionally independent of `tests/harness/projects.json`.
+Projects belong in that manifest only when they are maintained release
+validation or publication inputs.
 
 Pass `--verbose` to `generate` or `validate` when you want each Blueprint
 generator to print its own progress diagnostics during HTML emission.

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -231,16 +231,24 @@ checkout, writes `_out/.../reference-blueprints/local-blueprint/`, and runs
 `vbp check`. Each run replaces that generated output so removed pages cannot
 survive from an older composition. It temporarily overrides either an official
 Git dependency or a relative `verso-blueprint` path and restores the source
-checkout's lakefile and manifest afterwards. When the composed Lake graph
-contains Mathlib, the harness runs `lake exe cache get` before the build;
-composing a Blueprint must reuse Mathlib's cache rather than compiling Mathlib.
+checkout's lakefile and manifest afterwards. The nearest `lean-toolchain`
+inside the source checkout must select exactly the same Lean release as this
+`VersoBlueprint` checkout; `compose` reports a mismatch without rewriting
+either toolchain.
+
+When the composed Lake graph contains Mathlib, the harness requires a
+successful `lake exe cache get` before starting the build. This guarantees that
+cache retrieval succeeds at command level before composition. Mathlib treats
+individual remote-cache misses as warnings, however, so the harness cannot
+currently prohibit Lake from compiling an unavailable artifact afterwards.
 
 `compose` is intentionally independent of `tests/harness/projects.json`.
 Projects belong in that manifest only when they are maintained release
 validation or publication inputs.
 
-Pass `--verbose` to `generate` or `validate` when you want each Blueprint
-generator to print its own progress diagnostics during HTML emission.
+Pass `--verbose` to `compose`, `generate`, or `validate` when you want each
+Blueprint generator to print its own progress diagnostics during HTML
+emission.
 
 When editing an external reference repository, use an editable clone rather
 than the disposable validation clones:

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -229,7 +229,9 @@ python3 -m scripts.blueprint_reference_harness compose /path/to/source-checkout 
 The command builds the editable source against the current `VersoBlueprint`
 checkout, writes `_out/.../reference-blueprints/local-blueprint/`, and runs
 `vbp check`. Each run replaces that generated output so removed pages cannot
-survive from an older composition. It temporarily overrides either an official
+survive from an older composition. A custom output root must remain disjoint
+from the source checkout; `compose` rejects output directories that contain or
+sit inside that checkout. The command temporarily overrides either an official
 Git dependency or a relative `verso-blueprint` path and restores the source
 checkout's lakefile and manifest afterwards. The nearest `lean-toolchain`
 inside the source checkout must select exactly the same Lean release as this

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -54,6 +54,7 @@ python3 -m scripts.blueprint_harness release-status --require-sync
 python3 -m scripts.blueprint_harness start-release-line 4.31-rc2
 python3 -m scripts.blueprint_harness set-default-dev-branch v4.31.0
 python3 -m scripts.blueprint_harness paths
+python3 -m scripts.blueprint_reference_harness compose /path/to/source --project-root blueprint
 python3 -m scripts.blueprint_reference_harness projects
 python3 -m scripts.blueprint_reference_harness status
 python3 -m scripts.blueprint_reference_harness sync
@@ -99,7 +100,11 @@ script map, not a second command reference.
 - `blueprint_harness.py`
   Worktree, branch-landing, and coordination CLI.
 - `blueprint_reference_harness.py`
-  Reference-blueprint generation, validation, and reference-checkout CLI.
+  Editable external Blueprint composition plus reference-blueprint generation,
+  validation, and reference-checkout CLI.
+- `blueprint_harness_composition.py`
+  User-provided Blueprint composition, source-file preservation, toolchain
+  validation, and mandatory Mathlib-cache reuse.
 - `blueprint_test_blueprints.py`
   Local test-blueprint fixture catalog, generation, and validation CLI.
 - `blueprint_harness_cli.py`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -103,8 +103,8 @@ script map, not a second command reference.
   Editable external Blueprint composition plus reference-blueprint generation,
   validation, and reference-checkout CLI.
 - `blueprint_harness_composition.py`
-  User-provided Blueprint composition, source-file preservation, toolchain
-  validation, and mandatory Mathlib-cache reuse.
+  User-provided Blueprint composition, Lake-configuration preservation,
+  toolchain validation, and mandatory Mathlib-cache retrieval.
 - `blueprint_test_blueprints.py`
   Local test-blueprint fixture catalog, generation, and validation CLI.
 - `blueprint_harness_cli.py`

--- a/scripts/blueprint_harness_composition.py
+++ b/scripts/blueprint_harness_composition.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+import shutil
+
+from scripts.blueprint_harness_project_commands import (
+    ensure_and_log_embedded_asset_owner_outputs,
+    local_blueprint_dependency_override,
+    rebuild_and_log_embedded_asset_owners,
+    run_project_lake_update,
+)
+from scripts.blueprint_harness_references import read_reference_toolchain
+from scripts.blueprint_harness_utils import lean_low_priority_command, run_with_heartbeat
+
+
+COMPOSED_PROJECT_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+@dataclass(frozen=True)
+class ComposedBlueprint:
+    project_id: str
+    source_root: Path
+    project_dir: Path
+    output_dir: Path
+    site_dir: Path
+
+
+def _project_id(value: str) -> str:
+    if not COMPOSED_PROJECT_ID_PATTERN.fullmatch(value):
+        raise SystemExit(
+            "[blueprint-harness] composed Blueprint id must start with an alphanumeric "
+            "character and contain only alphanumerics, `.`, `_`, or `-`"
+        )
+    return value
+
+
+def resolve_composed_blueprint(
+    source_root: Path,
+    project_root: str,
+    output_root: Path,
+    *,
+    project_id: str | None,
+) -> ComposedBlueprint:
+    source_root = source_root.resolve()
+    if not source_root.is_dir():
+        raise SystemExit(f"[blueprint-harness] composed Blueprint source checkout does not exist: {source_root}")
+
+    relative_project_root = Path(project_root)
+    if relative_project_root.is_absolute():
+        raise SystemExit("[blueprint-harness] --project-root must be relative to the source checkout")
+    project_dir = (source_root / relative_project_root).resolve()
+    try:
+        project_dir.relative_to(source_root)
+    except ValueError as err:
+        raise SystemExit("[blueprint-harness] --project-root must stay inside the source checkout") from err
+    if not (project_dir / "lakefile.lean").is_file():
+        raise SystemExit(f"[blueprint-harness] composed Blueprint project has no lakefile.lean: {project_dir}")
+
+    resolved_id = _project_id(project_id or source_root.name)
+    output_dir = output_root.resolve() / resolved_id
+    return ComposedBlueprint(
+        project_id=resolved_id,
+        source_root=source_root,
+        project_dir=project_dir,
+        output_dir=output_dir,
+        site_dir=output_dir / "html-multi",
+    )
+
+
+def _nearest_toolchain(project: ComposedBlueprint) -> Path | None:
+    for directory in (project.project_dir, *project.project_dir.parents):
+        if directory != project.source_root and project.source_root not in directory.parents:
+            break
+        candidate = directory / "lean-toolchain"
+        if candidate.is_file():
+            return candidate
+        if directory == project.source_root:
+            break
+    return None
+
+
+def validate_composed_toolchain(package_root: Path, project: ComposedBlueprint) -> str:
+    package_path = package_root / "lean-toolchain"
+    project_path = _nearest_toolchain(project)
+    package_toolchain = read_reference_toolchain(package_path)
+    project_toolchain = read_reference_toolchain(project_path) if project_path is not None else None
+    if package_toolchain is None:
+        raise SystemExit(f"[blueprint-harness] selected Verso Blueprint checkout has no valid toolchain: {package_path}")
+    if project_toolchain is None:
+        raise SystemExit(
+            "[blueprint-harness] composed Blueprint has no valid lean-toolchain at or above "
+            f"{project.project_dir} within {project.source_root}"
+        )
+    if project_toolchain.lean_ref != package_toolchain.lean_ref:
+        raise SystemExit(
+            "[blueprint-harness] composed Blueprint toolchain mismatch: "
+            f"project `{project.project_dir}` uses Lean `{project_toolchain.lean_ref}`, but "
+            f"the selected Verso Blueprint checkout uses `{package_toolchain.lean_ref}`"
+        )
+    return project_toolchain.lean_ref
+
+
+def manifest_uses_mathlib(manifest_path: Path) -> bool:
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError) as err:
+        raise SystemExit(f"[blueprint-harness] could not inspect composed Lake manifest: {manifest_path}: {err}") from err
+    packages = manifest.get("packages")
+    if not isinstance(packages, list):
+        raise SystemExit(f"[blueprint-harness] composed Lake manifest has no package list: {manifest_path}")
+    return any(isinstance(package, dict) and package.get("name") == "mathlib" for package in packages)
+
+
+def ensure_composed_mathlib_cache(package_root: Path, project_dir: Path) -> bool:
+    if not manifest_uses_mathlib(project_dir / "lake-manifest.json"):
+        print("[blueprint-harness] composed dependency graph does not include Mathlib")
+        return False
+    command = lean_low_priority_command(package_root, "lake", "exe", "cache", "get")
+    run_with_heartbeat(command, cwd=project_dir, label="composed Blueprint: retrieve Mathlib cache")
+    print("[blueprint-harness] composed Blueprint uses the Mathlib cache")
+    return True
+
+
+@contextmanager
+def preserve_file(path: Path):
+    existed = path.exists()
+    original = path.read_bytes() if existed else None
+    try:
+        yield
+    finally:
+        if existed and original is not None:
+            path.write_bytes(original)
+        elif path.exists():
+            path.unlink()
+
+
+def compose_blueprint(package_root: Path, project: ComposedBlueprint, *, verbose: bool = False) -> None:
+    validate_composed_toolchain(package_root, project)
+    if project.output_dir.exists():
+        shutil.rmtree(project.output_dir)
+    project.output_dir.mkdir(parents=True, exist_ok=True)
+    rebuild_and_log_embedded_asset_owners(package_root)
+
+    manifest_path = project.project_dir / "lake-manifest.json"
+    with preserve_file(manifest_path):
+        with local_blueprint_dependency_override(
+            package_root,
+            project.project_dir,
+            restore_lakefile=True,
+            log=True,
+        ):
+            run_project_lake_update(package_root, project.project_dir)
+            ensure_composed_mathlib_cache(package_root, project.project_dir)
+            ensure_and_log_embedded_asset_owner_outputs(package_root)
+            build_command = [
+                "lake",
+                "exe",
+                "vbp",
+                "build",
+                "--output",
+                str(project.output_dir),
+            ]
+            if verbose:
+                build_command.append("--verbose")
+            run_with_heartbeat(
+                lean_low_priority_command(package_root, *build_command),
+                cwd=project.project_dir,
+                label=f"{project.project_id}: compose Blueprint",
+            )
+            run_with_heartbeat(
+                lean_low_priority_command(
+                    package_root,
+                    "lake",
+                    "exe",
+                    "vbp",
+                    "check",
+                    "--site",
+                    str(project.output_dir),
+                ),
+                cwd=project.project_dir,
+                label=f"{project.project_id}: check composed Blueprint",
+            )

--- a/scripts/blueprint_harness_composition.py
+++ b/scripts/blueprint_harness_composition.py
@@ -61,6 +61,16 @@ def resolve_composed_blueprint(
 
     resolved_id = _project_id(project_id or source_root.name)
     output_dir = output_root.resolve() / resolved_id
+    resolved_output_dir = output_dir.resolve()
+    if (
+        resolved_output_dir == source_root
+        or resolved_output_dir in source_root.parents
+        or source_root in resolved_output_dir.parents
+    ):
+        raise SystemExit(
+            "[blueprint-harness] composed Blueprint output must not overlap the source checkout: "
+            f"output `{output_dir}`, source `{source_root}`"
+        )
     return ComposedBlueprint(
         project_id=resolved_id,
         source_root=source_root,

--- a/scripts/blueprint_harness_composition.py
+++ b/scripts/blueprint_harness_composition.py
@@ -26,7 +26,6 @@ class ComposedBlueprint:
     source_root: Path
     project_dir: Path
     output_dir: Path
-    site_dir: Path
 
 
 def _project_id(value: str) -> str:
@@ -67,7 +66,6 @@ def resolve_composed_blueprint(
         source_root=source_root,
         project_dir=project_dir,
         output_dir=output_dir,
-        site_dir=output_dir / "html-multi",
     )
 
 

--- a/scripts/blueprint_harness_project_commands.py
+++ b/scripts/blueprint_harness_project_commands.py
@@ -29,7 +29,7 @@ OFFICIAL_BLUEPRINT_REQUIRE_PATTERN = re.compile(
     re.MULTILINE,
 )
 RELATIVE_BLUEPRINT_REQUIRE_PATTERN = re.compile(
-    r'^(?P<indent>\s*)require\s+VersoBlueprint\s+from\s+"(?P<path>(?:(?:\.\.?)/)+verso-blueprint/?)"\s*$',
+    r'^(?P<indent>[ \t]*)require\s+VersoBlueprint\s+from\s+"(?P<path>(?:(?:\.\.?)/)+verso-blueprint/?)"[ \t]*$',
     re.MULTILINE,
 )
 MATHLIB_STANDARD_LINTER_OPTION_PATTERN = re.compile(
@@ -41,7 +41,7 @@ MATHLIB_STANDARD_LINTER_OPTION_PATTERN = re.compile(
 def _blueprint_lakefile_text(project_dir: Path) -> tuple[Path, str]:
     lakefile = project_dir / "lakefile.lean"
     if not lakefile.exists():
-        raise SystemExit(f"[blueprint-harness] missing lakefile for cloned project: {lakefile}")
+        raise SystemExit(f"[blueprint-harness] missing lakefile for Blueprint project: {lakefile}")
     return lakefile, lakefile.read_text(encoding="utf-8")
 
 
@@ -61,7 +61,7 @@ def _require_official_blueprint_git_dependency(project_dir: Path, *, action: str
     match = _official_blueprint_git_dependency_match(text)
     if match is None:
         raise SystemExit(
-            "[blueprint-harness] expected the cloned project to declare `VersoBlueprint` in "
+            "[blueprint-harness] expected the Blueprint project to declare `VersoBlueprint` in "
             "`lakefile.lean` from an approved `VersoBlueprint` Git source "
             f"({OFFICIAL_BLUEPRINT_SOURCE_DESCRIPTION}); cannot {action}."
         )
@@ -75,7 +75,7 @@ def _require_approved_local_blueprint_dependency(project_dir: Path) -> tuple[Pat
         match = RELATIVE_BLUEPRINT_REQUIRE_PATTERN.search(text)
     if match is None:
         raise SystemExit(
-            "[blueprint-harness] expected the cloned project to declare `VersoBlueprint` in "
+            "[blueprint-harness] expected the Blueprint project to declare `VersoBlueprint` in "
             "`lakefile.lean` from an approved `VersoBlueprint` Git source "
             f"({OFFICIAL_BLUEPRINT_SOURCE_DESCRIPTION}) or a relative `verso-blueprint` checkout; "
             "cannot inject the local path override automatically."

--- a/scripts/blueprint_harness_project_commands.py
+++ b/scripts/blueprint_harness_project_commands.py
@@ -28,19 +28,25 @@ OFFICIAL_BLUEPRINT_REQUIRE_PATTERN = re.compile(
     r'^(?P<indent>[ \t]*)require\s+VersoBlueprint\s+from\s+git\s+"(?P<url>[^"]+)"(?:\s*@\s*"(?P<ref>[^"]+)")?[ \t]*$',
     re.MULTILINE,
 )
+RELATIVE_BLUEPRINT_REQUIRE_PATTERN = re.compile(
+    r'^(?P<indent>\s*)require\s+VersoBlueprint\s+from\s+"(?P<path>(?:(?:\.\.?)/)+verso-blueprint/?)"\s*$',
+    re.MULTILINE,
+)
 MATHLIB_STANDARD_LINTER_OPTION_PATTERN = re.compile(
     r"^(?P<indent>\s*)⟨`weak\.linter\.mathlibStandardSet,\s*true⟩",
     re.MULTILINE,
 )
 
 
-def _require_official_blueprint_git_dependency(project_dir: Path, *, action: str) -> tuple[Path, str, re.Match[str]]:
+def _blueprint_lakefile_text(project_dir: Path) -> tuple[Path, str]:
     lakefile = project_dir / "lakefile.lean"
     if not lakefile.exists():
         raise SystemExit(f"[blueprint-harness] missing lakefile for cloned project: {lakefile}")
+    return lakefile, lakefile.read_text(encoding="utf-8")
 
-    text = lakefile.read_text(encoding="utf-8")
-    match = next(
+
+def _official_blueprint_git_dependency_match(text: str) -> re.Match[str] | None:
+    return next(
         (
             candidate
             for candidate in OFFICIAL_BLUEPRINT_REQUIRE_PATTERN.finditer(text)
@@ -48,11 +54,31 @@ def _require_official_blueprint_git_dependency(project_dir: Path, *, action: str
         ),
         None,
     )
+
+
+def _require_official_blueprint_git_dependency(project_dir: Path, *, action: str) -> tuple[Path, str, re.Match[str]]:
+    lakefile, text = _blueprint_lakefile_text(project_dir)
+    match = _official_blueprint_git_dependency_match(text)
     if match is None:
         raise SystemExit(
             "[blueprint-harness] expected the cloned project to declare `VersoBlueprint` in "
             "`lakefile.lean` from an approved `VersoBlueprint` Git source "
             f"({OFFICIAL_BLUEPRINT_SOURCE_DESCRIPTION}); cannot {action}."
+        )
+    return lakefile, text, match
+
+
+def _require_approved_local_blueprint_dependency(project_dir: Path) -> tuple[Path, str, re.Match[str]]:
+    lakefile, text = _blueprint_lakefile_text(project_dir)
+    match = _official_blueprint_git_dependency_match(text)
+    if match is None:
+        match = RELATIVE_BLUEPRINT_REQUIRE_PATTERN.search(text)
+    if match is None:
+        raise SystemExit(
+            "[blueprint-harness] expected the cloned project to declare `VersoBlueprint` in "
+            "`lakefile.lean` from an approved `VersoBlueprint` Git source "
+            f"({OFFICIAL_BLUEPRINT_SOURCE_DESCRIPTION}) or a relative `verso-blueprint` checkout; "
+            "cannot inject the local path override automatically."
         )
     return lakefile, text, match
 
@@ -63,10 +89,7 @@ def rewrite_local_blueprint_dependency(
     *,
     relative: bool = False,
 ) -> Path:
-    lakefile, text, match = _require_official_blueprint_git_dependency(
-        project_dir,
-        action="inject the local path override automatically",
-    )
+    lakefile, text, match = _require_approved_local_blueprint_dependency(project_dir)
     local_path = (
         Path(os.path.relpath(package_root.resolve(), project_dir.resolve())).as_posix()
         if relative

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -27,7 +27,8 @@ from scripts.blueprint_harness_cli import (
     add_serial_argument,
     selected_output_root,
 )
-from scripts.blueprint_harness_paths import detect_harness_layout, resolve_output_root
+from scripts.blueprint_harness_composition import compose_blueprint, resolve_composed_blueprint
+from scripts.blueprint_harness_paths import detect_harness_layout, resolve_cli_path, resolve_output_root
 from scripts.blueprint_harness_projects import (
     HarnessProject,
     HarnessReleaseTarget,
@@ -1116,7 +1117,48 @@ def command_reference_prune(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_compose(args: argparse.Namespace) -> int:
+    layout = detect_harness_layout(Path(__file__))
+    require_safe_root_release(layout, allow_unsafe=args.allow_unsafe_root_release, command_name="compose")
+    output_root = resolve_output_root(selected_output_root(args), Path(__file__))
+    project = resolve_composed_blueprint(
+        resolve_cli_path(args.source_checkout),
+        args.project_root,
+        output_root,
+        project_id=args.project_id,
+    )
+    compose_blueprint(layout.package_root, project, verbose=args.verbose)
+    print(f"[blueprint-reference-harness] composed source checkout: {project.source_root}")
+    print(f"[blueprint-reference-harness] composed project root: {project.project_dir}")
+    print(f"[blueprint-reference-harness] composed output: {project.output_dir}")
+    return 0
+
+
 def add_generation_commands(subparsers) -> None:
+    compose = subparsers.add_parser(
+        "compose",
+        help="Build an editable user-provided Blueprint against this Verso Blueprint checkout.",
+    )
+    compose.add_argument(
+        "source_checkout",
+        help="Path to the user-provided source checkout. The harness never registers it in the reference catalog.",
+    )
+    compose.add_argument(
+        "--project-root",
+        default=".",
+        help="Blueprint Lake project root relative to the source checkout. Defaults to the checkout root.",
+    )
+    compose.add_argument(
+        "--id",
+        dest="project_id",
+        default=None,
+        help="Output id. Defaults to the source checkout directory name.",
+    )
+    add_output_root_argument(compose)
+    add_generation_verbose_argument(compose)
+    add_allow_unsafe_root_release_argument(compose)
+    compose.set_defaults(func=command_compose)
+
     generate = subparsers.add_parser(
         "generate",
         help="Build the selected blueprint harness projects.",
@@ -1352,7 +1394,7 @@ def add_prune_command(subparsers) -> None:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="python3 -m scripts.blueprint_reference_harness",
-        description="Reference blueprint generation, validation, and checkout lifecycle CLI.",
+        description="Blueprint composition plus reference generation, validation, and checkout lifecycle CLI.",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
     add_generation_commands(subparsers)

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -122,6 +122,27 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertTrue(args.allow_unsafe_root_release)
         self.assertEqual(args.release, "v4.29.0")
 
+    def test_reference_compose_parses_editable_source_and_nested_project(self) -> None:
+        parser = reference_harness_mod.build_parser()
+        args = parser.parse_args(
+            [
+                "compose",
+                "/tmp/rsk",
+                "--project-root",
+                "blueprint",
+                "--id",
+                "rsk-local",
+                "--output-root",
+                "/tmp/out",
+                "--verbose",
+            ]
+        )
+        self.assertEqual(args.source_checkout, "/tmp/rsk")
+        self.assertEqual(args.project_root, "blueprint")
+        self.assertEqual(args.project_id, "rsk-local")
+        self.assertEqual(selected_output_root(args), "/tmp/out")
+        self.assertTrue(args.verbose)
+
     def test_reference_generate_rejects_allow_unsafe_root_main_alias(self) -> None:
         parser = reference_harness_mod.build_parser()
         self.assertParseFails(parser, ["generate", "--allow-unsafe-root-main"])

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -127,19 +127,19 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         args = parser.parse_args(
             [
                 "compose",
-                "/tmp/rsk",
+                "/tmp/external-blueprint",
                 "--project-root",
                 "blueprint",
                 "--id",
-                "rsk-local",
+                "local-blueprint",
                 "--output-root",
                 "/tmp/out",
                 "--verbose",
             ]
         )
-        self.assertEqual(args.source_checkout, "/tmp/rsk")
+        self.assertEqual(args.source_checkout, "/tmp/external-blueprint")
         self.assertEqual(args.project_root, "blueprint")
-        self.assertEqual(args.project_id, "rsk-local")
+        self.assertEqual(args.project_id, "local-blueprint")
         self.assertEqual(selected_output_root(args), "/tmp/out")
         self.assertTrue(args.verbose)
 

--- a/tests/harness/test_blueprint_harness_composition.py
+++ b/tests/harness/test_blueprint_harness_composition.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+import scripts.blueprint_harness_composition as composition
+
+
+class BlueprintHarnessCompositionTests(unittest.TestCase):
+    def test_resolve_nested_composed_blueprint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source_root = Path(tmp) / "demo-source"
+            project_dir = source_root / "nested" / "blueprint"
+            project_dir.mkdir(parents=True)
+            (project_dir / "lakefile.lean").write_text("import Lake\n", encoding="utf-8")
+
+            project = composition.resolve_composed_blueprint(
+                source_root,
+                "nested/blueprint",
+                Path(tmp) / "out",
+                project_id=None,
+            )
+
+            self.assertEqual(project.project_id, "demo-source")
+            self.assertEqual(project.project_dir, project_dir.resolve())
+            self.assertEqual(project.output_dir, (Path(tmp) / "out" / "demo-source").resolve())
+
+    def test_resolve_rejects_project_root_escape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source_root = Path(tmp) / "source"
+            source_root.mkdir()
+            with self.assertRaisesRegex(SystemExit, "stay inside"):
+                composition.resolve_composed_blueprint(
+                    source_root,
+                    "../other",
+                    Path(tmp) / "out",
+                    project_id="demo",
+                )
+
+    def test_validate_toolchain_accepts_source_root_inheritance(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_root = root / "verso-blueprint"
+            source_root = root / "source"
+            project_dir = source_root / "blueprint"
+            package_root.mkdir()
+            project_dir.mkdir(parents=True)
+            (package_root / "lean-toolchain").write_text("leanprover/lean4:v4.32.0\n", encoding="utf-8")
+            (source_root / "lean-toolchain").write_text("leanprover/lean4:v4.32.0\n", encoding="utf-8")
+            project = composition.ComposedBlueprint("demo", source_root, project_dir, root / "out", root / "out/html-multi")
+
+            self.assertEqual(composition.validate_composed_toolchain(package_root, project), "v4.32.0")
+
+    def test_manifest_uses_mathlib(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = Path(tmp) / "lake-manifest.json"
+            manifest.write_text(json.dumps({"packages": [{"name": "mathlib"}]}), encoding="utf-8")
+            self.assertTrue(composition.manifest_uses_mathlib(manifest))
+
+            manifest.write_text(json.dumps({"packages": [{"name": "verso"}]}), encoding="utf-8")
+            self.assertFalse(composition.manifest_uses_mathlib(manifest))
+
+    def test_mathlib_dependency_requires_cache_get(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_root = root / "verso-blueprint"
+            project_dir = root / "project"
+            package_root.mkdir()
+            project_dir.mkdir()
+            (project_dir / "lake-manifest.json").write_text(
+                json.dumps({"packages": [{"name": "mathlib"}]}),
+                encoding="utf-8",
+            )
+            commands: list[list[str]] = []
+            original = composition.run_with_heartbeat
+            try:
+                composition.run_with_heartbeat = lambda command, **_kwargs: commands.append(command)
+                self.assertTrue(composition.ensure_composed_mathlib_cache(package_root, project_dir))
+            finally:
+                composition.run_with_heartbeat = original
+
+            self.assertEqual(commands, [[str(package_root / "scripts/lean-low-priority"), "lake", "exe", "cache", "get"]])
+
+    def test_preserve_file_restores_existing_and_removes_generated(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            existing = Path(tmp) / "existing"
+            generated = Path(tmp) / "generated"
+            existing.write_text("before", encoding="utf-8")
+
+            with composition.preserve_file(existing):
+                existing.write_text("during", encoding="utf-8")
+            with composition.preserve_file(generated):
+                generated.write_text("during", encoding="utf-8")
+
+            self.assertEqual(existing.read_text(encoding="utf-8"), "before")
+            self.assertFalse(generated.exists())
+
+    def test_compose_builds_and_checks_while_preserving_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_root = root / "verso-blueprint"
+            source_root = root / "source"
+            project_dir = source_root / "blueprint"
+            package_root.mkdir()
+            project_dir.mkdir(parents=True)
+            lakefile = project_dir / "lakefile.lean"
+            manifest = project_dir / "lake-manifest.json"
+            lakefile.write_text('require VersoBlueprint from "../../verso-blueprint"\n', encoding="utf-8")
+            manifest.write_text('{"packages": []}\n', encoding="utf-8")
+            project = composition.ComposedBlueprint(
+                "demo",
+                source_root,
+                project_dir,
+                root / "out" / "demo",
+                root / "out" / "demo" / "html-multi",
+            )
+            project.output_dir.mkdir(parents=True)
+            stale_output = project.output_dir / "stale.html"
+            stale_output.write_text("old", encoding="utf-8")
+            commands: list[list[str]] = []
+
+            @contextmanager
+            def fake_override(*_args, **_kwargs):
+                yield lakefile
+
+            originals = {
+                "validate_composed_toolchain": composition.validate_composed_toolchain,
+                "rebuild_and_log_embedded_asset_owners": composition.rebuild_and_log_embedded_asset_owners,
+                "local_blueprint_dependency_override": composition.local_blueprint_dependency_override,
+                "run_project_lake_update": composition.run_project_lake_update,
+                "ensure_composed_mathlib_cache": composition.ensure_composed_mathlib_cache,
+                "ensure_and_log_embedded_asset_owner_outputs": composition.ensure_and_log_embedded_asset_owner_outputs,
+                "run_with_heartbeat": composition.run_with_heartbeat,
+            }
+            try:
+                composition.validate_composed_toolchain = lambda *_args, **_kwargs: "leanprover/lean4:v4.32.0"
+                composition.rebuild_and_log_embedded_asset_owners = lambda *_args, **_kwargs: []
+                composition.local_blueprint_dependency_override = fake_override
+                composition.run_project_lake_update = lambda *_args, **_kwargs: manifest.write_text("changed", encoding="utf-8")
+                composition.ensure_composed_mathlib_cache = lambda *_args, **_kwargs: False
+                composition.ensure_and_log_embedded_asset_owner_outputs = lambda *_args, **_kwargs: []
+                composition.run_with_heartbeat = lambda command, **_kwargs: commands.append(command)
+                composition.compose_blueprint(package_root, project)
+            finally:
+                for name, value in originals.items():
+                    setattr(composition, name, value)
+
+            self.assertEqual(manifest.read_text(encoding="utf-8"), '{"packages": []}\n')
+            self.assertFalse(stale_output.exists())
+            self.assertIn([str(package_root / "scripts/lean-low-priority"), "lake", "exe", "vbp", "build", "--output", str(project.output_dir)], commands)
+            self.assertIn([str(package_root / "scripts/lean-low-priority"), "lake", "exe", "vbp", "check", "--site", str(project.output_dir)], commands)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/harness/test_blueprint_harness_composition.py
+++ b/tests/harness/test_blueprint_harness_composition.py
@@ -1,15 +1,38 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
 import json
 from pathlib import Path
 import tempfile
 import unittest
+from unittest.mock import patch
 
 import scripts.blueprint_harness_composition as composition
 
 
 class BlueprintHarnessCompositionTests(unittest.TestCase):
+    def _make_composed_project(
+        self,
+        root: Path,
+    ) -> tuple[Path, composition.ComposedBlueprint, Path, Path, str, str]:
+        package_root = root / "verso-blueprint"
+        source_root = root / "source"
+        project_dir = source_root / "blueprint"
+        package_root.mkdir()
+        project_dir.mkdir(parents=True)
+        lakefile = project_dir / "lakefile.lean"
+        manifest = project_dir / "lake-manifest.json"
+        lakefile_text = 'require VersoBlueprint from "../../verso-blueprint"\n'
+        manifest_text = '{"packages": []}\n'
+        lakefile.write_text(lakefile_text, encoding="utf-8")
+        manifest.write_text(manifest_text, encoding="utf-8")
+        project = composition.ComposedBlueprint(
+            "demo",
+            source_root,
+            project_dir,
+            root / "out" / "demo",
+        )
+        return package_root, project, lakefile, manifest, lakefile_text, manifest_text
+
     def test_resolve_nested_composed_blueprint(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             source_root = Path(tmp) / "demo-source"
@@ -50,9 +73,29 @@ class BlueprintHarnessCompositionTests(unittest.TestCase):
             project_dir.mkdir(parents=True)
             (package_root / "lean-toolchain").write_text("leanprover/lean4:v4.32.0\n", encoding="utf-8")
             (source_root / "lean-toolchain").write_text("leanprover/lean4:v4.32.0\n", encoding="utf-8")
-            project = composition.ComposedBlueprint("demo", source_root, project_dir, root / "out", root / "out/html-multi")
+            project = composition.ComposedBlueprint("demo", source_root, project_dir, root / "out")
 
             self.assertEqual(composition.validate_composed_toolchain(package_root, project), "v4.32.0")
+
+    def test_validate_toolchain_rejects_missing_and_mismatched_project_toolchain(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_root = root / "verso-blueprint"
+            source_root = root / "source"
+            project_dir = source_root / "blueprint"
+            package_root.mkdir()
+            project_dir.mkdir(parents=True)
+            (package_root / "lean-toolchain").write_text("leanprover/lean4:v4.32.0\n", encoding="utf-8")
+            project_toolchain = source_root / "lean-toolchain"
+            project_toolchain.write_text("leanprover/lean4:v4.31.0\n", encoding="utf-8")
+            project = composition.ComposedBlueprint("demo", source_root, project_dir, root / "out")
+
+            with self.assertRaisesRegex(SystemExit, "toolchain mismatch"):
+                composition.validate_composed_toolchain(package_root, project)
+
+            project_toolchain.unlink()
+            with self.assertRaisesRegex(SystemExit, "no valid lean-toolchain"):
+                composition.validate_composed_toolchain(package_root, project)
 
     def test_manifest_uses_mathlib(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -98,60 +141,101 @@ class BlueprintHarnessCompositionTests(unittest.TestCase):
             self.assertEqual(existing.read_text(encoding="utf-8"), "before")
             self.assertFalse(generated.exists())
 
-    def test_compose_builds_and_checks_while_preserving_manifest(self) -> None:
+    def test_compose_orders_steps_and_preserves_lake_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            package_root = root / "verso-blueprint"
-            source_root = root / "source"
-            project_dir = source_root / "blueprint"
-            package_root.mkdir()
-            project_dir.mkdir(parents=True)
-            lakefile = project_dir / "lakefile.lean"
-            manifest = project_dir / "lake-manifest.json"
-            lakefile.write_text('require VersoBlueprint from "../../verso-blueprint"\n', encoding="utf-8")
-            manifest.write_text('{"packages": []}\n', encoding="utf-8")
-            project = composition.ComposedBlueprint(
-                "demo",
-                source_root,
-                project_dir,
-                root / "out" / "demo",
-                root / "out" / "demo" / "html-multi",
+            package_root, project, lakefile, manifest, lakefile_text, manifest_text = (
+                self._make_composed_project(root)
             )
             project.output_dir.mkdir(parents=True)
             stale_output = project.output_dir / "stale.html"
             stale_output.write_text("old", encoding="utf-8")
             commands: list[list[str]] = []
+            events: list[str] = []
 
-            @contextmanager
-            def fake_override(*_args, **_kwargs):
-                yield lakefile
+            def fake_update(*_args, **_kwargs) -> None:
+                events.append("update")
+                manifest.write_text("changed", encoding="utf-8")
 
-            originals = {
-                "validate_composed_toolchain": composition.validate_composed_toolchain,
-                "rebuild_and_log_embedded_asset_owners": composition.rebuild_and_log_embedded_asset_owners,
-                "local_blueprint_dependency_override": composition.local_blueprint_dependency_override,
-                "run_project_lake_update": composition.run_project_lake_update,
-                "ensure_composed_mathlib_cache": composition.ensure_composed_mathlib_cache,
-                "ensure_and_log_embedded_asset_owner_outputs": composition.ensure_and_log_embedded_asset_owner_outputs,
-                "run_with_heartbeat": composition.run_with_heartbeat,
-            }
-            try:
-                composition.validate_composed_toolchain = lambda *_args, **_kwargs: "leanprover/lean4:v4.32.0"
-                composition.rebuild_and_log_embedded_asset_owners = lambda *_args, **_kwargs: []
-                composition.local_blueprint_dependency_override = fake_override
-                composition.run_project_lake_update = lambda *_args, **_kwargs: manifest.write_text("changed", encoding="utf-8")
-                composition.ensure_composed_mathlib_cache = lambda *_args, **_kwargs: False
-                composition.ensure_and_log_embedded_asset_owner_outputs = lambda *_args, **_kwargs: []
-                composition.run_with_heartbeat = lambda command, **_kwargs: commands.append(command)
+            def fake_cache(*_args, **_kwargs) -> bool:
+                events.append("cache")
+                return False
+
+            def fake_owner_outputs(*_args, **_kwargs) -> list[str]:
+                events.append("owner outputs")
+                return []
+
+            def fake_run(command: list[str], **_kwargs) -> None:
+                commands.append(command)
+                events.append("build" if "build" in command else "check")
+
+            with patch.multiple(
+                composition,
+                validate_composed_toolchain=lambda *_args, **_kwargs: "v4.32.0",
+                rebuild_and_log_embedded_asset_owners=lambda *_args, **_kwargs: [],
+                run_project_lake_update=fake_update,
+                ensure_composed_mathlib_cache=fake_cache,
+                ensure_and_log_embedded_asset_owner_outputs=fake_owner_outputs,
+                run_with_heartbeat=fake_run,
+            ):
                 composition.compose_blueprint(package_root, project)
-            finally:
-                for name, value in originals.items():
-                    setattr(composition, name, value)
 
-            self.assertEqual(manifest.read_text(encoding="utf-8"), '{"packages": []}\n')
+            self.assertEqual(lakefile.read_text(encoding="utf-8"), lakefile_text)
+            self.assertEqual(manifest.read_text(encoding="utf-8"), manifest_text)
             self.assertFalse(stale_output.exists())
-            self.assertIn([str(package_root / "scripts/lean-low-priority"), "lake", "exe", "vbp", "build", "--output", str(project.output_dir)], commands)
-            self.assertIn([str(package_root / "scripts/lean-low-priority"), "lake", "exe", "vbp", "check", "--site", str(project.output_dir)], commands)
+            self.assertEqual(events, ["update", "cache", "owner outputs", "build", "check"])
+            self.assertEqual(
+                commands,
+                [
+                    [
+                        str(package_root / "scripts/lean-low-priority"),
+                        "lake",
+                        "exe",
+                        "vbp",
+                        "build",
+                        "--output",
+                        str(project.output_dir),
+                    ],
+                    [
+                        str(package_root / "scripts/lean-low-priority"),
+                        "lake",
+                        "exe",
+                        "vbp",
+                        "check",
+                        "--site",
+                        str(project.output_dir),
+                    ],
+                ],
+            )
+
+    def test_compose_restores_lake_files_when_build_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_root, project, lakefile, manifest, lakefile_text, manifest_text = (
+                self._make_composed_project(root)
+            )
+
+            def fake_update(*_args, **_kwargs) -> None:
+                manifest.write_text("changed", encoding="utf-8")
+
+            def fail_build(command: list[str], **_kwargs) -> None:
+                if "build" in command:
+                    raise RuntimeError("build failed")
+
+            with patch.multiple(
+                composition,
+                validate_composed_toolchain=lambda *_args, **_kwargs: "v4.32.0",
+                rebuild_and_log_embedded_asset_owners=lambda *_args, **_kwargs: [],
+                run_project_lake_update=fake_update,
+                ensure_composed_mathlib_cache=lambda *_args, **_kwargs: False,
+                ensure_and_log_embedded_asset_owner_outputs=lambda *_args, **_kwargs: [],
+                run_with_heartbeat=fail_build,
+            ):
+                with self.assertRaisesRegex(RuntimeError, "build failed"):
+                    composition.compose_blueprint(package_root, project)
+
+            self.assertEqual(lakefile.read_text(encoding="utf-8"), lakefile_text)
+            self.assertEqual(manifest.read_text(encoding="utf-8"), manifest_text)
 
 
 if __name__ == "__main__":

--- a/tests/harness/test_blueprint_harness_composition.py
+++ b/tests/harness/test_blueprint_harness_composition.py
@@ -63,6 +63,29 @@ class BlueprintHarnessCompositionTests(unittest.TestCase):
                     project_id="demo",
                 )
 
+    def test_resolve_rejects_output_source_overlap(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source_root = root / "output" / "source"
+            project_dir = source_root / "blueprint"
+            project_dir.mkdir(parents=True)
+            (project_dir / "lakefile.lean").write_text("import Lake\n", encoding="utf-8")
+            overlapping_outputs = (
+                (root, "output"),
+                (root / "output", "source"),
+                (source_root, "generated"),
+            )
+
+            for output_root, project_id in overlapping_outputs:
+                with self.subTest(output_root=output_root, project_id=project_id):
+                    with self.assertRaisesRegex(SystemExit, "output must not overlap"):
+                        composition.resolve_composed_blueprint(
+                            source_root,
+                            "blueprint",
+                            output_root,
+                            project_id=project_id,
+                        )
+
     def test_validate_toolchain_accepts_source_root_inheritance(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -178,7 +201,7 @@ class BlueprintHarnessCompositionTests(unittest.TestCase):
                 ensure_and_log_embedded_asset_owner_outputs=fake_owner_outputs,
                 run_with_heartbeat=fake_run,
             ):
-                composition.compose_blueprint(package_root, project)
+                composition.compose_blueprint(package_root, project, verbose=True)
 
             self.assertEqual(lakefile.read_text(encoding="utf-8"), lakefile_text)
             self.assertEqual(manifest.read_text(encoding="utf-8"), manifest_text)
@@ -195,6 +218,7 @@ class BlueprintHarnessCompositionTests(unittest.TestCase):
                         "build",
                         "--output",
                         str(project.output_dir),
+                        "--verbose",
                     ],
                     [
                         str(package_root / "scripts/lean-low-priority"),

--- a/tests/harness/test_blueprint_harness_project_commands.py
+++ b/tests/harness/test_blueprint_harness_project_commands.py
@@ -77,6 +77,34 @@ class BlueprintHarnessProjectCommandTests(unittest.TestCase):
                 'require VersoBlueprint from ".."\n',
             )
 
+    def test_rewrite_local_blueprint_dependency_accepts_relative_checkout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            lakefile = project_dir / "lakefile.lean"
+            lakefile.write_text(
+                'require VersoBlueprint from "../../verso-blueprint"\n',
+                encoding="utf-8",
+            )
+
+            rewrite_local_blueprint_dependency(project_dir, PACKAGE_ROOT)
+
+            self.assertEqual(
+                lakefile.read_text(encoding="utf-8").strip(),
+                f'require VersoBlueprint from "{PACKAGE_ROOT.resolve()}"',
+            )
+
+    def test_rewrite_local_blueprint_dependency_rejects_absolute_checkout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            lakefile = project_dir / "lakefile.lean"
+            lakefile.write_text(
+                'require VersoBlueprint from "/tmp/verso-blueprint"\n',
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(SystemExit, "relative `verso-blueprint` checkout"):
+                rewrite_local_blueprint_dependency(project_dir, PACKAGE_ROOT)
+
     def test_rewrite_local_blueprint_dependency_disables_mathlib_header_linter(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             project_dir = Path(tmp)

--- a/tests/harness/test_blueprint_harness_project_commands.py
+++ b/tests/harness/test_blueprint_harness_project_commands.py
@@ -82,15 +82,15 @@ class BlueprintHarnessProjectCommandTests(unittest.TestCase):
             project_dir = Path(tmp)
             lakefile = project_dir / "lakefile.lean"
             lakefile.write_text(
-                'require VersoBlueprint from "../../verso-blueprint"\n',
+                'import Lake\n\nrequire VersoBlueprint from "../../verso-blueprint"\n\npackage Demo\n',
                 encoding="utf-8",
             )
 
             rewrite_local_blueprint_dependency(project_dir, PACKAGE_ROOT)
 
             self.assertEqual(
-                lakefile.read_text(encoding="utf-8").strip(),
-                f'require VersoBlueprint from "{PACKAGE_ROOT.resolve()}"',
+                lakefile.read_text(encoding="utf-8"),
+                f'import Lake\n\nrequire VersoBlueprint from "{PACKAGE_ROOT.resolve()}"\n\npackage Demo\n',
             )
 
     def test_rewrite_local_blueprint_dependency_rejects_absolute_checkout(self) -> None:


### PR DESCRIPTION
This PR adds a maintainer-facing composition command that builds a user-provided Blueprint against the current editable `verso-blueprint` checkout without registering it in the persistent reference catalog. It preserves the source project's Lake files, validates exact toolchain compatibility, and retrieves Mathlib artifacts through its cache before building.

Backport v4.31.0: #347