### PR TITLE
fix: finalize graph topology from semantic nodes

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -377,17 +377,68 @@ Three common workflows consume that same model:
 ## Graph Data APIs
 
 Lean callers can build the semantic graph object from elaboration state with
-`Informal.Graph.buildData`. Before Verso traversal finishes, graph data is
-semantic and may not yet include rendered hrefs or display titles:
+`Informal.Graph.buildModel`. Before Verso traversal finishes, the value is a
+`GraphModel`: it may not yet include rendered hrefs or display titles and it
+contains no derived edge, child, or DOT-variant caches:
 
 ```lean
 import VersoBlueprint.Graph
 
 def semanticGraph (state : Informal.Environment.State) :
-    Informal.Graph.GraphData :=
+    Informal.Graph.GraphModel :=
   let roots := state.data.toArray.map (·.1)
-  Informal.Graph.buildData state roots
+  Informal.Graph.buildModel state roots
 ```
+
+`GraphModel` has one topology representation: each node's `statementUses`,
+`proofUses`, and `parent`. Its `groupMetadata` records carry only label, title,
+and declaration status. Select and transform nodes at this stage. For the
+common live/disk overlay case, `mergePreferLeft` selects the preferred model's
+complete node record for each label rather than combining topology fields:
+
+```lean
+def mergedSemanticGraph
+    (live disk : Informal.Graph.GraphModel) : Informal.Graph.GraphModel :=
+  live.mergePreferLeft disk
+```
+
+If both inputs are already finalized, convert them back only for selection and
+merge, then finish the result immediately. This deliberately discards their old
+edges, group children, and variants instead of attempting to combine them:
+
+```lean
+def mergeFinishedGraph
+    (key : String)
+    (live disk : Informal.Graph.GraphData)
+    (options : Informal.Graph.GraphOptions) : Informal.Graph.GraphData :=
+  (live.toModel.mergePreferLeft disk.toModel).finish key options
+```
+
+The caller chooses the new record's stable key and render options; neither is
+inferred from the projections being discarded.
+
+`GraphModel.canonicalize` is safe before caching: it retains the first complete
+node record for each label, canonicalizes repeated dependency refs, and merges
+group metadata. `GraphModel.finish` is the lower-level finalization operation.
+It derives one edge per retained source/target pair with combined
+statement/proof axes, omits dependencies with a missing source endpoint,
+derives group membership from node parents, preserves metadata for retained
+groups, and generates the DOT variants from that same graph.
+
+The resulting `GraphData` constructor is private. A finished record can be
+inspected or converted back with `toModel`, but its topology cannot be changed
+while retaining old edges, children, or variants. `FromJson GraphData` likewise
+rejects duplicate dependencies and any edge, group-membership, preview mapping,
+or DOT variant that disagrees with the authoritative nodes.
+
+Topology finalization and preview-artifact resolution are separate boundaries.
+`GraphModel.finish` fixes topology and DOT exactly once. Later, after the
+manifest and rendered-fragment cache are both known,
+`PreviewManifest.File.finalizePreviewReferences` may use
+`GraphData.filterPreviewReferences` to remove unavailable preview keys from nodes
+and their variant lookup entries together. That synchronized post-pass cannot
+change nodes' dependencies or parents, derived edges or children, or DOT, and
+cannot rewrite one preview key into another.
 
 Once traversal has completed, use `Informal.GraphApi` to finalize either one
 rendered graph block or every graph cached during traversal:
@@ -398,8 +449,8 @@ import VersoBlueprint.GraphApi
 def graphForRenderedBlock
     (state : Verso.Genre.Manual.TraverseState)
     (blockId : Verso.Multi.InternalId)
-    (semantic : Informal.Graph.GraphData) : Informal.Graph.GraphData :=
-  Informal.GraphApi.finalDataForBlock state blockId semantic
+    (semantic : Informal.Graph.GraphModel) : Informal.Graph.GraphData :=
+  Informal.GraphApi.finishDataForBlock state blockId semantic {}
 
 def allRenderedGraphEntries
     (state : Verso.Genre.Manual.TraverseState) :
@@ -408,16 +459,34 @@ def allRenderedGraphEntries
   Informal.GraphApi.cachedEntries state
 ```
 
+Graph traversal caches store only canonical `GraphModel` plus `GraphOptions`.
+They do not cache edges, group children, or render variants, so topology changes
+cannot reuse a stale rendered projection and the cache stays smaller.
 `cachedEntries` preserves malformed traversal-cache records as `DecodeError`
 values and successful records as canonical-name/data pairs, so callers can
 report corruption instead of silently omitting graphs. The generated-manifest
 path reports those errors and continues with valid graph entries.
 
 Generated `blueprint-manifest.json` includes a `graphs` array. Each entry
-contains `schemaVersion`, `nodes`, `edges`, and `groups`, with status enums,
-dependency axes, preview keys, hrefs when traversal resolved them, and visual
-metadata for renderers that want Blueprint's default styling. Graph schema
-version 2 serializes each node `previewKey` as a string or `null`.
+contains `schemaVersion`, `nodes`, `edges`, `groups`, and `variants`, with
+status enums, dependency axes, preview keys, hrefs when traversal resolved
+them, and visual metadata for renderers that want Blueprint's default styling.
+Graph schema version 3 identifies records produced under the private-constructor
+topology contract. It retains version 2's string-or-`null` node `previewKey`
+shape, but is semantically incompatible because version 2 did not guarantee
+that edges, group children, and variants agreed with authoritative nodes.
+Regenerate generated Blueprint output when adopting this revision; there is no
+version-2 compatibility path.
+
+Generated `edges` and group `children` are guaranteed projections of the
+authoritative node fields. The browser API recognizes version-3 records with
+all top-level collections and a valid render-variant contract: `full` is first,
+variant keys are unique, and select/hover mappings target variants in the same
+record. It deliberately does not repeat Lean's graph finalization work. Lean's
+`FromJson GraphData` boundary additionally
+recomputes and rejects records whose edges, group membership, or variants
+disagree with their nodes. Browser consumers should treat generated graph data
+as immutable output rather than an input model to repair.
 
 That finished traversal state is the appropriate public boundary. Consumers
 should not reconstruct graph hrefs or titles from lower-level traversal
@@ -425,15 +494,19 @@ internals when the finalized graph data is available.
 
 Finalized graph data is traversal-backed. Imported semantic nodes or code-only
 nodes that have no rendered occurrence in the current site are omitted from the
-public graph; explicit unknown-reference diagnostics are retained. Graph node
-`previewKey` values are selected preview keys finalized against the generated
-manifest/cache pair: when a statement preview is unavailable but a proof preview
-exists, graph and relation UI can point at the proof preview. Bodyless
-source-backed nodes can point at their `externalMarkup:<label>` preview only
-when that key has a manifest entry and rendered cache body. When a retained node
-has no manifest/cache-backed preview in the generated artifact set, the finalized
-`previewKey` is `null` and bundled graph variants omit the node from
-`previewKeyByNodeId`. Use fixed facet keys such as
+public graph; explicit unknown-reference diagnostics are retained. Traversal
+selects each graph node's preferred `previewKey`; manifest graph records then
+validate those candidates against the emitted manifest/cache pair. When a
+statement preview is unavailable but a proof preview exists, graph and relation
+UI can point at the proof preview. Bodyless source-backed nodes can point at
+their `externalMarkup:<label>` preview only when that key has a manifest entry
+and rendered cache body. When a retained node has no manifest/cache-backed
+preview in the generated artifact set, the manifest graph's `previewKey` is
+`null` and its bundled variants omit the node from `previewKeyByNodeId`.
+Embedded page graph data is emitted earlier and may still carry a traversal
+candidate that later fails artifact validation; the runtime resolves candidates
+through the manifest/cache pair rather than treating page JSON as proof that a
+fragment exists. Use fixed facet keys such as
 `PreviewCache.statementKey` or `PreviewCache.proofKey` only when your code is
 explicitly requesting that facet.
 
@@ -445,10 +518,9 @@ explicitly requesting that facet.
 | Explicit proof facet identity | `PreviewCache.proofKey label` |
 
 The bundled graph renderer uses that finalized graph data as its block-level
-source of truth. Lean attaches DOT render variants with
-`Informal.Graph.GraphData.renderVariants` during graph finalization, so page
-rendering and custom clients exercise the same graph record shape without
-scraping rendered graph pages.
+source of truth. `GraphApi.finishData` attaches DOT render variants at the one
+semantic-to-public topology boundary, so page rendering and custom clients
+exercise the same schema and topology without scraping rendered graph pages.
 
 Browser callers can use the generated ESM graph module directly:
 
@@ -462,6 +534,11 @@ const graphs = await loadGraphs();
 // Read graph data embedded in a rendered graph block on the current page.
 const graph = getGraphData(document);
 ```
+
+`loadGraphs()` omits records that fail the current schema, top-level collection,
+or render-variant checks. `getGraphData()` returns `null` when embedded graph
+data is missing or fails the same checks. Lean remains responsible for semantic
+topology agreement before serialization.
 
 For rendering new graph blocks, prefer `loadGraphs()` and the manifest graph
 record's Lean-emitted `variants` field. Generated graph blocks embed one
@@ -493,8 +570,8 @@ Use `createGraphBlock(graph, options)` when a client wants to construct the
 standard `.bp_graph_fullwidth` element first and insert or render it later. Use
 `renderGraphData(host, graph, options)` when the host should be populated and
 rendered in one call. Both helpers consume the graph record's precomputed
-`variants` array, or an explicit `options.variants` override. They return
-`null` when neither source provides render variants.
+`variants` array and return `null` when it does not contain valid render
+variants.
 
 The module can also initialize an existing graph block. That existing-markup
 path is for markup that is already present, such as the standard
@@ -1249,7 +1326,7 @@ modules:
 
 | Chunk | Private responsibility |
 | --- | --- |
-| `blueprint-graph-core.mjs` | Graph JSON discovery, graph manifest loading, and graph-data normalization shared by the page runtime, slide runtime, and `api/graph.mjs`. |
+| `blueprint-graph-core.mjs` | Graph JSON discovery, graph manifest loading, and current-schema/top-level/render-variant validation shared by the page runtime, slide runtime, and `api/graph.mjs`; Lean remains the owner of semantic topology finalization. |
 | `blueprint-preview-core.mjs` | Generated-data URL helpers and preview-key construction shared by the page runtime, slide runtime, `api/data.mjs`, and `api/preview.mjs`. |
 | `blueprint-api-common.mjs` | Common generated-ESM wrapper mechanics shared by `api/data.mjs` and `api/preview.mjs`, including default data-base options, URL/key forwarding, default API handles, fallback statuses, and method dispatch. |
 

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -50,9 +50,9 @@ rather than invent parallel sources of truth.
 
 Command modules are split by concern:
 
-- `VersoBlueprint/Graph.lean` owns the shared graph data model, finalized
-  `GraphData` projection helpers, DOT rendering helpers, and graph-view
-  variant construction used by page graphs and compact widgets
+- `VersoBlueprint/Graph.lean` owns the semantic and finalized graph types,
+  materialization, DOT rendering helpers, and graph-view variant construction
+  used by page graphs and compact widgets
 - `VersoBlueprint/GraphApi.lean` owns the traversal/cache-facing API for
   storing semantic graph data and finalizing it against completed traversal
   state
@@ -276,7 +276,7 @@ that owner.
 | External Lean declaration snapshots | Elaboration / declaration snapshot registration | `ExternalRef` records on semantic nodes, enriched with presence/status/source/render data | block renderers, code-summary badges, summary, graph, manifest |
 | Numbering, hrefs, anchors, preview keys | Traversal | `TraverseState` and `TraversalIndex` domains | page rendering, preview manifest, browser triggers |
 | Statement/proof preview source blocks | Traversal | `TraversalIndex.TraversalPreviews` | manifest/cache emission, same-document manual grafts |
-| Public graph data | Elaboration plus completed traversal | semantic `Informal.Graph.GraphData` cached in `TraversalIndex.Graphs`, then finalized through `Informal.GraphApi.finalData` for `blueprint-manifest.json.graphs`, page JSON, and bundled graph rendering | graph command rendering, browser runtime, custom graph consumers |
+| Public graph data | Elaboration plus completed traversal | semantic `Informal.Graph.GraphModel` plus options cached in `TraversalIndex.Graphs`, then topology-finalized once through `Informal.GraphApi.finishData` into private-constructor `GraphData`; manifest emission subsequently resolves preview candidates against the artifact index without reopening topology | graph command rendering, browser runtime, custom graph consumers |
 | Lean code preview fragments | Traversal | `TraversalIndex.LeanCodePreviews` | Lean links, manifest/cache emission |
 | Rendered preview bodies | Preview-data emission | `blueprint-html-cache.json` | browser runtime, Slides, custom generated consumers |
 | Semantic preview/catalog entries | Preview-data emission | `blueprint-manifest.json` | browser runtime, Slides, audit/custom UIs |
@@ -288,6 +288,46 @@ working set. Manifest state is the serialized interchange artifact for
 generated consumers. A renderer may project traversal state into manifest-shaped
 entries for code reuse, but it should not pretend that generated manifest files
 are the traversal source of truth inside the current generator.
+
+Graph topology follows the same ownership rule. Before traversal completes,
+`GraphModel.nodes` owns dependency and membership semantics through each node's
+`statementUses`, `proofUses`, and `parent`; `groupMetadata` has no child list.
+Selection, filtering, and live/disk overlay happen only on this semantic type.
+`GraphModel.mergePreferLeft` selects one complete node record per label, and
+the traversal cache stores only that model plus render options.
+
+```mermaid
+flowchart LR
+  environment["Environment.State"] --> model["GraphModel<br/>authoritative nodes + group metadata"]
+  model --> cache["Traversal cache<br/>model + options"]
+  cache --> finish["GraphApi.finishData"]
+  finish --> data["GraphData<br/>derived edges + groups + variants"]
+  data --> page["Page JSON"]
+  data --> previewRefs["Preview artifact<br/>reference resolution"]
+  previewRefs --> manifest["Manifest JSON"]
+  page --> consumers["Browser / custom consumers"]
+  manifest --> consumers
+```
+
+`GraphApi.finishData` is the single traversal-aware semantic-to-public
+transition. It enriches the completed traversal model, then delegates to
+`GraphModel.finish`, the core materializer that canonicalizes dependencies,
+derives deduplicated edges while omitting dangling dependencies, derives group
+children while preserving title and declaration metadata, and generates DOT
+variants from the same topology.
+The `GraphData` constructor is private, so its public edges, children, and
+variants form one immutable materialized snapshot rather than another graph
+model. JSON decoding validates the same invariant before constructing it.
+
+Preview-reference resolution is deliberately downstream of topology
+finalization because the manifest/cache artifact index does not exist earlier.
+`GraphData.filterPreviewReferences` removes unavailable node preview keys and
+variant lookup entries together, without changing dependency fields, parents,
+edges, group children, or DOT. It accepts only a retention predicate, so this
+post-pass cannot rewrite preview identities. Thus topology still crosses one
+finalization boundary even though manifest emission later prunes preview
+candidates that did not produce both a manifest entry and a rendered cache
+body.
 
 ### Render Path Inventory
 
@@ -416,13 +456,13 @@ hydration.
 | Manifest/cache-backed block shell assembly | `Informal.PreviewManifest.BlockRender.renderWithRenderedContent` | Slides, grafts, and custom generated consumers | single manifest-backed assembly owner; callers only supply config and content |
 | Graft node lookup, diagnostics, and outer graft attrs | `Informal.Graft.renderNodeFromManifestCache` / `renderNodeWithContent` | Manual grafts, Slides grafts, external generated consumers | single graft owner |
 | Browser generated-data URLs and preview keys | `blueprint-preview-core.mjs` shared by the page runtime, `api/data.mjs`, and `api/preview.mjs` | browser runtime, ESM data/preview clients, custom generated pages | single ESM owner for generated-data URL construction and preview-key formatting; runtime stores and ESM helpers delegate to it instead of reimplementing the same string rules |
-| Browser graph JSON discovery and graph manifest loading | `blueprint-graph-core.mjs` shared by the page runtime and `api/graph.mjs` | graph command runtime, graph dashboards, custom browser clients | single ESM owner for graph-data normalization and graph JSON/script discovery; runtime code reaches it through the render API rather than compatibility globals |
+| Browser graph JSON discovery and graph manifest loading | `blueprint-graph-core.mjs` shared by the page runtime and `api/graph.mjs` | graph command runtime, graph dashboards, custom browser clients | single ESM owner for current-schema, top-level, and render-variant validation plus graph JSON/script discovery; Lean remains the semantic-topology owner, and runtime code reaches the shared reader through the render API rather than compatibility globals |
 | Browser manifest/cache loading and body-fragment insertion | `Commands/preview-runtime-data.mjs` factory-backed data/cache loading exposed through `api/data.mjs`, plus `Commands/preview-runtime-render.mjs` `resolvePreview` and `renderPreviewInto`, with `Commands/preview-runtime-surface.mjs` `resolvePreviewHtml` and `renderPreviewIntoSurface` adapting those helpers for bundled surfaces | graph, summary, relation panels, inline previews, custom browser clients | ESM data/cache and render owners; each data API instance owns its stores, delegates URL/key primitives to preview core and graph data to graph core, while the render chunk consumes the supplied data API and joins entries with rendered fragments |
 | Browser canonical generated-node insertion | `Commands/preview-runtime-render.mjs` `resolveCanonicalPreview` and `renderCanonicalPreviewInto` | standalone/custom browser clients that want regular Blueprint node visuals | single ESM canonical-preview owner; source-page loading accepts renderer-local `fetchText`, `loadDocument`, `canonicalBaseUrl`, and cache options |
 | Browser preview panel behavior | `Commands/preview-runtime-surface.mjs` `createPreviewSurface`, `hidePreviewSurfaces`, and panel helpers plus `Commands/preview-runtime-lifecycle.mjs` trigger/dismiss/reposition helpers | summary, code-summary, inline-preview, relation-panel, Slides, and graph feature scripts | single ESM behavior helper; feature scripts pass selectors/defaults through rendered descriptors or feature-specific callbacks instead of owning panel slots, trigger lifetimes, dismissal binding, or close-button wiring |
 | Browser preview-panel DOM creation and runtime diagnostic message markup | `Commands/preview-runtime-surface.mjs` `createPreviewPanel`, `createPreviewSurface`, and `previewMessageHtml` | inline preview panels, relation-panel runtime errors, and future bundled feature panels that need runtime-created chrome | single ESM panel/message/surface construction helper; feature scripts pass classes/slots/text |
 | Browser inline-preview panel behavior, child panel, footer, and nested hover behavior | `Commands/inline-preview.mjs` configured with explicit host policies plus `Commands/preview-runtime-surface.mjs` `createPreviewSurface` and lifecycle helpers | inline Lean links, bibliography links, single relation chips, nested previews | feature-owned preview lookup and nested-panel rules; graph/relation host behavior is data in the inline script, while panel slots, header/footer updates, close-button behavior, trigger lifetime, pointer checks, and resize/scroll binding use surfaces |
-| Browser graph preview, group-hover, popover, dismiss, and reposition behavior | `Commands/graph-runtime-core.mjs` for graph runtime utilities plus `Commands/graph.mjs` configured with runtime surfaces and popover helpers | graph command output, generated graph ESM render helpers, manifest-data graph rendering, and Slides graph refresh hooks | feature-owned graph state; normalization, canvas sizing, script loading, state slots, graph-block construction from public graph data, and graph-specific positioning are shared by the graph runtime, while graph rendering and UI event orchestration stay in the graph feature script and are surfaced to custom clients through `api/graph.mjs` rather than direct support-file imports |
+| Browser graph preview, group-hover, popover, dismiss, and reposition behavior | `Commands/graph-runtime-core.mjs` for graph runtime utilities plus `Commands/graph.mjs` configured with runtime surfaces and popover helpers | graph command output, generated graph ESM render helpers, manifest-data graph rendering, and Slides graph refresh hooks | feature-owned graph state; canvas sizing, script loading, state slots, graph-block construction from finalized public graph data, and graph-specific positioning are shared by the graph runtime, while graph rendering and UI event orchestration stay in the graph feature script and are surfaced to custom clients through `api/graph.mjs` rather than direct support-file imports |
 | Browser summary and code-summary preview binders | `Informal.HoverRender.templatePreviewDescriptorAttrs` emitted by Lean and auto-bound by `Commands/preview-runtime-template.mjs` | summary page labels and code-summary triggers in Manual pages, grafted nodes, and Slides | selector configuration is data on the rendered root; no per-feature JS binder owns this path |
 
 When adding node UI, use this checklist before introducing a renderer or

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -813,9 +813,10 @@ Group metadata may be used to organize the presentation, but grouping does not
 change dependency edges.
 
 Graph data is also available through documented Lean, manifest, and browser APIs.
-Lean callers can build semantic graph data before traversal or finalized graph
-records after traversal, while browser clients can read generated manifest graph
-records or data embedded in a rendered graph block. See
+Lean callers build a semantic `GraphModel` before traversal and cross one
+finalization boundary to obtain an immutable `GraphData` record after traversal,
+while browser clients can read generated manifest graph records or data embedded
+in a rendered graph block. See
 [`API.md#graph-data-apis`](./API.md#graph-data-apis) for the full graph API
 contract and examples.
 

--- a/scripts/check-js-api-types.mjs
+++ b/scripts/check-js-api-types.mjs
@@ -182,8 +182,8 @@ requireMatches(
 );
 
 const graphApiNames = [
+  "decodeGraphData",
   "graphsFromManifest",
-  "normalizeGraphData",
   ...publicApiContract.exports.graph.filter(
     (name) => !["dataUrl", "graphApiModuleUrl", "renderGraphBlock", "renderGraphs", "version"].includes(name)
   )
@@ -192,11 +192,11 @@ const graphInternalApiNames = [
   "ensureGraphRuntimeLibraries",
   "getGraphRenderApi",
   "graphCanvasFor",
+  "decodeGraphData",
   "graphsFromManifest",
   "initGraphBlock",
   "installGraphRenderApi",
   "loadJson",
-  "normalizeGraphData",
   "readGraphJsonScript"
 ];
 

--- a/src/VersoBlueprint/Commands/Graph.lean
+++ b/src/VersoBlueprint/Commands/Graph.lean
@@ -47,7 +47,7 @@ register_option verso.blueprint.graph.defaultPreviewPlacement : String := {
 }
 
 structure GraphBlockData where
-  semanticGraphData : Informal.Graph.GraphData := {}
+  graphModel : Informal.Graph.GraphModel
   options : GraphOptions := {}
   previewMode : Informal.HoverRender.PreviewMode := .pinned
   previewPlacement : Informal.HoverRender.PreviewPlacement := .docked
@@ -87,7 +87,7 @@ block_extension Block.graph (graphData : GraphBlockData) where
           (fun _ => "Malformed data in Block.graph.traverse") with
       | some graphData =>
         modify fun state =>
-          Informal.GraphApi.saveData state id graphData.semanticGraphData graphData.options
+          Informal.GraphApi.saveData state id graphData.graphModel graphData.options
       | Option.none =>
         pure ()
       return none
@@ -103,11 +103,11 @@ block_extension Block.graph (graphData : GraphBlockData) where
         match ← Informal.ExtensionDecode.decode? (α := GraphBlockData) data
             (fun err => s!"Malformed data in Block.graph.toHtml ({err})") with
         | some graphData => pure graphData
-        | Option.none => pure { semanticGraphData := {}, options := {} }
+        | Option.none => pure { graphModel := {}, options := {} }
       let s ← HtmlT.state
       let publicGraphData :=
-        Informal.GraphApi.finalDataForBlockWithOptions
-          s id graphData.semanticGraphData graphData.options
+        Informal.GraphApi.finishDataForBlock
+          s id graphData.graphModel graphData.options
       let publicGraphDataJson : String := Lean.Json.compress (toJson publicGraphData)
       let graphVariants := publicGraphData.variants
       let hasGroupVariant := graphVariants.any (fun variant => variant.key == groupVariantKey)
@@ -332,14 +332,14 @@ block_extension Block.graph (graphData : GraphBlockData) where
   extraCss := graphAssetBundle.css
   extraJs := graphAssetBundle.js
 
-def buildAll : CoreM Informal.Graph.GraphData := do
+def buildAll : CoreM Informal.Graph.GraphModel := do
   reportImportedConflicts
   let env ← getEnv
   let state := informalExt.getState env
   let roots : Array Name := state.data.toArray.map (·.1)
   let groupTitles := state.groups.toArray
-  let semanticGraphData := Informal.Graph.buildData state roots (groupTitles := groupTitles)
-  return semanticGraphData
+  let graphModel := Informal.Graph.buildModel state roots (groupTitles := groupTitles)
+  return graphModel
 
 open Verso.ArgParse
 
@@ -470,10 +470,10 @@ def mkGraphPart (stx : Syntax) (endPos : String.Pos.Raw) (options : GraphOptions
   let titleInlines ← `(inline | "Dependency Graph")
   let expandedTitle ← #[titleInlines].mapM (elabInline ·)
   let metadata : Option (TSyntax `term) := some (← `(term| { number := false }))
-  let semanticGraphData ← buildAll
+  let graphModel ← buildAll
   if verso.blueprint.debug.commands.get (← Lean.getOptions) then
-    logInfo m!"Adding {semanticGraphData.nodes.size} graph nodes"
-  let graphData : GraphBlockData := { semanticGraphData, options, previewMode, previewPlacement }
+    logInfo m!"Adding {graphModel.nodes.size} graph nodes"
+  let graphData : GraphBlockData := { graphModel, options, previewMode, previewPlacement }
   let block ← ``(Verso.Doc.Block.other (Informal.Commands.Block.graph $(quote graphData)) #[])
   let subParts := #[]
   pure <| FinishedPart.mk stx stx expandedTitle titlePreview metadata #[block] subParts endPos

--- a/src/VersoBlueprint/Commands/graph.mjs
+++ b/src/VersoBlueprint/Commands/graph.mjs
@@ -1,5 +1,8 @@
 import * as graphRuntimeCoreModule from "./graph-runtime-core.mjs";
-import { getGraphData as coreGetGraphData } from "../blueprint-graph-core.mjs";
+import {
+  getGraphData,
+  decodeGraphData
+} from "../blueprint-graph-core.mjs";
 
 const {
   debounce,
@@ -18,14 +21,6 @@ const {
   resetGraphvizForVariant,
   makeGroupPanelPositioner
 } = graphRuntimeCoreModule;
-
-function readPublicGraphData(root) {
-  return coreGetGraphData(root);
-}
-
-function readPublicGraphVariants(graphData) {
-  return graphData && Array.isArray(graphData.variants) ? graphData.variants : [];
-}
 
 function dotWithGraphAttribute(dot, name, value) {
   const source = String(dot || "");
@@ -57,20 +52,6 @@ function dotForVariantOptions(variant, options) {
 // then feeds the generated block into the same initializer used by page graphs.
 let runtimeGraphIdCounter = 0;
 
-function asArray(value) {
-  return Array.isArray(value) ? value : [];
-}
-
-function stringValue(value, fallback) {
-  if (typeof value === "string") return value;
-  if (typeof value === "number" || typeof value === "boolean") return String(value);
-  return typeof fallback === "string" ? fallback : "";
-}
-
-function graphName(value) {
-  return stringValue(value, "").trim();
-}
-
 function htmlIdKey(value) {
   let out = "";
   for (const char of String(value || "")) {
@@ -90,38 +71,13 @@ function prefixedHtmlId(prefix, value) {
   return body ? prefix + "-" + body : prefix;
 }
 
-function normalizePublicGraphData(rawData) {
-  if (!rawData || typeof rawData !== "object" || Array.isArray(rawData)) return null;
-  const data = rawData;
-  return {
-    schemaVersion: Number.isFinite(Number(data.schemaVersion)) ? Number(data.schemaVersion) : 1,
-    key: stringValue(data.key, "graph"),
-    nodes: asArray(data.nodes),
-    edges: asArray(data.edges),
-    groups: asArray(data.groups),
-    variants: asArray(data.variants)
-  };
-}
-
 function graphOptionsFromRenderOptions(options, variants) {
   const opts = options && typeof options === "object" ? options : {};
   const rawOptions =
     opts.graphOptions && typeof opts.graphOptions === "object"
       ? opts.graphOptions
-      : opts.options && typeof opts.options === "object"
-        ? opts.options
-        : variants[0] && variants[0].options && typeof variants[0].options === "object"
-          ? variants[0].options
-          : opts;
+      : variants[0] && variants[0].options;
   return normalizeGraphOptions(rawOptions);
-}
-
-function graphVariantsFromRenderOptions(data, options) {
-  const opts = options && typeof options === "object" ? options : {};
-  const rawVariants = asArray(opts.variants).length > 0 ? asArray(opts.variants) : asArray(data && data.variants);
-  return rawVariants.filter(function (variant) {
-    return variant && typeof variant === "object" && graphName(variant.key) && stringValue(variant.dot, "").trim();
-  });
 }
 
 function createEl(doc, tagName, attrs, text) {
@@ -183,11 +139,10 @@ function graphControlId(data, suffix) {
 
 export function createGraphBlock(graphData, options) {
   const opts = options && typeof options === "object" ? options : {};
-  const data = normalizePublicGraphData(graphData);
+  const data = decodeGraphData(graphData);
   if (!data) return null;
   const doc = opts.document && typeof opts.document.createElement === "function" ? opts.document : document;
-  const variants = graphVariantsFromRenderOptions(data, opts);
-  if (variants.length === 0) return null;
+  const variants = data.variants;
   const graphOptions = graphOptionsFromRenderOptions(opts, variants);
   const block = createEl(doc, "div", { class: "bp_graph_fullwidth", "data-bp-graph-source": "runtime" });
   if (opts.layout) block.setAttribute("data-bp-graph-layout", graphLayoutMode(block, opts));
@@ -639,7 +594,7 @@ export function initGraphBlock(previewUtils, graphBlock, options) {
               : null
           );
       if (existingController) return existingController;
-      const graphApiData = readPublicGraphData(graphBlock);
+      const graphApiData = getGraphData(graphBlock);
       if (graphApiData) {
         graphState.graphData = graphApiData;
         graphBlock.__bpGraphData = graphApiData;
@@ -708,35 +663,21 @@ export function initGraphBlock(previewUtils, graphBlock, options) {
         { keepOpen: true }
       );
 
-      const rawVariants = readPublicGraphVariants(graphApiData);
-      if (!Array.isArray(rawVariants) || rawVariants.length === 0) return;
-      const variantsByKey = new Map();
-      rawVariants.forEach(function (variant) {
-        if (!variant || typeof variant !== "object") return;
-        const key = String(variant.key || "").trim();
-        const label = String(variant.label || key).trim();
-        const dot = String(variant.dot || "").trim();
-        const options = normalizeGraphOptions(
-          variant.options && typeof variant.options === "object"
-            ? variant.options
-            : { direction: variant.direction, pack: variant.pack }
-        );
-        const selectOnNodeId = Array.isArray(variant.selectOnNodeId) ? variant.selectOnNodeId : [];
-        const hoverOnNodeId = Array.isArray(variant.hoverOnNodeId) ? variant.hoverOnNodeId : [];
-        const previewKeyByNodeId = Array.isArray(variant.previewKeyByNodeId) ? variant.previewKeyByNodeId : [];
-        if (!key || !dot) return;
-        variantsByKey.set(key, {
-          key: key,
-          label: label || key,
-          dot: dot,
-          options: options,
-          selectOnNodeId: selectOnNodeId,
-          hoverOnNodeId: hoverOnNodeId,
-          previewKeyByNodeId: new Map(previewKeyByNodeId)
-        });
+      const rawVariants = graphApiData.variants;
+      const variants = rawVariants.map(function (variant) {
+        return {
+          key: variant.key,
+          label: variant.label,
+          dot: variant.dot,
+          options: normalizeGraphOptions(variant.options),
+          selectOnNodeId: variant.selectOnNodeId,
+          hoverOnNodeId: variant.hoverOnNodeId,
+          previewKeyByNodeId: new Map(variant.previewKeyByNodeId)
+        };
       });
-      const variants = Array.from(variantsByKey.values());
-      if (variants.length === 0) return;
+      const variantsByKey = new Map(variants.map(function (variant) {
+        return [variant.key, variant];
+      }));
       graphBlock.__bpGraphVariants = variants;
 
       if (selector && selector.options.length === 0) {

--- a/src/VersoBlueprint/Graph.lean
+++ b/src/VersoBlueprint/Graph.lean
@@ -194,7 +194,7 @@ structure GraphRenderVariant where
   hoverOnNodeId : Array (String × String) := #[]
   /-- Node ids that open manifest/cache-backed previews; nodes without such previews are omitted. -/
   previewKeyByNodeId : Array (String × String) := #[]
-deriving Inhabited, Repr, ToJson, FromJson, Quote
+deriving Inhabited, Repr, BEq, ToJson, FromJson, Quote
 
 /-- Direction order used by the bundled graph controls. -/
 def allGraphDirections : Array GraphDirection := #[.TB, .LR, .RL, .BT]
@@ -235,14 +235,21 @@ inductive EdgeAxis where
   | proof
 deriving Inhabited, Repr, DecidableEq, ToJson, FromJson, Quote
 
-/-- Public dependency edge data. Edges point from dependency source to dependent target. -/
+/-- Finalized public dependency edge data. Edges point from dependency source to dependent target. -/
 structure EdgeData where
   source : Name
   target : Name
   axes : Array EdgeAxis := #[]
 deriving Inhabited, Repr, DecidableEq, ToJson, FromJson, Quote
 
-/-- Public group/parent metadata for graph consumers. -/
+/-- Group metadata carried by a semantic graph model before membership is derived. -/
+structure GroupMetadata where
+  label : Name
+  title : String
+  declared : Bool := false
+deriving Inhabited, Repr, DecidableEq, ToJson, FromJson, Quote
+
+/-- Finalized public group metadata and its node-derived membership projection. -/
 structure GroupData where
   label : Name
   title : String
@@ -266,7 +273,9 @@ structure NodeData where
   href : Option String := none
   /-- Selected manifest/cache-backed preview key for this node, if available. -/
   previewKey : Option PreviewKey := none
+  /-- Authoritative statement-side dependency data for this graph node. -/
   statementUses : Array Data.UseRef := #[]
+  /-- Authoritative proof-side dependency data for this graph node. -/
   proofUses : Array Data.UseRef := #[]
   statementStatus : StatementStatus := .blocked
   proofStatus : ProofStatus := .none
@@ -279,13 +288,49 @@ def NodeData.actionableStage? (node : NodeData) : Option String := do
   let kind ← node.kind
   actionableStageForStatuses? kind node.statementStatus node.proofStatus
 
-/--
-Public graph data shared by Lean, generated manifests, and browser runtime code.
+/-- Canonicalize duplicate dependency refs on each dependency axis. -/
+private def NodeData.normalizeDependencies (node : NodeData) : NodeData :=
+  {
+    node with
+      statementUses := Data.UseRef.mergeByLabel #[] node.statementUses
+      proofUses := Data.UseRef.mergeByLabel #[] node.proofUses
+  }
 
-`schemaVersion` is bumped only for incompatible public-shape changes.
+/--
+Semantic graph input used before traversal finishes.
+
+Topology exists only in `nodes`: dependencies live in `statementUses` and
+`proofUses`, and membership lives in `parent`. Group records carry metadata but
+no child projection. Select, filter, or merge this model, then cross the single
+`finish` materialization boundary to obtain immutable public `GraphData`.
+Traversal-aware callers use `GraphApi.finishData`, which enriches the model and
+then delegates to `finish`.
+-/
+structure GraphModel where
+  nodes : Array NodeData := #[]
+  groupMetadata : Array GroupMetadata := #[]
+deriving Inhabited, Repr, ToJson, FromJson, Quote
+
+private def graphDataSchemaVersion : Nat := 3
+
+/--
+Finished graph data shared by Lean, generated manifests, and browser clients.
+
+The private constructor makes this a materialized final value rather than a
+second mutable graph model. `edges`, group `children`, and topology-dependent
+variant data are built together exactly once from a `GraphModel`. Public callers
+can inspect them or convert back to `GraphModel`, but cannot update topology
+while retaining stale projections. Preview keys may subsequently be filtered
+against the emitted manifest/cache pair by `filterPreviewReferences`; that
+synchronized post-pass does not reopen topology or change DOT.
+
+`schemaVersion` is bumped for incompatible public JSON shapes or semantic
+contracts.
 -/
 structure GraphData where
-  schemaVersion : Nat := 2
+  private mk ::
+  schemaVersion : Nat := graphDataSchemaVersion
+  /-- Stable key identifying this graph block. -/
   key : String := "graph"
   nodes : Array NodeData := #[]
   edges : Array EdgeData := #[]
@@ -295,41 +340,51 @@ structure GraphData where
 
   Manifest clients should use these variants instead of re-deriving DOT from
   graph topology in JavaScript. The semantic fields above are the current data
-  interface for dashboards and audits.
+  interface for dashboards and audits. The private `GraphData` constructor ties
+  these variants to the same finalized topology. The first variant is `full`;
+  variant keys are unique, and select/hover mappings target keys in this array.
   -/
   variants : Array GraphRenderVariant := #[]
-deriving Inhabited, Repr, ToJson, FromJson, Quote
+deriving Repr, ToJson
 
 /-- Traversal-time graph cache payload, before href/title finalization. -/
 structure CachedGraphData where
-  data : GraphData := {}
-  options : GraphOptions := {}
+  model : GraphModel
+  options : GraphOptions
 deriving Inhabited, Repr, ToJson, FromJson, Quote
 
-def NodeData.toGraphNode (node : NodeData) : GraphNode String := {
-  label := node.label
-  displayLabel? := some node.displayLabel
-  deps := node.statementUses.map (fun useRef => (useRef.label : Name))
-  proofDeps := node.proofUses.map (fun useRef => (useRef.label : Name))
-  parent? := node.parent
-  shape := node.visual.shape
-  style := node.visual.style
-  fillcolor := node.visual.fillcolor
-  color := node.visual.color
-  penwidth := node.visual.penwidth
-  fontcolor := node.visual.fontcolor
-  peripheries := node.visual.peripheries
-  gradientangle? := node.visual.gradientangle?
-  tooltip? := node.visual.tooltip?
-  ref? := node.href
+private def NodeData.toGraphNode (node : NodeData) : GraphNode String :=
+  {
+    label := node.label
+    displayLabel? := some node.displayLabel
+    deps := node.statementUses.map (fun useRef => (useRef.label : Name))
+    proofDeps := node.proofUses.map (fun useRef => (useRef.label : Name))
+    parent? := node.parent
+    shape := node.visual.shape
+    style := node.visual.style
+    fillcolor := node.visual.fillcolor
+    color := node.visual.color
+    penwidth := node.visual.penwidth
+    fontcolor := node.visual.fontcolor
+    peripheries := node.visual.peripheries
+    gradientangle? := node.visual.gradientangle?
+    tooltip? := node.visual.tooltip?
+    ref? := node.href
+  }
+
+/-- Build render topology exclusively from the authoritative node fields. -/
+private def GraphModel.toGraph (model : GraphModel) : Graph String :=
+  model.nodes.map NodeData.toGraphNode
+
+/-- Recover a semantic model when finalized graph nodes must be selected or merged again. -/
+def GraphData.toModel (data : GraphData) : GraphModel := {
+  nodes := data.nodes
+  groupMetadata := data.groups.map fun group => {
+    label := group.label
+    title := group.title
+    declared := group.declared
+  }
 }
-
-def GraphData.toGraph (data : GraphData) : Graph String :=
-  data.nodes.map NodeData.toGraphNode
-
-def GraphData.groupTitleMap (data : GraphData) : Lean.NameMap String :=
-  data.groups.foldl (init := ({} : Lean.NameMap String)) fun acc group =>
-    acc.insert group.label group.title
 
 structure LegendSwatch where
   background : String := "#ffffff"
@@ -895,7 +950,7 @@ private def edgeAxes (isStatement isProof : Bool) : Array EdgeAxis :=
   let axes := if isStatement then axes.push .statement else axes
   if isProof then axes.push .proof else axes
 
-def edgesForNode (node : GraphNode Ref) : Array EdgeData :=
+private def edgesForNode (node : GraphNode Ref) : Array EdgeData :=
   let stmtDeps := eraseDups node.deps
   let proofDeps := eraseDups node.proofDeps
   let deps := proofDeps.foldl (init := stmtDeps) fun deps dep =>
@@ -906,44 +961,146 @@ def edgesForNode (node : GraphNode Ref) : Array EdgeData :=
     axes := edgeAxes (stmtDeps.contains dep) (proofDeps.contains dep)
   }
 
-def edgesForGraph (graph : Graph Ref) : Array EdgeData :=
+/--
+Project the graph's semantic edges, combining duplicate dependencies and
+dropping dependencies whose source endpoint is not present in the graph.
+-/
+private def edgesForGraph (graph : Graph Ref) : Array EdgeData :=
   let known : NameSet := graph.foldl (init := {}) fun acc node => acc.insert node.label
-  graph.foldl (init := #[]) fun edges node =>
-    edges ++ (edgesForNode node).filter (fun edge => known.contains edge.source)
+  let (_, edges) := graph.foldl
+    (init := (({} : Std.HashMap (Name × Name) Nat), (#[] : Array EdgeData)))
+    fun (edgeIndex, edges) node =>
+      (edgesForNode node).foldl (init := (edgeIndex, edges)) fun (edgeIndex, edges) edge =>
+        if !known.contains edge.source then
+          (edgeIndex, edges)
+        else
+          let endpoints := (edge.source, edge.target)
+          match edgeIndex.get? endpoints with
+          | none => (edgeIndex.insert endpoints edges.size, edges.push edge)
+          | some index =>
+            let current := edges[index]!
+            let merged := {
+              current with
+                axes := edgeAxes
+                  (current.axes.contains .statement || edge.axes.contains .statement)
+                  (current.axes.contains .proof || edge.axes.contains .proof)
+            }
+            (edgeIndex, edges.set! index merged)
+  edges
 
-def graphParentChildren (graph : Graph Ref) : Lean.NameMap (Array Name) :=
+private def graphParentChildren (graph : Graph Ref) : Lean.NameMap (Array Name) :=
   graph.foldl (init := ({} : Lean.NameMap (Array Name))) fun acc node =>
     match node.parent? with
     | none => acc
     | some parent =>
       let children := acc.getD parent #[]
-      acc.insert parent (children.push node.label)
+      if children.contains node.label then acc else acc.insert parent (children.push node.label)
 
-def graphNodeParents (graph : Graph Ref) : Lean.NameMap Name :=
+private def graphNodeParents (graph : Graph Ref) : Lean.NameMap Name :=
   graph.foldl (init := ({} : Lean.NameMap Name)) fun acc node =>
     match node.parent? with
     | none => acc
     | some parent => acc.insert node.label parent
 
-private def groupTitleMap (groupTitles : Array (Name × String)) : Lean.NameMap String :=
-  groupTitles.foldl (init := ({} : Lean.NameMap String)) fun acc (group, title) =>
-    acc.insert group title
-
-def groupTitle (groupTitles : Lean.NameMap String) (parent : Name) : String :=
+private def groupTitle (groupTitles : Lean.NameMap String) (parent : Name) : String :=
   let title := (groupTitles.getD parent parent.toString).trimAscii.toString
   if title.isEmpty then parent.toString else title
 
-def groupDataForGraph (graph : Graph Ref) (groupTitles : Array (Name × String) := #[]) :
+private def groupMetadataFromTitles (groupTitles : Array (Name × String)) : Array GroupMetadata :=
+  groupTitles.map fun (label, title) => {
+    label
+    title
+    declared := true
+  }
+
+private def normalizeGroupMetadata (group : GroupMetadata) : GroupMetadata :=
+  let title := group.title.trimAscii.toString
+  {
+    group with
+      title := if title.isEmpty then group.label.toString else title
+  }
+
+/--
+Merge duplicate group metadata records without consulting their derived child
+arrays. The first declared record wins; a later declared record replaces an
+earlier undeclared fallback.
+-/
+private def groupMetadataMap (groups : Array GroupMetadata) : Lean.NameMap GroupMetadata :=
+  groups.foldl (init := ({} : Lean.NameMap GroupMetadata)) fun acc incoming =>
+    let incoming := normalizeGroupMetadata incoming
+    match acc.get? incoming.label with
+    | none => acc.insert incoming.label incoming
+    | some current =>
+      let preferred := if !current.declared && incoming.declared then incoming else current
+      acc.insert incoming.label {
+        preferred with
+          declared := current.declared || incoming.declared
+      }
+
+private def canonicalNodes (nodes : Array NodeData) : Array NodeData :=
+  let (_, nodes) := nodes.foldl
+    (init := (({} : Lean.NameSet), (#[] : Array NodeData))) fun (seen, nodes) node =>
+      if seen.contains node.label then
+        (seen, nodes)
+      else
+        (seen.insert node.label, nodes.push node.normalizeDependencies)
+  nodes
+
+/--
+Canonicalize only the authoritative semantic model before caching or finishing.
+
+The first node for a label is retained, dependency refs are deduplicated, and
+group metadata is merged by label. No edge, child, or render projection exists
+at this stage.
+-/
+def GraphModel.canonicalize (model : GraphModel) : GraphModel := {
+  nodes := canonicalNodes model.nodes
+  groupMetadata := (groupMetadataMap model.groupMetadata).toArray.map (·.2)
+}
+
+/--
+Merge two semantic graph models, selecting the preferred model's complete node
+record whenever both models contain the same label.
+
+Dependencies and parent membership are deliberately not merged field by field:
+they are topology owned by the selected node. Group metadata is combined by
+label, preferring declared metadata over an undeclared fallback, and every
+derived projection is left to the later `finish` boundary.
+-/
+def GraphModel.mergePreferLeft (preferred fallback : GraphModel) : GraphModel :=
+  ({
+    nodes := preferred.nodes ++ fallback.nodes
+    groupMetadata := preferred.groupMetadata ++ fallback.groupMetadata
+  } : GraphModel).canonicalize
+
+private def GraphModel.groupTitleMap (model : GraphModel) : Lean.NameMap String :=
+  (groupMetadataMap model.groupMetadata).foldl (init := ({} : Lean.NameMap String))
+    fun acc label metadata => acc.insert label metadata.title
+
+/--
+Derive group membership from node parents while retaining group title and
+declaration metadata. Metadata for groups with no selected children is omitted.
+-/
+private def groupDataForGraphFromMetadata (graph : Graph Ref) (groups : Array GroupMetadata) :
     Array GroupData :=
-  let titleMap := groupTitleMap groupTitles
+  let metadata := groupMetadataMap groups
   graphParentChildren graph |>.toArray
-    |>.map (fun (parent, children) => {
-      label := parent
-      title := groupTitle titleMap parent
-      declared := titleMap.contains parent
-      children
-    })
-    |>.qsort (fun a b => a.title < b.title)
+    |>.map (fun (parent, children) =>
+      match metadata.get? parent with
+      | some group => {
+          label := group.label
+          title := group.title
+          declared := group.declared
+          children
+        }
+      | none => {
+          label := parent
+          title := parent.toString
+          declared := false
+          children
+        })
+    |>.qsort fun a b =>
+      a.title < b.title || (a.title == b.title && a.label.toString < b.label.toString)
 
 private def nodeTitle (resolveTitle? : Name → Option String) (label : Name) : String :=
   match resolveTitle? label with
@@ -996,27 +1153,26 @@ def nodeDataWithExternal
       visual := NodeVisual.ofGraphNode graphNode
     }
 
-def buildDataWithExternal
+def buildModelWithExternal
     (state : Environment.State)
     (roots : Array Name)
     (external : ExternalCodeStatus)
     (resolveHref? : Name → Option String := fun _ => none)
     (resolveTitle? : Name → Option String := fun _ => none)
-    (groupTitles : Array (Name × String) := #[]) : GraphData :=
+    (groupTitles : Array (Name × String) := #[]) : GraphModel :=
   let graph := buildWithExternal state roots external resolveHref?
   {
     nodes := graph.map (nodeDataWithExternal external state resolveHref? resolveTitle?)
-    edges := edgesForGraph graph
-    groups := groupDataForGraph graph groupTitles
+    groupMetadata := groupMetadataFromTitles groupTitles
   }
 
-def buildData
+def buildModel
     (state : Environment.State)
     (roots : Array Name)
     (resolveHref? : Name → Option String := fun _ => none)
     (resolveTitle? : Name → Option String := fun _ => none)
-    (groupTitles : Array (Name × String) := #[]) : GraphData :=
-  buildDataWithExternal state roots {} resolveHref? resolveTitle? groupTitles
+    (groupTitles : Array (Name × String) := #[]) : GraphModel :=
+  buildModelWithExternal state roots {} resolveHref? resolveTitle? groupTitles
 
 def escapeDotString (s : String) : String :=
   let s := s.replace "\\" "\\\\"
@@ -1235,10 +1391,11 @@ def graphToDot (g : Graph String) (options : GraphOptions := {})
   graphToDotWith g options {} resolveGroupTitle
     (some fun href => some s!"URL=\"{href}\", target=\"_self\"")
 
-/-- Render finalized graph data to DOT using its href and group-title fields. -/
-def GraphData.toDotWith (data : GraphData) (options : GraphOptions := {})
+/-- Render a semantic graph model directly, for pre-traversal clients such as widgets. -/
+def GraphModel.toDotWith (model : GraphModel) (options : GraphOptions := {})
     (style : GraphDotStyle := {}) : String :=
-  graphToDotWith data.toGraph options style (fun group => data.groupTitleMap.get? group)
+  let model := model.canonicalize
+  graphToDotWith model.toGraph options style (fun group => model.groupTitleMap.get? group)
     (some fun href => some s!"URL=\"{href}\", target=\"_self\"")
 
 /-- Stable key for the synthetic group overview variant. -/
@@ -1451,7 +1608,7 @@ Graphs without multi-child groups produce just the full graph variant. Grouped
 graphs additionally produce a synthetic group overview and one focused subgraph
 per parent group.
 -/
-def mkGraphVariants (graph : Graph String) (options : GraphOptions)
+private def mkGraphVariants (graph : Graph String) (options : GraphOptions)
     (groupTitles : Lean.NameMap String)
     (previewKeyForLabel : Name → Option PreviewKey := fun _ => none) :
     Array GraphRenderVariant :=
@@ -1511,12 +1668,91 @@ def mkGraphVariants (graph : Graph String) (options : GraphOptions)
       }
     #[fullVariant, groupVariant] ++ parentVariants
 
-/-- Build the bundled renderer's DOT variants from finalized public graph data. -/
-def GraphData.renderVariants (data : GraphData) (options : GraphOptions) : Array GraphRenderVariant :=
-  let previewKeyForLabel label :=
-    match data.nodes.find? (fun node => node.label == label) with
-    | some node => node.previewKey
-    | none => none
-  mkGraphVariants data.toGraph options data.groupTitleMap previewKeyForLabel
+/-- Finish a semantic model by materializing every public projection and render variant once. -/
+def GraphModel.finish (model : GraphModel) (key : String) (options : GraphOptions) : GraphData :=
+  let model := model.canonicalize
+  let graph := model.toGraph
+  let groups := groupDataForGraphFromMetadata graph model.groupMetadata
+  let groupTitles := groups.foldl (init := ({} : Lean.NameMap String)) fun acc group =>
+    acc.insert group.label group.title
+  let previewKeys := model.nodes.foldl (init := ({} : Lean.NameMap PreviewKey)) fun acc node =>
+    match node.previewKey with
+    | some key => acc.insert node.label key
+    | none => acc
+  {
+    schemaVersion := graphDataSchemaVersion
+    key
+    nodes := model.nodes
+    edges := edgesForGraph graph
+    groups
+    variants := mkGraphVariants graph options groupTitles previewKeys.get?
+  }
+
+/--
+Filter preview references without reopening finalized topology.
+
+This is the only supported post-finish update: unavailable node preview keys
+and their variant lookup entries are removed together, while topology and DOT
+remain unchanged. Preview keys cannot be rewritten after finalization.
+-/
+def GraphData.filterPreviewReferences
+    (data : GraphData)
+    (keep : PreviewKey → Bool) : GraphData :=
+  {
+    data with
+      nodes := data.nodes.map fun node => { node with previewKey := node.previewKey.filter keep }
+      variants := data.variants.map fun variant => {
+        variant with
+          previewKeyByNodeId := variant.previewKeyByNodeId.filterMap fun (nodeId, key) =>
+            (PreviewKey.ofString? key).filter keep |>.map fun key => (nodeId, toString key)
+      }
+  }
+
+private structure GraphDataJson where
+  schemaVersion : Nat
+  key : String
+  nodes : Array NodeData
+  edges : Array EdgeData
+  groups : Array GroupData
+  variants : Array GraphRenderVariant
+deriving FromJson
+
+/-- Decode only finalized graph records whose materialized projections agree. -/
+instance : FromJson GraphData where
+  fromJson? json := do
+    let decoded ← fromJson? (α := GraphDataJson) json
+    if decoded.schemaVersion != graphDataSchemaVersion then
+      throw s!"unsupported graph schema version {decoded.schemaVersion}; expected {graphDataSchemaVersion}"
+    let metadata : Array GroupMetadata := decoded.groups.map fun group => {
+      label := group.label
+      title := group.title
+      declared := group.declared
+    }
+    let model : GraphModel := { nodes := decoded.nodes, groupMetadata := metadata }
+    let canonical := model.canonicalize
+    if canonical.nodes.size != decoded.nodes.size then
+      throw "finalized graph contains duplicate node labels"
+    let dependenciesAreCanonical := decoded.nodes.all fun node =>
+      let normalized := node.normalizeDependencies
+      node.statementUses == normalized.statementUses && node.proofUses == normalized.proofUses
+    if !dependenciesAreCanonical then
+      throw "finalized graph contains duplicate dependency refs"
+    let some firstVariant := decoded.variants[0]?
+      | throw "finalized graph contains no render variants"
+    let expected := model.finish decoded.key firstVariant.options
+    if decoded.edges != expected.edges then
+      throw "finalized graph edges disagree with node dependencies"
+    if decoded.groups != expected.groups then
+      throw "finalized graph group children disagree with node parents"
+    if decoded.variants != expected.variants then
+      throw "finalized graph variants disagree with node topology or preview references"
+    pure {
+      schemaVersion := decoded.schemaVersion
+      key := decoded.key
+      nodes := decoded.nodes
+      edges := decoded.edges
+      groups := decoded.groups
+      variants := decoded.variants
+    }
 
 end Informal.Graph

--- a/src/VersoBlueprint/GraphApi.lean
+++ b/src/VersoBlueprint/GraphApi.lean
@@ -12,11 +12,10 @@ import VersoBlueprint.TraversalIndex
 /-!
 Public graph-data helpers.
 
-`Informal.Graph` owns the public graph data structures and the semantic
-environment builder. This module adds the traversal-state bridge: graph blocks
-store semantic `GraphData` plus render options during traversal, and
-renderers/manifests finalize that cached object against the completed traversal
-state to add hrefs, display titles, and Lean-computed graph render variants.
+`Informal.Graph` owns semantic `GraphModel`, immutable finished `GraphData`, and
+the environment builder. This module adds the traversal-state bridge: graph
+blocks cache only `GraphModel` plus render options, then page and manifest
+consumers call the same `finishData` operation after traversal completes.
 -/
 
 namespace Informal.GraphApi
@@ -28,11 +27,6 @@ open Verso.Genre Manual
 /-- Stable traversal-cache key for a rendered graph block. -/
 def cacheKey (id : Verso.Multi.InternalId) : String :=
   s!"graph:{id}"
-
-/-- Attach the rendered block key to graph data. -/
-def keyedData (id : Verso.Multi.InternalId) (data : Informal.Graph.GraphData) :
-    Informal.Graph.GraphData :=
-  { data with key := cacheKey id }
 
 private def nodeTitle? (state : TraverseState) (label : Name) : Option String :=
   (Informal.TraversalIndex.Nodes.data? state label).map fun data =>
@@ -53,8 +47,8 @@ private def enrichNode (state : TraverseState) (node : Informal.Graph.NodeData) 
   let previewKey := Informal.PreviewSource.traversalPreviewCandidateKey? state node.label
   { node with title, href, previewKey }
 
-private def enrichGroup (state : TraverseState) (group : Informal.Graph.GroupData) :
-    Informal.Graph.GroupData :=
+private def enrichGroup (state : TraverseState) (group : Informal.Graph.GroupMetadata) :
+    Informal.Graph.GroupMetadata :=
   match groupTitle? state group.label with
   | some title => { group with title, declared := true }
   | none => group
@@ -71,98 +65,51 @@ private def keepFinalNode (state : TraverseState) (node : Informal.Graph.NodeDat
     node.href.isSome ||
     hasPreviewCandidate node
 
-private def labelSet (nodes : Array Informal.Graph.NodeData) : Lean.NameSet :=
-  nodes.foldl (init := {}) fun acc node => acc.insert node.label
-
-private def keepEdge (labels : Lean.NameSet) (edge : Informal.Graph.EdgeData) : Bool :=
-  labels.contains edge.source && labels.contains edge.target
-
-private def filterGroupChildren? (labels : Lean.NameSet) (group : Informal.Graph.GroupData) :
-    Option Informal.Graph.GroupData :=
-  let children := group.children.filter (fun child => labels.contains child)
-  if children.isEmpty then
-    none
-  else
-    some { group with children }
-
-private def filterFinalData
-    (state : TraverseState) (data : Informal.Graph.GraphData) :
-    Informal.Graph.GraphData :=
-  let nodes := data.nodes.filter (keepFinalNode state)
-  let labels := labelSet nodes
+private def finalModel
+    (state : TraverseState) (model : Informal.Graph.GraphModel) :
+    Informal.Graph.GraphModel :=
   {
-    data with
-      nodes
-      edges := data.edges.filter (keepEdge labels)
-      groups := data.groups.filterMap (filterGroupChildren? labels)
+    nodes := model.nodes.map (enrichNode state) |>.filter (keepFinalNode state)
+    groupMetadata := model.groupMetadata.map (enrichGroup state)
   }
 
 /--
-Finalize graph data against a completed traversal state.
+Finish one graph after traversal.
 
-This is the single projection from semantic graph data to public graph data:
-rendered page JSON and manifest/cache output both use it so href, title, and
-group metadata stay consistent. The projection keeps nodes that are backed by
-the current traversal, nodes with an explicit href or traversal preview
-candidate, and unknown-ref diagnostics; imported or code-only semantic nodes
-with no rendered occurrence in the current site are omitted from the public
-graph.
+This is the single traversal-aware semantic-to-public transition. It enriches
+and selects nodes from completed traversal state, then delegates to
+`GraphModel.finish` to materialize edges, group membership, and render variants
+together. Page JSON and manifest output both call this function.
 -/
-def finalData (state : TraverseState) (data : Informal.Graph.GraphData) :
-    Informal.Graph.GraphData :=
-  filterFinalData state {
-    data with
-      nodes := data.nodes.map (enrichNode state)
-      groups := data.groups.map (enrichGroup state)
-  }
-
-/-- Finalize graph data and attach Lean-computed render variants. -/
-def finalDataWithVariants
+def finishData
     (state : TraverseState)
-    (data : Informal.Graph.GraphData)
+    (key : String)
+    (model : Informal.Graph.GraphModel)
     (options : Informal.Graph.GraphOptions) : Informal.Graph.GraphData :=
-  let data := finalData state data
-  { data with variants := data.renderVariants options }
+  (finalModel state model).finish key options
 
-/--
-Finalize a graph block's semantic graph data for public page JSON.
-
-Use this when rendering one graph block from its block payload and rendered
-block id.
--/
-def finalDataForBlock
+/-- Finish one rendered graph block using its stable traversal key. -/
+def finishDataForBlock
     (state : TraverseState)
     (id : Verso.Multi.InternalId)
-    (data : Informal.Graph.GraphData) : Informal.Graph.GraphData :=
-  finalData state (keyedData id data)
-
-/--
-Finalize a graph block's semantic graph data and attach render variants.
-
-This is the render-ready form used by generated graph pages and manifest
-clients that render graphs without scraping the graph page HTML.
--/
-def finalDataForBlockWithOptions
-    (state : TraverseState)
-    (id : Verso.Multi.InternalId)
-    (data : Informal.Graph.GraphData)
+    (model : Informal.Graph.GraphModel)
     (options : Informal.Graph.GraphOptions) : Informal.Graph.GraphData :=
-  finalDataWithVariants state (keyedData id data) options
+  finishData state (cacheKey id) model options
 
 /--
 Store graph block data during traversal.
 
-The cached payload deliberately remains semantic data plus the stable block key;
-call `cachedEntries` after traversal finishes to read the public, finalized form.
+The traversal entry stores only semantic data and render options under the
+stable block key; call `cachedEntries` after traversal finishes to read the
+public, finalized form.
 -/
 def saveData
     (state : TraverseState)
     (id : Verso.Multi.InternalId)
-    (data : Informal.Graph.GraphData)
+    (model : Informal.Graph.GraphModel)
     (options : Informal.Graph.GraphOptions) : TraverseState :=
   let key := cacheKey id
-  let data := keyedData id data
-  let cached : Informal.Graph.CachedGraphData := { data, options }
+  let cached : Informal.Graph.CachedGraphData := { model := model.canonicalize, options }
   state
     |> (fun state => Informal.TraversalIndex.Graphs.saveId state key id)
     |> (fun state => Informal.TraversalIndex.Graphs.saveData state key cached)
@@ -183,7 +130,7 @@ def cachedEntries (state : TraverseState) :
     | .ok stored =>
         .ok {
           canonicalName := stored.canonicalName
-          data := finalDataWithVariants state stored.data.data stored.data.options
+          data := finishData state stored.canonicalName stored.data.model stored.data.options
         }
 
 end Informal.GraphApi

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -1275,10 +1275,6 @@ private def PreviewArtifactIndex.previewKey?
     Option Informal.PreviewKey :=
   key?.filter fun key => index.resolves key.value
 
-private def PreviewArtifactIndex.previewKeyString?
-    (index : PreviewArtifactIndex) (key : String) : Option String :=
-  if index.resolves key then some key else none
-
 private def RelatedEntry.finalizePreviewReferences
     (index : PreviewArtifactIndex) (entry : RelatedEntry) : RelatedEntry :=
   { entry with previewKey := index.previewKey? entry.previewKey }
@@ -1296,28 +1292,10 @@ private def Entry.finalizePreviewReferences
       usedBy := entry.usedBy.map (RelatedEntry.finalizePreviewReferences index)
   }
 
-private def graphNodeFinalizePreviewReferences
-    (index : PreviewArtifactIndex) (node : Informal.Graph.NodeData) :
-    Informal.Graph.NodeData :=
-  { node with previewKey := index.previewKey? node.previewKey }
-
-private def graphVariantFinalizePreviewReferences
-    (index : PreviewArtifactIndex) (variant : Informal.Graph.GraphRenderVariant) :
-    Informal.Graph.GraphRenderVariant :=
-  {
-    variant with
-      previewKeyByNodeId := variant.previewKeyByNodeId.filterMap fun (nodeId, key) =>
-        (index.previewKeyString? key).map fun key => (nodeId, key)
-  }
-
 private def graphFinalizePreviewReferences
     (index : PreviewArtifactIndex) (graph : Informal.Graph.GraphData) :
     Informal.Graph.GraphData :=
-  {
-    graph with
-      nodes := graph.nodes.map (graphNodeFinalizePreviewReferences index)
-      variants := graph.variants.map (graphVariantFinalizePreviewReferences index)
-  }
+  graph.filterPreviewReferences fun key => index.resolves key.value
 
 /--
 Finalize traversal-derived preview references against the manifest/cache pair.

--- a/src/VersoBlueprint/TraversalIndex.lean
+++ b/src/VersoBlueprint/TraversalIndex.lean
@@ -325,7 +325,7 @@ def spec : StoreSpec := {
   name := Resolve.graphDomainName
   kind := .runtimeCache
   key := "graph block key"
-  value := "semantic GraphData, render options, and graph block anchor ids"
+  value := "semantic GraphModel, render options, and graph block anchor ids"
   summary := "Traversal-cached Blueprint graph data finalized by GraphApi for manifest and browser consumers."
 }
 

--- a/src/VersoBlueprint/Widget.lean
+++ b/src/VersoBlueprint/Widget.lean
@@ -282,11 +282,11 @@ def buildFor [Monad m] [MonadEnv m] [MonadError m] (label : Name) : m BuildResul
           |>.map (·.1.toString)
           |>.take 12
       throwError m!"No Label Found for '{label}'. Known labels (first {available.size}): {String.intercalate ", " available.toList}"
-  let graphData := Informal.Graph.buildData state #[label] (groupTitles := state.groups.toArray)
-  let dot := graphData.toDotWith { direction := .LR } Informal.Graph.GraphDotStyle.compact
+  let graphModel := Informal.Graph.buildModel state #[label] (groupTitles := state.groups.toArray)
+  let dot := graphModel.toDotWith { direction := .LR } Informal.Graph.GraphDotStyle.compact
   let previewSelection? := Informal.PreviewSource.environmentSelection? env label
   let includeMathlibLegend :=
-    graphData.nodes.any (fun node => node.visual.color == Informal.Graph.statementBorderMathlibColor)
+    graphModel.nodes.any (fun node => node.visual.color == Informal.Graph.statementBorderMathlibColor)
   let legend := toJson (Informal.Graph.graphLegendGroups includeMathlibLegend)
   pure { dot, previewSelection?, legend }
 

--- a/src/VersoBlueprint/blueprint-api-types.mjs
+++ b/src/VersoBlueprint/blueprint-api-types.mjs
@@ -318,6 +318,10 @@
 /**
  * Public graph dependency edge payload.
  *
+ * This is a derived projection of the target node's `statementUses` and
+ * `proofUses`. Duplicate dependencies are combined by source/target and
+ * dangling dependencies are omitted.
+ *
  * @typedef {Object} BlueprintGraphEdge
  * @property {string} source Dependency source label.
  * @property {string} target Dependent target label.
@@ -331,11 +335,12 @@
  * @property {string} label Canonical group label.
  * @property {string} title Resolved group title.
  * @property {boolean} declared Whether the group was explicitly declared.
- * @property {string[]} children Child node labels.
+ * @property {string[]} children Child node labels derived from node `parent` fields.
  */
 
 /**
- * Two-item graph-renderer mapping emitted as `[svgNodeId, value]`.
+ * Graph-renderer mapping emitted as exactly two elements:
+ * `[svgNodeId, value]`. The runtime decoder enforces the tuple length.
  *
  * @typedef {Array.<string>} BlueprintGraphNodeIdPair
  */
@@ -343,8 +348,11 @@
 /**
  * Public graph node payload.
  *
- * `previewKey` is the finalized manifest/cache-backed preview key for this
- * label. It is `null` when the retained graph node has no generated preview.
+ * In manifest-loaded graph records, `previewKey` is the finalized
+ * manifest/cache-backed preview key for this label. Embedded page records are
+ * emitted earlier and may carry a traversal candidate that the runtime still
+ * resolves through the manifest/cache pair. It is `null` when no key is
+ * advertised by that record.
  *
  * @typedef {Object} BlueprintGraphNode
  * @property {string} label Canonical Blueprint node label.
@@ -353,7 +361,7 @@
  * @property {string | null} kind Node kind, when available.
  * @property {string | null} parent Parent/group label, when available.
  * @property {string | null} href Link to the canonical generated node, when available.
- * @property {string | null} previewKey Finalized manifest/cache-backed preview key, when available.
+ * @property {string | null} previewKey Preview key advertised by this graph record, when available.
  * @property {BlueprintUseRef[]} statementUses Structured statement dependency refs.
  * @property {BlueprintUseRef[]} proofUses Structured proof dependency refs.
  * @property {string} statementStatus Statement-track status.
@@ -365,13 +373,17 @@
 /**
  * Graph data exported by the Blueprint manifest or embedded in a graph page.
  *
+ * Node `statementUses`, `proofUses`, and `parent` fields are authoritative.
+ * Lean materializes `edges`, group `children`, and render `variants` together
+ * from that topology at the graph finalization boundary.
+ *
  * @typedef {Object} BlueprintGraphData
- * @property {number} schemaVersion Graph payload schema version; version 2 uses string-or-null node preview keys.
- * @property {string} key Variant key.
+ * @property {3} schemaVersion Current finalized graph payload schema version.
+ * @property {string} key Stable graph/block key.
  * @property {BlueprintGraphNode[]} nodes Graph node payloads.
- * @property {BlueprintGraphEdge[]} edges Graph edge payloads.
- * @property {BlueprintGraphGroup[]} groups Graph grouping payloads.
- * @property {BlueprintGraphVariant[]} [variants] Precomputed DOT variants for the bundled graph renderer.
+ * @property {BlueprintGraphEdge[]} edges Derived, deduplicated graph edge payloads with dangling sources omitted.
+ * @property {BlueprintGraphGroup[]} groups Group metadata with membership derived from node parents.
+ * @property {BlueprintGraphVariant[]} variants Precomputed DOT variants for the bundled graph renderer. The first variant is `full`; keys are unique, and select/hover mappings target keys in this array.
  */
 
 /**
@@ -381,10 +393,10 @@
  * @property {string} key Variant key.
  * @property {string} label Human-readable variant label.
  * @property {string} dot DOT source.
- * @property {Record<string, unknown>} [options] Rendering options emitted with the variant.
+ * @property {BlueprintGraphLayoutOptions} options Rendering options emitted with the variant.
  * @property {BlueprintGraphNodeIdPair[]} selectOnNodeId Two-item `[svgNodeId, variantKey]` pairs selected when the variant is active.
  * @property {BlueprintGraphNodeIdPair[]} hoverOnNodeId Two-item `[svgNodeId, variantKey]` pairs highlighted on hover.
- * @property {BlueprintGraphNodeIdPair[]} previewKeyByNodeId Two-item `[svgNodeId, previewKey]` pairs; nodes without manifest/cache-backed previews are omitted.
+ * @property {BlueprintGraphNodeIdPair[]} previewKeyByNodeId Two-item `[svgNodeId, previewKey]` pairs; manifest records omit nodes without artifact-backed previews.
  */
 
 /**
@@ -399,11 +411,9 @@
  * Options accepted by graph rendering helpers in `api/graph.mjs`.
  *
  * @typedef {Object} BlueprintGraphRenderOptions
- * @property {Record<string, unknown>} previewUtils Render-capable Blueprint preview API required by public `api/graph.mjs` render helpers.
+ * @property {Record<string, unknown>} [previewUtils] Render-capable Blueprint preview API required by rendering operations; `createGraphBlock` does not use it.
  * @property {"page" | "block" | "fill" | string} [layout] Graph sizing mode.
  * @property {BlueprintGraphLayoutOptions} [graphOptions] Initial graph-control values for graph data rendered from manifest records.
- * @property {BlueprintGraphVariant[]} [variants] Optional precomputed DOT variants overriding `graphData.variants`;
- * required when rendering graph records that do not already carry Lean-emitted variants.
  * @property {"pinned" | "hover" | string} [previewMode] Initial graph node preview behavior for graph data rendered from manifest records.
  * @property {"docked" | "anchored" | string} [previewPlacement] Initial graph node preview placement for graph data rendered from manifest records.
  * @property {boolean} [replace] In `renderGraphData`, replace host children by default; set to `false` to append.

--- a/src/VersoBlueprint/blueprint-graph-api.mjs
+++ b/src/VersoBlueprint/blueprint-graph-api.mjs
@@ -15,8 +15,8 @@ import {
  * Data-only calls do not load the interactive graph renderer; render helpers
  * lazy-load it when called.
  *
- * Use the data helpers when a dashboard needs finalized graph records from the
- * manifest or graph JSON embedded beside a rendered graph block. Use
+ * Use the data helpers when a dashboard needs topology-finalized graph records
+ * from the manifest or graph JSON embedded beside a rendered graph block. Use
  * {@link renderGraphData} to create the standard graph UI from a finalized
  * manifest graph record, or {@link renderGraphs} / {@link renderGraphBlock}
  * when the page already contains generated graph-block markup. Rendering graph
@@ -29,7 +29,7 @@ import {
 
 /** @import { BlueprintDataApiOptions, BlueprintGraphController, BlueprintGraphData, BlueprintGraphRenderOptions, BlueprintGraphVariant } from "./blueprint-api-types.mjs" */
 
-/** Graph API schema/runtime version. */
+/** Browser graph API module version; distinct from `BlueprintGraphData.schemaVersion`. */
 export const version = coreVersion;
 const moduleUrl = import.meta.url;
 
@@ -55,7 +55,8 @@ export const graphApiModuleUrl = (baseUrl = moduleUrl) => coreGraphApiModuleUrl(
  *
  * This is for pages that already contain generated graph-block markup. Use
  * {@link loadGraphs} when the current document does not contain the graph you
- * want to inspect.
+ * want to inspect. Payloads that are missing or fail the current schema,
+ * top-level collection, or render-variant checks return `null`.
  *
  * @param {ParentNode | Element | Document | DocumentFragment} [root] Search root.
  * @returns {BlueprintGraphData | null}
@@ -76,7 +77,8 @@ export function getGraphVariants(root) {
 }
 
 /**
- * Load finalized graph records from a manifest URL.
+ * Load finalized graph records from a manifest URL. Records that fail the
+ * current schema, top-level collection, or render-variant checks are omitted.
  *
  * @param {string} [url] Manifest URL. Defaults to this module's generated-data manifest.
  * @param {BlueprintDataApiOptions} [options] Optional per-call load overrides.
@@ -92,6 +94,8 @@ export const loadManifestGraphs = (url, options) => {
 
 /**
  * Load finalized graph records from this generated site's default manifest.
+ * Records that fail the current schema, top-level collection, or render-variant
+ * checks are omitted.
  *
  * This is the simplest graph-data entry point for dashboards and audits that
  * need graph records but do not need to render graph blocks.
@@ -220,8 +224,8 @@ export async function renderGraphs(root, options) {
  * {@link loadGraphs} and wants to insert the same graph block shape used by
  * generated pages. The returned element is not rendered until it is inserted
  * and passed to {@link renderGraphBlock}, or until {@link renderGraphData} is
- * used. Returns `null` when the graph record does not contain precomputed
- * render variants and no `options.variants` override is supplied.
+ * used. Returns `null` when the graph record does not contain valid
+ * precomputed render variants.
  *
  * @param {BlueprintGraphData} graphData Finalized graph record.
  * @param {BlueprintGraphRenderOptions} [options] Graph render options.
@@ -240,8 +244,7 @@ export async function createGraphBlock(graphData, options) {
  * `host`, lazy-loads the graph renderer, and returns the same controller as
  * {@link renderGraphBlock}. Pass `replace: false` to append instead of replacing
  * the host's existing children. Returns `null` without changing `host` when the
- * graph record does not contain precomputed render variants and no
- * `options.variants` override is supplied.
+ * graph record does not contain valid precomputed render variants.
  *
  * @param {Element} host Element that will contain the graph block.
  * @param {BlueprintGraphData} graphData Finalized graph record, typically from {@link loadGraphs}.

--- a/src/VersoBlueprint/blueprint-graph-core.mjs
+++ b/src/VersoBlueprint/blueprint-graph-core.mjs
@@ -145,27 +145,130 @@ export function readGraphJsonScript(root, selector) {
   }
 }
 
+const graphDataSchemaVersion = 3;
+
 /**
- * Normalize raw graph JSON into the current graph payload shape.
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+function isRecord(value) {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+function isNonemptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+function isTrimmedNonemptyString(value) {
+  return typeof value === "string" && value.length > 0 && value === value.trim();
+}
+
+/**
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+function isGraphNodeIdPair(value) {
+  return Array.isArray(value) && value.length === 2 && value.every(isTrimmedNonemptyString);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+function areGraphNodeIdPairsValid(value) {
+  if (!Array.isArray(value) || !value.every(isGraphNodeIdPair)) return false;
+  const nodeIds = value.map(function (pair) { return pair[0]; });
+  return new Set(nodeIds).size === nodeIds.length;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+function isGraphLayoutOptions(value) {
+  if (!isRecord(value)) return false;
+  const options = /** @type {Record<string, unknown>} */ (value);
+  return typeof options.direction === "string" &&
+    ["TB", "LR", "RL", "BT"].includes(options.direction) &&
+    typeof options.pack === "boolean";
+}
+
+/**
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+function isGraphVariant(value) {
+  if (!isRecord(value)) return false;
+  const variant = /** @type {Record<string, unknown>} */ (value);
+  return isTrimmedNonemptyString(variant.key) &&
+    isTrimmedNonemptyString(variant.label) &&
+    isNonemptyString(variant.dot) &&
+    isGraphLayoutOptions(variant.options) &&
+    areGraphNodeIdPairsValid(variant.selectOnNodeId) &&
+    areGraphNodeIdPairsValid(variant.hoverOnNodeId) &&
+    areGraphNodeIdPairsValid(variant.previewKeyByNodeId);
+}
+
+/**
+ * @param {unknown[]} variants
+ * @returns {boolean}
+ */
+function areGraphVariantsValid(variants) {
+  if (variants.length === 0 || !variants.every(isGraphVariant)) return false;
+  const records = variants.map(function (variant) {
+    return /** @type {Record<string, unknown>} */ (variant);
+  });
+  const keys = records.map(function (variant) { return variant.key; });
+  const keySet = new Set(keys);
+  if (records[0].key !== "full" || keySet.size !== keys.length) return false;
+  return records.every(function (variant) {
+    return [variant.selectOnNodeId, variant.hoverOnNodeId].every(function (pairs) {
+      return /** @type {unknown[][]} */ (pairs).every(function (pair) {
+        return keySet.has(pair[1]);
+      });
+    });
+  });
+}
+
+/**
+ * Recognize the current finalized graph payload shape.
+ *
+ * Topology is finalized by Lean before serialization. Browser clients consume
+ * that snapshot and do not carry a second implementation of graph finalization.
+ * This boundary validates the schema, top-level collections, and render-variant
+ * contract; it trusts Lean's producer boundary for semantic topology agreement.
  *
  * @param {unknown} rawData Parsed graph JSON.
  * @returns {BlueprintGraphData | null}
  */
-export function normalizeGraphData(rawData) {
-  if (!rawData || typeof rawData !== "object" || Array.isArray(rawData)) return null;
+export function decodeGraphData(rawData) {
+  if (!isRecord(rawData)) return null;
   const data = /** @type {Record<string, unknown>} */ (rawData);
+  if (data.schemaVersion !== graphDataSchemaVersion || !isTrimmedNonemptyString(data.key)) return null;
+  if (!Array.isArray(data.nodes) || !Array.isArray(data.edges) ||
+      !Array.isArray(data.groups) || !Array.isArray(data.variants)) return null;
+  if (!areGraphVariantsValid(data.variants)) return null;
   return {
-    schemaVersion: Number.isFinite(data.schemaVersion) ? Number(data.schemaVersion) : 1,
-    key: typeof data.key === "string" ? data.key : "graph",
-    nodes: Array.isArray(data.nodes) ? data.nodes : [],
-    edges: Array.isArray(data.edges) ? data.edges : [],
-    groups: Array.isArray(data.groups) ? data.groups : [],
-    variants: Array.isArray(data.variants) ? data.variants : []
+    schemaVersion: graphDataSchemaVersion,
+    key: /** @type {string} */ (data.key),
+    nodes: data.nodes,
+    edges: data.edges,
+    groups: data.groups,
+    variants: data.variants
   };
 }
 
 /**
- * Extract graph records from a parsed Blueprint manifest.
+ * Extract graph records that pass the current schema, top-level collection,
+ * and render-variant checks. Other records are omitted.
  *
  * @param {unknown} manifest Parsed manifest JSON.
  * @returns {BlueprintGraphData[]}
@@ -179,18 +282,20 @@ export function graphsFromManifest(manifest) {
     return [];
   }
   return data.graphs
-    .map(normalizeGraphData)
+    .map(decodeGraphData)
     .filter(function (graphData) { return !!graphData; });
 }
 
 /**
- * Read embedded graph data from a generated graph page.
+ * Read embedded graph data from a generated graph page, returning `null` when
+ * the payload is missing or fails the current schema, top-level collection, or
+ * render-variant checks.
  *
  * @param {ParentNode | Element | Document | DocumentFragment | null} [root] Search root. Defaults to `document`.
  * @returns {BlueprintGraphData | null}
  */
 export function getGraphData(root) {
-  return normalizeGraphData(readGraphJsonScript(root || currentDocument(), "script.bp-graph-data"));
+  return decodeGraphData(readGraphJsonScript(root || currentDocument(), "script.bp-graph-data"));
 }
 
 /**
@@ -202,10 +307,7 @@ export function getGraphData(root) {
  */
 export function getGraphVariants(root) {
   const data = getGraphData(root || currentDocument());
-  if (data && Array.isArray(data.variants) && data.variants.length > 0) {
-    return /** @type {BlueprintGraphVariant[]} */ (data.variants);
-  }
-  return [];
+  return data ? data.variants : [];
 }
 
 /**
@@ -241,7 +343,8 @@ export function loadJson(url, options, errorPrefix) {
 }
 
 /**
- * Load graph records from a manifest URL.
+ * Load graph records that pass the current schema, top-level collection, and
+ * render-variant checks from a manifest URL. Other records are omitted.
  *
  * @param {string} [url] Manifest URL. Defaults to `blueprint-manifest.json`.
  * @param {BlueprintDataApiOptions} [options] Optional loader options.
@@ -258,7 +361,8 @@ export function loadManifestGraphs(url, options) {
 }
 
 /**
- * Load graph records from the default generated manifest URL.
+ * Load graph records that pass the current schema, top-level collection, and
+ * render-variant checks from the default manifest. Other records are omitted.
  *
  * @param {BlueprintDataApiOptions} [options] Optional loader options.
  * @returns {Promise<BlueprintGraphData[]>}
@@ -273,7 +377,7 @@ export const graphCore = {
   graphApiModuleUrl,
   graphCanvasFor,
   readGraphJsonScript,
-  normalizeGraphData,
+  decodeGraphData,
   graphsFromManifest,
   getGraphData,
   getGraphVariants,

--- a/tests/VersoBlueprintTests/BlueprintGraph.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraph.lean
@@ -8,3 +8,4 @@ import VersoBlueprintTests.BlueprintGraph.Basics
 import VersoBlueprintTests.BlueprintGraph.Groups
 import VersoBlueprintTests.BlueprintGraph.Legend
 import VersoBlueprintTests.BlueprintGraph.NodeStatus
+import VersoBlueprintTests.BlueprintGraph.Topology

--- a/tests/VersoBlueprintTests/BlueprintGraph/Groups.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraph/Groups.lean
@@ -67,18 +67,30 @@ def groupedGraphTitleMap : Lean.NameMap String :=
 def groupedOverview : Informal.Graph.Graph String :=
   Informal.Graph.mkParentOverviewGraph groupedGraphInput #[`group_alpha, `group_beta] groupedGraphTitleMap
 
-def groupedGraphData : Informal.Graph.GraphData :=
-  {
-    nodes := #[]
-    edges := Informal.Graph.edgesForGraph groupedGraphInput
-    groups := Informal.Graph.groupDataForGraph groupedGraphInput groupedGraphTitles
+def groupedNodeData (node : Informal.Graph.GraphNode String) : Informal.Graph.NodeData := {
+  label := node.label
+  title := node.displayLabel
+  displayLabel := node.displayLabel
+  parent := node.parent?
+  statementUses := node.deps.map fun label => { label }
+  proofUses := node.proofDeps.map fun label => { label }
+  visual := Informal.Graph.NodeVisual.ofGraphNode node
+}
+
+def groupedGraphModel : Informal.Graph.GraphModel := {
+    nodes := groupedGraphInput.map groupedNodeData
+    groupMetadata := groupedGraphTitles.map fun (label, title) => {
+      label
+      title
+      declared := true
+    }
   }
 
+def groupedGraphData : Informal.Graph.GraphData :=
+  groupedGraphModel.finish "grouped-test" { direction := .TB, pack := true }
+
 def groupedVariants : Array Informal.Graph.GraphRenderVariant :=
-  Informal.Graph.mkGraphVariants
-    groupedGraphInput
-    { direction := .TB, pack := true }
-    groupedGraphTitleMap
+  groupedGraphData.variants
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/VersoBlueprintTests/BlueprintGraph/NodeStatus.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraph/NodeStatus.lean
@@ -60,14 +60,15 @@ def graphStatus : Graph Unit :=
   build stateStatus #[`def_formal, `def_ready, `def_blocked, `thm_ready, `lean_only, `local_sorry, `thm_type_sorry]
 
 def graphDataStatus : GraphData :=
-  buildData stateStatus
-    #[`def_formal, `def_ready, `def_blocked, `thm_ready, `lean_only, `local_sorry, `thm_type_sorry]
-    (resolveHref? := fun
-      | `def_formal => some "#def-formal"
-      | _ => none)
-    (resolveTitle? := fun
-      | `def_formal => some "Definition 1"
-      | _ => none)
+  buildModel stateStatus
+      #[`def_formal, `def_ready, `def_blocked, `thm_ready, `lean_only, `local_sorry, `thm_type_sorry]
+      (resolveHref? := fun
+        | `def_formal => some "#def-formal"
+        | _ => none)
+      (resolveTitle? := fun
+        | `def_formal => some "Definition 1"
+        | _ => none)
+    |>.finish "node-status" {}
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/VersoBlueprintTests/BlueprintGraph/Topology.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraph/Topology.lean
@@ -1,0 +1,356 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoBlueprintTests.BlueprintGraph.Shared
+
+namespace Verso.VersoBlueprintTests.BlueprintGraph.Topology
+
+open Lean
+open Informal
+open Informal.Data
+open Informal.Graph
+
+private def topologyUse (label : Name) (origin : UseOrigin := UseOrigin.manual) : UseRef := {
+  label
+  origin
+}
+
+private def topologyNode
+    (label : Name)
+    (statementUses : Array UseRef := #[])
+    (proofUses : Array UseRef := #[])
+    (parent : Option Name := none) : NodeData := {
+  label
+  title := label.toString
+  displayLabel := label.toString
+  parent
+  statementUses
+  proofUses
+  visual := { fillcolor := "#ffffff" }
+}
+
+/- A wire edge cannot introduce a dependency absent from its target node. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  let finalized :=
+    ({ nodes := #[topologyNode `edge_source, topologyNode `edge_target] } : GraphModel)
+      |>.finish "inconsistent-edge" {}
+  let inconsistent := (toJson finalized).setObjVal! "edges" (toJson #[({
+    source := `edge_source
+    target := `edge_target
+    axes := #[EdgeAxis.statement]
+  } : EdgeData)])
+  match fromJson? (α := GraphData) inconsistent with
+  | .error _ => true
+  | .ok _ => false
+
+/- Repeated live/disk-equivalent refs collapse to one semantic mixed-axis edge. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  let live : GraphModel := {
+    nodes := #[
+      topologyNode `duplicate_source,
+      topologyNode `duplicate_target
+        #[topologyUse `duplicate_source UseOrigin.automatic,
+          topologyUse `duplicate_source UseOrigin.manual]
+        #[topologyUse `duplicate_source, topologyUse `duplicate_source]
+    ]
+  }
+  let disk : GraphModel := {
+    nodes := #[
+      topologyNode `duplicate_source,
+      topologyNode `duplicate_target
+        #[topologyUse `duplicate_source]
+        #[topologyUse `duplicate_source]
+    ]
+  }
+  let finalized := live.mergePreferLeft disk |>.finish "duplicate-edge" {}
+  match finalized.nodes.find? (·.label == `duplicate_target), finalized.edges[0]? with
+  | some target, some edge =>
+      target.statementUses.size == 1 &&
+        target.statementUses[0]!.origin == UseOrigin.manual &&
+        target.proofUses.size == 1 &&
+        finalized.edges.size == 1 &&
+        edge.source == `duplicate_source &&
+        edge.target == `duplicate_target &&
+        edge.axes == #[EdgeAxis.statement, EdgeAxis.proof]
+  | _, _ => false
+
+/- Dangling dependencies remain node metadata but do not become graph edges. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  let model : GraphModel := {
+    nodes := #[topologyNode `dangling_target #[topologyUse `missing_source]]
+  }
+  let finalized := model.finish "dangling-edge" {}
+  finalized.edges.isEmpty &&
+    match finalized.nodes[0]? with
+    | some target => target.statementUses.map (·.label) == #[`missing_source]
+    | none => false
+
+private def diskGroupModel : GraphModel := {
+  nodes := #[
+    topologyNode `moved_node (parent := some `disk_group),
+    topologyNode `live_group_peer (parent := some `live_group)
+  ]
+  groupMetadata := #[
+    {
+      label := `disk_group
+      title := "Disk-recorded group"
+      declared := true
+    },
+    {
+      label := `live_group
+      title := "Live selected group"
+      declared := true
+    }
+  ]
+}
+
+/- A preferred live node replaces its disk copy as one unit, including parent. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  let disk := diskGroupModel.finish "disk" {}
+  let live : GraphModel := {
+    nodes := #[topologyNode `moved_node (parent := some `live_group)]
+  }
+  let merged := live.mergePreferLeft disk.toModel |>.finish "merged" {}
+  match
+      merged.groups.find? (·.label == `disk_group),
+      merged.groups.find? (·.label == `live_group) with
+  | none, some group =>
+      group.title == "Live selected group" &&
+        group.declared &&
+        group.children == #[`moved_node, `live_group_peer]
+  | _, _ => false
+
+private def nestedGroupModel : GraphModel := {
+  nodes := #[
+    topologyNode `inner_group (parent := some `outer_group),
+    topologyNode `outer_peer (parent := some `outer_group),
+    topologyNode `inner_leaf_a #[topologyUse `outer_peer] (parent := some `inner_group),
+    topologyNode `inner_leaf_b (parent := some `inner_group)
+  ]
+  groupMetadata := #[
+    {
+      label := `outer_group
+      title := "Outer group title"
+      declared := true
+    },
+    {
+      label := `inner_group
+      title := "Inner group title"
+      declared := true
+    }
+  ]
+}
+
+/- Nested group membership is derived at both parent levels and still renders. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  let finalized := nestedGroupModel.finish "nested" {}
+  let dot := finalized.variants.find? (·.key == "full") |>.map (·.dot) |>.getD ""
+  match
+      finalized.groups.find? (·.label == `outer_group),
+      finalized.groups.find? (·.label == `inner_group) with
+  | some outer, some inner =>
+      outer.children == #[`inner_group, `outer_peer] &&
+        inner.children == #[`inner_leaf_a, `inner_leaf_b] &&
+        dot.contains "Outer group title" &&
+        dot.contains "Inner group title"
+  | _, _ => false
+
+/- Topology changes happen on GraphModel and finishing regenerates every variant. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  let original : GraphModel := {
+    nodes := #[
+      topologyNode `old_source,
+      topologyNode `new_source,
+      topologyNode `variant_target #[topologyUse `old_source]
+    ]
+  }
+  let rendered := original.finish "variants" {}
+  let changed : GraphModel := {
+    original with
+      nodes := original.nodes.map fun (node : NodeData) =>
+        if node.label == `variant_target then
+          { node with statementUses := #[topologyUse `new_source] }
+        else
+          node
+  }
+  let regenerated := changed.finish "variants" {}
+  rendered.variants.any (fun variant =>
+      variant.key == "full" &&
+        variant.dot.contains "\"old_source\" -> \"variant_target\"") &&
+    regenerated.variants.any (fun variant =>
+      variant.key == "full" &&
+        variant.dot.contains "\"new_source\" -> \"variant_target\"" &&
+        !variant.dot.contains "\"old_source\" -> \"variant_target\"")
+
+/- A stale serialized variant cannot cross the public GraphData decode boundary. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  let original : GraphModel := {
+    nodes := #[
+      topologyNode `old_source,
+      topologyNode `new_source,
+      topologyNode `variant_target #[topologyUse `old_source]
+    ]
+  }
+  let changed : GraphModel := {
+    nodes := #[
+      topologyNode `old_source,
+      topologyNode `new_source,
+      topologyNode `variant_target #[topologyUse `new_source]
+    ]
+  }
+  let oldFinished := original.finish "variants" {}
+  let changedFinished := changed.finish "variants" {}
+  let stale := (toJson changedFinished).setObjVal! "variants" (toJson oldFinished.variants)
+  match fromJson? (α := GraphData) stale with
+  | .error _ => true
+  | .ok _ => false
+
+/- Preview filtering cannot reopen or rewrite finalized topology. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  let retainedKey := "informal:retained_preview:statement"
+  let removedKey := "informal:removed_preview:statement"
+  let model : GraphModel := {
+    nodes := #[
+      {
+        topologyNode `preview_source with
+          previewKey := PreviewKey.ofString? retainedKey
+      },
+      {
+        topologyNode `preview_target #[topologyUse `preview_source]
+            (parent := some `preview_group) with
+          previewKey := PreviewKey.ofString? removedKey
+      }
+    ]
+    groupMetadata := #[{
+      label := `preview_group
+      title := "Preview group"
+      declared := true
+    }]
+  }
+  let finalized := model.finish "preview-filter" {}
+  let filtered := finalized.filterPreviewReferences fun key => key.value == retainedKey
+  let nodeTopologyUnchanged :=
+    (filtered.nodes.zip finalized.nodes).all fun (after, before) =>
+      after.label == before.label &&
+        after.statementUses == before.statementUses &&
+        after.proofUses == before.proofUses &&
+        after.parent == before.parent
+  let variantsUnchangedExceptPreview :=
+    (filtered.variants.zip finalized.variants).all fun (after, before) =>
+      after.key == before.key &&
+        after.label == before.label &&
+        after.dot == before.dot &&
+        after.options == before.options &&
+        after.selectOnNodeId == before.selectOnNodeId &&
+        after.hoverOnNodeId == before.hoverOnNodeId
+  filtered.nodes.size == finalized.nodes.size &&
+    filtered.variants.size == finalized.variants.size &&
+    nodeTopologyUnchanged &&
+    filtered.edges == finalized.edges &&
+    filtered.groups == finalized.groups &&
+    variantsUnchangedExceptPreview &&
+    (match filtered.nodes.find? (·.label == `preview_source) with
+      | some node => node.previewKey == PreviewKey.ofString? retainedKey
+      | none => false) &&
+    (match filtered.nodes.find? (·.label == `preview_target) with
+      | some node => node.previewKey.isNone
+      | none => false) &&
+    (match filtered.variants.find? (·.key == "full") with
+      | some variant =>
+          variant.previewKeyByNodeId == #[(graphNodeSvgId `preview_source, retainedKey)]
+      | none => false) &&
+    filtered.variants.all fun variant =>
+      variant.previewKeyByNodeId.all fun (_, key) => key == retainedKey
+
+/- Finalized decoding has no obsolete-schema or variant-less compatibility path. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  let finalized := nestedGroupModel.finish "strict-schema" {}
+  let obsoleteSchema := (toJson finalized).setObjVal! "schemaVersion" (toJson 2)
+  let noVariants := (toJson finalized).setObjVal! "variants" (toJson (#[] : Array GraphRenderVariant))
+  finalized.schemaVersion == 3 &&
+  (match fromJson? (α := GraphData) obsoleteSchema with
+    | .error _ => true
+    | .ok _ => false) &&
+  (match fromJson? (α := GraphData) noVariants with
+    | .error _ => true
+    | .ok _ => false)
+
+/- The traversal cache contains only the canonical semantic model and options. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  let cached : CachedGraphData := {
+    model := nestedGroupModel.canonicalize
+    options := { direction := .LR, pack := true }
+  }
+  let json := Json.compress (toJson cached)
+  json.contains "\"model\"" &&
+    json.contains "\"groupMetadata\"" &&
+    !json.contains "\"edges\"" &&
+    !json.contains "\"children\"" &&
+    !json.contains "\"variants\""
+
+private def edgeMatchesAuthoritativeNode (data : GraphData) (edge : EdgeData) : Bool :=
+  data.nodes.any (·.label == edge.source) &&
+    match data.nodes.find? (·.label == edge.target) with
+    | none => false
+    | some target =>
+      let statement := target.statementUses.any (fun useRef => useRef.label == edge.source)
+      let proof := target.proofUses.any (fun useRef => useRef.label == edge.source)
+      edge.axes == edgeAxesForTest statement proof
+where
+  edgeAxesForTest (statement proof : Bool) : Array EdgeAxis :=
+    let axes := if statement then #[EdgeAxis.statement] else #[]
+    if proof then axes.push EdgeAxis.proof else axes
+
+private def groupsMatchAuthoritativeParents (data : GraphData) : Bool :=
+  data.groups.all fun group =>
+    group.children.all fun child =>
+      data.nodes.any fun node => node.label == child && node.parent == some group.label
+
+/- JSON round-trip preserves a finalized record whose public projections agree exactly. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  let finalized := nestedGroupModel.finish "nested" {}
+  match Lean.fromJson? (α := GraphData) (Lean.toJson finalized) with
+  | .error _ => false
+  | .ok decoded =>
+    match decoded.variants[0]? with
+    | none => false
+    | some firstVariant =>
+      let expected := decoded.toModel.finish decoded.key firstVariant.options
+      decoded.edges == expected.edges &&
+        decoded.groups == expected.groups &&
+        decoded.variants == expected.variants &&
+        decoded.edges.all (edgeMatchesAuthoritativeNode decoded) &&
+        groupsMatchAuthoritativeParents decoded &&
+        decoded.nodes.all fun node =>
+          match node.parent with
+          | none => true
+          | some parent =>
+            decoded.groups.any fun group =>
+              group.label == parent && group.children.contains node.label
+
+end Verso.VersoBlueprintTests.BlueprintGraph.Topology

--- a/tests/VersoBlueprintTests/BlueprintPreviewSource.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewSource.lean
@@ -92,7 +92,7 @@ namespace Verso.VersoBlueprintTests.BlueprintPreviewSource
     let label := Name.mkSimple "preview.proof_fallback"
     let statementKey := PreviewCache.statementKey label
     let proofKey := PreviewCache.proofKey label
-    let semantic : Informal.Graph.GraphData := {
+    let semantic : Informal.Graph.GraphModel := {
       nodes := #[{
         label
         title := "Proof fallback"
@@ -101,13 +101,12 @@ namespace Verso.VersoBlueprintTests.BlueprintPreviewSource
         visual := { fillcolor := "#ffffff" }
       }]
     }
-    let finalized := Informal.GraphApi.finalData st semantic
-    let variants := finalized.renderVariants {}
+    let finalized := Informal.GraphApi.finishData st "preview-proof-fallback" semantic {}
     pure <|
       match finalized.nodes[0]? with
       | some node =>
         node.previewKey == PreviewKey.ofString? proofKey &&
-        variants.any (fun variant =>
+        finalized.variants.any (fun variant =>
           variant.previewKeyByNodeId.any (fun (_, key) => key == proofKey))
       | none => false
 
@@ -119,7 +118,7 @@ namespace Verso.VersoBlueprintTests.BlueprintPreviewSource
       Verso.VersoBlueprintTests.BlueprintPreviewSource.Provider.proofFallbackPreviewSourceDoc
     let label := Name.mkSimple "preview.missing"
     let statementKey := PreviewCache.statementKey label
-    let semantic : Informal.Graph.GraphData := {
+    let semantic : Informal.Graph.GraphModel := {
       nodes := #[{
         label
         title := "Missing preview"
@@ -128,13 +127,12 @@ namespace Verso.VersoBlueprintTests.BlueprintPreviewSource
         visual := { fillcolor := "#ffffff" }
       }]
     }
-    let finalized := Informal.GraphApi.finalData st semantic
-    let variants := finalized.renderVariants {}
+    let finalized := Informal.GraphApi.finishData st "preview-missing" semantic {}
     pure <|
       finalized.nodes.isEmpty &&
       finalized.edges.isEmpty &&
       finalized.groups.isEmpty &&
-      variants.all (fun variant =>
+      finalized.variants.all (fun variant =>
         variant.previewKeyByNodeId.all (fun (_, key) =>
           !key.isEmpty && key != statementKey))
 
@@ -145,7 +143,7 @@ namespace Verso.VersoBlueprintTests.BlueprintPreviewSource
     let (_out, st) ← renderManualDocHtmlStringAndState extension_impls%
       Verso.VersoBlueprintTests.BlueprintPreviewSource.Provider.proofFallbackPreviewSourceDoc
     let label := Name.mkSimple "preview.unknown"
-    let semantic : Informal.Graph.GraphData := {
+    let semantic : Informal.Graph.GraphModel := {
       nodes := #[{
         label
         title := "Unknown preview"
@@ -155,15 +153,14 @@ namespace Verso.VersoBlueprintTests.BlueprintPreviewSource
         visual := { fillcolor := "#ffffff" }
       }]
     }
-    let finalized := Informal.GraphApi.finalData st semantic
-    let variants := finalized.renderVariants {}
+    let finalized := Informal.GraphApi.finishData st "preview-unknown" semantic {}
     pure <|
       match finalized.nodes[0]? with
       | some node =>
         node.label == label &&
         node.warnings.unknownRef &&
         node.previewKey.isNone &&
-        variants.all (fun variant => variant.previewKeyByNodeId.isEmpty)
+        finalized.variants.all (fun variant => variant.previewKeyByNodeId.isEmpty)
       | none => false
 
 /-- info: true -/
@@ -174,7 +171,7 @@ namespace Verso.VersoBlueprintTests.BlueprintPreviewSource
       Verso.VersoBlueprintTests.BlueprintPreviewSource.Provider.externalMarkupPreviewSourceDoc
     let label := Name.mkSimple "preview.external_bodyless"
     let externalKey := Informal.PreviewSource.externalMarkupKey label
-    let semantic : Informal.Graph.GraphData := {
+    let semantic : Informal.Graph.GraphModel := {
       nodes := #[{
         label
         title := "External bodyless"
@@ -182,13 +179,12 @@ namespace Verso.VersoBlueprintTests.BlueprintPreviewSource
         visual := { fillcolor := "#ffffff" }
       }]
     }
-    let finalized := Informal.GraphApi.finalData st semantic
-    let variants := finalized.renderVariants {}
+    let finalized := Informal.GraphApi.finishData st "preview-external" semantic {}
     pure <|
       match finalized.nodes[0]? with
       | some node =>
         node.previewKey == PreviewKey.ofString? externalKey &&
-          variants.any (fun variant =>
+          finalized.variants.any (fun variant =>
             variant.previewKeyByNodeId.any (fun (_, key) => key == externalKey))
       | none => false
 

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -4,6 +4,7 @@ import VersoBlueprint.VbpMain
 namespace Verso.VersoBlueprintTests.Vbp
 
 open Lean
+open Informal.Graph
 
 abbrev ManifestFile := Informal.PreviewManifest.File
 abbrev HtmlCacheFile := Informal.PreviewManifest.HtmlCache.File
@@ -27,6 +28,9 @@ private def relatedWithoutPreview (value title : String) : RelatedEntry :=
     href := some s!"{value}/"
     axes := #[.statement]
   }
+
+private def finishedGraph (key : String) (nodes : Array NodeData) : GraphData :=
+  ({ nodes } : GraphModel).finish key {}
 
 private def sampleManifest : ManifestFile := {
   previews := #[
@@ -169,9 +173,8 @@ private def sampleGraphReferenceManifest : ManifestFile := {
       title := "Semantic graph target"
     }
   ]
-  graphs := #[{
-    key := "graph-fixture"
-    nodes := #[{
+  graphs := #[finishedGraph "graph-fixture" #[
+    {
       label := label "semantic_graph_target"
       title := "Semantic graph target"
       displayLabel := "Semantic graph target"
@@ -179,14 +182,15 @@ private def sampleGraphReferenceManifest : ManifestFile := {
         Informal.PreviewKey.ofString?
           (Informal.PreviewManifest.externalMarkupEntryKey (label "semantic_graph_target"))
       visual := { fillcolor := "#ffffff" }
-    }]
-    variants := #[{
-      key := "full"
-      label := "Full"
-      dot := "digraph {}"
-      previewKeyByNodeId := #[("node-1", "informal:cache_only_graph:statement")]
-    }]
-  }]
+    },
+    {
+      label := label "cache_only_graph"
+      title := "Cache-only graph target"
+      displayLabel := "Cache-only graph target"
+      previewKey := Informal.PreviewKey.ofString? "informal:cache_only_graph:statement"
+      visual := { fillcolor := "#ffffff" }
+    }
+  ]]
 }
 
 private def sampleGraphReferenceCache : HtmlCacheFile := {
@@ -263,9 +267,7 @@ private def sampleUnfinalizedReferenceManifest : ManifestFile := {
       related "missing_cache_target" "Missing-cache target" "informal:missing_cache_target:statement"
     ]
   }]
-  graphs := #[{
-    key := "reference-finalization"
-    nodes := #[
+  graphs := #[finishedGraph "reference-finalization" #[
       {
         label := label "valid_target"
         title := "Valid target"
@@ -287,18 +289,7 @@ private def sampleUnfinalizedReferenceManifest : ManifestFile := {
         previewKey := Informal.PreviewKey.ofString? "informal:missing_cache_target:statement"
         visual := { fillcolor := "#ffffff" }
       }
-    ]
-    variants := #[{
-      key := "full"
-      label := "Full"
-      dot := "digraph {}"
-      previewKeyByNodeId := #[
-        ("valid-node", "informal:valid_target:statement"),
-        ("cache-only-node", "informal:cache_only_target:statement"),
-        ("missing-cache-node", "informal:missing_cache_target:statement")
-      ]
-    }]
-  }]
+    ]]
 }
 
 private def sampleUnfinalizedReferenceCache : HtmlCacheFile := {
@@ -347,9 +338,7 @@ private def sampleMetadataManifest : ManifestFile := {
       title := "Proof statement"
     }
   ]
-  graphs := #[{
-    key := "metadata-status"
-    nodes := #[
+  graphs := #[finishedGraph "metadata-status" #[
       {
         label := label "zeta_statement"
         title := "Zeta"
@@ -376,8 +365,7 @@ private def sampleMetadataManifest : ManifestFile := {
         proofStatus := .incomplete
         visual := { fillcolor := "#ffffff" }
       }
-    ]
-  }]
+    ]]
 }
 
 private def jsonField? (json : Json) (field : String) : Option Json :=
@@ -587,7 +575,8 @@ private def graphNodePreviewKeys
           relatedPreviewKeys source.usedBy == expectedRelatedKeys &&
           groupKeys == expectedRelatedKeys &&
           graphNodePreviewKeys graph.nodes == expectedRelatedKeys &&
-          variantKeys == #[("valid-node", "informal:valid_target:statement")]
+          variantKeys == #[(graphNodeSvgId (label "valid_target"),
+            "informal:valid_target:statement")]
     | _, _ => false
 
 private partial def freshVbpFixtureRoot : IO System.FilePath := do
@@ -966,11 +955,11 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
     errors.any (fun err =>
       err.contains "missing HTML cache entry for graph graph-fixture node semantic_graph_target" &&
         err.contains (Informal.PreviewManifest.externalMarkupEntryKey (label "semantic_graph_target"))) &&
-      errors.any (fun err =>
-        err.contains "missing manifest entry for graph graph-fixture variant full node node-1" &&
+    errors.any (fun err =>
+        err.contains s!"missing manifest entry for graph graph-fixture variant full node {graphNodeSvgId (label "cache_only_graph")}" &&
           err.contains "informal:cache_only_graph:statement") &&
       !errors.any (fun err =>
-        err.contains "missing HTML cache entry for graph graph-fixture variant full node node-1" &&
+        err.contains s!"missing HTML cache entry for graph graph-fixture variant full node {graphNodeSvgId (label "cache_only_graph")}" &&
           err.contains "informal:cache_only_graph:statement")
 
 /-- info: true -/

--- a/tests/browser/test_graph_layout_runtime.py
+++ b/tests/browser/test_graph_layout_runtime.py
@@ -197,7 +197,6 @@ class TestGraphLayoutRuntime:
     def test_public_graph_api_exposes_rendered_page_and_manifest_data(self, server: str, page: Page):
         page.set_viewport_size({"width": 1400, "height": 900})
         goto_graph_page(page, f"{server}/Dependency-Graph/")
-        wait_for_graph(page)
 
         graph_data = page.evaluate(
             blueprint_render_api_script(
@@ -212,6 +211,24 @@ class TestGraphLayoutRuntime:
                 const manifestSample = manifestGraph
                     ? manifestGraph.nodes.find((node) => node.label === "used_target") || null
                     : null;
+                const topologySnapshot = (graph) => JSON.stringify({
+                    nodes: graph.nodes.map((node) => ({
+                        label: node.label,
+                        parent: node.parent,
+                        statementUses: node.statementUses,
+                        proofUses: node.proofUses
+                    })),
+                    edges: graph.edges,
+                    groups: graph.groups,
+                    variants: graph.variants.map((variant) => ({
+                        key: variant.key,
+                        label: variant.label,
+                        dot: variant.dot,
+                        options: variant.options,
+                        selectOnNodeId: variant.selectOnNodeId,
+                        hoverOnNodeId: variant.hoverOnNodeId
+                    }))
+                });
                 return {
                     hasLegacyGlobal: typeof window.bpGraphApi !== "undefined",
                     previewHasGraphData: typeof api.getGraphData === "function",
@@ -226,6 +243,11 @@ class TestGraphLayoutRuntime:
                     manifestNodes: manifestGraph ? manifestGraph.nodes.length : 0,
                     manifestEdges: manifestGraph ? manifestGraph.edges.length : 0,
                     manifestGroups: manifestGraph ? manifestGraph.groups.length : 0,
+                    pageSchemaVersion: pageGraph.schemaVersion,
+                    manifestSchemaVersion: manifestGraph ? manifestGraph.schemaVersion : 0,
+                    topologyMatches: manifestGraph
+                        ? topologySnapshot(pageGraph) === topologySnapshot(manifestGraph)
+                        : false,
                     variantKeys: variants.map((variant) => variant.key),
                     sampleTitle: sample ? sample.title : "",
                     sampleHref: sample ? sample.href : "",
@@ -249,11 +271,94 @@ class TestGraphLayoutRuntime:
         assert graph_data["manifestNodes"] == graph_data["pageNodes"]
         assert graph_data["manifestEdges"] == graph_data["pageEdges"]
         assert graph_data["manifestGroups"] == graph_data["pageGroups"]
+        assert graph_data["pageSchemaVersion"] == 3
+        assert graph_data["manifestSchemaVersion"] == 3
+        assert graph_data["topologyMatches"]
         assert {"full", "group"}.issubset(set(graph_data["variantKeys"]))
         assert graph_data["sampleTitle"].startswith("Definition")
         assert graph_data["sampleHref"] == "Preview-Relationships/#--informal-preview-used_target--statement"
         assert graph_data["manifestSampleTitle"] == graph_data["sampleTitle"]
         assert graph_data["manifestSampleHref"] == graph_data["sampleHref"]
+
+    def test_public_graph_api_rejects_obsolete_or_malformed_records(
+        self, server: str, page: Page
+    ):
+        goto_graph_page(page, f"{server}/Dependency-Graph/")
+
+        keys = page.evaluate(
+            blueprint_render_api_script(
+                """
+                const graphModule = await import(api.graphApiModuleUrl());
+                const fullVariant = {
+                    key: "full",
+                    label: "Full Graph",
+                    dot: "strict digraph {}",
+                    options: { direction: "TB", pack: false },
+                    selectOnNodeId: [],
+                    hoverOnNodeId: [],
+                    previewKeyByNodeId: []
+                };
+                const completeRecord = (schemaVersion, key, variants) => ({
+                    schemaVersion,
+                    key,
+                    nodes: [],
+                    edges: [],
+                    groups: [],
+                    variants
+                });
+                const graphs = await graphModule.loadManifestGraphs(
+                    "https://example.invalid/blueprint-manifest.json",
+                    {
+                        fetchJson: () => ({
+                            graphs: [
+                                completeRecord(3, "graph:current", [fullVariant]),
+                                completeRecord(2, "graph:obsolete-schema", [fullVariant]),
+                                completeRecord(3, "graph:no-variants", []),
+                                completeRecord(3, "graph:blank-dot", [
+                                    { ...fullVariant, dot: " " }
+                                ]),
+                                completeRecord(3, "graph:invalid-options", [
+                                    { ...fullVariant, options: { direction: "sideways", pack: false } }
+                                ]),
+                                completeRecord(3, "graph:invalid-pair", [
+                                    { ...fullVariant, previewKeyByNodeId: [["node-only"]] }
+                                ]),
+                                completeRecord(3, "graph:duplicate-variant", [
+                                    fullVariant,
+                                    { ...fullVariant, label: "Duplicate Full Graph" }
+                                ]),
+                                completeRecord(3, "graph:missing-full", [
+                                    { ...fullVariant, key: "group", label: "Group View" }
+                                ]),
+                                completeRecord(3, "graph:unknown-variant-target", [
+                                    { ...fullVariant, selectOnNodeId: [["node-id", "missing"]] }
+                                ]),
+                                completeRecord(3, "graph:duplicate-node-mapping", [
+                                    {
+                                        ...fullVariant,
+                                        previewKeyByNodeId: [
+                                            ["node-id", "preview:first"],
+                                            ["node-id", "preview:second"]
+                                        ]
+                                    }
+                                ]),
+                                {
+                                    schemaVersion: 3,
+                                    key: "graph:incomplete-record",
+                                    nodes: [],
+                                    edges: [],
+                                    groups: []
+                                }
+                            ]
+                        })
+                    }
+                );
+                return graphs.map((graph) => graph.key);
+                """
+            )
+        )
+
+        assert keys == ["graph:current"]
 
     def test_public_graph_api_can_render_copied_graph_block(self, server: str, page: Page):
         page.set_viewport_size({"width": 1400, "height": 900})

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -737,16 +737,7 @@ class TestPreviewRuntimeRegressions:
                                         sourceLocation: unavailableSourceLocation
                                     }
                                 ],
-                                groups: [],
-                                graphs: [
-                                    {
-                                        schemaVersion: 1,
-                                        key: "graph:custom-loader",
-                                        nodes: [],
-                                        edges: [],
-                                        groups: []
-                                    }
-                                ]
+                                groups: []
                             });
                         }
                         if (url.endsWith("blueprint-html-cache.json")) {
@@ -773,11 +764,6 @@ class TestPreviewRuntimeRegressions:
                         customHost,
                         "custom_loader--statement",
                         { hydrate: false, renderMath: false }
-                    );
-                    const graphModule = await import(api.graphApiModuleUrl());
-                    const customGraphs = await graphModule.loadManifestGraphs(
-                      customApi.manifestUrl(),
-                      { fetchJson: customFetchJson }
                     );
                     const afterCustomHost = document.createElement("section");
                     document.body.appendChild(afterCustomHost);
@@ -811,7 +797,6 @@ class TestPreviewRuntimeRegressions:
                         customOk: customResult.ok,
                         customText: customText,
                         customCalls: customCalls,
-                        customGraphCount: customGraphs.length,
                         afterCustomOk: afterCustomResult.ok,
                         afterCustomText: afterCustomText,
                         constructorHydrator: constructorHydrator,
@@ -846,7 +831,6 @@ class TestPreviewRuntimeRegressions:
             call.endswith("blueprint-html-cache.json")
             for call in standalone_module["customCalls"]
         )
-        assert standalone_module["customGraphCount"] == 1
         assert standalone_module["constructorHydrator"] == "constructorOption"
         assert standalone_module["callConstructorHydrator"] == ""
         assert standalone_module["callHydrator"] == "options"

--- a/tests/harness/test_preview_runtime_api_docs.py
+++ b/tests/harness/test_preview_runtime_api_docs.py
@@ -53,7 +53,7 @@ GRAPH_CORE_HELPERS = {
     "dataUrl",
     "graphCanvasFor",
     "readGraphJsonScript",
-    "normalizeGraphData",
+    "decodeGraphData",
     "graphsFromManifest",
     "getGraphData",
     "getGraphVariants",
@@ -65,7 +65,7 @@ GRAPH_CORE_IMPLEMENTATION_HELPERS = {
     "dataUrl",
     "graphCanvasFor",
     "readGraphJsonScript",
-    "normalizeGraphData",
+    "decodeGraphData",
     "graphsFromManifest",
     "getGraphData",
     "getGraphVariants",
@@ -416,12 +416,12 @@ class PreviewRuntimeApiDocsTests(unittest.TestCase):
         self.assertNotIn("window.bpSlideNodeRuntime", runtime)
         self.assertNotIn("window.bpSlideNodeRuntimeConfig", runtime)
 
-    def test_graph_runtime_uses_structured_variants_only(self) -> None:
+    def test_graph_runtime_has_no_legacy_variant_path(self) -> None:
         runtime = (BLUEPRINT_SRC / "Commands" / "graph.mjs").read_text(
             encoding="utf-8"
         )
 
-        self.assertIn("readPublicGraphVariants(graphApiData)", runtime)
+        self.assertNotIn("readPublicGraphVariants", runtime)
         self.assertNotIn("coreGetGraphVariants", runtime)
         self.assertIn("export function startGraphRuntime(previewUtils, options)", runtime)
         self.assertNotIn("legacyGraphVariants", runtime)


### PR DESCRIPTION
This PR makes node dependency and parent data the sole graph topology source, materializes derived edges, group membership, and render variants at a single finalization boundary, and makes Lean, manifest, renderer, and browser graph consumers observe the same topology.

Backport v4.31.0: #349