### PR TITLE
[backport v4.31.0] feat: complete attribute-first Blueprint rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ theorem nat_add_zero_right (n : Nat) : n + 0 = n := by
   simp
 ```
 
-After importing a Lean module containing tagged declarations, include all of
-that module's nodes as a source-ordered Manual part with:
+After importing a Lean module containing tagged declarations, include one node
+per distinct directly owned label as a source-ordered Manual part with:
 
 ```lean
 {includeBlueprintModule 0 MyProject.Formalization.Addition (title := "Compiled Addition Results")}
@@ -170,8 +170,10 @@ location in an existing Manual chapter, place that node with:
 The declaration docstring supplies the informal statement when present; without
 one, Blueprint still renders a code-only node in either workflow. Docstrings are
 prose, not Blueprint dependency syntax: put `uses` and `proofUses` on the
-attribute. See the Manual's “Attribute-first use-case matrix” for the precise
-dependency, prose, proof, metadata, and source-rendering boundaries.
+attribute. See the Manual's
+[“Attribute-first use-case matrix”](doc/MANUAL.md#attribute-first-use-case-matrix)
+for the precise dependency, prose, proof, metadata, and source-rendering
+boundaries.
 
 Add `(autoDeps := true)` when a tagged declaration, labeled inline Lean block,
 or `(lean := "...")` statement should infer statement/proof dependency edges to

--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ theorem nat_add_zero_right (n : Nat) : n + 0 = n := by
 Blueprint supports three main ways to connect informal nodes to Lean:
 
 - inline code with a labeled Lean code block
-- compiled code tagged with `@[blueprint "addition_right_identity"]`
+- compiled code tagged with `@[blueprint]` or
+  `@[blueprint "addition_right_identity"]`
 - existing declarations referenced with `(lean := "Nat.add_assoc")`
 
 ```lean
@@ -151,6 +152,12 @@ Blueprint supports three main ways to connect informal nodes to Lean:
 theorem nat_add_zero_right (n : Nat) : n + 0 = n := by
   simp
 ```
+
+The string selects a short, explicit Blueprint label. Omitting it uses the
+declaration's qualified Lean name, so `@[blueprint] theorem
+MyProject.nat_add_zero_right ...` is referenced as
+`"MyProject.nat_add_zero_right"`. Attribute options remain available in the
+bare form, for example `@[blueprint (uses := ["addition_spec"])]`.
 
 After importing a Lean module containing tagged declarations, include one node
 per distinct directly owned label as a source-ordered Manual part with:
@@ -170,7 +177,8 @@ location in an existing Manual chapter, place that node with:
 The declaration docstring supplies the informal statement when present; without
 one, Blueprint still renders a code-only node in either workflow. Docstrings are
 prose, not Blueprint dependency syntax: put `uses` and `proofUses` on the
-attribute. See the Manual's
+attribute. Standard `doc.verso` structure, including math, is preserved in both
+the statement and the attached “Lean code for…” declaration panel. See the Manual's
 [“Attribute-first use-case matrix”](doc/MANUAL.md#attribute-first-use-case-matrix)
 for the precise dependency, prose, proof, metadata, and source-rendering
 boundaries.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,27 @@ theorem nat_add_zero_right (n : Nat) : n + 0 = n := by
   simp
 ```
 
+After importing a Lean module containing tagged declarations, include all of
+that module's nodes as a source-ordered Manual part with:
+
+```lean
+{includeBlueprintModule 0 MyProject.Formalization.Addition (title := "Compiled Addition Results")}
+```
+
+The `import MyProject.Formalization.Addition` statement still belongs in the
+Lean file header. When only one declaration should appear at a particular
+location in an existing Manual chapter, place that node with:
+
+```lean
+{blueprint_node "addition_right_identity"}
+```
+
+The declaration docstring supplies the informal statement when present; without
+one, Blueprint still renders a code-only node in either workflow. Docstrings are
+prose, not Blueprint dependency syntax: put `uses` and `proofUses` on the
+attribute. See the Manual's “Attribute-first use-case matrix” for the precise
+dependency, prose, proof, metadata, and source-rendering boundaries.
+
 Add `(autoDeps := true)` when a tagged declaration, labeled inline Lean block,
 or `(lean := "...")` statement should infer statement/proof dependency edges to
 directly referenced Lean declarations that are already associated with Blueprint

--- a/README.md
+++ b/README.md
@@ -178,10 +178,11 @@ The declaration docstring supplies the informal statement when present; without
 one, Blueprint still renders a code-only node in either workflow. Docstrings are
 prose, not Blueprint dependency syntax: put `uses` and `proofUses` on the
 attribute. Standard `doc.verso` structure, including math, is preserved in both
-the statement and the attached “Lean code for…” declaration panel. See the Manual's
+the statement and the attached “Lean code for…” declaration panel. For the
+precise dependency, prose, proof, metadata, and source-rendering boundaries, see
+the Manual's
 [“Attribute-first use-case matrix”](doc/MANUAL.md#attribute-first-use-case-matrix)
-for the precise dependency, prose, proof, metadata, and source-rendering
-boundaries.
+section.
 
 Add `(autoDeps := true)` when a tagged declaration, labeled inline Lean block,
 or `(lean := "...")` statement should infer statement/proof dependency edges to

--- a/doc/API.md
+++ b/doc/API.md
@@ -127,7 +127,8 @@ Generated Blueprint sites write reusable data under `-verso-data/`:
 - `blueprint-manifest.json` contains semantic entries keyed by preview key,
   generated-page hrefs, graph records, labels, dependency data, Lean-code
   associations, a shared group catalog, ownership, tags, priority, effort,
-  status metadata, and display metadata.
+  status metadata, display metadata, and the folding policy needed by reusable
+  block renderers.
 - `blueprint-html-cache.json` contains rendered body fragments keyed by
   preview keys for entries that have generated preview bodies. Some semantic
   entries, such as source-backed external markup generated with

--- a/doc/API.md
+++ b/doc/API.md
@@ -660,6 +660,18 @@ The useful data boundary is small:
 - Slide generators and other generated consumers should import and use the
   `Informal.Graft` node/config names directly.
 
+Manual documents expose two attribute-owned authoring paths before reaching
+this rendering boundary. `{includeBlueprintModule 0 Some.Module}` reads that
+imported module's persistent, source-ordered label catalog and creates one
+Manual part containing all directly owned nodes. `{blueprint_node "label"}`
+materializes one imported attribute node at the command's source position. In
+both cases a docstring supplies the statement body when present; otherwise a
+code-only preview entry is produced. Ordinary informal nodes must already be
+in the traversal, and Slides always use the manifest/cache supplied by their
+generator. The module command is deliberately Manual-only. Module selection and
+materialization are document-elaboration concerns; the config, manifest entry,
+and rendering APIs below remain shared.
+
 `VersoBlueprint.Graft.Render` packages that lookup-and-render path for custom
 interfaces. A consumer such as an audit view can provide its own wrapper
 classes and diagnostics while reusing the same manifest/cache content:

--- a/doc/API.md
+++ b/doc/API.md
@@ -669,8 +669,9 @@ both cases a docstring supplies the statement body when present; otherwise a
 code-only preview entry is produced. Ordinary informal nodes must already be
 in the traversal, and Slides always use the manifest/cache supplied by their
 generator. The module command is deliberately Manual-only. Module selection and
-materialization are document-elaboration concerns; the config, manifest entry,
-and rendering APIs below remain shared.
+statement-facet materialization are document-elaboration concerns; persisted
+informal proof bodies are not yet materialized from imported modules. The
+config, manifest entry, and rendering APIs below remain shared.
 
 `VersoBlueprint.Graft.Render` packages that lookup-and-render path for custom
 interfaces. A consumer such as an audit view can provide its own wrapper

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -218,7 +218,12 @@ The same flow can be read as four contracts:
    `Informal.Environment.State`. This is the canonical semantic store for
    Blueprint-owned facts. It is persisted through Lean environment extensions
    and imported through compiled oleans, so downstream modules see one merged
-   object database.
+   object database. Attribute registration also writes a small per-module
+   catalog of distinct labels that preserves first application order. The node
+   itself remains the single source of truth for associated Lean declarations.
+   This is the ownership and ordering source for `{includeBlueprintModule}`;
+   the include path does not infer chapters by sorting labels or reparsing Lean
+   source.
 
 2. **Environment to traversal.**
    During Verso traversal, Blueprint reads the semantic environment and writes
@@ -229,6 +234,21 @@ The same flow can be read as four contracts:
    public graph data records, and external declaration row anchors. These
    facts are intentionally not pushed back into `Environment.State`, because
    their values depend on the current rendered document and output mode.
+   An imported attribute-owned node has no source block of its own, so a Manual
+   `{blueprint_node}` placement expands to an invisible materialization block
+   followed by the ordinary graft. The materializer writes the same node,
+   preview, Lean-code, anchor, numbering, and relation indexes as an informal
+   block; its only HTML is the empty destination anchor immediately before the
+   visible graft. This keeps placement phase-safe without introducing a second
+   renderer for attribute nodes.
+   `{includeBlueprintModule}` builds a real Verso part by applying that same
+   materializer-plus-graft expansion to every entry in one imported module's
+   catalog. Catalog lookup is exact-module, so transitive imports appear only
+   when explicitly included as their own parts.
+   Statement payloads that already contain elaborated Manual blocks are
+   reconstructed through Manual's typed JSON instances. This is a localized
+   value-quotation bridge, not a second persisted body schema and not a
+   synthetic document elaboration pass.
 
 3. **Traversal to generated artifacts.**
    Page rendering and preview-data emission both consume the traversal state.
@@ -878,6 +898,10 @@ rather than page-local template bodies:
    then hydrates links, math, and related-entry preview panels; it does not
    reconstruct Blueprint block markup or relationship topology from ad hoc
    manifest scans.
+   `VersoBlueprint.ModuleInclude` owns the module-to-part authoring boundary:
+   it reads the persistent attribute catalog, creates the Verso part, and
+   delegates every contained node to the same Manual graft materialization
+   path.
 
 Inline Blueprint references, citation references, and the `used by`/group
 relationship panels are now preview-data callers: the rendered page carries the

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -293,6 +293,7 @@ that owner.
 | Fact family | Owner | Stored as | Main consumers |
 | --- | --- | --- | --- |
 | Blueprint labels, node kind, declared dependencies, parent/group, owner, tags, priority, effort, PR URL | Elaboration | `Environment.State.data` and related environment maps | traversal, graph, summary, manifest construction |
+| Attribute-module ownership and first-application order | Attribute elaboration | `Environment.State.blueprintAttributeLabelsByModule`; node semantics remain in `Environment.State.data` | `{includeBlueprintModule}`, exact-module diagnostics |
 | Group and author declarations | Elaboration | `Environment.State.groups` and `Environment.State.authors` | block rendering, summary, graph/group panels |
 | Inline Lean and Rust attachments | Elaboration plus traversal | semantic code refs in environment; render-time code-panel indexes in `TraversalIndex.InlineCode` and `TraversalIndex.RustInlineCode` | block renderers, code panels, manifest entries |
 | External Lean declaration snapshots | Elaboration / declaration snapshot registration | `ExternalRef` records on semantic nodes, enriched with presence/status/source/render data | block renderers, code-summary badges, summary, graph, manifest |
@@ -365,6 +366,9 @@ flowchart TD
   previewExtra["Preview-data extra step<br/>emitBlueprintPreviewData"]
   previewFiles["Manifest/cache files<br/>blueprint-manifest.json<br/>blueprint-html-cache.json"]
 
+  attributeEnv["Persistent attribute node/catalog<br/>Environment.State"]
+  moduleInclude["Attribute module part command<br/>includeBlueprintModule"]
+  attributeMaterializer["Attribute traversal materializer<br/>blueprintAttributeNodeSource"]
   manualGraft["Manual graft command<br/>Graft.renderManualGraftNode"]
   traversalPreview["Traversal preview lookup<br/>PreviewSource / TraversalPreviews"]
   manualPreviewHtml["Manual preview-body render<br/>renderManualBlocksHtmlWithStateAndHovers"]
@@ -384,6 +388,10 @@ flowchart TD
   manualMain --> previewExtra
   previewExtra --> previewFiles
 
+  attributeEnv --> moduleInclude
+  attributeEnv --> attributeMaterializer
+  moduleInclude --> attributeMaterializer
+  attributeMaterializer --> traversalPreview
   manualGraft --> traversalPreview
   traversalPreview --> manualPreviewHtml
   manualPreviewHtml --> graftContent
@@ -407,7 +415,8 @@ The current paths are:
 | --- | --- | --- | --- | --- |
 | Normal Manual site pages | `Informal.PreviewManifest.blueprintMainWithPreviewData` | `Environment.State` plus `TraverseState` | `Informal.Block.Render.renderInformalBlockModel` for informal blocks; command-specific renderers for graph, summary, and bibliography | generated Manual HTML pages and assets |
 | Preview manifest/cache emission | `Informal.PreviewManifest.emitBlueprintPreviewData` via `blueprintMainWithPreviewData` | completed Manual `TraverseState` and `TraversalIndex` domains | Manual preview render helpers plus manifest entry builders | `blueprint-manifest.json`, `blueprint-html-cache.json`, merged hover docs |
-| Manual same-document graft | `Informal.Graft.renderManualGraftNode` through `{blueprint_node}` in Manual | current page traversal preview entry and current `TraverseState` | `Informal.Graft.renderNodeWithContent` | grafted Manual HTML block |
+| Manual attribute materialization | `{blueprint_node}` for an untraversed attribute node, or `{includeBlueprintModule}` for a module catalog | persistent node/catalog data from `Environment.State` plus persisted statement blocks | `Block.blueprintAttributeNodeSource` registers through the ordinary block traversal path | current-document traversal entries followed by grafted Manual HTML |
+| Manual same-document graft | `Informal.Graft.renderManualGraftNode` through `{blueprint_node}` in Manual | current page traversal preview entry and current `TraverseState`, whether authored directly or attribute-materialized | `Informal.Graft.renderNodeWithContent` | grafted Manual HTML block |
 | Manual side-by-side graft wrapper | `Block.blueprintGraftSideBySide.toHtml` | already elaborated/rendered child blocks | wrapper only; child nodes follow the Manual graft path | side-by-side Manual HTML wrapper |
 | Slides graft node | `Informal.Slides.slidesMainWithBlueprintPreviews` plus `Informal.Slides.renderBlueprintSlideNode` | serialized manifest/cache files copied from the Blueprint site | `Informal.Graft.renderNodeFromManifestCache` then `renderNodeWithContent` | static slide-node HTML plus slide assets |
 | Slides side-by-side wrapper | `VersoSlides.BlockExt.wrap` emitted by `blueprint_side_by_side` in Slides | already rendered child slide blocks | upstream Slides wrapper; child nodes follow the Slides graft-node path | side-by-side slide HTML wrapper |

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -1,6 +1,6 @@
 # Blueprint Design Rationale
 
-Last updated: 2026-06-20
+Last updated: 2026-07-25
 
 This document records the current architecture boundaries and the reasons the
 Blueprint implementation is shaped the way it is.

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -237,10 +237,12 @@ The same flow can be read as four contracts:
    An imported attribute-owned node has no source block of its own, so a Manual
    `{blueprint_node}` placement expands to an invisible materialization block
    followed by the ordinary graft. The materializer writes the same node,
-   preview, Lean-code, anchor, numbering, and relation indexes as an informal
-   block; its only HTML is the empty destination anchor immediately before the
-   visible graft. This keeps placement phase-safe without introducing a second
-   renderer for attribute nodes.
+   statement-preview, Lean-code, anchor, numbering, and relation indexes as an
+   informal statement block; its only HTML is the empty destination anchor
+   immediately before the visible graft. This keeps placement phase-safe
+   without introducing a second renderer for attribute nodes. Persisted
+   provider-module proof bodies are not yet projected into proof-facet traversal
+   entries.
    `{includeBlueprintModule}` builds a real Verso part by applying that same
    materializer-plus-graft expansion to every entry in one imported module's
    catalog. Catalog lookup is exact-module, so transitive imports appear only

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -212,7 +212,8 @@ flowchart TD
 The same flow can be read as four contracts:
 
 1. **Elaboration to environment.**
-   Source directives, inline Lean blocks, `@[blueprint "..."]` attributes,
+   Source directives, inline Lean blocks, `@[blueprint]` attributes with
+   declaration-name or explicit labels,
    external `(lean := "...")` references, group declarations, author
    declarations, citations, and metadata are elaborated into
    `Informal.Environment.State`. This is the canonical semantic store for
@@ -297,7 +298,7 @@ that owner.
 | Group and author declarations | Elaboration | `Environment.State.groups` and `Environment.State.authors` | block rendering, summary, graph/group panels |
 | Inline Lean and Rust attachments | Elaboration plus traversal | semantic code refs in environment; render-time code-panel indexes in `TraversalIndex.InlineCode` and `TraversalIndex.RustInlineCode` | block renderers, code panels, manifest entries |
 | External Lean declaration snapshots | Elaboration / declaration snapshot registration | `ExternalRef` records on semantic nodes, enriched with presence/status/source/render data | block renderers, code-summary badges, summary, graph, manifest |
-| Numbering, hrefs, anchors, preview keys | Traversal | `TraverseState` and `TraversalIndex` domains | page rendering, preview manifest, browser triggers |
+| Numbering, hrefs, anchors, preview keys, and placement folding policy | Traversal | `TraverseState` and `TraversalIndex` domains, projected into semantic preview entries where rendering needs them | page rendering, preview manifest, browser triggers |
 | Statement/proof preview source blocks | Traversal | `TraversalIndex.TraversalPreviews` | manifest/cache emission, same-document manual grafts |
 | Public graph data | Elaboration plus completed traversal | semantic `Informal.Graph.GraphModel` plus options cached in `TraversalIndex.Graphs`, then topology-finalized once through `Informal.GraphApi.finishData` into private-constructor `GraphData`; manifest emission subsequently resolves preview candidates against the artifact index without reopening topology | graph command rendering, browser runtime, custom graph consumers |
 | Lean code preview fragments | Traversal | `TraversalIndex.LeanCodePreviews` | Lean links, manifest/cache emission |

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -39,8 +39,9 @@ Those labels are the key to the whole system. They are used to:
 - tag compiled declarations with `@[blueprint "label"]`, optionally using
   `(autoDeps := true)` or `set_option verso.blueprint.autoDeps true` to infer
   edges to directly referenced Lean declarations associated with Blueprint labels
-- turn all directly tagged declarations from one imported Lean module into a
-  source-ordered Manual chapter with `{includeBlueprintModule 0 Some.Module}`
+- turn the distinct labels owned directly by one imported Lean module into a
+  source-ordered Manual chapter with `{includeBlueprintModule 0 Some.Module}`;
+  declarations that share a label become one node
 - place an imported attribute-owned declaration at a specific chapter location
   with `{blueprint_node "label"}`; its docstring becomes the statement body and
   an undocumented declaration renders as a code-only node

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -151,7 +151,7 @@ small enough to copy and adapt.
 
 The top-level file in
 [project_template/ProjectTemplate/Blueprint.lean](../project_template/ProjectTemplate/Blueprint.lean)
-does two jobs:
+does three jobs:
 
 1. it includes the chapter modules into the document
 2. it projects the tagged formalization module into a generated chapter

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -39,6 +39,11 @@ Those labels are the key to the whole system. They are used to:
 - tag compiled declarations with `@[blueprint "label"]`, optionally using
   `(autoDeps := true)` or `set_option verso.blueprint.autoDeps true` to infer
   edges to directly referenced Lean declarations associated with Blueprint labels
+- turn all directly tagged declarations from one imported Lean module into a
+  source-ordered Manual chapter with `{includeBlueprintModule 0 Some.Module}`
+- place an imported attribute-owned declaration at a specific chapter location
+  with `{blueprint_node "label"}`; its docstring becomes the statement body and
+  an undocumented declaration renders as a code-only node
 
 If you pick stable labels early, the rest of the project structure becomes much
 easier to maintain.
@@ -93,6 +98,8 @@ Use [project_template/](../project_template/) as the starting point.
 Its key files are:
 
 - `ProjectTemplate/Chapters/Addition.lean`: the first chapter
+- `ProjectTemplate/Formalization/Addition.lean`: an ordinary Lean module whose
+  attribute-owned declarations become a generated chapter
 - `ProjectTemplate/Chapters/Multiplication.lean`: the second chapter
 - `ProjectTemplate/Chapters/Collatz.lean`: a third chapter with a deliberately
   unfinished open problem
@@ -104,16 +111,18 @@ Its key files are:
 The template is intentionally small. It is meant to teach the shape of a
 Blueprint project before you scale it up.
 
-## The three Verso forms to recognize first
+## The four Verso forms to recognize first
 
-If you are new to Verso, there are only three forms you need to understand at
+If you are new to Verso, there are only four forms you need to understand at
 the start:
 
 - `#doc (Manual) "Title" =>` starts a document module
 - `{include 0 Some.Module}` includes a chapter into the top-level file
+- `{includeBlueprintModule 0 Some.Formalization}` turns that imported Lean
+  module's tagged declarations into a generated Manual chapter
 - `:::definition "label_1"` starts a Blueprint block
 
-You can get a long way just by following those three patterns in the template.
+You can get a long way just by following those four patterns in the template.
 
 ## Read the first chapters
 
@@ -144,12 +153,15 @@ The top-level file in
 does two jobs:
 
 1. it includes the chapter modules into the document
-2. it chooses which rendered overview pages to include
+2. it projects the tagged formalization module into a generated chapter
+3. it chooses which rendered overview pages to include
 
 The starter template includes:
 
 - the chapter pages with `{include 0 ProjectTemplate.Chapters.Addition}` and
   the other chapter includes
+- the compiled-results page with
+  `{includeBlueprintModule 0 ProjectTemplate.Formalization.Addition ...}`
 - a dependency graph with `{blueprint_graph}`
 - a progress summary with `{blueprint_summary}`
 

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -36,9 +36,11 @@ Those labels are the key to the whole system. They are used to:
 - attach inline Lean code with a labeled `lean` code block
 - attach external TeX or Markdown source for porting with `tex` or `md` code
   blocks
-- tag compiled declarations with `@[blueprint "label"]`, optionally using
-  `(autoDeps := true)` or `set_option verso.blueprint.autoDeps true` to infer
-  edges to directly referenced Lean declarations associated with Blueprint labels
+- tag compiled declarations with `@[blueprint]`, which defaults to the
+  qualified declaration name, or `@[blueprint "label"]` for an explicit short
+  label; either form can use `(autoDeps := true)` or
+  `set_option verso.blueprint.autoDeps true` to infer edges to directly
+  referenced Lean declarations associated with Blueprint labels
 - turn the distinct labels owned directly by one imported Lean module into a
   source-ordered Manual chapter with `{includeBlueprintModule 0 Some.Module}`;
   declarations that share a label become one node

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -1,6 +1,6 @@
 # Blueprint Maintainer Guide
 
-Last updated: 2026-05-04
+Last updated: 2026-07-25
 
 This document is the repository-level workflow guide for maintaining Blueprint
 support in `verso-blueprint`, its in-repo validation projects, and its

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -147,6 +147,26 @@ interaction behavior:
 uv run --project tests/browser --extra test python -m pytest tests/browser -q --browser chromium
 ```
 
+### Cover Feature Intersections
+
+User-facing authoring behavior should be tested through its final rendered
+surface, not only at the parser or environment-extension boundary. For a feature
+that crosses phases, cover the applicable rows of this matrix:
+
+| Boundary | What to assert | Current attribute-first fixtures |
+| --- | --- | --- |
+| Declaration and import | persisted label, declaration association, dependencies, module ownership/order | `BlueprintAttribute/Provider.lean`, `HybridProvider.lean`, and `DefaultLabelProvider.lean` |
+| Consumer traversal | numbering, folding/options, relation data, preview keys | `BlueprintAttribute.lean` |
+| Final Manual HTML | statement body, code-only fallback, structural docstrings/math, code-panel disclosure state | `BlueprintAttribute.lean` |
+| Generated site | embedded assets and the reusable external-declaration renderer | `preview_runtime_showcase` and `check_blueprint_code_panels.py` |
+| Browser runtime | transformations or hydration that cannot be proved from static HTML | `test_preview_runtime_regressions.py` |
+
+When a new option or source form applies to more than one placement path, add
+one compact cross-feature regression that exercises those paths together. A
+unit test for each isolated component is not sufficient when data is projected
+through the environment, traversal store, preview manifest, HTML cache, and
+browser runtime.
+
 Browser tests that need the public Blueprint render API should use
 `blueprint_render_api_script` or `wait_for_blueprint_render_api` from
 `tests/browser/support.py`. Those helpers import

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -155,7 +155,7 @@ that crosses phases, cover the applicable rows of this matrix:
 
 | Boundary | What to assert | Current attribute-first fixtures |
 | --- | --- | --- |
-| Declaration and import | persisted label, declaration association, dependencies, module ownership/order | `BlueprintAttribute/Provider.lean`, `HybridProvider.lean`, and `DefaultLabelProvider.lean` |
+| Declaration and import | persisted label, declaration association, dependencies, module ownership/order | `BlueprintAttribute.lean` with `BlueprintAttribute/Provider.lean`, `HybridProvider.lean`, and `DefaultLabelProvider.lean` |
 | Consumer traversal | numbering, folding/options, relation data, preview keys | `BlueprintAttributeRendering.lean` |
 | Final Manual HTML | statement body, code-only fallback, structural docstrings/math, code-panel disclosure state | `BlueprintAttributeRendering.lean` |
 | Generated site | embedded assets and the reusable external-declaration renderer | `preview_runtime_showcase` and `check_blueprint_code_panels.py` |

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -156,8 +156,8 @@ that crosses phases, cover the applicable rows of this matrix:
 | Boundary | What to assert | Current attribute-first fixtures |
 | --- | --- | --- |
 | Declaration and import | persisted label, declaration association, dependencies, module ownership/order | `BlueprintAttribute/Provider.lean`, `HybridProvider.lean`, and `DefaultLabelProvider.lean` |
-| Consumer traversal | numbering, folding/options, relation data, preview keys | `BlueprintAttribute.lean` |
-| Final Manual HTML | statement body, code-only fallback, structural docstrings/math, code-panel disclosure state | `BlueprintAttribute.lean` |
+| Consumer traversal | numbering, folding/options, relation data, preview keys | `BlueprintAttributeRendering.lean` |
+| Final Manual HTML | statement body, code-only fallback, structural docstrings/math, code-panel disclosure state | `BlueprintAttributeRendering.lean` |
 | Generated site | embedded assets and the reusable external-declaration renderer | `preview_runtime_showcase` and `check_blueprint_code_panels.py` |
 | Browser runtime | transformations or hydration that cannot be proved from static HTML | `test_preview_runtime_regressions.py` |
 

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -319,11 +319,15 @@ registered, but there is no imported informal statement body.
 
 Enabling `doc.verso` does not elaborate a declaration docstring as a Blueprint
 Manual fragment. Blueprint currently flattens every Lean docstring extension
-node to its child content, discarding the extension wrapper rather than looking
-up a Manual adapter. Custom role or directive semantics are therefore not
-preserved. In particular, `{uses ...}[]` inside a docstring is not Blueprint
-dependency metadata. Record those edges with the attribute's `(uses := [...])`
-or `(proofUses := [...])` options. Blueprint deliberately does not create a
+node that successfully elaborates to its child content, discarding the
+extension wrapper rather than looking up a Manual adapter. Custom Lean
+docstring-extension semantics are therefore not preserved.
+
+Blueprint Manual roles are a separate registry. In particular,
+`{uses ...}[]` is not a Lean `doc.verso` role and is rejected during docstring
+elaboration; it is neither flattened nor recorded as Blueprint dependency
+metadata. Record those edges with the attribute's `(uses := [...])` or
+`(proofUses := [...])` options. Blueprint deliberately does not create a
 synthetic `DocElabM` context to reinterpret an imported docstring.
 
 #### Including an attribute module as a chapter
@@ -551,7 +555,7 @@ the inferred dependency edges.
 | Reuse the same node in several places | Supported. The node keeps one semantic identity; later `{blueprint_node}` occurrences are presentation views and may use compact/header/display-label options. |
 | Use the declaration docstring as the statement | Supported for plain Markdown and standard structural `doc.verso` content that can be converted to Manual blocks. Structural `doc.verso` markup and math are also preserved in the attached external-declaration panel. Custom docstring extension semantics are flattened to child content rather than re-elaborated. An absent docstring produces a code-only placement. |
 | Infer formal dependencies | Supported with `(autoDeps := true)` or `set_option verso.blueprint.autoDeps true`. Type references become statement dependencies and body references become proof dependencies. Inference is direct, not transitive through untagged helpers. |
-| Curate dependencies manually | Supported with attribute options `uses` and `proofUses`, using either Blueprint label strings or tagged Lean declaration names. Prefixing an entry with `-` excludes it on that axis. A `{uses ...}[]` form inside a declaration docstring is not interpreted as dependency metadata. |
+| Curate dependencies manually | Supported with attribute options `uses` and `proofUses`, using either Blueprint label strings or tagged Lean declaration names. Prefixing an entry with `-` excludes it on that axis. Blueprint's `{uses ...}[]` Manual role is not registered for Lean `doc.verso` docstrings and is rejected there rather than interpreted as dependency metadata. |
 | Attach several labels to one Lean declaration, or several Lean declarations to one label | Supported. Associations are many-to-many and are deduplicated by canonical Lean name or Blueprint label as appropriate. |
 | Add a separate informal proof | Supported with `:::proof "label"` once the node has a statement payload. For an undocumented, dependency-free attribute node, first add a matching statement directive. A proof body persisted in an imported provider module is not yet materialized by `{includeBlueprintModule}` or an initial `{blueprint_node}` placement. |
 | Show the formal declaration | Supported as a highlighted external-declaration panel with its signature, kind-specific structure information, docstring, proof/completeness status, and source link when available. |

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -334,7 +334,9 @@ same label, the part contains one node with all of their Lean panels. Re-exporte
 or otherwise transitive modules are not folded into the part: include each
 desired module explicitly. Every node follows the same docstring/code-only,
 numbering, relation, preview, manifest, and cache path as an individual
-placement.
+placement. Its local display number is assigned in the consuming document's
+traversal order; the generated placement does not retain a display number from
+the provider module.
 
 Module inclusion currently materializes the statement facet only. A separate
 informal `:::proof` body persisted in the defining module is not automatically
@@ -1377,7 +1379,7 @@ renders a pointer to the HTML output, and `Not in PDF` is absent from
 | External Markdown or TeX markup attachments | Stored in the manifest; headers show attachment badges; bodyless Markdown-backed nodes can render source-backed HTML cache fragments | Partial | Explicit external-markup blocks render only when shown with `(display := summary)` or `(display := source)`; source-backed HTML cache bodies are not converted into PDF bodies |
 | Source provenance and source-PDF spans | Source chips, manifest entries, and data/preview API access for source document ids and text/PDF spans | Not in PDF | Not shown as source chips or page overlays in the PDF |
 | Dependency graph and progress summary pages | Interactive graph and summary views with runtime controls and previews | Notice only | Static notice pointing readers to the HTML output |
-| Grafted Blueprint nodes | Rendered from the preview manifest and HTML cache | Partial | Inserted graft nodes render as a static notice; side-by-side authored content still renders statically |
+| Grafted Blueprint nodes, including `{includeBlueprintModule}` and attribute-owned `{blueprint_node}` placements | Rendered from the preview manifest and HTML cache | Partial | Inserted graft nodes render as a static notice; side-by-side authored content still renders statically |
 | Browser preview runtime, relation panels, and interactive controls | Supported in generated HTML | Not in PDF | Not available in PDF |
 | Preview manifest, HTML cache, and JavaScript APIs | Emitted for generated-data and browser consumers | Not in PDF | Not embedded in `main.pdf`; still emitted alongside HTML unless those outputs are disabled |
 | Slides and other generator-side consumers | Supported through their own HTML/data render paths | Not in PDF | Not part of the `--pdf` output path |

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -58,7 +58,7 @@ These identifiers are used by:
 - labeled inline Lean code blocks
 - labeled inline Rust code blocks
 - `tex` and `md` code blocks carrying external markup source
-- `@[blueprint "label"]` on compiled Lean declarations
+- `@[blueprint]` or `@[blueprint "label"]` on compiled Lean declarations
 - summary and graph nodes
 - preview lookup and exported metadata
 
@@ -277,11 +277,23 @@ theorem nat_add_zero_right (n : Nat) : n + 0 = n := by
 This is the clearest way to connect a Blueprint entry to local formalization
 work in the same project.
 
-### Compiled code tagged with `@[blueprint "addition_assoc_compiled"]`
+### Compiled code tagged with `@[blueprint]`
 
-Use the `@[blueprint "label"]` attribute when a compiled definition-like
+Use the `@[blueprint]` attribute when a compiled definition-like
 declaration or theorem should appear as a compiled-declaration-backed Blueprint
-node:
+node. With no string argument, its Blueprint label is the declaration's
+qualified Lean name:
+
+```lean
+/-- Associativity of addition under its qualified declaration name. -/
+@[blueprint]
+theorem MyProject.addition_assoc (a b c : Nat) :
+    (a + b) + c = a + (b + c) := by
+  simpa [Nat.add_assoc]
+```
+
+Use `@[blueprint "label"]` when the document should own a shorter or otherwise
+independent label:
 
 ```lean
 /--
@@ -300,9 +312,10 @@ If the declaration has a docstring, Blueprint tries to reuse it as the informal
 statement body for that attribute-owned node. Plain docstrings are parsed
 through the Manual Markdown path when possible. With the `doc.verso` option
 enabled, standard structural content such as paragraphs, emphasis, lists,
-links, code, quotations, and section content is converted into Manual blocks.
-If no docstring is available, the node is still registered, but there is no
-imported informal statement body.
+links, code, math, quotations, and section content is converted into Manual
+blocks. The same structural content is rendered inside the attached “Lean code
+for…” declaration panel. If no docstring is available, the node is still
+registered, but there is no imported informal statement body.
 
 Enabling `doc.verso` does not elaborate a declaration docstring as a Blueprint
 Manual fragment. Blueprint currently flattens every Lean docstring extension
@@ -341,6 +354,15 @@ numbering, relation, preview, manifest, and cache path as an individual
 placement. Its local display number is assigned in the consuming document's
 traversal order; the generated placement does not retain a display number from
 the provider module.
+
+This is Blueprint's current Verso-native counterpart to
+[LeanArchitect's `\inputleanmodule`](https://github.com/hanwenzhu/LeanArchitect#extracting-entire-lean-file-to-latex):
+it turns tagged declarations from a regular imported Lean module into document
+content. The current command includes declaration-backed nodes only. It does
+not yet have LeanArchitect's ordered `blueprint_comment` equivalent for prose
+interleaved among declarations; put compact prose in declaration docstrings, or
+use individual `{blueprint_node "label"}` placements inside an ordinary Verso
+chapter when the prose needs its own position.
 
 Module inclusion currently materializes the statement facet only. A separate
 informal `:::proof` body persisted in the defining module is not automatically
@@ -521,12 +543,13 @@ the inferred dependency edges.
 | Use case | Current behavior |
 | --- | --- |
 | Definitions, theorems, structures, and inductives | Supported. They become definition- or theorem-shaped Blueprint nodes. Constructors, recursors, axioms, and declarations introduced with `opaque` are not accepted as direct attribute targets. |
+| Omit an explicit Blueprint label | Supported with bare `@[blueprint]`; the label defaults to the declaration's qualified Lean name. Attribute options such as `uses`, `proofUses`, and `autoDeps` remain available. |
 | Direct and transitive imports | Supported. Attribute nodes, Lean associations, docstring bodies, and dependency metadata persist through imported `.olean` files. Duplicate imported Blueprint labels are diagnosed. |
 | Include a regular Lean module as a Blueprint chapter | Supported in Manual documents with `{includeBlueprintModule 0 Some.Module}` after importing the module. Distinct directly owned labels are emitted in first attribute-application order; transitive modules must be named and included explicitly. |
 | Place a tagged declaration on a specific Manual page | Supported with `{blueprint_node "label"}` after importing its module. The placement participates in numbering, links, relations, previews, the manifest, and the rendered-fragment cache. |
 | Add chapter prose around the declaration | Supported with ordinary prose before and after the placement command. For an attribute node without a docstring, a matching statement directive can instead supply prose inside the node shell. |
 | Reuse the same node in several places | Supported. The node keeps one semantic identity; later `{blueprint_node}` occurrences are presentation views and may use compact/header/display-label options. |
-| Use the declaration docstring as the statement | Supported for plain Markdown and standard structural `doc.verso` content that can be converted to Manual blocks. Custom docstring extension semantics are flattened to child content rather than re-elaborated. An absent docstring produces a code-only placement. |
+| Use the declaration docstring as the statement | Supported for plain Markdown and standard structural `doc.verso` content that can be converted to Manual blocks. Structural `doc.verso` markup and math are also preserved in the attached external-declaration panel. Custom docstring extension semantics are flattened to child content rather than re-elaborated. An absent docstring produces a code-only placement. |
 | Infer formal dependencies | Supported with `(autoDeps := true)` or `set_option verso.blueprint.autoDeps true`. Type references become statement dependencies and body references become proof dependencies. Inference is direct, not transitive through untagged helpers. |
 | Curate dependencies manually | Supported with attribute options `uses` and `proofUses`, using either Blueprint label strings or tagged Lean declaration names. Prefixing an entry with `-` excludes it on that axis. A `{uses ...}[]` form inside a declaration docstring is not interpreted as dependency metadata. |
 | Attach several labels to one Lean declaration, or several Lean declarations to one label | Supported. Associations are many-to-many and are deduplicated by canonical Lean name or Blueprint label as appropriate. |
@@ -561,6 +584,8 @@ Notes:
 - `(lean := "Nat.add, Nat.succ")` supports comma-separated declaration lists
 - `@[blueprint "addition_assoc_compiled"]` registers a
   compiled-declaration-backed Blueprint node
+- bare `@[blueprint]` uses the qualified declaration name as its Blueprint
+  label
 - `(autoDeps := true)` is accepted by `@[blueprint]`, labeled inline Lean blocks,
   and statement blocks with `(lean := "...")`
 - Blueprint labels are Blueprint-owned metadata
@@ -1433,7 +1458,9 @@ prefixes with document-order block counts.
   - renders proof blocks as collapsed disclosure blocks
 - `verso.blueprint.foldCodeBlocks`
   - default: `false`
-  - renders Lean, Rust, and external code panels as collapsed disclosure blocks
+  - renders Lean, Rust, and external code panels as collapsed disclosure blocks,
+    including panels produced by attribute-owned `{blueprint_node}` placements
+    and `{includeBlueprintModule}`
 - `verso.blueprint.trimTeXLabelPrefix`
   - default: `false`
   - trims TeX-style label prefixes when deriving Lean names

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -498,8 +498,8 @@ by the declaration's type and compiled body. Declarations associated with
 Blueprint labels and used directly by the type become statement dependencies;
 declarations associated with Blueprint labels and used directly by the body
 become proof dependencies. A Lean declaration is associated with a Blueprint
-label by `@[blueprint "..."]`, by a labeled inline Lean code block, or by an
-informal statement block with `(lean := "...")`.
+label by `@[blueprint]` or `@[blueprint "..."]`, by a labeled inline Lean code
+block, or by an informal statement block with `(lean := "...")`.
 
 Lean associations are many-to-many. One Blueprint label may be associated with
 several Lean code items, and one Lean declaration may be associated with several

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -279,11 +279,15 @@ work in the same project.
 
 ### Compiled code tagged with `@[blueprint "addition_assoc_compiled"]`
 
-Use the `@[blueprint "label"]` attribute when a compiled definition-like declaration or theorem
-should appear as a Lean-owned Blueprint node:
+Use the `@[blueprint "label"]` attribute when a compiled definition-like
+declaration or theorem should appear as a compiled-declaration-backed Blueprint
+node:
 
 ```lean
-/-- Associativity of addition, exposed as a Lean-owned blueprint node. -/
+/--
+Associativity of addition, exposed as a compiled-declaration-backed Blueprint
+node.
+-/
 @[blueprint "addition_assoc_compiled"]
 theorem addition_assoc_compiled (a b c : Nat) : (a + b) + c = a + (b + c) := by
   simpa [Nat.add_assoc]
@@ -293,12 +297,12 @@ This mode is useful when the formal declaration already exists as ordinary Lean
 code and you want to register it as a Blueprint node.
 
 If the declaration has a docstring, Blueprint tries to reuse it as the informal
-statement body for that Lean-owned node. Plain docstrings are parsed through the
-Manual Markdown path when possible. With `set_option doc.verso true`, standard
-structural content such as paragraphs, emphasis, lists, links, code, quotations,
-and section content is converted into Manual blocks. If no docstring is
-available, the node is still registered, but there is no imported informal
-statement body.
+statement body for that attribute-owned node. Plain docstrings are parsed
+through the Manual Markdown path when possible. With the `doc.verso` option
+enabled, standard structural content such as paragraphs, emphasis, lists,
+links, code, quotations, and section content is converted into Manual blocks.
+If no docstring is available, the node is still registered, but there is no
+imported informal statement body.
 
 Enabling `doc.verso` does not elaborate a declaration docstring as a Blueprint
 Manual fragment. Blueprint currently flattens every Lean docstring extension
@@ -555,7 +559,8 @@ Notes:
 
 - `(lean := "Nat.add_assoc")` points at Lean-owned declaration names
 - `(lean := "Nat.add, Nat.succ")` supports comma-separated declaration lists
-- `@[blueprint "addition_assoc_compiled"]` registers a Lean-owned Blueprint node
+- `@[blueprint "addition_assoc_compiled"]` registers a
+  compiled-declaration-backed Blueprint node
 - `(autoDeps := true)` is accepted by `@[blueprint]`, labeled inline Lean blocks,
   and statement blocks with `(lean := "...")`
 - Blueprint labels are Blueprint-owned metadata
@@ -1379,7 +1384,7 @@ renders a pointer to the HTML output, and `Not in PDF` is absent from
 | External Markdown or TeX markup attachments | Stored in the manifest; headers show attachment badges; bodyless Markdown-backed nodes can render source-backed HTML cache fragments | Partial | Explicit external-markup blocks render only when shown with `(display := summary)` or `(display := source)`; source-backed HTML cache bodies are not converted into PDF bodies |
 | Source provenance and source-PDF spans | Source chips, manifest entries, and data/preview API access for source document ids and text/PDF spans | Not in PDF | Not shown as source chips or page overlays in the PDF |
 | Dependency graph and progress summary pages | Interactive graph and summary views with runtime controls and previews | Notice only | Static notice pointing readers to the HTML output |
-| Grafted Blueprint nodes, including `{includeBlueprintModule}` and attribute-owned `{blueprint_node}` placements | Rendered from the preview manifest and HTML cache | Partial | Inserted graft nodes render as a static notice; side-by-side authored content still renders statically |
+| Grafted Blueprint nodes, including `{includeBlueprintModule}` and attribute-owned `{blueprint_node}` placements | Rendered from current traversal preview data and emitted to the preview manifest and HTML cache | Partial | Inserted graft nodes render as a static notice; side-by-side authored content still renders statically |
 | Browser preview runtime, relation panels, and interactive controls | Supported in generated HTML | Not in PDF | Not available in PDF |
 | Preview manifest, HTML cache, and JavaScript APIs | Emitted for generated-data and browser consumers | Not in PDF | Not embedded in `main.pdf`; still emitted alongside HTML unless those outputs are disabled |
 | Slides and other generator-side consumers | Supported through their own HTML/data render paths | Not in PDF | Not part of the `--pdf` output path |

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -116,6 +116,8 @@ ProjectTemplate/
     Addition.lean
     Multiplication.lean
     Collatz.lean
+  Formalization/
+    Addition.lean
 ProjectTemplate.lean
 ProjectTemplateMain.lean
 lakefile.lean
@@ -124,6 +126,8 @@ lakefile.lean
 The role of each file is:
 
 - `ProjectTemplate/Chapters/Addition.lean`: a chapter with Blueprint blocks
+- `ProjectTemplate/Formalization/Addition.lean`: ordinary Lean declarations
+  tagged with `@[blueprint]` and included as a generated module chapter
 - `ProjectTemplate/Chapters/Multiplication.lean`: another chapter with the same
   pattern
 - `ProjectTemplate/Chapters/Collatz.lean`: a separate chapter for an
@@ -147,6 +151,7 @@ import VersoBlueprint.Commands.Summary
 import ProjectTemplate.Chapters.Addition
 import ProjectTemplate.Chapters.Collatz
 import ProjectTemplate.Chapters.Multiplication
+import ProjectTemplate.Formalization.Addition
 
 open Verso.Genre
 open Verso.Genre.Manual
@@ -158,6 +163,7 @@ This small Blueprint tracks a few basic arithmetic facts on natural numbers,
 then ends with a separate Collatz chapter that is intentionally unfinished.
 
 {include 0 ProjectTemplate.Chapters.Addition}
+{includeBlueprintModule 0 ProjectTemplate.Formalization.Addition (title := "Compiled Addition Results")}
 {include 0 ProjectTemplate.Chapters.Multiplication}
 {include 0 ProjectTemplate.Chapters.Collatz}
 
@@ -288,9 +294,123 @@ code and you want to register it as a Blueprint node.
 
 If the declaration has a docstring, Blueprint tries to reuse it as the informal
 statement body for that Lean-owned node. Plain docstrings are parsed through the
-manual Markdown path when possible, and richer internal docstring structures are
-converted into Manual blocks directly. If no docstring is available, the node is
-still registered, but there is no imported informal statement body.
+Manual Markdown path when possible. With `set_option doc.verso true`, standard
+structural content such as paragraphs, emphasis, lists, links, code, quotations,
+and section content is converted into Manual blocks. If no docstring is
+available, the node is still registered, but there is no imported informal
+statement body.
+
+Enabling `doc.verso` does not elaborate a declaration docstring as a Blueprint
+Manual fragment. Lean docstring extension nodes are flattened to their child
+content when they have no Manual representation, so custom role or directive
+semantics are not preserved. In particular, `{uses ...}[]` inside a docstring is
+not Blueprint dependency metadata. Record those edges with the attribute's
+`(uses := [...])` or `(proofUses := [...])` options. Blueprint deliberately does
+not create a synthetic `DocElabM` context to reinterpret an imported docstring.
+
+#### Including an attribute module as a chapter
+
+When a regular Lean module is the primary Blueprint source, import it in the
+document module's Lean header and include all of its directly tagged
+declarations as one Verso part:
+
+```lean
+import MyProject.Formalization.Interpolation
+
+open Verso.Genre
+open Verso.Genre.Manual
+open Informal
+
+#doc (Manual) "Project Blueprint" =>
+
+{includeBlueprintModule 0 MyProject.Formalization.Interpolation (title := "Interpolation Spaces")}
+```
+
+The generated Manual part contains one materialized Blueprint node for each
+distinct `@[blueprint]` label owned directly by the named module, in first
+attribute-application order. If several declarations in that module use the
+same label, the part contains one node with all of their Lean panels. Re-exported
+or otherwise transitive modules are not folded into the part: include each
+desired module explicitly. Every node follows the same docstring/code-only,
+numbering, relation, preview, manifest, and cache path as an individual
+placement.
+
+The first positional number has the same structural role as in Verso's regular
+`{include 0 Some.Document}` command. It is optional; without it, the generated
+part is a child of the current part. The optional `(title := "...")` overrides
+the generated title, whose default is the final component of the module name:
+
+```lean
+{includeBlueprintModule MyProject.Formalization.Interpolation}
+```
+
+The command is available only in Manual documents. It reads Blueprint metadata
+from the imported `.olean`; it does not perform a Lean import from inside the
+document body. If the exact named module is not available through the Lean
+module's import graph, or if it directly owns no `@[blueprint]` declarations,
+the command reports an error. A module include is best when declaration
+docstrings are the chapter prose. To interleave longer prose between selected
+declarations, use individual `{blueprint_node "label"}` placements instead.
+
+#### Placing an attribute-owned node in a chapter
+
+Import the module containing the tagged declaration, then write
+`{blueprint_node "label"}` at the exact place where the node should appear:
+
+```lean
+import MyProject.Formalization.Interpolation
+
+open Verso.Genre
+open Verso.Genre.Manual
+open Informal
+
+#doc (Manual) "Interpolation spaces" =>
+
+The next result packages the formal definition used throughout this chapter.
+
+{blueprint_node "k-interpolation-space"}
+
+The surrounding chapter can continue with examples, motivation, or links to
+later Blueprint nodes.
+```
+
+For an imported `@[blueprint]` node, this command does two jobs. It projects the
+persistent Lean-side node into the current document traversal, which gives it a
+number, page destination, relation metadata, and generated preview entries; it
+then renders that entry through the ordinary Blueprint graft path. A docstring
+becomes the statement body. A declaration without a docstring renders as a
+code-only node instead of failing with “Blueprint node not found”.
+
+This placement behavior is specific to attribute-owned nodes in Manual
+documents. For ordinary `:::theorem` and related blocks, `{blueprint_node}`
+continues to mean “render another view of a node already traversed in this
+document”. In Slides, grafts continue to read the Blueprint site manifest/cache
+passed to the Slides generator.
+
+The usual graft options apply at the placement site, including `+compact`,
+`-header`, `(displayLabel := "...")`, and `(facet := "proof")`. Compact mode
+intentionally hides the attached Lean panel. A proof facet exists only when the
+Blueprint node has a separate `:::proof` body; a compiled theorem proof does not
+automatically become informal proof prose.
+
+Additional prose can simply surround the placement command. If the tagged
+declaration has no docstring and the prose should live inside the numbered
+statement shell, write a matching statement block instead; it fills the
+attribute-created node and keeps the Lean association and dependency metadata:
+
+```lean
+:::theorem "k-interpolation-space"
+An interpolation space satisfying the conditions used in this chapter.
+:::
+
+:::proof "k-interpolation-space"
+The informal proof outline can be maintained separately from the Lean proof.
+:::
+```
+
+Do not also use `{blueprint_node "k-interpolation-space"}` merely to create the
+first occurrence in that case: the statement block is already the canonical
+placement. Later `{blueprint_node}` commands may reuse it elsewhere.
 
 Automatic dependency inference is opt-in. Enable it locally with
 `(autoDeps := true)`, or set the file/section default with:
@@ -378,6 +498,26 @@ A tagged declaration can still receive a prose statement or proof block with the
 same Blueprint label. If the attribute has only created dependency metadata for
 that statement or proof, the later block fills in the rendered body and keeps
 the inferred dependency edges.
+
+#### Attribute-first use-case matrix
+
+| Use case | Current behavior |
+| --- | --- |
+| Definitions, theorems, structures, and inductives | Supported. They become definition- or theorem-shaped Blueprint nodes. Constructors, recursors, axioms, and declarations introduced with `opaque` are not accepted as direct attribute targets. |
+| Direct and transitive imports | Supported. Attribute nodes, Lean associations, docstring bodies, and dependency metadata persist through imported `.olean` files. Duplicate imported Blueprint labels are diagnosed. |
+| Include a regular Lean module as a Blueprint chapter | Supported in Manual documents with `{includeBlueprintModule 0 Some.Module}` after importing the module. Distinct directly owned labels are emitted in first attribute-application order; transitive modules must be named and included explicitly. |
+| Place a tagged declaration on a specific Manual page | Supported with `{blueprint_node "label"}` after importing its module. The placement participates in numbering, links, relations, previews, the manifest, and the rendered-fragment cache. |
+| Add chapter prose around the declaration | Supported with ordinary prose before and after the placement command. For an attribute node without a docstring, a matching statement directive can instead supply prose inside the node shell. |
+| Reuse the same node in several places | Supported. The node keeps one semantic identity; later `{blueprint_node}` occurrences are presentation views and may use compact/header/display-label options. |
+| Use the declaration docstring as the statement | Supported for plain Markdown and standard structural `doc.verso` content that can be converted to Manual blocks. Custom docstring extension semantics are flattened to child content rather than re-elaborated. An absent docstring produces a code-only placement. |
+| Infer formal dependencies | Supported with `(autoDeps := true)` or `set_option verso.blueprint.autoDeps true`. Type references become statement dependencies and body references become proof dependencies. Inference is direct, not transitive through untagged helpers. |
+| Curate dependencies manually | Supported with attribute options `uses` and `proofUses`, using either Blueprint label strings or tagged Lean declaration names. Prefixing an entry with `-` excludes it on that axis. A `{uses ...}[]` form inside a declaration docstring is not interpreted as dependency metadata. |
+| Attach several labels to one Lean declaration, or several Lean declarations to one label | Supported. Associations are many-to-many and are deduplicated by canonical Lean name or Blueprint label as appropriate. |
+| Add a separate informal proof | Supported with `:::proof "label"` once the node has a statement payload. For an undocumented, dependency-free attribute node, first add a matching statement directive. |
+| Show the formal declaration | Supported as a highlighted external-declaration panel with its signature, kind-specific structure information, docstring, proof/completeness status, and source link when available. |
+| Show the original definition body or `:= by ...` proof text | Not currently supported by the compiled-declaration renderer. The panel renders the declaration interface, not the original source body. Use the source link, or a labeled inline Lean block when the exact authored proof text must be embedded in the page. |
+| Put `parent`, `owner`, `tags`, `effort`, `priority`, or `pr_url` directly on `@[blueprint]` | Not currently supported. These remain Blueprint statement-block metadata. A separate attribute-side metadata surface needs an ownership and validation design before it is added. |
+| Use an unplaced attribute node in global views | The persistent node can contribute semantic graph/summary facts, but it has no page destination or rendered preview until it is placed in a Manual document. |
 
 ### Existing Lean declarations
 
@@ -964,8 +1104,8 @@ contract shared by those workflows.
 Use `{blueprint_node "label"}` when an overview, introduction, roadmap, or slide
 needs to feature an existing Blueprint entry without rewriting it.
 
-In Manual documents, the command resolves the target from the current traversal
-state:
+In Manual documents, an ordinary informal node resolves from the current
+traversal state:
 
 ```lean
 import VersoBlueprint
@@ -983,6 +1123,13 @@ The statement to feature.
 {blueprint_node "thm:key" -header +compact}
 :::::::
 ```
+
+An imported node owned by `@[blueprint "label"]` is the other Manual case. If
+the label is not yet in the traversal, the command first materializes the
+persistent attribute node at that source position, then renders the same graft
+shell. See [Placing an attribute-owned node in a
+chapter](#placing-an-attribute-owned-node-in-a-chapter) for the attribute-first
+workflow and its current code/proof limitations.
 
 In Slides decks, the same source command is available after importing
 `VersoBlueprint.Slides`, but the rendered node comes from the manifest/cache

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -1171,10 +1171,10 @@ The statement to feature.
 :::::::
 ```
 
-An imported node owned by `@[blueprint "label"]` is the other Manual case. If
-the label is not yet in the traversal, the command first materializes the
-persistent attribute node at that source position, then renders the same graft
-shell. See [Placing an attribute-owned node in a
+An imported node owned by bare `@[blueprint]` or `@[blueprint "label"]` is the
+other Manual case. If the label is not yet in the traversal, the command first
+materializes the persistent attribute node at that source position, then
+renders the same graft shell. See [Placing an attribute-owned node in a
 chapter](#placing-an-attribute-owned-node-in-a-chapter) for the attribute-first
 workflow and its current code/proof limitations.
 

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -301,12 +301,13 @@ available, the node is still registered, but there is no imported informal
 statement body.
 
 Enabling `doc.verso` does not elaborate a declaration docstring as a Blueprint
-Manual fragment. Lean docstring extension nodes are flattened to their child
-content when they have no Manual representation, so custom role or directive
-semantics are not preserved. In particular, `{uses ...}[]` inside a docstring is
-not Blueprint dependency metadata. Record those edges with the attribute's
-`(uses := [...])` or `(proofUses := [...])` options. Blueprint deliberately does
-not create a synthetic `DocElabM` context to reinterpret an imported docstring.
+Manual fragment. Blueprint currently flattens every Lean docstring extension
+node to its child content, discarding the extension wrapper rather than looking
+up a Manual adapter. Custom role or directive semantics are therefore not
+preserved. In particular, `{uses ...}[]` inside a docstring is not Blueprint
+dependency metadata. Record those edges with the attribute's `(uses := [...])`
+or `(proofUses := [...])` options. Blueprint deliberately does not create a
+synthetic `DocElabM` context to reinterpret an imported docstring.
 
 #### Including an attribute module as a chapter
 
@@ -334,6 +335,13 @@ or otherwise transitive modules are not folded into the part: include each
 desired module explicitly. Every node follows the same docstring/code-only,
 numbering, relation, preview, manifest, and cache path as an individual
 placement.
+
+Module inclusion currently materializes the statement facet only. A separate
+informal `:::proof` body persisted in the defining module is not automatically
+registered in the consuming document. Proof prose written and traversed in the
+consuming document remains available through the ordinary proof facet. This is
+separate from the compiled Lean proof: Blueprint's external-declaration panel
+does not reproduce the original `:= by ...` source text.
 
 The first positional number has the same structural role as in Verso's regular
 `{include 0 Some.Document}` command. It is optional; without it, the generated
@@ -389,9 +397,12 @@ passed to the Slides generator.
 
 The usual graft options apply at the placement site, including `+compact`,
 `-header`, `(displayLabel := "...")`, and `(facet := "proof")`. Compact mode
-intentionally hides the attached Lean panel. A proof facet exists only when the
-Blueprint node has a separate `:::proof` body; a compiled theorem proof does not
-automatically become informal proof prose.
+intentionally hides the attached Lean panel. For an imported attribute-owned
+node, the initial placement currently materializes only its statement facet; a
+proof facet is available after a matching `:::proof` has been traversed in the
+consuming document. A persisted provider-module proof is not automatically
+materialized, and a compiled theorem proof does not automatically become
+informal proof prose.
 
 Additional prose can simply surround the placement command. If the tagged
 declaration has no docstring and the prose should live inside the numbered
@@ -513,7 +524,7 @@ the inferred dependency edges.
 | Infer formal dependencies | Supported with `(autoDeps := true)` or `set_option verso.blueprint.autoDeps true`. Type references become statement dependencies and body references become proof dependencies. Inference is direct, not transitive through untagged helpers. |
 | Curate dependencies manually | Supported with attribute options `uses` and `proofUses`, using either Blueprint label strings or tagged Lean declaration names. Prefixing an entry with `-` excludes it on that axis. A `{uses ...}[]` form inside a declaration docstring is not interpreted as dependency metadata. |
 | Attach several labels to one Lean declaration, or several Lean declarations to one label | Supported. Associations are many-to-many and are deduplicated by canonical Lean name or Blueprint label as appropriate. |
-| Add a separate informal proof | Supported with `:::proof "label"` once the node has a statement payload. For an undocumented, dependency-free attribute node, first add a matching statement directive. |
+| Add a separate informal proof | Supported with `:::proof "label"` once the node has a statement payload. For an undocumented, dependency-free attribute node, first add a matching statement directive. A proof body persisted in an imported provider module is not yet materialized by `{includeBlueprintModule}` or an initial `{blueprint_node}` placement. |
 | Show the formal declaration | Supported as a highlighted external-declaration panel with its signature, kind-specific structure information, docstring, proof/completeness status, and source link when available. |
 | Show the original definition body or `:= by ...` proof text | Not currently supported by the compiled-declaration renderer. The panel renders the declaration interface, not the original source body. Use the source link, or a labeled inline Lean block when the exact authored proof text must be embedded in the page. |
 | Put `parent`, `owner`, `tags`, `effort`, `priority`, or `pr_url` directly on `@[blueprint]` | Not currently supported. These remain Blueprint statement-block metadata. A separate attribute-side metadata surface needs an ownership and validation design before it is added. |

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -169,15 +169,18 @@ Work:
 9. revisit external declaration footer/status semantics once out-of-workspace
    declarations are represented precisely enough to distinguish declaration
    completeness from dependency completeness
-10. continue the attribute-first authoring path after declaration placement:
-    decide whether explicit Blueprint prose should override an imported
-    docstring fallback, design attribute-side `parent`/owner/tag/effort/priority
-    metadata without duplicating statement-block validation, evaluate
-    `only`/`except` filters and module-level introductory prose for
-    `{includeBlueprintModule}`, design typed adapters for custom Lean docstring
-    extensions that need Manual semantics, and capture exact definition/proof
-    source only after Lean exposes a reliable post-declaration range or syntax
-    hook to the attribute pipeline
+10. design facet-aware materialization for persisted informal proof bodies and
+    decide whether `{includeBlueprintModule}` renders them by default
+11. decide whether explicit Blueprint prose should override an imported
+    docstring fallback
+12. design attribute-side `parent`/owner/tag/effort/priority metadata without
+    duplicating statement-block validation
+13. evaluate `only`/`except` filters and module-level introductory prose for
+    `{includeBlueprintModule}`
+14. extract or upstream the shared structural `Lean.Doc` conversion before
+    designing typed adapters for custom extensions that need Manual semantics
+15. capture exact definition/proof source only after Lean exposes a reliable
+    post-declaration range or syntax hook to the attribute pipeline
 
 ### Asset and Build Reliability
 

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -175,8 +175,10 @@ Work:
     docstring fallback
 12. design attribute-side `parent`/owner/tag/effort/priority metadata without
     duplicating statement-block validation
-13. evaluate `only`/`except` filters and module-level introductory prose for
-    `{includeBlueprintModule}`
+13. evaluate `only`/`except` filters and an ordered module-prose representation
+    for `{includeBlueprintModule}`, including a `blueprint_comment`-like way to
+    interleave prose among tagged declarations rather than only adding one
+    introductory paragraph
 14. extract or upstream the shared structural `Lean.Doc` conversion before
     designing typed adapters for custom extensions that need Manual semantics
 15. capture exact definition/proof source only after Lean exposes a reliable

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -169,6 +169,15 @@ Work:
 9. revisit external declaration footer/status semantics once out-of-workspace
    declarations are represented precisely enough to distinguish declaration
    completeness from dependency completeness
+10. continue the attribute-first authoring path after declaration placement:
+    decide whether explicit Blueprint prose should override an imported
+    docstring fallback, design attribute-side `parent`/owner/tag/effort/priority
+    metadata without duplicating statement-block validation, evaluate
+    `only`/`except` filters and module-level introductory prose for
+    `{includeBlueprintModule}`, design typed adapters for custom Lean docstring
+    extensions that need Manual semantics, and capture exact definition/proof
+    source only after Lean exposes a reliable post-declaration range or syntax
+    hook to the attribute pipeline
 
 ### Asset and Build Reliability
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -33,6 +33,7 @@ lean_lib VersoBlueprintTests where
     `VersoBlueprintTests.BlueprintAssets,
     `VersoBlueprintTests.BlueprintAutoDeps,
     `VersoBlueprintTests.BlueprintAttribute,
+    `VersoBlueprintTests.BlueprintAttributeRendering,
     `VersoBlueprintTests.BlueprintCodeRenderMatrix,
     `VersoBlueprintTests.BlueprintImportedDuplicates.Direct,
     `VersoBlueprintTests.BlueprintImportedDuplicates.ProviderA,

--- a/project_template/ProjectTemplate/Blueprint.lean
+++ b/project_template/ProjectTemplate/Blueprint.lean
@@ -6,6 +6,7 @@ import VersoBlueprint.Commands.Summary
 import ProjectTemplate.Chapters.Addition
 import ProjectTemplate.Chapters.Collatz
 import ProjectTemplate.Chapters.Multiplication
+import ProjectTemplate.Formalization.Addition
 
 open Verso.Genre
 open Verso.Genre.Manual
@@ -18,6 +19,7 @@ then ends with a separate Collatz chapter that is intentionally unfinished. It
 is intentionally small, so it can serve as a starting point for a new project.
 
 {include 0 ProjectTemplate.Chapters.Addition}
+{includeBlueprintModule 0 ProjectTemplate.Formalization.Addition (title := "Compiled Addition Results")}
 {include 0 ProjectTemplate.Chapters.Multiplication}
 {include 0 ProjectTemplate.Chapters.Collatz}
 

--- a/project_template/ProjectTemplate/Formalization/Addition.lean
+++ b/project_template/ProjectTemplate/Formalization/Addition.lean
@@ -1,0 +1,15 @@
+import VersoBlueprint
+
+namespace ProjectTemplate.Formalization.Addition
+
+/-- Addition of natural numbers is commutative. -/
+@[blueprint "addition_comm_compiled" (uses := ["addition_spec"])]
+theorem addition_comm_compiled (a b : Nat) : a + b = b + a := by
+  simpa using Nat.add_comm a b
+
+/-- Zero is a left identity for addition of natural numbers. -/
+@[blueprint "addition_zero_compiled" (uses := ["addition_right_identity"])]
+theorem addition_zero_compiled (a : Nat) : 0 + a = a := by
+  simp
+
+end ProjectTemplate.Formalization.Addition

--- a/project_template/README.md
+++ b/project_template/README.md
@@ -33,6 +33,8 @@ project_template/
       Addition.lean
       Multiplication.lean
       Collatz.lean
+    Formalization/
+      Addition.lean
   ProjectTemplateMain.lean
   source/
     addition-source.pdf
@@ -43,6 +45,9 @@ project_template/
 The important files are:
 
 - `ProjectTemplate/Chapters/Addition.lean`: the first chapter
+- `ProjectTemplate/Formalization/Addition.lean`: an ordinary Lean module whose
+  tagged declarations become a generated chapter through
+  `{includeBlueprintModule}`
 - `ProjectTemplate/Chapters/Multiplication.lean`: the second chapter
 - `ProjectTemplate/Chapters/Collatz.lean`: a separate exploratory chapter with
   the intentionally unfinished conjecture
@@ -64,6 +69,8 @@ The important files are:
 - local Lean code attached to a Blueprint label
 - local Rust code attached to a Blueprint label
 - a statement linked to an existing Lean declaration
+- an imported Lean module whose `@[blueprint]` declarations are included as a
+  source-ordered Blueprint chapter
 - source-document metadata attached to one theorem
 - group and author metadata
 - rendered progress summary and dependency graph pages

--- a/src/VersoBlueprint.lean
+++ b/src/VersoBlueprint.lean
@@ -54,6 +54,7 @@ import VersoBlueprint.LeanNameParsing
 import VersoBlueprint.PreviewCache
 import VersoBlueprint.PreviewManifest
 import VersoBlueprint.Graft
+import VersoBlueprint.ModuleInclude
 import VersoBlueprint.Resolve
 import VersoBlueprint.TraversalIndex
 import VersoBlueprint.StyleSwitcher

--- a/src/VersoBlueprint/Attribute.lean
+++ b/src/VersoBlueprint/Attribute.lean
@@ -326,6 +326,7 @@ private def registerLeanOnlyDecl (decl : Name) (cfg : BlueprintAttrConfig) (ref 
         data.insert label node
       | none => data
     return data
+  Environment.registerBlueprintAttributeNode label
 
 open Lean in
 initialize

--- a/src/VersoBlueprint/Attribute.lean
+++ b/src/VersoBlueprint/Attribute.lean
@@ -298,7 +298,7 @@ private def payloadWithDeps
       else
         some { stx := ref, deps }
 
-private def registerLeanOnlyDecl (decl : Name) (cfg : BlueprintAttrConfig) (ref : Syntax) : CoreM Unit := do
+private def registerBlueprintDecl (decl : Name) (cfg : BlueprintAttrConfig) (ref : Syntax) : CoreM Unit := do
   let decl := decl.eraseMacroScopes
   let label := cfg.label.eraseMacroScopes
   let some info := (← getEnv).find? decl
@@ -340,7 +340,7 @@ initialize
       unless ((← getEnv).getModuleIdxFor? decl).isNone do
         throwError "invalid attribute '[blueprint]', declaration is in an imported module"
       let cfg ← elabBlueprintConfig stx
-      registerLeanOnlyDecl decl cfg stx
+      registerBlueprintDecl decl cfg stx
     descr := "Registers a compiled declaration as a Blueprint node; supports opt-in automatic dependency inference"
   }
 

--- a/src/VersoBlueprint/Attribute.lean
+++ b/src/VersoBlueprint/Attribute.lean
@@ -326,7 +326,7 @@ private def registerLeanOnlyDecl (decl : Name) (cfg : BlueprintAttrConfig) (ref 
         data.insert label node
       | none => data
     return data
-  Environment.registerBlueprintAttributeNode label
+  Environment.registerBlueprintAttributeLabel label
 
 open Lean in
 initialize

--- a/src/VersoBlueprint/Attribute.lean
+++ b/src/VersoBlueprint/Attribute.lean
@@ -341,7 +341,7 @@ initialize
         throwError "invalid attribute '[blueprint]', declaration is in an imported module"
       let cfg ← elabBlueprintConfig stx
       registerLeanOnlyDecl decl cfg stx
-    descr := "Registers a definition/theorem as a Lean-only blueprint node; supports opt-in automatic dependency inference"
+    descr := "Registers a compiled declaration as a Blueprint node; supports opt-in automatic dependency inference"
   }
 
 end Informal

--- a/src/VersoBlueprint/Attribute.lean
+++ b/src/VersoBlueprint/Attribute.lean
@@ -8,10 +8,10 @@ import Lean
 import Lean.DocString.Extension
 import VersoManual
 import VersoBlueprint.DependencyAnalysis
+import VersoBlueprint.Docstring
 import VersoBlueprint.Environment
 import VersoBlueprint.ExternalRefSnapshot
 import VersoBlueprint.LabelNameParsing
-import VersoBlueprint.Math
 
 namespace Informal
 
@@ -23,7 +23,7 @@ declare_syntax_cat blueprintAttrOption
 syntax (name := blueprintAutoDepsAttrOption) "(" &"autoDeps" " := " ident ")" : blueprintAttrOption
 syntax (name := blueprintUsesAttrOption) "(" &"uses" " := " blueprintDepList ")" : blueprintAttrOption
 syntax (name := blueprintProofUsesAttrOption) "(" &"proofUses" " := " blueprintDepList ")" : blueprintAttrOption
-syntax (name := blueprint) "blueprint" ppSpace str (ppSpace blueprintAttrOption)* : attr
+syntax (name := blueprint) "blueprint" (ppSpace str)? (ppSpace blueprintAttrOption)* : attr
 
 private inductive AutoDepTarget where
   | label (label : Data.Label)
@@ -93,108 +93,33 @@ private def parseDepList : TSyntax ``blueprintDepList → CoreM AutoDepEntries
       | _ => throwError "unsupported dependency syntax in '[blueprint]' attribute"
   | _ => throwError "unsupported dependency list syntax in '[blueprint]' attribute"
 
-private def elabBlueprintConfig : Syntax → CoreM BlueprintAttrConfig
-  | `(attr| blueprint $label:str $[$opts:blueprintAttrOption]*) => do
-    let mut cfg : BlueprintAttrConfig := { label := parseLabel label.getString }
-    for opt in opts do
-      match opt with
-      | `(blueprintAttrOption| (autoDeps := $value:ident)) =>
-        match value.getId.eraseMacroScopes with
-        | `true => cfg := { cfg with autoDeps := some true }
-        | `false => cfg := { cfg with autoDeps := some false }
-        | _ => throwErrorAt value "'autoDeps' expects 'true' or 'false'"
-      | `(blueprintAttrOption| (uses := $deps:blueprintDepList)) =>
-        let deps ← parseDepList deps
-        cfg := { cfg with uses := cfg.uses.append deps }
-      | `(blueprintAttrOption| (proofUses := $deps:blueprintDepList)) =>
-        let deps ← parseDepList deps
-        cfg := { cfg with proofUses := cfg.proofUses.append deps }
-      | _ => throwError "unsupported option syntax in '[blueprint]' attribute"
-    return cfg
+private def elabBlueprintOptions
+    (cfg : BlueprintAttrConfig)
+    (opts : Array (TSyntax `blueprintAttrOption)) :
+    CoreM BlueprintAttrConfig := do
+  let mut cfg := cfg
+  for opt in opts do
+    match opt with
+    | `(blueprintAttrOption| (autoDeps := $value:ident)) =>
+      match value.getId.eraseMacroScopes with
+      | `true => cfg := { cfg with autoDeps := some true }
+      | `false => cfg := { cfg with autoDeps := some false }
+      | _ => throwErrorAt value "'autoDeps' expects 'true' or 'false'"
+    | `(blueprintAttrOption| (uses := $deps:blueprintDepList)) =>
+      let deps ← parseDepList deps
+      cfg := { cfg with uses := cfg.uses.append deps }
+    | `(blueprintAttrOption| (proofUses := $deps:blueprintDepList)) =>
+      let deps ← parseDepList deps
+      cfg := { cfg with proofUses := cfg.proofUses.append deps }
+    | _ => throwError "unsupported option syntax in '[blueprint]' attribute"
+  return cfg
+
+private def elabBlueprintConfig (decl : Name) : Syntax → CoreM BlueprintAttrConfig
+  | `(attr| blueprint $label:str $[$opts:blueprintAttrOption]*) =>
+    elabBlueprintOptions { label := parseLabel label.getString } opts
+  | `(attr| blueprint $[$opts:blueprintAttrOption]*) =>
+    elabBlueprintOptions { label := parseLabel decl.eraseMacroScopes.toString } opts
   | _ => throwError "invalid syntax for '[blueprint]' attribute"
-
-mutual
-
-private partial def inlineToManualStx (inl : Lean.Doc.Inline Lean.ElabInline) : CoreM (TSyntax `term) := do
-  match inl with
-  | .text s => `(Verso.Doc.Inline.text $(quote s))
-  | .emph content =>
-    let content ← content.mapM inlineToManualStx
-    `(Verso.Doc.Inline.emph #[$content,*])
-  | .bold content =>
-    let content ← content.mapM inlineToManualStx
-    `(Verso.Doc.Inline.bold #[$content,*])
-  | .code s => `(Verso.Doc.Inline.code $(quote s))
-  | .math .inline s => Informal.Math.mkBpMathInlineTerm .inline s
-  | .math .display s => Informal.Math.mkBpMathInlineTerm .display s
-  | .linebreak s => `(Verso.Doc.Inline.linebreak $(quote s))
-  | .link content url =>
-    let content ← content.mapM inlineToManualStx
-    `(Verso.Doc.Inline.link #[$content,*] $(quote url))
-  | .footnote name content =>
-    let content ← content.mapM inlineToManualStx
-    `(Verso.Doc.Inline.footnote $(quote name) #[$content,*])
-  | .image alt url => `(Verso.Doc.Inline.image $(quote alt) $(quote url))
-  | .concat content =>
-    let content ← content.mapM inlineToManualStx
-    `(Verso.Doc.Inline.concat #[$content,*])
-  -- Fallback for docstring extensions not available in the Manual genre.
-  | .other _ content =>
-    let content ← content.mapM inlineToManualStx
-    `(Verso.Doc.Inline.concat #[$content,*])
-
-private partial def listItemToManualStx
-    (item : Lean.Doc.ListItem (Lean.Doc.Block Lean.ElabInline Lean.ElabBlock)) : CoreM (TSyntax `term) := do
-  let contents ← item.contents.mapM blockToManualStx
-  `(Verso.Doc.ListItem.mk #[$contents,*])
-
-private partial def descItemToManualStx
-    (item : Lean.Doc.DescItem (Lean.Doc.Inline Lean.ElabInline) (Lean.Doc.Block Lean.ElabInline Lean.ElabBlock)) :
-    CoreM (TSyntax `term) := do
-  let term ← item.term.mapM inlineToManualStx
-  let desc ← item.desc.mapM blockToManualStx
-  `(Verso.Doc.DescItem.mk #[$term,*] #[$desc,*])
-
-private partial def blockToManualStx (b : Lean.Doc.Block Lean.ElabInline Lean.ElabBlock) : CoreM (TSyntax `term) := do
-  match b with
-  | .para contents =>
-    let contents ← contents.mapM inlineToManualStx
-    `(Verso.Doc.Block.para #[$contents,*])
-  | .code content => `(Verso.Doc.Block.code $(quote content))
-  | .ul items =>
-    let items ← items.mapM listItemToManualStx
-    `(Verso.Doc.Block.ul #[$items,*])
-  | .ol start items =>
-    let items ← items.mapM listItemToManualStx
-    `(Verso.Doc.Block.ol $(quote start) #[$items,*])
-  | .dl items =>
-    let items ← items.mapM descItemToManualStx
-    `(Verso.Doc.Block.dl #[$items,*])
-  | .blockquote items =>
-    let items ← items.mapM blockToManualStx
-    `(Verso.Doc.Block.blockquote #[$items,*])
-  | .concat content =>
-    let content ← content.mapM blockToManualStx
-    `(Verso.Doc.Block.concat #[$content,*])
-  -- Fallback for docstring extensions not available in the Manual genre.
-  | .other _ content =>
-    let content ← content.mapM blockToManualStx
-    `(Verso.Doc.Block.concat #[$content,*])
-
-end
-
-private partial def partToManualBlocksStx
-    (p : Lean.Doc.Part Lean.ElabInline Lean.ElabBlock Empty) : CoreM (Array (TSyntax `term)) := do
-  let mut out : Array (TSyntax `term) := #[]
-  if !p.title.isEmpty then
-    let title ← p.title.mapM inlineToManualStx
-    let titleBold ← `(Verso.Doc.Inline.bold #[$title,*])
-    let titleBlock ← `(Verso.Doc.Block.para #[$titleBold])
-    out := out.push titleBlock
-  out := out ++ (← p.content.mapM blockToManualStx)
-  for child in p.subParts do
-    out := out ++ (← partToManualBlocksStx child)
-  pure out
 
 private def statementFromDocstring? (decl : Name) (ref : Syntax) : CoreM (Option Data.InformalData) := do
   let env ← getEnv
@@ -214,11 +139,8 @@ private def statementFromDocstring? (decl : Name) (ref : Syntax) : CoreM (Option
               (handleHeaders := Verso.Genre.Manual.Markdown.strongEmphHeaders))
         | none =>
           pure #[← `(Verso.Doc.Block.para #[Verso.Doc.Inline.text $(quote doc)])]
-    | some (.inr d) =>
-      let mut blocks ← d.text.mapM blockToManualStx
-      for part in d.subsections do
-        blocks := blocks ++ (← partToManualBlocksStx part)
-      pure blocks
+    | some (.inr doc) =>
+      Informal.Docstring.versoDocstringToManualBlocksStx doc
   if elabStx.isEmpty then
     pure none
   else
@@ -339,9 +261,9 @@ initialize
         throwError "invalid attribute '[blueprint]', must be global"
       unless ((← getEnv).getModuleIdxFor? decl).isNone do
         throwError "invalid attribute '[blueprint]', declaration is in an imported module"
-      let cfg ← elabBlueprintConfig stx
+      let cfg ← elabBlueprintConfig decl stx
       registerBlueprintDecl decl cfg stx
-    descr := "Registers a compiled declaration as a Blueprint node; supports opt-in automatic dependency inference"
+    descr := "Registers a compiled declaration as a Blueprint node, using its qualified declaration name as the default label; supports opt-in automatic dependency inference"
   }
 
 end Informal

--- a/src/VersoBlueprint/Data.lean
+++ b/src/VersoBlueprint/Data.lean
@@ -494,7 +494,8 @@ inductive CodeRef where
   /-
   Blueprint code references can currently come from two sources:
   1. An inline Lean block processed by Verso/Lean integration (`.literate`).
-  2. A regular Lean declaration tagged with `@[blueprint "..."]` (`.external`, origin `.blueprintAttr`).
+  2. A regular Lean declaration tagged with `@[blueprint]` or
+     `@[blueprint "..."]` (`.external`, origin `.blueprintAttr`).
      A `(lean := "...")` directive reference to Lean code we do not directly control
      also lands in `.external` (origin `.directiveLean`).
 

--- a/src/VersoBlueprint/Docstring.lean
+++ b/src/VersoBlueprint/Docstring.lean
@@ -1,0 +1,225 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import Lean.DocString.Extension
+import VersoManual
+import VersoBlueprint.Math
+
+namespace Informal.Docstring
+
+open Lean
+
+mutual
+
+private partial def inlineToManualStx
+    (inl : Lean.Doc.Inline Lean.ElabInline) : CoreM (TSyntax `term) := do
+  match inl with
+  | .text s => `(Verso.Doc.Inline.text $(quote s))
+  | .emph content =>
+    let content ← content.mapM inlineToManualStx
+    `(Verso.Doc.Inline.emph #[$content,*])
+  | .bold content =>
+    let content ← content.mapM inlineToManualStx
+    `(Verso.Doc.Inline.bold #[$content,*])
+  | .code s => `(Verso.Doc.Inline.code $(quote s))
+  | .math .inline s => Informal.Math.mkBpMathInlineTerm .inline s
+  | .math .display s => Informal.Math.mkBpMathInlineTerm .display s
+  | .linebreak s => `(Verso.Doc.Inline.linebreak $(quote s))
+  | .link content url =>
+    let content ← content.mapM inlineToManualStx
+    `(Verso.Doc.Inline.link #[$content,*] $(quote url))
+  | .footnote name content =>
+    let content ← content.mapM inlineToManualStx
+    `(Verso.Doc.Inline.footnote $(quote name) #[$content,*])
+  | .image alt url => `(Verso.Doc.Inline.image $(quote alt) $(quote url))
+  | .concat content =>
+    let content ← content.mapM inlineToManualStx
+    `(Verso.Doc.Inline.concat #[$content,*])
+  -- Extensions without a Manual adapter retain their converted child content.
+  | .other _ content =>
+    let content ← content.mapM inlineToManualStx
+    `(Verso.Doc.Inline.concat #[$content,*])
+
+private partial def listItemToManualStx
+    (item : Lean.Doc.ListItem (Lean.Doc.Block Lean.ElabInline Lean.ElabBlock)) :
+    CoreM (TSyntax `term) := do
+  let contents ← item.contents.mapM blockToManualStx
+  `(Verso.Doc.ListItem.mk #[$contents,*])
+
+private partial def descItemToManualStx
+    (item :
+      Lean.Doc.DescItem
+        (Lean.Doc.Inline Lean.ElabInline)
+        (Lean.Doc.Block Lean.ElabInline Lean.ElabBlock)) :
+    CoreM (TSyntax `term) := do
+  let term ← item.term.mapM inlineToManualStx
+  let desc ← item.desc.mapM blockToManualStx
+  `(Verso.Doc.DescItem.mk #[$term,*] #[$desc,*])
+
+private partial def blockToManualStx
+    (block : Lean.Doc.Block Lean.ElabInline Lean.ElabBlock) :
+    CoreM (TSyntax `term) := do
+  match block with
+  | .para contents =>
+    let contents ← contents.mapM inlineToManualStx
+    `(Verso.Doc.Block.para #[$contents,*])
+  | .code content => `(Verso.Doc.Block.code $(quote content))
+  | .ul items =>
+    let items ← items.mapM listItemToManualStx
+    `(Verso.Doc.Block.ul #[$items,*])
+  | .ol start items =>
+    let items ← items.mapM listItemToManualStx
+    `(Verso.Doc.Block.ol $(quote start) #[$items,*])
+  | .dl items =>
+    let items ← items.mapM descItemToManualStx
+    `(Verso.Doc.Block.dl #[$items,*])
+  | .blockquote items =>
+    let items ← items.mapM blockToManualStx
+    `(Verso.Doc.Block.blockquote #[$items,*])
+  | .concat content =>
+    let content ← content.mapM blockToManualStx
+    `(Verso.Doc.Block.concat #[$content,*])
+  -- Extensions without a Manual adapter retain their converted child content.
+  | .other _ content =>
+    let content ← content.mapM blockToManualStx
+    `(Verso.Doc.Block.concat #[$content,*])
+
+end
+
+/--
+Convert an elaborated Verso docstring into the Manual blocks used by an
+attribute-owned Blueprint statement.
+
+The conversion preserves standard structural nodes and deliberately flattens
+custom extensions whose semantics are not available in the Manual genre.
+-/
+partial def versoDocstringToManualBlocksStx
+    (doc : Lean.VersoDocString) : CoreM (Array (TSyntax `term)) := do
+  let mut blocks ← doc.text.mapM blockToManualStx
+  for part in doc.subsections do
+    blocks := blocks ++ (← partToManualBlocksStx part)
+  pure blocks
+where
+  partToManualBlocksStx
+      (part : Lean.Doc.Part Lean.ElabInline Lean.ElabBlock Empty) :
+      CoreM (Array (TSyntax `term)) := do
+    let mut out : Array (TSyntax `term) := #[]
+    if !part.title.isEmpty then
+      let title ← part.title.mapM inlineToManualStx
+      let titleBold ← `(Verso.Doc.Inline.bold #[$title,*])
+      let titleBlock ← `(Verso.Doc.Block.para #[$titleBold])
+      out := out.push titleBlock
+    out := out ++ (← part.content.mapM blockToManualStx)
+    for child in part.subParts do
+      out := out ++ (← partToManualBlocksStx child)
+    pure out
+
+private def mathAttrs (mode : Lean.Doc.MathMode) (texPrelude : String) :
+    Array (String × String) :=
+  let classes :=
+    "bp_math " ++ match mode with
+      | .inline => "inline"
+      | .display => "display"
+  if texPrelude.isEmpty then
+    #[("class", classes)]
+  else
+    #[("class", classes), ("data-bp-tex-prelude", texPrelude)]
+
+mutual
+
+private partial def inlineToHtml
+    (texPrelude : String)
+    (inline : Lean.Doc.Inline Lean.ElabInline) : Verso.Output.Html :=
+  match inline with
+  | .text text => .text true text
+  | .emph content => .tag "em" #[] (.seq <| content.map (inlineToHtml texPrelude))
+  | .bold content => .tag "strong" #[] (.seq <| content.map (inlineToHtml texPrelude))
+  | .code code => .tag "code" #[] (.text true code)
+  | .math mode source =>
+    .tag "code" (mathAttrs mode texPrelude) (.text true source)
+  | .linebreak text => .text false text
+  | .link content url =>
+    .tag "a" #[("href", url)] (.seq <| content.map (inlineToHtml texPrelude))
+  | .footnote name content =>
+    .tag "details" #[("class", "footnote")] <|
+      .seq #[
+        .tag "summary" #[] (.text true s!"[{name}]"),
+        .seq <| content.map (inlineToHtml texPrelude)
+      ]
+  | .image alt url => .tag "img" #[("src", url), ("alt", alt)] .empty
+  | .concat content => .seq <| content.map (inlineToHtml texPrelude)
+  -- Keep the same fallback policy as Manual-block conversion.
+  | .other _ content => .seq <| content.map (inlineToHtml texPrelude)
+
+private partial def listItemToHtml
+    (texPrelude : String)
+    (item : Lean.Doc.ListItem (Lean.Doc.Block Lean.ElabInline Lean.ElabBlock)) :
+    Verso.Output.Html :=
+  .tag "li" #[] (.seq <| item.contents.map (blockToHtml texPrelude))
+
+private partial def descItemToHtml
+    (texPrelude : String)
+    (item :
+      Lean.Doc.DescItem
+        (Lean.Doc.Inline Lean.ElabInline)
+        (Lean.Doc.Block Lean.ElabInline Lean.ElabBlock)) :
+    Verso.Output.Html :=
+  .seq #[
+    .tag "dt" #[] (.seq <| item.term.map (inlineToHtml texPrelude)),
+    .tag "dd" #[] (.seq <| item.desc.map (blockToHtml texPrelude))
+  ]
+
+private partial def blockToHtml
+    (texPrelude : String)
+    (block : Lean.Doc.Block Lean.ElabInline Lean.ElabBlock) :
+    Verso.Output.Html :=
+  match block with
+  | .para contents =>
+    .tag "p" #[] (.seq <| contents.map (inlineToHtml texPrelude))
+  | .code content => .tag "pre" #[] (.text true content)
+  | .ul items => .tag "ul" #[] (.seq <| items.map (listItemToHtml texPrelude))
+  | .ol start items =>
+    .tag "ol" #[("start", toString (max start 0))]
+      (.seq <| items.map (listItemToHtml texPrelude))
+  | .dl items => .tag "dl" #[] (.seq <| items.map (descItemToHtml texPrelude))
+  | .blockquote items =>
+    .tag "blockquote" #[] (.seq <| items.map (blockToHtml texPrelude))
+  | .concat content => .seq <| content.map (blockToHtml texPrelude)
+  -- Keep the same fallback policy as Manual-block conversion.
+  | .other _ content => .seq <| content.map (blockToHtml texPrelude)
+
+end
+
+/--
+Render the standard structural subset of an elaborated Verso docstring as
+static HTML for external declaration panels.
+
+Custom extension wrappers are flattened to their children, matching statement
+materialization. Blueprint math receives the same classes and TeX prelude
+metadata as normal Blueprint math nodes.
+-/
+partial def versoDocstringToHtml
+    (doc : Lean.VersoDocString) (texPrelude : String := "") :
+    Verso.Output.Html :=
+  let text := .seq <| doc.text.map (blockToHtml texPrelude)
+  let subsections := .seq <| doc.subsections.map (partToHtml texPrelude)
+  .seq #[text, subsections]
+where
+  partToHtml
+      (texPrelude : String)
+      (part : Lean.Doc.Part Lean.ElabInline Lean.ElabBlock Empty) :
+      Verso.Output.Html :=
+    let title :=
+      if part.title.isEmpty then
+        .empty
+      else
+        .tag "p" #[] <|
+          .tag "strong" #[] (.seq <| part.title.map (inlineToHtml texPrelude))
+    let content := .seq <| part.content.map (blockToHtml texPrelude)
+    let children := .seq <| part.subParts.map (partToHtml texPrelude)
+    .seq #[title, content, children]
+
+end Informal.Docstring

--- a/src/VersoBlueprint/Environment.lean
+++ b/src/VersoBlueprint/Environment.lean
@@ -60,9 +60,9 @@ structure State where
   data : Data := Data.empty
   localData : NameMap Node := {}
   /-- Attribute-owned labels grouped by their defining module, in application order. -/
-  blueprintAttributeModules : NameMap (Array Label) := {}
+  blueprintAttributeLabelsByModule : NameMap (Array Label) := {}
   /-- Current-module subset exported through the persistent extension. -/
-  localBlueprintAttributeModules : NameMap (Array Label) := {}
+  localBlueprintAttributeLabelsByModule : NameMap (Array Label) := {}
   groups : NameMap String := {}
   localGroups : NameMap String := {}
   authors : NameMap AuthorInfo := {}
@@ -97,7 +97,7 @@ private def sortImportedConflicts (conflicts : Array ImportedConflict) : Array I
 
 inductive Entry where
   | node (label : Name) (node : Node)
-  | blueprintAttributeNode (moduleName : Name) (label : Label)
+  | blueprintAttributeLabel (moduleName : Name) (label : Label)
   | group (label : Name) (header : String)
   | author (label : Name) (info : AuthorInfo)
 deriving Inhabited, Repr
@@ -105,7 +105,7 @@ deriving Inhabited, Repr
 private def pushLabelUnique (labels : Array Label) (label : Label) : Array Label :=
   if labels.contains label then labels else labels.push label
 
-private def addBlueprintAttributeNode
+private def addBlueprintAttributeLabel
     (modules : NameMap (Array Label))
     (moduleName : Name) (label : Label) :
     NameMap (Array Label) :=
@@ -166,12 +166,12 @@ initialize informalExt : PersistentEnvExtension Entry Entry State ←
           localData := state.localData.insert label node
           leanNameLabels := addNodeLeanDeclLabels state.leanNameLabels label node
         }
-      | .blueprintAttributeNode moduleName label =>
+      | .blueprintAttributeLabel moduleName label =>
         { state with
-          blueprintAttributeModules :=
-            addBlueprintAttributeNode state.blueprintAttributeModules moduleName label
-          localBlueprintAttributeModules :=
-            addBlueprintAttributeNode state.localBlueprintAttributeModules moduleName label
+          blueprintAttributeLabelsByModule :=
+            addBlueprintAttributeLabel state.blueprintAttributeLabelsByModule moduleName label
+          localBlueprintAttributeLabelsByModule :=
+            addBlueprintAttributeLabel state.localBlueprintAttributeLabelsByModule moduleName label
         }
       | .group label header =>
         { state with
@@ -184,7 +184,7 @@ initialize informalExt : PersistentEnvExtension Entry Entry State ←
           localAuthors := state.localAuthors.insert label info
         }
     addImportedFn entries := do
-      let (data, attributeModules, groups, authors, leanNameLabels, importedConflicts) :=
+      let (data, attributeLabelsByModule, groups, authors, leanNameLabels, importedConflicts) :=
         entries.foldl
           (init := (
             ({} : NameMap Node),
@@ -195,37 +195,37 @@ initialize informalExt : PersistentEnvExtension Entry Entry State ←
             (#[] : Array ImportedConflict)
           )) fun acc entry =>
         entry.foldl (init := acc) fun
-            (dataAcc, attributeModulesAcc, groupAcc, authorAcc, leanNameAcc, conflictsAcc) item =>
+            (dataAcc, attributeLabelsAcc, groupAcc, authorAcc, leanNameAcc, conflictsAcc) item =>
           match item with
           | .node label node =>
             if dataAcc.contains label then
-              (dataAcc, attributeModulesAcc, groupAcc, authorAcc, leanNameAcc,
+              (dataAcc, attributeLabelsAcc, groupAcc, authorAcc, leanNameAcc,
                 pushImportedConflict conflictsAcc .node label)
             else
               let leanNameAcc := addNodeLeanDeclLabels leanNameAcc label node
-              (dataAcc.insert label node, attributeModulesAcc, groupAcc, authorAcc,
+              (dataAcc.insert label node, attributeLabelsAcc, groupAcc, authorAcc,
                 leanNameAcc, conflictsAcc)
-          | .blueprintAttributeNode moduleName label =>
+          | .blueprintAttributeLabel moduleName label =>
             (dataAcc,
-              addBlueprintAttributeNode attributeModulesAcc moduleName label,
+              addBlueprintAttributeLabel attributeLabelsAcc moduleName label,
               groupAcc, authorAcc, leanNameAcc, conflictsAcc)
           | .group label header =>
             if groupAcc.contains label then
-              (dataAcc, attributeModulesAcc, groupAcc, authorAcc, leanNameAcc,
+              (dataAcc, attributeLabelsAcc, groupAcc, authorAcc, leanNameAcc,
                 pushImportedConflict conflictsAcc .group label)
             else
-              (dataAcc, attributeModulesAcc, groupAcc.insert label header, authorAcc,
+              (dataAcc, attributeLabelsAcc, groupAcc.insert label header, authorAcc,
                 leanNameAcc, conflictsAcc)
           | .author label info =>
             if authorAcc.contains label then
-              (dataAcc, attributeModulesAcc, groupAcc, authorAcc, leanNameAcc,
+              (dataAcc, attributeLabelsAcc, groupAcc, authorAcc, leanNameAcc,
                 pushImportedConflict conflictsAcc .author label)
             else
-              (dataAcc, attributeModulesAcc, groupAcc, authorAcc.insert label info,
+              (dataAcc, attributeLabelsAcc, groupAcc, authorAcc.insert label info,
                 leanNameAcc, conflictsAcc)
       pure {
         data
-        blueprintAttributeModules := attributeModules
+        blueprintAttributeLabelsByModule := attributeLabelsByModule
         groups
         authors
         leanNameLabels
@@ -239,15 +239,15 @@ initialize informalExt : PersistentEnvExtension Entry Entry State ←
         let proof := node.proof.map fun p =>
           if p.previewBlocks.isEmpty then p else { p with elabStx := #[] }
         Entry.node name { node with statement, proof }
-      let attributeNodeEntries :=
-        state.localBlueprintAttributeModules.toArray.flatMap fun (moduleName, labels) =>
-          labels.map (Entry.blueprintAttributeNode moduleName)
+      let attributeLabelEntries :=
+        state.localBlueprintAttributeLabelsByModule.toArray.flatMap fun (moduleName, labels) =>
+          labels.map (Entry.blueprintAttributeLabel moduleName)
       let groupEntries := state.localGroups.toArray.map fun (label, header) =>
         Entry.group label header
       let authorEntries := state.localAuthors.toArray.map fun (label, info) =>
         Entry.author label info
       OLeanEntries.uniform
-        (nodeEntries ++ attributeNodeEntries ++ groupEntries ++ authorEntries)
+        (nodeEntries ++ attributeLabelEntries ++ groupEntries ++ authorEntries)
   }
 
 section EnvOps
@@ -272,15 +272,16 @@ Record one successful `@[blueprint]` label under the module currently being
 compiled. Repeated registrations keep the first application position while the
 semantic node continues to collect every Lean declaration.
 -/
-def registerBlueprintAttributeNode (label : Label) : m Unit := do
+def registerBlueprintAttributeLabel (label : Label) : m Unit := do
   let moduleName := (← getEnv).mainModule
   modifyEnv fun env =>
     informalExt.addEntry env <|
-      .blueprintAttributeNode moduleName label.eraseMacroScopes
+      .blueprintAttributeLabel moduleName label.eraseMacroScopes
 
-/-- Attribute-owned Blueprint nodes declared directly by `moduleName`, in source order. -/
-def blueprintAttributeNodesForModule (moduleName : Name) : m (Array Label) := do
-  return (informalExt.getState (← getEnv)).blueprintAttributeModules.getD moduleName #[]
+/-- Attribute-owned Blueprint labels declared directly by `moduleName`, in source order. -/
+def blueprintAttributeLabelsForModule (moduleName : Name) : m (Array Label) := do
+  let state := informalExt.getState (← getEnv)
+  return state.blueprintAttributeLabelsByModule.getD moduleName #[]
 
 def importedConflicts : m (Array ImportedConflict) := do
   return (informalExt.getState (← getEnv)).importedConflicts

--- a/src/VersoBlueprint/Environment.lean
+++ b/src/VersoBlueprint/Environment.lean
@@ -59,6 +59,10 @@ data.
 structure State where
   data : Data := Data.empty
   localData : NameMap Node := {}
+  /-- Attribute-owned labels grouped by their defining module, in application order. -/
+  blueprintAttributeModules : NameMap (Array Label) := {}
+  /-- Current-module subset exported through the persistent extension. -/
+  localBlueprintAttributeModules : NameMap (Array Label) := {}
   groups : NameMap String := {}
   localGroups : NameMap String := {}
   authors : NameMap AuthorInfo := {}
@@ -93,12 +97,20 @@ private def sortImportedConflicts (conflicts : Array ImportedConflict) : Array I
 
 inductive Entry where
   | node (label : Name) (node : Node)
+  | blueprintAttributeNode (moduleName : Name) (label : Label)
   | group (label : Name) (header : String)
   | author (label : Name) (info : AuthorInfo)
 deriving Inhabited, Repr
 
 private def pushLabelUnique (labels : Array Label) (label : Label) : Array Label :=
   if labels.contains label then labels else labels.push label
+
+private def addBlueprintAttributeNode
+    (modules : NameMap (Array Label))
+    (moduleName : Name) (label : Label) :
+    NameMap (Array Label) :=
+  modules.insert moduleName <|
+    pushLabelUnique (modules.getD moduleName #[]) label
 
 private def nodeLeanDecls (node : Node) : Array Name :=
   node.leanDecls
@@ -154,6 +166,13 @@ initialize informalExt : PersistentEnvExtension Entry Entry State ←
           localData := state.localData.insert label node
           leanNameLabels := addNodeLeanDeclLabels state.leanNameLabels label node
         }
+      | .blueprintAttributeNode moduleName label =>
+        { state with
+          blueprintAttributeModules :=
+            addBlueprintAttributeNode state.blueprintAttributeModules moduleName label
+          localBlueprintAttributeModules :=
+            addBlueprintAttributeNode state.localBlueprintAttributeModules moduleName label
+        }
       | .group label header =>
         { state with
           groups := state.groups.insert label header
@@ -165,33 +184,53 @@ initialize informalExt : PersistentEnvExtension Entry Entry State ←
           localAuthors := state.localAuthors.insert label info
         }
     addImportedFn entries := do
-      let (data, groups, authors, leanNameLabels, importedConflicts) := entries.foldl
+      let (data, attributeModules, groups, authors, leanNameLabels, importedConflicts) :=
+        entries.foldl
           (init := (
             ({} : NameMap Node),
+            ({} : NameMap (Array Label)),
             ({} : NameMap String),
             ({} : NameMap AuthorInfo),
             ({} : NameMap (Array Label)),
             (#[] : Array ImportedConflict)
           )) fun acc entry =>
-        entry.foldl (init := acc) fun (dataAcc, groupAcc, authorAcc, leanNameAcc, conflictsAcc) item =>
+        entry.foldl (init := acc) fun
+            (dataAcc, attributeModulesAcc, groupAcc, authorAcc, leanNameAcc, conflictsAcc) item =>
           match item with
           | .node label node =>
             if dataAcc.contains label then
-              (dataAcc, groupAcc, authorAcc, leanNameAcc, pushImportedConflict conflictsAcc .node label)
+              (dataAcc, attributeModulesAcc, groupAcc, authorAcc, leanNameAcc,
+                pushImportedConflict conflictsAcc .node label)
             else
               let leanNameAcc := addNodeLeanDeclLabels leanNameAcc label node
-              (dataAcc.insert label node, groupAcc, authorAcc, leanNameAcc, conflictsAcc)
+              (dataAcc.insert label node, attributeModulesAcc, groupAcc, authorAcc,
+                leanNameAcc, conflictsAcc)
+          | .blueprintAttributeNode moduleName label =>
+            (dataAcc,
+              addBlueprintAttributeNode attributeModulesAcc moduleName label,
+              groupAcc, authorAcc, leanNameAcc, conflictsAcc)
           | .group label header =>
             if groupAcc.contains label then
-              (dataAcc, groupAcc, authorAcc, leanNameAcc, pushImportedConflict conflictsAcc .group label)
+              (dataAcc, attributeModulesAcc, groupAcc, authorAcc, leanNameAcc,
+                pushImportedConflict conflictsAcc .group label)
             else
-              (dataAcc, groupAcc.insert label header, authorAcc, leanNameAcc, conflictsAcc)
+              (dataAcc, attributeModulesAcc, groupAcc.insert label header, authorAcc,
+                leanNameAcc, conflictsAcc)
           | .author label info =>
             if authorAcc.contains label then
-              (dataAcc, groupAcc, authorAcc, leanNameAcc, pushImportedConflict conflictsAcc .author label)
+              (dataAcc, attributeModulesAcc, groupAcc, authorAcc, leanNameAcc,
+                pushImportedConflict conflictsAcc .author label)
             else
-              (dataAcc, groupAcc, authorAcc.insert label info, leanNameAcc, conflictsAcc)
-      pure { data, groups, authors, leanNameLabels, importedConflicts := sortImportedConflicts importedConflicts }
+              (dataAcc, attributeModulesAcc, groupAcc, authorAcc.insert label info,
+                leanNameAcc, conflictsAcc)
+      pure {
+        data
+        blueprintAttributeModules := attributeModules
+        groups
+        authors
+        leanNameLabels
+        importedConflicts := sortImportedConflicts importedConflicts
+      }
     -- Strip transient elaboration cache before exporting nodes to the environment.
     exportEntriesFnEx env := fun state =>
       let nodeEntries := state.localData.toArray.map fun (name, node) =>
@@ -200,11 +239,15 @@ initialize informalExt : PersistentEnvExtension Entry Entry State ←
         let proof := node.proof.map fun p =>
           if p.previewBlocks.isEmpty then p else { p with elabStx := #[] }
         Entry.node name { node with statement, proof }
+      let attributeNodeEntries :=
+        state.localBlueprintAttributeModules.toArray.flatMap fun (moduleName, labels) =>
+          labels.map (Entry.blueprintAttributeNode moduleName)
       let groupEntries := state.localGroups.toArray.map fun (label, header) =>
         Entry.group label header
       let authorEntries := state.localAuthors.toArray.map fun (label, info) =>
         Entry.author label info
-      OLeanEntries.uniform (nodeEntries ++ groupEntries ++ authorEntries)
+      OLeanEntries.uniform
+        (nodeEntries ++ attributeNodeEntries ++ groupEntries ++ authorEntries)
   }
 
 section EnvOps
@@ -223,6 +266,21 @@ def modifyDataForLabel (label : Label) (f : Data -> m Data) : m Unit := do
   modifyM fun state => do
     let data ← f state.data
     return state.commitDataForLabel label data
+
+/--
+Record one successful `@[blueprint]` label under the module currently being
+compiled. Repeated registrations keep the first application position while the
+semantic node continues to collect every Lean declaration.
+-/
+def registerBlueprintAttributeNode (label : Label) : m Unit := do
+  let moduleName := (← getEnv).mainModule
+  modifyEnv fun env =>
+    informalExt.addEntry env <|
+      .blueprintAttributeNode moduleName label.eraseMacroScopes
+
+/-- Attribute-owned Blueprint nodes declared directly by `moduleName`, in source order. -/
+def blueprintAttributeNodesForModule (moduleName : Name) : m (Array Label) := do
+  return (informalExt.getState (← getEnv)).blueprintAttributeModules.getD moduleName #[]
 
 def importedConflicts : m (Array ImportedConflict) := do
   return (informalExt.getState (← getEnv)).importedConflicts

--- a/src/VersoBlueprint/ExternalDeclRender.lean
+++ b/src/VersoBlueprint/ExternalDeclRender.lean
@@ -7,8 +7,10 @@ Author: Emilio J. Gallego Arias
 import Lean
 import Verso
 import VersoManual
+import VersoBlueprint.Docstring
 import VersoBlueprint.Lib.HtmlId
 import VersoBlueprint.Lib.HoverInline
+import VersoBlueprint.Macros
 
 open Lean Meta
 
@@ -283,9 +285,30 @@ private def plainDocstringHtml (docs? : Option String) : ExternalDeclHtml :=
   | some docs =>
     {{<pre class="docstring">{{.text true docs}}</pre>}}
 
-private def docsHtml (docs? : Option String) : ExternalDeclHtml :=
+private def structuralDocstringHtml
+    (doc : Lean.VersoDocString) (texPrelude : String) : ExternalDeclHtml :=
+  .tag "div" #[("class", "docstring")]
+    (Informal.Docstring.versoDocstringToHtml doc texPrelude)
+
+private def internalDocstringHtml
+    (doc? : Option (String ⊕ Lean.VersoDocString))
+    (fallback? : Option String)
+    (texPrelude : String) : ExternalDeclHtml :=
+  match doc? with
+  | some (.inl doc) => plainDocstringHtml (some doc)
+  | some (.inr doc) => structuralDocstringHtml doc texPrelude
+  | none => plainDocstringHtml fallback?
+
+private def docstringHtmlForDecl
+    (env : Lean.Environment) (decl : Name)
+    (fallback? : Option String) (texPrelude : String) :
+    MetaM ExternalDeclHtml := do
+  let doc? ← liftM <| findInternalDocString? env decl
+  pure <| internalDocstringHtml doc? fallback? texPrelude
+
+private def docsHtml (doc : ExternalDeclHtml) : ExternalDeclHtml :=
   open Verso.Output.Html in
-  {{<div class="docs">{{plainDocstringHtml docs?}}</div>}}
+  {{<div class="docs">{{doc}}</div>}}
 
 private def externalDeclSectionLabelId (decl : Name) (title : String) : String :=
   Informal.HtmlId.prefixed "bp-external-decl-section" s!"{decl.toString}:{title}"
@@ -420,18 +443,22 @@ private def visibilityHtml (v : Verso.Genre.Manual.Block.Docstring.Visibility) :
   | .private => {{<span class="keyword">"private"</span>" "}}
   | .protected => .empty
 
-private def renderDocNameCtor (docName : Verso.Genre.Manual.Block.Docstring.DocName) :
+private def renderDocNameCtor
+    (docName : Verso.Genre.Manual.Block.Docstring.DocName)
+    (docstring : ExternalDeclHtml) :
     ExternalDeclHighlightRender ExternalDeclHtml :=
   open Verso.Output.Html in do
   let signatureHtml ← highlightedToHtml docName.signature
   pure {{
     <div class="constructor">
       <pre class="name-and-type hl lean">{{signatureHtml}}</pre>
-      {{docsHtml docName.docstring?}}
+      {{docsHtml docstring}}
     </div>
   }}
 
-private def renderFieldSignature (field : Verso.Genre.Manual.Block.Docstring.FieldInfo) :
+private def renderFieldSignature
+    (field : Verso.Genre.Manual.Block.Docstring.FieldInfo)
+    (docstring : ExternalDeclHtml) :
     ExternalDeclHighlightRender ExternalDeclHtml :=
   open Verso.Output.Html in do
   let inheritedInfo : ExternalDeclHtml :=
@@ -455,9 +482,27 @@ private def renderFieldSignature (field : Verso.Genre.Manual.Block.Docstring.Fie
         {{visibilityHtml field.visibility}}{{fieldNameHtml}} " : " {{fieldTypeHtml}}
       </pre>
       {{inheritedInfo}}
-      {{docsHtml field.docString?}}
+      {{docsHtml docstring}}
     </section>
   }}
+
+private def nestedDocstrings
+    (env : Lean.Environment)
+    (declType : Verso.Genre.Manual.Block.Docstring.DeclType)
+    (texPrelude : String) :
+    MetaM (NameMap ExternalDeclHtml) := do
+  let nested : Array (Name × Option String) :=
+    match declType with
+    | .structure _ ctor? _ fields _ _ =>
+      let ctorDocs :=
+        (ctor?.map fun ctor => #[(ctor.name, ctor.docstring?)]).getD #[]
+      ctorDocs ++ fields.map fun field => (field.projFn, field.docString?)
+    | .inductive ctors _ _ =>
+      ctors.map fun ctor => (ctor.name, ctor.docstring?)
+    | _ => #[]
+  nested.foldlM (init := {}) fun docs (decl, fallback?) => do
+    let html ← docstringHtmlForDecl env decl fallback? texPrelude
+    return docs.insert decl html
 
 private def renderParentsSection
     (decl : Name)
@@ -521,7 +566,9 @@ private def renderDeclHtmlDocstringFromInfoE
     withOptions (verso.docstring.allowMissing.set · true) <|
       Verso.Genre.Manual.Block.Docstring.DeclType.ofName decl (hideStructureConstructor := true)
   let signature ← Verso.Genre.Manual.Signature.forName decl
-  let docs? ← liftM <| findDocString? env decl
+  let texPrelude ← Informal.Macros.getTexPrelude
+  let docstring ← docstringHtmlForDecl env decl none texPrelude
+  let nestedDocstrings ← nestedDocstrings env declType texPrelude
 
   let rendered := renderWithHoverPayloads <| do
     let ctorSection? : Option ExternalDeclHtml ←
@@ -530,7 +577,8 @@ private def renderDeclHtmlDocstringFromInfoE
         match ctor? with
         | some ctor =>
           let title := if isClass then "Instance Constructor" else "Constructor"
-          let ctorHtml ← renderDocNameCtor ctor
+          let ctorHtml ← renderDocNameCtor ctor <|
+            nestedDocstrings.getD ctor.name (plainDocstringHtml ctor.docstring?)
           pure <| renderTitledSection? decl title #[ctorHtml]
         | none => pure none
       | _ => pure none
@@ -538,7 +586,10 @@ private def renderDeclHtmlDocstringFromInfoE
     let methodsOrFieldsSection? : Option ExternalDeclHtml ←
       match declType with
       | .structure isClass _ _ fieldInfo _ _ =>
-        let rows ← fieldInfo.filter (fun f => f.subobject?.isNone) |>.mapM renderFieldSignature
+        let rows ←
+          fieldInfo.filter (fun f => f.subobject?.isNone) |>.mapM fun field =>
+            renderFieldSignature field <|
+              nestedDocstrings.getD field.projFn (plainDocstringHtml field.docString?)
         pure <| renderTitledSection? decl (if isClass then "Methods" else "Fields") rows
       | _ => pure none
 
@@ -550,7 +601,9 @@ private def renderDeclHtmlDocstringFromInfoE
     let inductiveCtorsSection? : Option ExternalDeclHtml ←
       match declType with
       | .inductive ctors _ _ =>
-        let rows ← ctors.mapM renderDocNameCtor
+        let rows ← ctors.mapM fun ctor =>
+          renderDocNameCtor ctor <|
+            nestedDocstrings.getD ctor.name (plainDocstringHtml ctor.docstring?)
         pure <| renderTitledSection? decl "Constructors" rows
       | _ => pure none
 
@@ -570,9 +623,9 @@ private def renderDeclHtmlDocstringFromInfoE
 
     let body : ExternalDeclHtml :=
       if sections.isEmpty then
-        plainDocstringHtml docs?
+        docstring
       else
-        {{ {{plainDocstringHtml docs?}} {{sections}} }}
+        {{ {{docstring}} {{sections}} }}
     pure <| renderExternalDeclWrapper
       decl presentation.kindClass presentation.kindMarker signatureHtml body
       (headerBadge? := headerBadge?) (headerMeta := headerMeta) (headerSource? := headerSource?)

--- a/src/VersoBlueprint/Graft.lean
+++ b/src/VersoBlueprint/Graft.lean
@@ -8,7 +8,6 @@ import VersoManual
 import VersoSlides
 import Verso.Doc.Elab
 import VersoBlueprint.Informal.Block.Assets
-import VersoBlueprint.Informal.Block.Store
 import VersoBlueprint.Informal.Block.Traversal
 import VersoBlueprint.Informal.LeanCodePreview
 import VersoBlueprint.Environment
@@ -174,9 +173,7 @@ block_extension Block.blueprintAttributeNodeSource (data : Informal.BlockData) w
           data
           (fun err => s!"Malformed attribute-owned Blueprint node data ({err}): {data}")
       | pure none
-    let blockData := blockData.withTraversalNumberingContext (← read)
-    Informal.registerTraversedBlockAssets id blockData contents
-    Informal.saveTraversedBlockData id blockData
+    Informal.registerTraversedBlock id blockData contents
     pure none
   toTeX := some <| fun _goI _goB _id _data _blocks => pure .empty
   toHtml := some <| fun _goI _goB id _data _blocks => do

--- a/src/VersoBlueprint/Graft.lean
+++ b/src/VersoBlueprint/Graft.lean
@@ -179,8 +179,6 @@ block_extension Block.blueprintAttributeNodeSource (data : Informal.BlockData) w
     Informal.saveTraversedBlockData id blockData
     pure none
   toTeX := some <| fun _goI _goB _id _data _blocks => pure .empty
-  extraCss := manualGraftAssetBundle.css
-  extraJs := manualGraftAssetBundle.js
   toHtml := some <| fun _goI _goB id _data _blocks => do
     let state ← Doc.Html.HtmlT.state
     pure <| Html.tag "span"

--- a/src/VersoBlueprint/Graft.lean
+++ b/src/VersoBlueprint/Graft.lean
@@ -304,22 +304,12 @@ private meta def attributeNodeBlockData?
     sourceLocation
     foldProofBlock := verso.blueprint.foldProofBlocks.get opts
     foldCodeBlock := verso.blueprint.foldCodeBlocks.get opts
-    parent := node.parent
-    count := node.count
+    count := 0
     numberingMode := Informal.numberingMode opts
     subNumberingPrefix := Informal.subNumberingPrefix opts
     subNumberingCounter := Informal.subNumberingCounter opts
-    statementUses := node.statement.map (·.deps) |>.getD #[]
-    proofUses := node.proof.map (·.deps) |>.getD #[]
-    owner := node.owner
-    ownerDisplayName := ownerInfo?.map (·.displayName)
-    ownerUrl := ownerInfo?.bind (·.url)
-    ownerImageUrl := ownerInfo?.bind (·.imageUrl)
-    tags := node.tags
-    effort := node.effort
-    priority := node.priority
-    prUrl := node.prUrl
   }
+  let blockData := blockData.withSemanticNodeMetadata (some node) ownerInfo?
   pure <| some (blockData, statementStxs)
 
 private meta def manualBlueprintNodeBlock
@@ -340,6 +330,7 @@ private meta def manualBlueprintNodeBlock
 
 public meta def blueprintNodeBlock (cfg : Informal.Graft.BlueprintNodeConfig) :
     DocElabM Term := do
+  Informal.Environment.reportImportedConflicts
   if ← inManualGenre then
     manualBlueprintNodeBlock cfg
   else if ← inSlidesGenre then

--- a/src/VersoBlueprint/Graft.lean
+++ b/src/VersoBlueprint/Graft.lean
@@ -8,7 +8,10 @@ import VersoManual
 import VersoSlides
 import Verso.Doc.Elab
 import VersoBlueprint.Informal.Block.Assets
+import VersoBlueprint.Informal.Block.Store
+import VersoBlueprint.Informal.Block.Traversal
 import VersoBlueprint.Informal.LeanCodePreview
+import VersoBlueprint.Environment
 import VersoBlueprint.Graft.Assets
 import VersoBlueprint.Graft.Node
 import VersoBlueprint.Graft.Render
@@ -125,12 +128,16 @@ private def renderManualGraftNode
         renderNotice "bp_graft_node_notice" "error" "Blueprint node not found"
           node.selectionDescription
   | some (preview, entry) =>
-      if !preview.hasRenderedBody then
+      if !preview.hasRenderedBody && entry.leanCodePreviewKeys.isEmpty then
         pure <| Html.tag "div" (manualNodeAttrs node) <|
           renderNotice "bp_graft_node_notice" "error"
             "Blueprint node has no cached content" node.key
       else
-        let body ← renderManualBlocks goB preview.renderedBody.blocks
+        let body ←
+          if preview.hasRenderedBody then
+            renderManualBlocks goB preview.renderedBody.blocks
+          else
+            pure .empty
         let codeBodies ←
           if node.compact then
             pure #[]
@@ -146,6 +153,42 @@ private def renderManualGraftNode
           entry
           content
           (Informal.PreviewManifest.groupRelationForEntry? state entry)
+
+/-
+Invisible source block that moves an imported `@[blueprint]` node from the
+persistent environment into the current document's traversal indexes.
+
+The visible output still goes through the ordinary graft renderer. Keeping the
+materializer limited to an empty destination anchor gives attribute-owned nodes
+the same numbering, relations, previews, and generated-data path as authored
+Blueprint blocks.
+-/
+open Verso Doc Elab Genre Manual in
+block_extension Block.blueprintAttributeNodeSource (data : Informal.BlockData) where
+  data := toJson data
+  usePackages := Informal.TeX.standardMathUsePackages
+  traverse id data contents := do
+    let some blockData ←
+        Informal.ExtensionDecode.decode?
+          (α := Informal.BlockData)
+          data
+          (fun err => s!"Malformed attribute-owned Blueprint node data ({err}): {data}")
+      | pure none
+    let blockData := blockData.withTraversalNumberingContext (← read)
+    Informal.registerTraversedBlockAssets id blockData contents
+    Informal.saveTraversedBlockData id blockData
+    pure none
+  toTeX := some <| fun _goI _goB _id _data _blocks => pure .empty
+  extraCss := manualGraftAssetBundle.css
+  extraJs := manualGraftAssetBundle.js
+  toHtml := some <| fun _goI _goB id _data _blocks => do
+    let state ← Doc.Html.HtmlT.state
+    pure <| Html.tag "span"
+      (state.htmlId id ++ #[
+        ("class", "bp_attribute_node_anchor"),
+        ("aria-hidden", "true")
+      ])
+      .empty
 
 open Verso Doc Elab Genre Manual in
 block_extension Block.blueprintGraftNode (cfg : Informal.Graft.BlueprintNodeConfig) where
@@ -198,18 +241,109 @@ private meta def currentGenreIs (genreTerm : Term) : DocElabM Bool := do
   let expected ← Lean.Elab.Term.elabTerm genreTerm (some (.const ``Verso.Doc.Genre []))
   Lean.Meta.isDefEq current expected
 
-private meta def inManualGenre : DocElabM Bool := do
+public meta def inManualGenre : DocElabM Bool := do
   currentGenreIs (← `(Verso.Genre.Manual))
 
 private meta def inSlidesGenre : DocElabM Bool := do
   currentGenreIs (← `(VersoSlides.Slides))
 
-public meta def blueprintNodeBlock (cfg : Informal.Graft.BlueprintNodeConfig) :
-    DocElabM Term := do
-  if ← inManualGenre then
+private def nodeIsBlueprintAttributeOwned (node : Informal.Data.Node) : Bool :=
+  node.externalRefs.any fun ref => ref.origin == .blueprintAttr
+
+/--
+Reconstruct one persisted Manual block inside the consuming document.
+
+Attribute-owned nodes may have bodies that were already elaborated in their
+defining module. Encoding those values through Manual's typed JSON instances
+lets the generated materializer feed them back through ordinary traversal
+without running a synthetic document elaborator or introducing another body
+schema.
+-/
+public def persistedManualBlockFromJson (jsonText : String) : Verso.Doc.Block Verso.Genre.Manual :=
+  match Lean.Json.parse jsonText >>= Lean.fromJson? with
+  | .ok block => block
+  | .error err =>
+    .para #[.text s!"Blueprint persisted statement block could not be decoded: {err}"]
+
+private meta def persistedManualBlockTerm
+    (block : Verso.Doc.Block Verso.Genre.Manual) : DocElabM (TSyntax `term) := do
+  let jsonText := Lean.toJson block |>.compress
+  `(Informal.Graft.persistedManualBlockFromJson $(quote jsonText))
+
+private meta def attributeNodeBlockData?
+    (cfg : Informal.Graft.BlueprintNodeConfig) :
+    DocElabM (Option (Informal.BlockData × Array Syntax)) := do
+  let graftNode := cfg.toNode
+  let label := Informal.LabelNameParsing.parse graftNode.label
+  let some node ← Informal.Environment.getNode? label
+    | return none
+  if !nodeIsBlueprintAttributeOwned node then
+    return none
+  let statementStxs ←
+    match node.statement with
+    | none => pure #[]
+    | some statement =>
+      if statement.previewBlocks.isEmpty then
+        pure statement.elabStx
+      else
+        statement.previewBlocks.mapM fun block =>
+          return (← persistedManualBlockTerm block).raw
+  let ownerInfo? ←
+    match node.owner with
+    | some owner => Informal.Environment.getAuthor? owner
+    | none => pure none
+  let opts ← getOptions
+  let sourceLocation :=
+    match ← Informal.Data.SourceLocation.ofSyntax? (← getRef) with
+    | some location => Informal.Data.SourceLocationResult.found location
+    | none =>
+      Informal.Data.SourceLocationResult.unavailable
+        s!"placement source location unavailable for {label}"
+  let blockData : Informal.BlockData := {
+    kind := .statement node.kind
+    codeData := Informal.BlockCodeData.ofExternalRefs node.externalRefs
+    label
+    sourceLocation
+    foldProofBlock := verso.blueprint.foldProofBlocks.get opts
+    foldCodeBlock := verso.blueprint.foldCodeBlocks.get opts
+    parent := node.parent
+    count := node.count
+    numberingMode := Informal.numberingMode opts
+    subNumberingPrefix := Informal.subNumberingPrefix opts
+    subNumberingCounter := Informal.subNumberingCounter opts
+    statementUses := node.statement.map (·.deps) |>.getD #[]
+    proofUses := node.proof.map (·.deps) |>.getD #[]
+    owner := node.owner
+    ownerDisplayName := ownerInfo?.map (·.displayName)
+    ownerUrl := ownerInfo?.bind (·.url)
+    ownerImageUrl := ownerInfo?.bind (·.imageUrl)
+    tags := node.tags
+    effort := node.effort
+    priority := node.priority
+    prUrl := node.prUrl
+  }
+  pure <| some (blockData, statementStxs)
+
+private meta def manualBlueprintNodeBlock
+    (cfg : Informal.Graft.BlueprintNodeConfig) : DocElabM Term := do
+  let graft ←
     ``(Verso.Doc.Block.other
         (Informal.Graft.Block.blueprintGraftNode $(quote cfg))
         #[])
+  let some (blockData, statementStxs) ← attributeNodeBlockData? cfg
+    | return graft
+  let statementTerms : Array (TSyntax `term) := statementStxs.map fun stx => ⟨stx⟩
+  ``(Verso.Doc.Block.concat #[
+      Verso.Doc.Block.other
+        (Informal.Graft.Block.blueprintAttributeNodeSource $(quote blockData))
+        #[$statementTerms,*],
+      $graft
+    ])
+
+public meta def blueprintNodeBlock (cfg : Informal.Graft.BlueprintNodeConfig) :
+    DocElabM Term := do
+  if ← inManualGenre then
+    manualBlueprintNodeBlock cfg
   else if ← inSlidesGenre then
     Informal.Slides.blueprintNodeBlock cfg
   else

--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -70,16 +70,7 @@ block_extension Block.informal (data : BlockData) where
     | none =>
       pure none
     | some blockData =>
-      let blockData := blockData.withTraversalNumberingContext (← read)
-      registerTraversedBlockAssets id blockData _contents
-      saveTraversedBlockData id blockData
-      if let some sourceRef := blockData.sourceRef then
-        match Informal.TraversalIndex.SourceRefs.data? (← get) blockData.label with
-        | some existing =>
-            unless existing == sourceRef do
-              Verso.reportError s!"Label {blockData.label} already has conflicting source provenance"
-        | none =>
-            modify fun st => Informal.TraversalIndex.SourceRefs.saveData st blockData.label sourceRef
+      registerTraversedBlock id blockData _contents
       return none
   toTeX := some <| fun _goI goB _id data blocks => do
       let .ok data := fromJson? (α := BlockData) data

--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -163,10 +163,6 @@ block_extension Block.informal (data : BlockData) where
         let usedByEntry ← RelatedPanel.renderUsedByExtra relatedPanelContext data
         let markupEntry? :=
           renderExternalMarkupHeaderExtra? markup
-        let foldInformalBlock :=
-          match data.kind with
-          | .proof => data.foldProofBlock
-          | .statement _ => false
         let headerExtras : HeaderExtras :=
           match data.kind with
           | .proof =>
@@ -188,7 +184,7 @@ block_extension Block.informal (data : BlockData) where
             (proofCaption? := some (data.displayTitle s))
             (attrs := attrs)
             (headerExtras := headerExtras)
-            (folded := foldInformalBlock)
+            (folded := data.foldInformalShell)
           content
           companionPanels := #[externalPanel]
         }

--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -260,10 +260,6 @@ private def expanderImpl (kind : Data.NodeKind) (isProof : Bool := false) : Dire
       | .statement _ =>
         let externalRefs := node?.map (·.externalRefs) |>.getD #[]
         BlockCodeData.ofExternalRefs externalRefs
-    let statementPayload? := node?.bind (·.statement)
-    let proofPayload? := node?.bind (·.proof)
-    let statementUses := statementPayload?.map (·.deps) |>.getD #[]
-    let proofUses := proofPayload?.map (·.deps) |>.getD #[]
     let owner := node?.bind (·.owner)
     let ownerInfo? ←
       match owner with
@@ -283,22 +279,12 @@ private def expanderImpl (kind : Data.NodeKind) (isProof : Bool := false) : Dire
       sourceLocation
       foldProofBlock := verso.blueprint.foldProofBlocks.get opts
       foldCodeBlock := verso.blueprint.foldCodeBlocks.get opts
-      parent := node?.bind (·.parent)
       count
       numberingMode := numberingMode opts
       subNumberingPrefix := subNumberingPrefix opts
       subNumberingCounter := subNumberingCounter opts
-      statementUses
-      proofUses
-      owner
-      ownerDisplayName := ownerInfo?.map (·.displayName)
-      ownerUrl := ownerInfo?.bind (·.url)
-      ownerImageUrl := ownerInfo?.bind (·.imageUrl)
-      tags := node?.map (·.tags) |>.getD #[]
-      effort := node?.bind (·.effort)
-      priority := node?.bind (·.priority)
-      prUrl := node?.bind (·.prUrl)
     }
+    let data := data.withSemanticNodeMetadata node? ownerInfo?
     ``(Block.other (Block.informal $(quote data)) #[$contents,*])
 
 private def directiveName (kind : Data.NodeKind) (isProof : Bool): String :=

--- a/src/VersoBlueprint/Informal/Block/Assets.lean
+++ b/src/VersoBlueprint/Informal/Block/Assets.lean
@@ -6,6 +6,7 @@ Author: Emilio J. Gallego Arias
 
 import VersoManual
 import VersoBlueprint.Commands.Common
+import VersoBlueprint.Macros
 import VersoBlueprint.StyleSwitcher
 
 namespace Informal.Block.Assets
@@ -1838,7 +1839,7 @@ def codeAssetBundle : Informal.Commands.BlueprintAssetBundle :=
 def blockAssetBundle : Informal.Commands.BlueprintAssetBundle :=
   Informal.Commands.previewPanelInlinePreviewAssetBundle
     (cssExtras := [css, Informal.StyleSwitcher.css, Verso.Genre.Manual.docstringStyle])
-    (jsAfter := [Informal.StyleSwitcher.jsInteractive])
+    (jsAfter := [Informal.Macros.blueprintMathJs, Informal.StyleSwitcher.jsInteractive])
 
 def codeCssAssets : List String :=
   codeAssetBundle.css

--- a/src/VersoBlueprint/Informal/Block/Model.lean
+++ b/src/VersoBlueprint/Informal/Block/Model.lean
@@ -176,9 +176,9 @@ structure BlockData where
   foldCodeBlock : Bool := false
   parent : Option Data.Parent := none
   /--
-  Elaboration-assigned source-local count. Zero means unassigned; traversal
-  replaces it with the next source-local count after assigned counts already
-  encountered, before applying the configured numbering policy.
+  Elaboration-assigned source-local count. Traversal replaces zero or a count
+  behind its source-local cursor with the next available count before applying
+  the configured numbering policy.
   -/
   count : Nat
   numberingMode : NumberingMode := .sub

--- a/src/VersoBlueprint/Informal/Block/Model.lean
+++ b/src/VersoBlueprint/Informal/Block/Model.lean
@@ -175,6 +175,10 @@ structure BlockData where
   foldProofBlock : Bool := false
   foldCodeBlock : Bool := false
   parent : Option Data.Parent := none
+  /--
+  Elaboration-assigned local count. Zero means unassigned; traversal replaces it
+  with the document-order count before applying the configured numbering policy.
+  -/
   count : Nat
   numberingMode : NumberingMode := .sub
   /-- Prefix policy for `numberingMode = .sub`. -/
@@ -220,6 +224,7 @@ structure StoredBlockData where
   sourceLocation : Data.SourceLocationResult :=
     Data.SourceLocationResult.unavailable "label source location unavailable"
   parent : Option Data.Parent := none
+  /-- Local count copied from `BlockData`; zero remains the unassigned sentinel. -/
   count : Nat
   numberingMode : NumberingMode := .sub
   /-- Prefix policy for `numberingMode = .sub`. -/

--- a/src/VersoBlueprint/Informal/Block/Model.lean
+++ b/src/VersoBlueprint/Informal/Block/Model.lean
@@ -249,6 +249,8 @@ structure StoredBlockData where
   /-- Source location for this rendered occurrence, ordinarily the user-written label token. -/
   sourceLocation : Data.SourceLocationResult :=
     Data.SourceLocationResult.unavailable "label source location unavailable"
+  foldProofBlock : Bool := false
+  foldCodeBlock : Bool := false
   parent : Option Data.Parent := none
   /-- Source-local count copied from `BlockData`; zero remains the unassigned sentinel. -/
   count : Nat
@@ -275,6 +277,8 @@ def BlockData.toStoredData (data : BlockData) : StoredBlockData := {
   kind := data.kind
   label := data.label
   sourceLocation := data.sourceLocation
+  foldProofBlock := data.foldProofBlock
+  foldCodeBlock := data.foldCodeBlock
   parent := data.parent
   count := data.count
   numberingMode := data.numberingMode
@@ -300,6 +304,8 @@ def StoredBlockData.toBlockData (data : StoredBlockData)
   codeData
   label := data.label
   sourceLocation := data.sourceLocation
+  foldProofBlock := data.foldProofBlock
+  foldCodeBlock := data.foldCodeBlock
   parent := data.parent
   count := data.count
   numberingMode := data.numberingMode

--- a/src/VersoBlueprint/Informal/Block/Model.lean
+++ b/src/VersoBlueprint/Informal/Block/Model.lean
@@ -211,6 +211,12 @@ structure BlockData where
   prUrl : Option String := none
 deriving FromJson, ToJson, Quote
 
+/-- Whether this block's informal statement/proof shell should be collapsed. -/
+def BlockData.foldInformalShell (data : BlockData) : Bool :=
+  match data.kind with
+  | .proof => data.foldProofBlock
+  | .statement _ => false
+
 /--
 Copy the semantic metadata shared by every rendered occurrence of a Blueprint
 node into placement-specific block data.

--- a/src/VersoBlueprint/Informal/Block/Model.lean
+++ b/src/VersoBlueprint/Informal/Block/Model.lean
@@ -211,6 +211,31 @@ structure BlockData where
 deriving FromJson, ToJson, Quote
 
 /--
+Copy the semantic metadata shared by every rendered occurrence of a Blueprint
+node into placement-specific block data.
+
+Callers remain responsible for occurrence-local fields such as the block kind,
+code payload, source provenance, numbering options, and source location.
+-/
+def BlockData.withSemanticNodeMetadata
+    (data : BlockData) (node? : Option Data.Node)
+    (ownerInfo? : Option Data.AuthorInfo := none) : BlockData :=
+  {
+    data with
+      parent := node?.bind (·.parent)
+      statementUses := node?.bind (·.statement) |>.map (·.deps) |>.getD #[]
+      proofUses := node?.bind (·.proof) |>.map (·.deps) |>.getD #[]
+      owner := node?.bind (·.owner)
+      ownerDisplayName := ownerInfo?.map (·.displayName)
+      ownerUrl := ownerInfo?.bind (·.url)
+      ownerImageUrl := ownerInfo?.bind (·.imageUrl)
+      tags := node?.map (·.tags) |>.getD #[]
+      effort := node?.bind (·.effort)
+      priority := node?.bind (·.priority)
+      prUrl := node?.bind (·.prUrl)
+  }
+
+/--
 Slim traversal-store payload for Blueprint node metadata.
 
 Unlike `BlockData`, this intentionally excludes `codeData`. Code-specific

--- a/src/VersoBlueprint/Informal/Block/Model.lean
+++ b/src/VersoBlueprint/Informal/Block/Model.lean
@@ -169,15 +169,16 @@ structure BlockData where
   /-- Optional original-source provenance attached with directive-local metadata. -/
   sourceRef : Option Source.Ref := none
   label : Data.Label
-  /-- Source location result for the user-written label token. -/
+  /-- Source location for this rendered occurrence, ordinarily the user-written label token. -/
   sourceLocation : Data.SourceLocationResult :=
     Data.SourceLocationResult.unavailable "label source location unavailable"
   foldProofBlock : Bool := false
   foldCodeBlock : Bool := false
   parent : Option Data.Parent := none
   /--
-  Elaboration-assigned local count. Zero means unassigned; traversal replaces it
-  with the document-order count before applying the configured numbering policy.
+  Elaboration-assigned source-local count. Zero means unassigned; traversal
+  replaces it with the next source-local count after assigned counts already
+  encountered, before applying the configured numbering policy.
   -/
   count : Nat
   numberingMode : NumberingMode := .sub
@@ -245,11 +246,11 @@ main semantic node index.
 structure StoredBlockData where
   kind : Data.InProgressKind := .proof
   label : Data.Label
-  /-- Source location result for the user-written label token. -/
+  /-- Source location for this rendered occurrence, ordinarily the user-written label token. -/
   sourceLocation : Data.SourceLocationResult :=
     Data.SourceLocationResult.unavailable "label source location unavailable"
   parent : Option Data.Parent := none
-  /-- Local count copied from `BlockData`; zero remains the unassigned sentinel. -/
+  /-- Source-local count copied from `BlockData`; zero remains the unassigned sentinel. -/
   count : Nat
   numberingMode : NumberingMode := .sub
   /-- Prefix policy for `numberingMode = .sub`. -/

--- a/src/VersoBlueprint/Informal/Block/Store.lean
+++ b/src/VersoBlueprint/Informal/Block/Store.lean
@@ -40,6 +40,31 @@ def reserveGlobalBlockNumber (st : TraverseState) : Nat × TraverseState :=
   let next := nextGlobalBlockNumber st
   (next, st.set numberingCounterState (next + 1))
 
+/--
+Traversal-state key for the next source-local number available to a block whose
+elaboration phase left its `count` unassigned.
+-/
+private def sourceNumberingCounterState : Name :=
+  Lean.Name.mkSimple "Informal.Block.sourceNumberingCounter"
+
+private def nextSourceBlockNumber (st : TraverseState) : Nat :=
+  match st.get? sourceNumberingCounterState with
+  | some (.ok (n : Nat)) => n
+  | _ => 1
+
+/--
+Resolve a source-local block number while keeping later unassigned placements
+after every assigned number already encountered during traversal.
+-/
+private def resolveSourceBlockNumber (st : TraverseState) (count : Nat) :
+    Nat × TraverseState :=
+  if count == 0 then
+    let next := nextSourceBlockNumber st
+    (next, st.set sourceNumberingCounterState (next + 1))
+  else
+    let next := max (nextSourceBlockNumber st) (count + 1)
+    (count, st.set sourceNumberingCounterState next)
+
 /-- Prefix-local counters, stored as a small association list in traversal state. -/
 private def prefixBlockCounters (st : TraverseState) : Array (String × Nat) :=
   match st.get? prefixNumberingCounterState with
@@ -115,9 +140,7 @@ private def StoredBlockData.withReservedNumbering
     match data.globalCount with
     | some globalCount => (globalCount, st)
     | none => reserveGlobalBlockNumber st
-  -- Attribute-owned nodes have no document elaboration pass in their defining
-  -- module, so zero marks their count as unassigned until placement traversal.
-  let sourceCount := if data.count == 0 then globalCount else data.count
+  let (sourceCount, st) := resolveSourceBlockNumber st data.count
   let (count, st) :=
     match data.numberingMode with
     | .sub => reserveSubBlockNumber st { data with count := sourceCount }

--- a/src/VersoBlueprint/Informal/Block/Store.lean
+++ b/src/VersoBlueprint/Informal/Block/Store.lean
@@ -116,7 +116,8 @@ def numberedPartPrefix? (mode : SubNumberingPrefix) (ctxt : TraverseContext) : O
 Resolve the appended number for a sub-numbered block.
 
 Only `SubNumberingCounter.prefix` reserves a new prefix-local number. In
-document-order mode, the block keeps the elaboration-time `count`.
+document-order mode, the block keeps the source-local `count` already resolved
+during traversal.
 -/
 def reserveSubBlockNumber (st : TraverseState) (data : StoredBlockData) : Nat × TraverseState :=
   match data.subNumberingCounter, data.partPrefix with

--- a/src/VersoBlueprint/Informal/Block/Store.lean
+++ b/src/VersoBlueprint/Informal/Block/Store.lean
@@ -41,8 +41,7 @@ def reserveGlobalBlockNumber (st : TraverseState) : Nat × TraverseState :=
   (next, st.set numberingCounterState (next + 1))
 
 /--
-Traversal-state key for the next source-local number available to a block whose
-elaboration phase left its `count` unassigned.
+Traversal-state key for the next source-local number available during traversal.
 -/
 private def sourceNumberingCounterState : Name :=
   Lean.Name.mkSimple "Informal.Block.sourceNumberingCounter"
@@ -53,17 +52,18 @@ private def nextSourceBlockNumber (st : TraverseState) : Nat :=
   | _ => 1
 
 /--
-Resolve a source-local block number while keeping later unassigned placements
-after every assigned number already encountered during traversal.
+Resolve a source-local block number monotonically in traversal order.
+
+Zero is the unassigned sentinel. A nonzero elaboration-time count is also
+reassigned when an earlier generated placement has already advanced beyond it.
 -/
 private def resolveSourceBlockNumber (st : TraverseState) (count : Nat) :
     Nat × TraverseState :=
-  if count == 0 then
-    let next := nextSourceBlockNumber st
+  let next := nextSourceBlockNumber st
+  if count == 0 || count < next then
     (next, st.set sourceNumberingCounterState (next + 1))
   else
-    let next := max (nextSourceBlockNumber st) (count + 1)
-    (count, st.set sourceNumberingCounterState next)
+    (count, st.set sourceNumberingCounterState (count + 1))
 
 /-- Prefix-local counters, stored as a small association list in traversal state. -/
 private def prefixBlockCounters (st : TraverseState) : Array (String × Nat) :=

--- a/src/VersoBlueprint/Informal/Block/Store.lean
+++ b/src/VersoBlueprint/Informal/Block/Store.lean
@@ -115,10 +115,11 @@ private def StoredBlockData.withReservedNumbering
     match data.globalCount with
     | some globalCount => (globalCount, st)
     | none => reserveGlobalBlockNumber st
+  let sourceCount := if data.count == 0 then globalCount else data.count
   let (count, st) :=
     match data.numberingMode with
-    | .sub => reserveSubBlockNumber st data
-    | _ => (data.count, st)
+    | .sub => reserveSubBlockNumber st { data with count := sourceCount }
+    | _ => (sourceCount, st)
   ({ data with count, globalCount := some globalCount }, st)
 
 /-- Look up the stored semantic payload for an informal block label. -/

--- a/src/VersoBlueprint/Informal/Block/Store.lean
+++ b/src/VersoBlueprint/Informal/Block/Store.lean
@@ -115,6 +115,8 @@ private def StoredBlockData.withReservedNumbering
     match data.globalCount with
     | some globalCount => (globalCount, st)
     | none => reserveGlobalBlockNumber st
+  -- Attribute-owned nodes have no document elaboration pass in their defining
+  -- module, so zero marks their count as unassigned until placement traversal.
   let sourceCount := if data.count == 0 then globalCount else data.count
   let (count, st) :=
     match data.numberingMode with

--- a/src/VersoBlueprint/Informal/Block/Traversal.lean
+++ b/src/VersoBlueprint/Informal/Block/Traversal.lean
@@ -6,6 +6,7 @@ Author: Emilio J. Gallego Arias
 
 import VersoManual
 import VersoBlueprint.Informal.Block.Model
+import VersoBlueprint.Informal.Block.Store
 import VersoBlueprint.Informal.LeanCodePreview
 import VersoBlueprint.PreviewCache
 import VersoBlueprint.Resolve
@@ -144,5 +145,33 @@ def registerTraversedBlockAssets
   registerBlockPreviewData id blockData contents
   registerExternalCodePreviews id externalDecls
   registerExternalDeclAnchors blockData.label externalDecls
+
+/--
+Register one decoded informal block through the shared traversal path.
+
+This applies the current numbering context, stores preview and declaration
+assets, saves the semantic block entry, and records optional source provenance.
+-/
+def registerTraversedBlock
+    {m}
+    [Monad m]
+    [MonadReaderOf TraverseContext m]
+    [MonadStateOf TraverseState m]
+    [MonadLiftT IO m]
+    [MonadBuildLog m]
+    (id : Verso.Multi.InternalId)
+    (blockData : BlockData)
+    (contents : Array (Verso.Doc.Block Verso.Genre.Manual)) :
+    m Unit := do
+  let blockData := blockData.withTraversalNumberingContext (← read)
+  registerTraversedBlockAssets id blockData contents
+  saveTraversedBlockData id blockData
+  if let some sourceRef := blockData.sourceRef then
+    match Informal.TraversalIndex.SourceRefs.data? (← get) blockData.label with
+    | some existing =>
+        unless existing == sourceRef do
+          Verso.reportError s!"Label {blockData.label} already has conflicting source provenance"
+    | none =>
+        modify fun st => Informal.TraversalIndex.SourceRefs.saveData st blockData.label sourceRef
 
 end Informal

--- a/src/VersoBlueprint/Informal/Block/Traversal.lean
+++ b/src/VersoBlueprint/Informal/Block/Traversal.lean
@@ -131,7 +131,7 @@ This keeps the block extension focused on orchestration while the traversal
 store owns hover-preview payloads, external Lean previews, and rendered
 declaration anchors.
 -/
-def registerTraversedBlockAssets
+private def registerTraversedBlockAssets
     {m}
     [Monad m]
     [MonadReaderOf TraverseContext m]

--- a/src/VersoBlueprint/ModuleInclude.lean
+++ b/src/VersoBlueprint/ModuleInclude.lean
@@ -73,6 +73,16 @@ Use {lit}`(title := "...")` to replace the default final module-name component.
 @[part_command Lean.Doc.Syntax.command]
 public meta def includeBlueprintModuleCmd : PartCommand
   | stx@`(block|command{includeBlueprintModule $args*}) => do
+    let ref ← getRef
+    Hover.addCustomHover ref
+      r#"Includes the `@[blueprint]` declarations owned directly by an imported Lean module as one Manual part.
+
+  * `{includeBlueprintModule MODULE}`: Includes the declarations as a child part.
+  * `{includeBlueprintModule N MODULE}`: Includes the declarations at header level `N`.
+  * `(title := "...")`: Replaces the default title derived from the module name.
+
+The named module must already be available through the document module's Lean imports.
+  "#
     let cfg ← Verso.ArgParse.parseThe BlueprintModuleConfig (← parseArgs args)
     let endPos := stx.getTailPos?.get!
     let part ← mkBlueprintModulePart stx endPos cfg

--- a/src/VersoBlueprint/ModuleInclude.lean
+++ b/src/VersoBlueprint/ModuleInclude.lean
@@ -64,6 +64,12 @@ private meta def mkBlueprintModulePart
   pure <| FinishedPart.mk stx stx #[titleInline] title none blocks #[] endPos
 
 open PartElabM in
+/--
+Include the declarations marked with {lit}`@[blueprint]` and owned directly by
+an imported Lean module as a source-ordered Manual part. The optional leading
+level controls where the part is inserted; omitting it creates a child part.
+Use {lit}`(title := "...")` to replace the default final module-name component.
+-/
 @[part_command Lean.Doc.Syntax.command]
 public meta def includeBlueprintModuleCmd : PartCommand
   | stx@`(block|command{includeBlueprintModule $args*}) => do

--- a/src/VersoBlueprint/ModuleInclude.lean
+++ b/src/VersoBlueprint/ModuleInclude.lean
@@ -17,13 +17,13 @@ open Lean
 open Verso Doc Elab Syntax ArgParse
 
 /-- Selection and presentation options for `{includeBlueprintModule ...}`. -/
-public structure BlueprintModuleConfig where
+private structure BlueprintModuleConfig where
   level? : Option Nat := none
   moduleName : Name
   title? : Option String := none
 deriving Inhabited, Repr
 
-public meta instance : FromArgs BlueprintModuleConfig PartElabM where
+private meta instance : FromArgs BlueprintModuleConfig PartElabM where
   fromArgs :=
     ((fun level moduleName title? =>
         { level? := some level, moduleName, title? })

--- a/src/VersoBlueprint/ModuleInclude.lean
+++ b/src/VersoBlueprint/ModuleInclude.lean
@@ -51,13 +51,13 @@ private meta def mkBlueprintModulePart
     throwErrorAt stx
       "Blueprint module include: module '{cfg.moduleName}' is not available through this Lean module's imports; add `import {cfg.moduleName}`"
   Informal.Environment.reportImportedConflicts
-  let nodes ← Informal.Environment.blueprintAttributeNodesForModule cfg.moduleName
-  if nodes.isEmpty then
+  let labels ← Informal.Environment.blueprintAttributeLabelsForModule cfg.moduleName
+  if labels.isEmpty then
     throwErrorAt stx
       "Blueprint module include: imported module '{cfg.moduleName}' has no declarations registered with `@[blueprint]`"
   let title := cfg.title?.getD (defaultTitle cfg.moduleName)
   let titleInline ← ``(Verso.Doc.Inline.text $(quote title))
-  let blocks ← nodes.mapM fun label =>
+  let blocks ← labels.mapM fun label =>
     PartElabM.liftDocElabM <| Informal.Graft.blueprintNodeBlock {
       label := label.getString!
     }

--- a/src/VersoBlueprint/ModuleInclude.lean
+++ b/src/VersoBlueprint/ModuleInclude.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoManual
+import Verso.Doc.Elab
+import VersoBlueprint.Environment
+import VersoBlueprint.Graft
+
+set_option doc.verso true
+
+namespace Informal.ModuleInclude
+
+open Lean
+open Verso Doc Elab Syntax ArgParse
+
+/-- Selection and presentation options for `{includeBlueprintModule ...}`. -/
+public structure BlueprintModuleConfig where
+  level? : Option Nat := none
+  moduleName : Name
+  title? : Option String := none
+deriving Inhabited, Repr
+
+public meta instance : FromArgs BlueprintModuleConfig PartElabM where
+  fromArgs :=
+    ((fun level moduleName title? =>
+        { level? := some level, moduleName, title? })
+      <$> .positional' `level
+      <*> .positional' `module
+      <*> .named' `title true) <|>
+    ((fun moduleName title? => { moduleName, title? })
+      <$> .positional' `module
+      <*> .named' `title true)
+
+private def moduleIsImported (env : Lean.Environment) (moduleName : Name) : Bool :=
+  env.header.moduleNames.contains moduleName
+
+private def defaultTitle (moduleName : Name) : String :=
+  moduleName.getString!
+
+private meta def mkBlueprintModulePart
+    (stx : Syntax) (endPos : String.Pos.Raw) (cfg : BlueprintModuleConfig) :
+    PartElabM FinishedPart := do
+  unless ← PartElabM.liftDocElabM Informal.Graft.inManualGenre do
+    throwErrorAt stx
+      "Blueprint module include is only available in Manual documents"
+  let env ← getEnv
+  unless moduleIsImported env cfg.moduleName do
+    throwErrorAt stx
+      "Blueprint module include: module '{cfg.moduleName}' is not available through this Lean module's imports; add `import {cfg.moduleName}`"
+  Informal.Environment.reportImportedConflicts
+  let nodes ← Informal.Environment.blueprintAttributeNodesForModule cfg.moduleName
+  if nodes.isEmpty then
+    throwErrorAt stx
+      "Blueprint module include: imported module '{cfg.moduleName}' has no declarations registered with `@[blueprint]`"
+  let title := cfg.title?.getD (defaultTitle cfg.moduleName)
+  let titleInline ← ``(Verso.Doc.Inline.text $(quote title))
+  let blocks ← nodes.mapM fun label =>
+    PartElabM.liftDocElabM <| Informal.Graft.blueprintNodeBlock {
+      label := label.getString!
+    }
+  pure <| FinishedPart.mk stx stx #[titleInline] title none blocks #[] endPos
+
+open PartElabM in
+@[part_command Lean.Doc.Syntax.command]
+public meta def includeBlueprintModuleCmd : PartCommand
+  | stx@`(block|command{includeBlueprintModule $args*}) => do
+    let cfg ← Verso.ArgParse.parseThe BlueprintModuleConfig (← parseArgs args)
+    let endPos := stx.getTailPos?.get!
+    let part ← mkBlueprintModulePart stx endPos cfg
+    if let some level := cfg.level? then
+      closePartsUntil level endPos
+    addPart part
+  | _ => (Lean.Elab.throwUnsupportedSyntax : PartElabM Unit)
+
+end Informal.ModuleInclude

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -978,6 +978,10 @@ structure Entry where
   leanCodePreviewKeys : Array String := #[]
   /-- Canonical Lean code data associated with this informal node, if any. -/
   codeData : Option Informal.BlockCodeData := none
+  /-- Whether the statement/proof shell is collapsed for this rendered occurrence. -/
+  foldProofBlock : Bool := false
+  /-- Whether an associated Lean code panel is collapsed for this rendered occurrence. -/
+  foldCodeBlock : Bool := false
   /-- Raw external markup attachments keyed by language and slot. -/
   externalMarkup : Array Informal.Data.ExternalMarkup := #[]
   /-- Original-source provenance attached to this entry. Lean entries may aggregate several nodes. -/
@@ -1021,6 +1025,8 @@ def Entry.blockData (entry : Entry) : Informal.BlockData := {
   sourceRef := entry.primarySource?
   label := entry.label
   sourceLocation := entry.sourceLocation
+  foldProofBlock := entry.foldProofBlock
+  foldCodeBlock := entry.foldCodeBlock
   parent := entry.parent
   count := 0
   statementUses := entry.statementUses
@@ -2091,6 +2097,8 @@ private def blockSemanticManifestEntry
     proofUses := blockData?.map (·.proofUses) |>.getD #[]
     leanCodePreviewKeys := blockLeanCodePreviewKeys state preview.label preview
     codeData
+    foldProofBlock := blockData?.map (·.foldProofBlock) |>.getD false
+    foldCodeBlock := blockData?.map (·.foldCodeBlock) |>.getD false
     externalMarkup := externalMarkup?.getD (externalMarkupArray state preview.label)
     sources := sourceRefsForBlockLabel state preview.label
     uses := blockData?.map (buildUsesRelations state ·) |>.getD #[]

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -978,9 +978,9 @@ structure Entry where
   leanCodePreviewKeys : Array String := #[]
   /-- Canonical Lean code data associated with this informal node, if any. -/
   codeData : Option Informal.BlockCodeData := none
-  /-- Whether the statement/proof shell is collapsed for this rendered occurrence. -/
+  /-- Whether the canonical proof shell is collapsed when this is a proof entry. -/
   foldProofBlock : Bool := false
-  /-- Whether an associated Lean code panel is collapsed for this rendered occurrence. -/
+  /-- Whether the associated Lean code panel is collapsed for this canonical traversal entry. -/
   foldCodeBlock : Bool := false
   /-- Raw external markup attachments keyed by language and slot. -/
   externalMarkup : Array Informal.Data.ExternalMarkup := #[]

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -308,6 +308,14 @@ private def logLeanCodePreviewTimings
 private def htmlStringIsBlank (html : String) : Bool :=
   html.all Char.isWhitespace
 
+/--
+Non-visual cache body for a semantic block whose only visible payload is an
+associated Lean-code panel. Browser cache readers reject empty HTML strings, so
+code-only nodes use an explicit inert fragment as their block body.
+-/
+private def codeOnlyBlockPreviewHtml : String :=
+  "<span class=\"bp_code_only_preview_body\" aria-hidden=\"true\"></span>"
+
 private def callbackLogger (logError : String → IO Unit) : Verso.Logger IO where
   log severity text loc := do
     let msg := Verso.LogMessage.format { severity, text, loc }
@@ -2121,14 +2129,22 @@ private def buildTraversalEntries
       logError s!"Blueprint manifest: malformed preview entry {err.canonicalName}: {err.message}"
     | .ok stored =>
       let entry := stored.entry
-      if !entry.hasRenderedBody then
+      let hasLeanCode := !entry.leanCodePreviewKeys.isEmpty
+      let hasExternalMarkup := !(externalMarkupArray state entry.label).isEmpty
+      if !entry.hasRenderedBody && (!hasLeanCode || hasExternalMarkup) then
         continue
-      let rendered ← Informal.renderManualBlocksHtmlWithStateAndHovers entry.renderedBody.blocks impls state
-        (logError := logError) (hoverState := hoverState)
-      hoverState := rendered.hoverState
-      let html := rendered.html.asString
-      if htmlStringIsBlank html then
-        continue
+      let html ←
+        if entry.hasRenderedBody then
+          let rendered ← Informal.renderManualBlocksHtmlWithStateAndHovers
+            entry.renderedBody.blocks impls state
+            (logError := logError) (hoverState := hoverState)
+          hoverState := rendered.hoverState
+          let html := rendered.html.asString
+          if htmlStringIsBlank html then
+            continue
+          pure html
+        else
+          pure codeOnlyBlockPreviewHtml
       let manifestEntry := blockEntryOfTraversalPreview state entry
       entries := entries.push manifestEntry
       htmlEntries := htmlEntries.push { key := stored.key, html }

--- a/src/VersoBlueprint/PreviewManifest/BlockRender.lean
+++ b/src/VersoBlueprint/PreviewManifest/BlockRender.lean
@@ -246,6 +246,7 @@ def renderWithRenderedContent
         (titleRowAttrs? := cfg.titleRowAttrs? entry)
         (headerExtras := renderHeaderExtras cfg.relationPanels entry blockData group?)
         (sourceRefs := entry.sources)
+        (folded := blockData.foldInformalShell)
       content := #[content.body]
       companionPanels := #[codePanel]
       wrapperClass? := some cfg.wrapperClass

--- a/src/VersoBlueprint/PreviewManifest/BlockRender.lean
+++ b/src/VersoBlueprint/PreviewManifest/BlockRender.lean
@@ -220,6 +220,7 @@ private def renderCodePanel
       panelSummary.summaryTitle
       panelSummary.indicator
       body
+      (folded := entry.blockData.foldCodeBlock)
 
 /-- Render a Blueprint block shell from semantic entry data and rendered content. -/
 def renderWithRenderedContent

--- a/src/VersoBlueprint/blueprint-api-types.mjs
+++ b/src/VersoBlueprint/blueprint-api-types.mjs
@@ -279,6 +279,8 @@
  * @property {BlueprintSourceRef[]} [sources] Original source refs for this entry.
  * @property {BlueprintUseRef[]} statementUses Structured statement dependency refs.
  * @property {BlueprintUseRef[]} proofUses Structured proof dependency refs.
+ * @property {boolean} foldProofBlock Whether the owning proof/statement shell is collapsed.
+ * @property {boolean} foldCodeBlock Whether the associated code panel is collapsed.
  * @property {BlueprintRelatedEntry[]} uses Related nodes used by this entry.
  * @property {BlueprintRelatedEntry[]} usedBy Related nodes that use this entry.
  */

--- a/src/VersoBlueprint/blueprint-api-types.mjs
+++ b/src/VersoBlueprint/blueprint-api-types.mjs
@@ -279,8 +279,8 @@
  * @property {BlueprintSourceRef[]} [sources] Original source refs for this entry.
  * @property {BlueprintUseRef[]} statementUses Structured statement dependency refs.
  * @property {BlueprintUseRef[]} proofUses Structured proof dependency refs.
- * @property {boolean} foldProofBlock Whether the owning proof/statement shell is collapsed.
- * @property {boolean} foldCodeBlock Whether the associated code panel is collapsed.
+ * @property {boolean} foldProofBlock Whether the canonical proof shell is collapsed for proof entries.
+ * @property {boolean} foldCodeBlock Whether the associated code panel is collapsed for this canonical traversal entry.
  * @property {BlueprintRelatedEntry[]} uses Related nodes used by this entry.
  * @property {BlueprintRelatedEntry[]} usedBy Related nodes that use this entry.
  */

--- a/tests/VersoBlueprintTests/Blueprint.lean
+++ b/tests/VersoBlueprintTests/Blueprint.lean
@@ -5,6 +5,7 @@ Author: Emilio J. Gallego Arias
 -/
 
 import VersoBlueprintTests.BlueprintAttribute
+import VersoBlueprintTests.BlueprintAttributeRendering
 import VersoBlueprintTests.BlueprintAssets
 import VersoBlueprintTests.BlueprintAutoDeps
 import VersoBlueprintTests.BlueprintBlockFolding

--- a/tests/VersoBlueprintTests/BlueprintAssets.lean
+++ b/tests/VersoBlueprintTests/BlueprintAssets.lean
@@ -78,7 +78,8 @@ namespace Verso.VersoBlueprintTests.BlueprintAssets
       [Informal.Commands.blueprintTokensCss, Informal.Commands.previewPanelCss,
         Informal.Block.Assets.css, Informal.StyleSwitcher.css, Verso.Genre.Manual.docstringStyle,
         Informal.Commands.previewHeaderCss, Informal.Commands.inlinePreviewCss] &&
-    Informal.Block.Assets.blockAssetBundle.js == [Informal.StyleSwitcher.jsInteractive]
+    Informal.Block.Assets.blockAssetBundle.js ==
+      [Informal.Macros.blueprintMathJs, Informal.StyleSwitcher.jsInteractive]
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/VersoBlueprintTests/BlueprintAttribute.lean
+++ b/tests/VersoBlueprintTests/BlueprintAttribute.lean
@@ -1,4 +1,4 @@
-/- 
+/-
 Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Emilio J. Gallego Arias
@@ -7,127 +7,27 @@ Author: Emilio J. Gallego Arias
 import VersoBlueprintTests.BlueprintAttribute.Reexport
 import VersoBlueprintTests.BlueprintAttribute.HybridProvider
 import VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider
-import VersoBlueprintTests.Blueprint.Support
 
 open Lean
 open Informal
 
 namespace Verso.VersoBlueprintTests.BlueprintAttribute
 
-open Verso
-open Verso.Genre.Manual
-open Verso.VersoBlueprintTests.Blueprint.Support
-
-private def manualImpls : ExtensionImpls := extension_impls%
-
-#docs (Genre.Manual) placedAttributeDoc "Placed attribute-owned nodes" :=
-:::::::
-Introductory prose before the imported declaration.
-
-{blueprint_node "attr.exported.theorem"}
-
-Connecting prose between declarations.
-
-{blueprint_node "attr.exported.undocumented"}
-
-Concluding prose after the imported declarations.
-:::::::
-
-#docs (Genre.Manual) includedAttributeModuleDoc "Attribute module inclusion" :=
-:::::::
-{includeBlueprintModule 0 VersoBlueprintTests.BlueprintAttribute.Provider (title := "Imported attribute declarations")}
-:::::::
-
-#docs (Genre.Manual) includedAttributeModuleDefaultDoc "Default attribute module inclusion" :=
-:::::::
-{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.Provider}
-:::::::
-
-#docs (Genre.Manual) includedHybridAttributeModuleDoc "Hybrid attribute module inclusion" :=
-:::::::
-{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.HybridProvider}
-:::::::
-
-set_option verso.blueprint.foldCodeBlocks true
-
-#docs (Genre.Manual) placedDefaultLabelDoc "Placed default-label declaration" :=
-:::::::
-{blueprint_node "Verso.VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider.qualifiedDefaultLabel"}
-:::::::
-
-#docs (Genre.Manual) includedDefaultLabelModuleDoc "Default-label module inclusion" :=
-:::::::
-{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider}
-:::::::
-
-set_option verso.blueprint.foldCodeBlocks false
-
-set_option verso.blueprint.numbering "global" in
-#docs (Genre.Manual) globallyNumberedAttributeModuleDoc "Globally numbered attribute module" :=
-:::::::
-{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.Provider}
-:::::::
-
-set_option verso.blueprint.numbering "global" in
-#docs (Genre.Manual) repeatedAttributePlacementDoc "Repeated attribute placement" :=
-:::::::
-{blueprint_node "attr.exported.theorem"}
-
-Intervening prose between two placements of the same declaration.
-
-{blueprint_node "attr.exported.theorem"}
-:::::::
-
-set_option verso.blueprint.numbering "local" in
-#docs (Genre.Manual) interleavedLocalAttributePlacementDoc "Interleaved local attribute placement" :=
-:::::::
-:::definition "attr.consumer.before.placement"
-A consumer-authored node before an imported attribute placement.
-:::
-
-{blueprint_node "attr.exported.theorem"}
-
-:::definition "attr.consumer.after.placement"
-A consumer-authored node after an imported attribute placement.
-:::
-:::::::
-
-set_option verso.blueprint.numbering "local" in
-#docs (Genre.Manual) locallyNumberedHybridAttributeModuleDoc "Locally numbered hybrid module" :=
-:::::::
-:::definition "attr.consumer.before.module"
-A consumer-authored node that precedes the imported attribute module.
-:::
-
-{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.HybridProvider}
-:::::::
-
+/-
+`uses` is a Manual role, not a Lean `doc.verso` role. Keep the diagnostic
+explicit so documentation cannot drift back toward describing it as a flattened
+docstring extension.
+-/
 /--
-error: Blueprint module include: imported module 'VersoBlueprintTests.BlueprintAttribute.Reexport' has no declarations registered with `@[blueprint]`
+error: `uses : Doc.Elab.RoleExpanderOf UsesConfig` is not registered as a role
 -/
 #guard_msgs in
-#docs (Genre.Manual) rejectedEmptyAttributeModuleDoc "Rejected empty attribute module" :=
-:::::::
-{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.Reexport}
-:::::::
-
+set_option doc.verso true in
 /--
-error: Blueprint module include: module 'NotImported.BlueprintModule' is not available through this Lean module's imports; add `import NotImported.BlueprintModule`
+A declaration docstring containing {uses "attr.exported.theorem"}[].
 -/
-#guard_msgs in
-#docs (Genre.Manual) rejectedUnimportedAttributeModuleDoc "Rejected unimported attribute module" :=
-:::::::
-{includeBlueprintModule NotImported.BlueprintModule}
-:::::::
-
-/--
-error: Blueprint module include is only available in Manual documents
--/
-#guard_msgs in
-#docs (VersoSlides.Slides) rejectedSlidesAttributeModuleDoc "Rejected Slides module include" :=
-:::::::
-{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.Provider}
-:::::::
+@[blueprint "attr.docstring.rejected_uses"]
+def rejectedDocstringUsesRole : Nat := 0
 
 private def importedState : CoreM Informal.Environment.State := do
   pure <| Informal.Environment.informalExt.getState (← getEnv)
@@ -140,17 +40,6 @@ private def importedNodeByName? (label : Name) : CoreM (Option Informal.Data.Nod
 
 private def importedNodeInLocalData (label : String) : CoreM Bool := do
   pure <| (← importedState).localData.contains (Name.mkSimple label)
-
-private def substringsInOrder (text : String) : List String → Bool
-  | [] => true
-  | needle :: rest =>
-    match text.splitOn needle with
-    | _before :: after =>
-      if after.isEmpty then
-        false
-      else
-        substringsInOrder (String.intercalate needle after) rest
-    | _ => false
 
 private def isBlueprintAttrRef (expectedDecl : Name) (expectedKind : Informal.Data.NodeKind)
     (node : Informal.Data.Node) : Bool :=
@@ -255,14 +144,6 @@ private def isBlueprintAttrRef (expectedDecl : Name) (expectedKind : Informal.Da
         `Verso.VersoBlueprintTests.BlueprintAttribute.HybridProvider.hybridSharedSecond
       ]
 
-/- The no-level form creates a child part and derives its title from the module name. -/
-/-- info: true -/
-#guard_msgs in
-#eval
-  show Bool from
-    includedAttributeModuleDefaultDoc.toPart.subParts.any fun part =>
-      part.titleString == "Provider" && part.content.size == 4
-
 /-- info: true -/
 #guard_msgs in
 #eval
@@ -274,9 +155,15 @@ private def isBlueprintAttrRef (expectedDecl : Name) (expectedKind : Informal.Da
     let some inductiveNode ← importedNode? "attr.exported.inductive"
       | return false
     pure <|
-      isBlueprintAttrRef `Verso.VersoBlueprintTests.BlueprintAttribute.Provider.exportedTheorem .theorem theoremNode &&
-      isBlueprintAttrRef `Verso.VersoBlueprintTests.BlueprintAttribute.Provider.exportedDefinition .definition definitionNode &&
-      isBlueprintAttrRef `Verso.VersoBlueprintTests.BlueprintAttribute.Provider.exportedInductive .definition inductiveNode
+      isBlueprintAttrRef
+          `Verso.VersoBlueprintTests.BlueprintAttribute.Provider.exportedTheorem
+          .theorem theoremNode &&
+      isBlueprintAttrRef
+          `Verso.VersoBlueprintTests.BlueprintAttribute.Provider.exportedDefinition
+          .definition definitionNode &&
+      isBlueprintAttrRef
+          `Verso.VersoBlueprintTests.BlueprintAttribute.Provider.exportedInductive
+          .definition inductiveNode
 
 /-- Imported statement payloads should keep empty deps and at least one preview source. -/
 private def importedStatementExportOk (node : Informal.Data.Node) : Bool :=
@@ -302,197 +189,7 @@ private def importedStatementExportOk (node : Informal.Data.Node) : Bool :=
       importedStatementExportOk inductiveNode &&
       undocumentedNode.statement.isNone
 
-/-- info: true -/
-#guard_msgs in
-#eval
-  show IO Bool from do
-    let (html, state) ← renderManualDocHtmlStringAndState manualImpls placedAttributeDoc
-    let theoremKey := Informal.PreviewCache.statementKey (Name.mkSimple "attr.exported.theorem")
-    let undocumentedKey :=
-      Informal.PreviewCache.statementKey (Name.mkSimple "attr.exported.undocumented")
-    pure <|
-      hasSubstr html "Introductory prose before the imported declaration." &&
-      hasSubstr html "Connecting prose between declarations." &&
-      hasSubstr html "Concluding prose after the imported declarations." &&
-      hasSubstr html "Exported theorem used to verify" &&
-      hasSubstr html "bp_attribute_node_anchor" &&
-      hasSubstr html "exportedTheorem" &&
-      hasSubstr html "exportedUndocumentedDefinition" &&
-      !hasSubstr html "Blueprint node not found" &&
-      !hasSubstr html "Blueprint node has no cached content" &&
-      (Informal.PreviewManifest.findTraversalBlockEntry? state theoremKey).isSome &&
-      (Informal.PreviewManifest.findTraversalBlockEntry? state undocumentedKey).isSome
-
-/- A regular imported Lean module can become a source-ordered Verso part. -/
-/-- info: true -/
-#guard_msgs in
-#eval
-  show IO Bool from do
-    let (html, state) ← renderManualDocHtmlStringAndState manualImpls includedAttributeModuleDoc
-    let hasIncludedTitle :=
-      includedAttributeModuleDoc.toPart.subParts.any
-        (·.titleString == "Imported attribute declarations")
-    let labels := #[
-      "attr.exported.theorem",
-      "attr.exported.definition",
-      "attr.exported.inductive",
-      "attr.exported.undocumented"
-    ]
-    let hasAnchor := hasSubstr html "bp_attribute_node_anchor"
-    let ordered := substringsInOrder html [
-        "exportedTheorem",
-        "exportedDefinition",
-        "exportedInductive",
-        "exportedUndocumentedDefinition"
-      ]
-    let hasEntries := labels.all fun label =>
-        let key := Informal.PreviewCache.statementKey (Name.mkSimple label)
-        (Informal.PreviewManifest.findTraversalBlockEntry? state key).isSome
-    pure <| hasIncludedTitle && hasAnchor && ordered && hasEntries
-
-/- Generated module nodes honor non-default Blueprint numbering options. -/
-/-- info: true -/
-#guard_msgs in
-#eval
-  show IO Bool from do
-    let (_html, state) ←
-      renderManualDocHtmlStringAndState manualImpls globallyNumberedAttributeModuleDoc
-    let theoremLabel := Name.mkSimple "attr.exported.theorem"
-    let definitionLabel := Name.mkSimple "attr.exported.definition"
-    let some theoremData := Informal.TraversalIndex.Nodes.data? state theoremLabel
-      | return false
-    let some definitionData := Informal.TraversalIndex.Nodes.data? state definitionLabel
-      | return false
-    pure <|
-      theoremData.numberingMode == .global &&
-      theoremData.globalCount == some 1 &&
-      theoremData.count == 1 &&
-      theoremData.displayNumber state == "1" &&
-      definitionData.numberingMode == .global &&
-      definitionData.globalCount == some 2 &&
-      definitionData.count == 2 &&
-      definitionData.displayNumber state == "2"
-
-/- Repeated placements keep the first number and canonical traversal anchors. -/
-/-- info: true -/
-#guard_msgs in
-#eval
-  show IO Bool from do
-    let (html, state) ←
-      renderManualDocHtmlStringAndState manualImpls repeatedAttributePlacementDoc
-    let label := Name.mkSimple "attr.exported.theorem"
-    let previewKey := Informal.PreviewCache.statementKey label
-    let some data := Informal.TraversalIndex.Nodes.data? state label
-      | return false
-    let some nodeObject := Informal.TraversalIndex.Nodes.object? state label
-      | return false
-    let some previewObject :=
-        Informal.TraversalIndex.TraversalPreviews.object? state previewKey
-      | return false
-    pure <|
-      data.numberingMode == .global &&
-      data.globalCount == some 1 &&
-      data.count == 1 &&
-      Informal.nextGlobalBlockNumber state == 2 &&
-      nodeObject.ids.toArray.size == 1 &&
-      previewObject.ids.toArray.size == 1 &&
-      (html.splitOn "class=\"bp_graft_node bp_graft_manifest_node\"").length == 3
-
-/- Generated placements cannot reuse a later authored block's source-local count. -/
-/-- info: true -/
-#guard_msgs in
-#eval
-  show IO Bool from do
-    let (_html, state) ←
-      renderManualDocHtmlStringAndState manualImpls interleavedLocalAttributePlacementDoc
-    let some beforeData :=
-        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.consumer.before.placement")
-      | return false
-    let some attributeData :=
-        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.exported.theorem")
-      | return false
-    let some afterData :=
-        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.consumer.after.placement")
-      | return false
-    pure <|
-      beforeData.numberingMode == .local &&
-      attributeData.numberingMode == .local &&
-      afterData.numberingMode == .local &&
-      beforeData.count + 1 == attributeData.count &&
-      attributeData.count + 1 == afterData.count &&
-      beforeData.globalCount == some 1 &&
-      attributeData.globalCount == some 2 &&
-      afterData.globalCount == some 3
-
-/- Imported placements receive source-local numbers in consumer traversal order. -/
-/-- info: true -/
-#guard_msgs in
-#eval
-  show IO Bool from do
-    let (_html, state) ←
-      renderManualDocHtmlStringAndState manualImpls locallyNumberedHybridAttributeModuleDoc
-    let some consumerData :=
-        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.consumer.before.module")
-      | return false
-    let some bodyData :=
-        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.hybrid.body")
-      | return false
-    let some versoDocstringData :=
-        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.hybrid.verso_docstring")
-      | return false
-    let some sharedData :=
-        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.hybrid.shared")
-      | return false
-    pure <|
-      consumerData.numberingMode == .local &&
-      bodyData.numberingMode == .local &&
-      consumerData.count + 1 == bodyData.count &&
-      bodyData.count + 1 == versoDocstringData.count &&
-      versoDocstringData.count + 1 == sharedData.count &&
-      consumerData.globalCount == some 1 &&
-      bodyData.globalCount == some 2 &&
-      versoDocstringData.globalCount == some 3 &&
-      sharedData.globalCount == some 4
-
-/- Persisted Manual bodies, Verso docstrings, and repeated labels share the module path. -/
-/-- info: true -/
-#guard_msgs in
-#eval
-  show IO Bool from do
-    let (html, state) ← renderManualDocHtmlStringAndState manualImpls includedHybridAttributeModuleDoc
-    let labels := #[
-      "attr.hybrid.body",
-      "attr.hybrid.verso_docstring",
-      "attr.hybrid.shared"
-    ]
-    let hasEntries := labels.all fun label =>
-      let key := Informal.PreviewCache.statementKey (Name.mkSimple label)
-      (Informal.PreviewManifest.findTraversalBlockEntry? state key).isSome
-    let some bodyData :=
-        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.hybrid.body")
-      | return false
-    pure <|
-      hasSubstr html "<strong>structural emphasis</strong>" &&
-      hasSubstr html "First persisted Manual list item." &&
-      hasSubstr html "Second persisted Manual list item." &&
-      hasSubstr html "<strong>structurally emphasized Verso docstring body</strong>" &&
-      hasSubstr html "<code>Nat.succ</code>" &&
-      hasSubstr html "First imported docstring list item." &&
-      hasSubstr html "Second imported docstring list item." &&
-      3 ≤ (html.splitOn "<ul>").length &&
-      hasSubstr html "<code class=\"bp_math inline\">1 + 1 = 2</code>" &&
-      hasSubstr html "<code class=\"bp_math inline\">2 + 2 = 4</code>" &&
-      hasSubstr html "hybridSharedFirst" &&
-      hasSubstr html "hybridSharedSecond" &&
-      bodyData.statementUses.map (·.label) ==
-        #[Name.mkSimple "attr.hybrid.verso_docstring"] &&
-      bodyData.proofUses.map (·.label) == #[Name.mkSimple "attr.hybrid.shared"] &&
-      hasEntries
-
-/- This is the cross-feature regression case behind the attribute-first authoring
-   feedback: an imported bare attribute, a structural Verso docstring, explicit
-   dependencies, both placement paths, and consumer-side code folding. Keep the
-   assertions on final HTML rather than only on the imported catalog. -/
+/- Bare attributes use qualified declaration names and retain explicit dependencies. -/
 /-- info: true -/
 #guard_msgs in
 #eval
@@ -515,52 +212,5 @@ private def importedStatementExportOk (node : Informal.Data.Node) : Bool :=
         `Verso.VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider.qualifiedDefaultDefinition
         .definition
         definitionNode
-
-/-- info: true -/
-#guard_msgs in
-#eval
-  show IO Bool from do
-    let label := Name.mkSimple
-      "Verso.VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider.qualifiedDefaultLabel"
-    let (placedHtml, placedState) ←
-      renderManualDocHtmlStringAndState manualImpls placedDefaultLabelDoc
-    let (moduleHtml, moduleState) ←
-      renderManualDocHtmlStringAndState manualImpls includedDefaultLabelModuleDoc
-    let key := Informal.PreviewCache.statementKey label
-    let renderedAsExpected (html : String) : Bool :=
-      countSubstr html "<strong>qualified default-label theorem</strong>" == 2 &&
-      countSubstr html "<code class=\"bp_math inline\">3 + 4 = 7</code>" == 2 &&
-      countSubstr html "<code class=\"bp_math display\">3 + 5 = 8</code>" == 2 &&
-      2 ≤ countSubstr html "First qualified-label list item." &&
-      hasSubstr html "class=\"bp_code_block bp_code_panel\"" &&
-      hasSubstr html "qualifiedDefaultLabel" &&
-      !hasSubstr html "open=\"open\""
-    pure <|
-      (Informal.PreviewManifest.findTraversalBlockEntry? placedState key).isSome &&
-      (Informal.PreviewManifest.findTraversalBlockEntry? moduleState key).isSome &&
-      (Informal.PreviewManifest.findTraversalBlockEntry? placedState key).map
-          (·.2.foldCodeBlock) == some true &&
-      (Informal.PreviewManifest.findTraversalBlockEntry? moduleState key).map
-          (·.2.foldCodeBlock) == some true &&
-      renderedAsExpected placedHtml &&
-      renderedAsExpected moduleHtml &&
-      hasSubstr moduleHtml "qualifiedDefaultDefinition"
-
-/- Attribute-owned, code-only nodes remain available in the manifest/cache pair. -/
-/-- info: true -/
-#guard_msgs in
-#eval
-  show IO Bool from do
-    let files ← buildManualPreviewDataFiles manualImpls placedAttributeDoc
-    let key := Informal.PreviewCache.statementKey (Name.mkSimple "attr.exported.undocumented")
-    let some entry := files.manifest.previews.find? (·.key == key)
-      | return false
-    let some body := files.htmlCache.findHtml? key
-      | return false
-    pure <|
-      body.contains "bp_code_only_preview_body" &&
-      !entry.leanCodePreviewKeys.isEmpty &&
-      entry.kind == some .definition &&
-      (files.htmlCache.codeHtmlBodies entry |>.any (·.contains "exportedUndocumentedDefinition"))
 
 end Verso.VersoBlueprintTests.BlueprintAttribute

--- a/tests/VersoBlueprintTests/BlueprintAttribute.lean
+++ b/tests/VersoBlueprintTests/BlueprintAttribute.lean
@@ -53,6 +53,26 @@ set_option verso.blueprint.numbering "global" in
 {includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.Provider}
 :::::::
 
+set_option verso.blueprint.numbering "global" in
+#docs (Genre.Manual) repeatedAttributePlacementDoc "Repeated attribute placement" :=
+:::::::
+{blueprint_node "attr.exported.theorem"}
+
+Intervening prose between two placements of the same declaration.
+
+{blueprint_node "attr.exported.theorem"}
+:::::::
+
+set_option verso.blueprint.numbering "local" in
+#docs (Genre.Manual) locallyNumberedHybridAttributeModuleDoc "Locally numbered hybrid module" :=
+:::::::
+:::definition "attr.consumer.before.module"
+A consumer-authored node that precedes the imported attribute module.
+:::
+
+{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.HybridProvider}
+:::::::
+
 /--
 error: Blueprint module include: imported module 'VersoBlueprintTests.BlueprintAttribute.Reexport' has no declarations registered with `@[blueprint]`
 -/
@@ -313,6 +333,61 @@ private def importedStatementExportOk (node : Informal.Data.Node) : Bool :=
       definitionData.count == 2 &&
       definitionData.displayNumber state == "2"
 
+/- Repeated placements keep the first number and canonical traversal anchors. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (html, state) ←
+      renderManualDocHtmlStringAndState manualImpls repeatedAttributePlacementDoc
+    let label := Name.mkSimple "attr.exported.theorem"
+    let previewKey := Informal.PreviewCache.statementKey label
+    let some data := Informal.TraversalIndex.Nodes.data? state label
+      | return false
+    let some nodeObject := Informal.TraversalIndex.Nodes.object? state label
+      | return false
+    let some previewObject :=
+        Informal.TraversalIndex.TraversalPreviews.object? state previewKey
+      | return false
+    pure <|
+      data.numberingMode == .global &&
+      data.globalCount == some 1 &&
+      data.count == 1 &&
+      Informal.nextGlobalBlockNumber state == 2 &&
+      nodeObject.ids.toArray.size == 1 &&
+      previewObject.ids.toArray.size == 1 &&
+      (html.splitOn "class=\"bp_graft_node bp_graft_manifest_node\"").length == 3
+
+/- Imported placements receive source-local numbers in consumer traversal order. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (_html, state) ←
+      renderManualDocHtmlStringAndState manualImpls locallyNumberedHybridAttributeModuleDoc
+    let some consumerData :=
+        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.consumer.before.module")
+      | return false
+    let some bodyData :=
+        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.hybrid.body")
+      | return false
+    let some versoDocstringData :=
+        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.hybrid.verso_docstring")
+      | return false
+    let some sharedData :=
+        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.hybrid.shared")
+      | return false
+    pure <|
+      consumerData.numberingMode == .local &&
+      bodyData.numberingMode == .local &&
+      consumerData.count + 1 == bodyData.count &&
+      bodyData.count + 1 == versoDocstringData.count &&
+      versoDocstringData.count + 1 == sharedData.count &&
+      consumerData.globalCount == some 1 &&
+      bodyData.globalCount == some 2 &&
+      versoDocstringData.globalCount == some 3 &&
+      sharedData.globalCount == some 4
+
 /- Persisted Manual bodies, Verso docstrings, and repeated labels share the module path. -/
 /-- info: true -/
 #guard_msgs in
@@ -327,6 +402,9 @@ private def importedStatementExportOk (node : Informal.Data.Node) : Bool :=
     let hasEntries := labels.all fun label =>
       let key := Informal.PreviewCache.statementKey (Name.mkSimple label)
       (Informal.PreviewManifest.findTraversalBlockEntry? state key).isSome
+    let some bodyData :=
+        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.hybrid.body")
+      | return false
     pure <|
       hasSubstr html "<strong>structural emphasis</strong>" &&
       hasSubstr html "First persisted Manual list item." &&
@@ -340,6 +418,9 @@ private def importedStatementExportOk (node : Informal.Data.Node) : Bool :=
       hasSubstr html "<code class=\"bp_math inline\">2 + 2 = 4</code>" &&
       hasSubstr html "hybridSharedFirst" &&
       hasSubstr html "hybridSharedSecond" &&
+      bodyData.statementUses.map (·.label) ==
+        #[Name.mkSimple "attr.hybrid.verso_docstring"] &&
+      bodyData.proofUses.map (·.label) == #[Name.mkSimple "attr.hybrid.shared"] &&
       hasEntries
 
 /- Attribute-owned, code-only nodes remain available in the manifest/cache pair. -/

--- a/tests/VersoBlueprintTests/BlueprintAttribute.lean
+++ b/tests/VersoBlueprintTests/BlueprintAttribute.lean
@@ -152,25 +152,25 @@ private def isBlueprintAttrRef (expectedDecl : Name) (expectedKind : Informal.Da
 #guard_msgs in
 #eval
   show CoreM Bool from do
-    let providerNodes ← Informal.Environment.blueprintAttributeNodesForModule
+    let providerLabels ← Informal.Environment.blueprintAttributeLabelsForModule
       `VersoBlueprintTests.BlueprintAttribute.Provider
-    let reexportNodes ← Informal.Environment.blueprintAttributeNodesForModule
+    let reexportLabels ← Informal.Environment.blueprintAttributeLabelsForModule
       `VersoBlueprintTests.BlueprintAttribute.Reexport
-    let hybridNodes ← Informal.Environment.blueprintAttributeNodesForModule
+    let hybridLabels ← Informal.Environment.blueprintAttributeLabelsForModule
       `VersoBlueprintTests.BlueprintAttribute.HybridProvider
     pure <|
-      providerNodes == #[
+      providerLabels == #[
         Name.mkSimple "attr.exported.theorem",
         Name.mkSimple "attr.exported.definition",
         Name.mkSimple "attr.exported.inductive",
         Name.mkSimple "attr.exported.undocumented"
       ] &&
-      hybridNodes == #[
+      hybridLabels == #[
         Name.mkSimple "attr.hybrid.body",
         Name.mkSimple "attr.hybrid.verso_docstring",
         Name.mkSimple "attr.hybrid.shared"
       ] &&
-      reexportNodes.isEmpty
+      reexportLabels.isEmpty
 
 /- Hybrid fixtures exercise persisted bodies, structural Verso docstrings, and many-to-one labels. -/
 /-- info: true -/
@@ -245,17 +245,6 @@ private def importedStatementExportOk (node : Informal.Data.Node) : Bool :=
 /-- info: true -/
 #guard_msgs in
 #eval
-  show CoreM Bool from do
-    let state ← importedState
-    pure <|
-      state.data.contains (Name.mkSimple "attr.exported.theorem") &&
-      state.data.contains (Name.mkSimple "attr.exported.definition") &&
-      state.data.contains (Name.mkSimple "attr.exported.inductive") &&
-      state.data.contains (Name.mkSimple "attr.exported.undocumented")
-
-/-- info: true -/
-#guard_msgs in
-#eval
   show IO Bool from do
     let (html, state) ← renderManualDocHtmlStringAndState manualImpls placedAttributeDoc
     let theoremKey := Informal.PreviewCache.statementKey (Name.mkSimple "attr.exported.theorem")
@@ -317,9 +306,11 @@ private def importedStatementExportOk (node : Informal.Data.Node) : Bool :=
     pure <|
       theoremData.numberingMode == .global &&
       theoremData.globalCount == some 1 &&
+      theoremData.count == 1 &&
       theoremData.displayNumber state == "1" &&
       definitionData.numberingMode == .global &&
       definitionData.globalCount == some 2 &&
+      definitionData.count == 2 &&
       definitionData.displayNumber state == "2"
 
 /- Persisted Manual bodies, Verso docstrings, and repeated labels share the module path. -/
@@ -337,11 +328,18 @@ private def importedStatementExportOk (node : Informal.Data.Node) : Bool :=
       let key := Informal.PreviewCache.statementKey (Name.mkSimple label)
       (Informal.PreviewManifest.findTraversalBlockEntry? state key).isSome
     pure <|
-      hasSubstr html "Hybrid statement body persisted as already elaborated Manual blocks." &&
-      hasSubstr html "A Verso docstring body that survives Blueprint conversion." &&
+      hasSubstr html "<strong>structural emphasis</strong>" &&
+      hasSubstr html "First persisted Manual list item." &&
+      hasSubstr html "Second persisted Manual list item." &&
+      hasSubstr html "<strong>structurally emphasized Verso docstring body</strong>" &&
+      hasSubstr html "<code>Nat.succ</code>" &&
+      hasSubstr html "First imported docstring list item." &&
+      hasSubstr html "Second imported docstring list item." &&
+      3 ≤ (html.splitOn "<ul>").length &&
+      hasSubstr html "<code class=\"bp_math inline\">1 + 1 = 2</code>" &&
+      hasSubstr html "<code class=\"bp_math inline\">2 + 2 = 4</code>" &&
       hasSubstr html "hybridSharedFirst" &&
       hasSubstr html "hybridSharedSecond" &&
-      !hasSubstr html "bp_code_only_preview_body" &&
       hasEntries
 
 /- Attribute-owned, code-only nodes remain available in the manifest/cache pair. -/

--- a/tests/VersoBlueprintTests/BlueprintAttribute.lean
+++ b/tests/VersoBlueprintTests/BlueprintAttribute.lean
@@ -17,7 +17,7 @@ open Verso
 open Verso.Genre.Manual
 open Verso.VersoBlueprintTests.Blueprint.Support
 
-def manualImpls : ExtensionImpls := extension_impls%
+private def manualImpls : ExtensionImpls := extension_impls%
 
 #docs (Genre.Manual) placedAttributeDoc "Placed attribute-owned nodes" :=
 :::::::

--- a/tests/VersoBlueprintTests/BlueprintAttribute.lean
+++ b/tests/VersoBlueprintTests/BlueprintAttribute.lean
@@ -64,6 +64,20 @@ Intervening prose between two placements of the same declaration.
 :::::::
 
 set_option verso.blueprint.numbering "local" in
+#docs (Genre.Manual) interleavedLocalAttributePlacementDoc "Interleaved local attribute placement" :=
+:::::::
+:::definition "attr.consumer.before.placement"
+A consumer-authored node before an imported attribute placement.
+:::
+
+{blueprint_node "attr.exported.theorem"}
+
+:::definition "attr.consumer.after.placement"
+A consumer-authored node after an imported attribute placement.
+:::
+:::::::
+
+set_option verso.blueprint.numbering "local" in
 #docs (Genre.Manual) locallyNumberedHybridAttributeModuleDoc "Locally numbered hybrid module" :=
 :::::::
 :::definition "attr.consumer.before.module"
@@ -357,6 +371,32 @@ private def importedStatementExportOk (node : Informal.Data.Node) : Bool :=
       nodeObject.ids.toArray.size == 1 &&
       previewObject.ids.toArray.size == 1 &&
       (html.splitOn "class=\"bp_graft_node bp_graft_manifest_node\"").length == 3
+
+/- Generated placements cannot reuse a later authored block's source-local count. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (_html, state) ←
+      renderManualDocHtmlStringAndState manualImpls interleavedLocalAttributePlacementDoc
+    let some beforeData :=
+        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.consumer.before.placement")
+      | return false
+    let some attributeData :=
+        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.exported.theorem")
+      | return false
+    let some afterData :=
+        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.consumer.after.placement")
+      | return false
+    pure <|
+      beforeData.numberingMode == .local &&
+      attributeData.numberingMode == .local &&
+      afterData.numberingMode == .local &&
+      beforeData.count + 1 == attributeData.count &&
+      attributeData.count + 1 == afterData.count &&
+      beforeData.globalCount == some 1 &&
+      attributeData.globalCount == some 2 &&
+      afterData.globalCount == some 3
 
 /- Imported placements receive source-local numbers in consumer traversal order. -/
 /-- info: true -/

--- a/tests/VersoBlueprintTests/BlueprintAttribute.lean
+++ b/tests/VersoBlueprintTests/BlueprintAttribute.lean
@@ -6,6 +6,7 @@ Author: Emilio J. Gallego Arias
 
 import VersoBlueprintTests.BlueprintAttribute.Reexport
 import VersoBlueprintTests.BlueprintAttribute.HybridProvider
+import VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider
 import VersoBlueprintTests.Blueprint.Support
 
 open Lean
@@ -46,6 +47,20 @@ Concluding prose after the imported declarations.
 :::::::
 {includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.HybridProvider}
 :::::::
+
+set_option verso.blueprint.foldCodeBlocks true
+
+#docs (Genre.Manual) placedDefaultLabelDoc "Placed default-label declaration" :=
+:::::::
+{blueprint_node "Verso.VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider.qualifiedDefaultLabel"}
+:::::::
+
+#docs (Genre.Manual) includedDefaultLabelModuleDoc "Default-label module inclusion" :=
+:::::::
+{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider}
+:::::::
+
+set_option verso.blueprint.foldCodeBlocks false
 
 set_option verso.blueprint.numbering "global" in
 #docs (Genre.Manual) globallyNumberedAttributeModuleDoc "Globally numbered attribute module" :=
@@ -120,6 +135,9 @@ private def importedState : CoreM Informal.Environment.State := do
 private def importedNode? (label : String) : CoreM (Option Informal.Data.Node) := do
   pure <| (← importedState).data.get? (Name.mkSimple label)
 
+private def importedNodeByName? (label : Name) : CoreM (Option Informal.Data.Node) := do
+  pure <| (← importedState).data.get? label
+
 private def importedNodeInLocalData (label : String) : CoreM Bool := do
   pure <| (← importedState).localData.contains (Name.mkSimple label)
 
@@ -192,6 +210,8 @@ private def isBlueprintAttrRef (expectedDecl : Name) (expectedKind : Informal.Da
       `VersoBlueprintTests.BlueprintAttribute.Reexport
     let hybridLabels ← Informal.Environment.blueprintAttributeLabelsForModule
       `VersoBlueprintTests.BlueprintAttribute.HybridProvider
+    let defaultLabelProviderLabels ← Informal.Environment.blueprintAttributeLabelsForModule
+      `VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider
     pure <|
       providerLabels == #[
         Name.mkSimple "attr.exported.theorem",
@@ -203,6 +223,12 @@ private def isBlueprintAttrRef (expectedDecl : Name) (expectedKind : Informal.Da
         Name.mkSimple "attr.hybrid.body",
         Name.mkSimple "attr.hybrid.verso_docstring",
         Name.mkSimple "attr.hybrid.shared"
+      ] &&
+      defaultLabelProviderLabels == #[
+        Name.mkSimple
+          "Verso.VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider.qualifiedDefaultLabel",
+        Name.mkSimple
+          "Verso.VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider.qualifiedDefaultDefinition"
       ] &&
       reexportLabels.isEmpty
 
@@ -462,6 +488,62 @@ private def importedStatementExportOk (node : Informal.Data.Node) : Bool :=
         #[Name.mkSimple "attr.hybrid.verso_docstring"] &&
       bodyData.proofUses.map (·.label) == #[Name.mkSimple "attr.hybrid.shared"] &&
       hasEntries
+
+/- This is the cross-feature regression case behind the attribute-first authoring
+   feedback: an imported bare attribute, a structural Verso docstring, explicit
+   dependencies, both placement paths, and consumer-side code folding. Keep the
+   assertions on final HTML rather than only on the imported catalog. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  show CoreM Bool from do
+    let decl :=
+      `Verso.VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider.qualifiedDefaultLabel
+    let label := Name.mkSimple decl.toString
+    let some node ← importedNodeByName? label
+      | return false
+    let defaultDefinition :=
+      Name.mkSimple
+        "Verso.VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider.qualifiedDefaultDefinition"
+    let some definitionNode ← importedNodeByName? defaultDefinition
+      | return false
+    pure <|
+      node.statement.map (·.deps.map (·.label)) ==
+        some #[Name.mkSimple "attr.exported.theorem"] &&
+      isBlueprintAttrRef decl .theorem node &&
+      isBlueprintAttrRef
+        `Verso.VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider.qualifiedDefaultDefinition
+        .definition
+        definitionNode
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let label := Name.mkSimple
+      "Verso.VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider.qualifiedDefaultLabel"
+    let (placedHtml, placedState) ←
+      renderManualDocHtmlStringAndState manualImpls placedDefaultLabelDoc
+    let (moduleHtml, moduleState) ←
+      renderManualDocHtmlStringAndState manualImpls includedDefaultLabelModuleDoc
+    let key := Informal.PreviewCache.statementKey label
+    let renderedAsExpected (html : String) : Bool :=
+      countSubstr html "<strong>qualified default-label theorem</strong>" == 2 &&
+      countSubstr html "<code class=\"bp_math inline\">3 + 4 = 7</code>" == 2 &&
+      2 ≤ countSubstr html "First qualified-label list item." &&
+      hasSubstr html "class=\"bp_code_block bp_code_panel\"" &&
+      hasSubstr html "qualifiedDefaultLabel" &&
+      !hasSubstr html "open=\"open\""
+    pure <|
+      (Informal.PreviewManifest.findTraversalBlockEntry? placedState key).isSome &&
+      (Informal.PreviewManifest.findTraversalBlockEntry? moduleState key).isSome &&
+      (Informal.PreviewManifest.findTraversalBlockEntry? placedState key).map
+          (·.2.foldCodeBlock) == some true &&
+      (Informal.PreviewManifest.findTraversalBlockEntry? moduleState key).map
+          (·.2.foldCodeBlock) == some true &&
+      renderedAsExpected placedHtml &&
+      renderedAsExpected moduleHtml &&
+      hasSubstr moduleHtml "qualifiedDefaultDefinition"
 
 /- Attribute-owned, code-only nodes remain available in the manifest/cache pair. -/
 /-- info: true -/

--- a/tests/VersoBlueprintTests/BlueprintAttribute.lean
+++ b/tests/VersoBlueprintTests/BlueprintAttribute.lean
@@ -5,11 +5,80 @@ Author: Emilio J. Gallego Arias
 -/
 
 import VersoBlueprintTests.BlueprintAttribute.Reexport
+import VersoBlueprintTests.BlueprintAttribute.HybridProvider
+import VersoBlueprintTests.Blueprint.Support
 
 open Lean
 open Informal
 
 namespace Verso.VersoBlueprintTests.BlueprintAttribute
+
+open Verso
+open Verso.Genre.Manual
+open Verso.VersoBlueprintTests.Blueprint.Support
+
+def manualImpls : ExtensionImpls := extension_impls%
+
+#docs (Genre.Manual) placedAttributeDoc "Placed attribute-owned nodes" :=
+:::::::
+Introductory prose before the imported declaration.
+
+{blueprint_node "attr.exported.theorem"}
+
+Connecting prose between declarations.
+
+{blueprint_node "attr.exported.undocumented"}
+
+Concluding prose after the imported declarations.
+:::::::
+
+#docs (Genre.Manual) includedAttributeModuleDoc "Attribute module inclusion" :=
+:::::::
+{includeBlueprintModule 0 VersoBlueprintTests.BlueprintAttribute.Provider (title := "Imported attribute declarations")}
+:::::::
+
+#docs (Genre.Manual) includedAttributeModuleDefaultDoc "Default attribute module inclusion" :=
+:::::::
+{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.Provider}
+:::::::
+
+#docs (Genre.Manual) includedHybridAttributeModuleDoc "Hybrid attribute module inclusion" :=
+:::::::
+{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.HybridProvider}
+:::::::
+
+set_option verso.blueprint.numbering "global" in
+#docs (Genre.Manual) globallyNumberedAttributeModuleDoc "Globally numbered attribute module" :=
+:::::::
+{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.Provider}
+:::::::
+
+/--
+error: Blueprint module include: imported module 'VersoBlueprintTests.BlueprintAttribute.Reexport' has no declarations registered with `@[blueprint]`
+-/
+#guard_msgs in
+#docs (Genre.Manual) rejectedEmptyAttributeModuleDoc "Rejected empty attribute module" :=
+:::::::
+{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.Reexport}
+:::::::
+
+/--
+error: Blueprint module include: module 'NotImported.BlueprintModule' is not available through this Lean module's imports; add `import NotImported.BlueprintModule`
+-/
+#guard_msgs in
+#docs (Genre.Manual) rejectedUnimportedAttributeModuleDoc "Rejected unimported attribute module" :=
+:::::::
+{includeBlueprintModule NotImported.BlueprintModule}
+:::::::
+
+/--
+error: Blueprint module include is only available in Manual documents
+-/
+#guard_msgs in
+#docs (VersoSlides.Slides) rejectedSlidesAttributeModuleDoc "Rejected Slides module include" :=
+:::::::
+{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.Provider}
+:::::::
 
 private def importedState : CoreM Informal.Environment.State := do
   pure <| Informal.Environment.informalExt.getState (← getEnv)
@@ -19,6 +88,17 @@ private def importedNode? (label : String) : CoreM (Option Informal.Data.Node) :
 
 private def importedNodeInLocalData (label : String) : CoreM Bool := do
   pure <| (← importedState).localData.contains (Name.mkSimple label)
+
+private def substringsInOrder (text : String) : List String → Bool
+  | [] => true
+  | needle :: rest =>
+    match text.splitOn needle with
+    | _before :: after =>
+      if after.isEmpty then
+        false
+      else
+        substringsInOrder (String.intercalate needle after) rest
+    | _ => false
 
 private def isBlueprintAttrRef (expectedDecl : Name) (expectedKind : Informal.Data.NodeKind)
     (node : Informal.Data.Node) : Bool :=
@@ -66,6 +146,62 @@ private def isBlueprintAttrRef (expectedDecl : Name) (expectedKind : Informal.Da
       !(← importedNodeInLocalData "attr.exported.definition") &&
       !(← importedNodeInLocalData "attr.exported.inductive") &&
       !(← importedNodeInLocalData "attr.exported.undocumented")
+
+/- Imported module catalogs retain direct attribute ownership and source order. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  show CoreM Bool from do
+    let providerNodes ← Informal.Environment.blueprintAttributeNodesForModule
+      `VersoBlueprintTests.BlueprintAttribute.Provider
+    let reexportNodes ← Informal.Environment.blueprintAttributeNodesForModule
+      `VersoBlueprintTests.BlueprintAttribute.Reexport
+    let hybridNodes ← Informal.Environment.blueprintAttributeNodesForModule
+      `VersoBlueprintTests.BlueprintAttribute.HybridProvider
+    pure <|
+      providerNodes == #[
+        Name.mkSimple "attr.exported.theorem",
+        Name.mkSimple "attr.exported.definition",
+        Name.mkSimple "attr.exported.inductive",
+        Name.mkSimple "attr.exported.undocumented"
+      ] &&
+      hybridNodes == #[
+        Name.mkSimple "attr.hybrid.body",
+        Name.mkSimple "attr.hybrid.verso_docstring",
+        Name.mkSimple "attr.hybrid.shared"
+      ] &&
+      reexportNodes.isEmpty
+
+/- Hybrid fixtures exercise persisted bodies, structural Verso docstrings, and many-to-one labels. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  show CoreM Bool from do
+    let some bodyNode ← importedNode? "attr.hybrid.body"
+      | return false
+    let some sharedNode ← importedNode? "attr.hybrid.shared"
+      | return false
+    let versoDoc? ← liftM <| findInternalDocString? (← getEnv)
+      `Verso.VersoBlueprintTests.BlueprintAttribute.HybridProvider.hybridVersoDocstring
+    let bodyWasPersisted :=
+      match bodyNode.statement with
+      | some statement => !statement.previewBlocks.isEmpty && statement.elabStx.isEmpty
+      | none => false
+    pure <|
+      bodyWasPersisted &&
+      (match versoDoc? with | some (.inr _) => true | _ => false) &&
+      sharedNode.leanDecls == #[
+        `Verso.VersoBlueprintTests.BlueprintAttribute.HybridProvider.hybridSharedFirst,
+        `Verso.VersoBlueprintTests.BlueprintAttribute.HybridProvider.hybridSharedSecond
+      ]
+
+/- The no-level form creates a child part and derives its title from the module name. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    includedAttributeModuleDefaultDoc.toPart.subParts.any fun part =>
+      part.titleString == "Provider" && part.content.size == 4
 
 /-- info: true -/
 #guard_msgs in
@@ -116,5 +252,113 @@ private def importedStatementExportOk (node : Informal.Data.Node) : Bool :=
       state.data.contains (Name.mkSimple "attr.exported.definition") &&
       state.data.contains (Name.mkSimple "attr.exported.inductive") &&
       state.data.contains (Name.mkSimple "attr.exported.undocumented")
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (html, state) ← renderManualDocHtmlStringAndState manualImpls placedAttributeDoc
+    let theoremKey := Informal.PreviewCache.statementKey (Name.mkSimple "attr.exported.theorem")
+    let undocumentedKey :=
+      Informal.PreviewCache.statementKey (Name.mkSimple "attr.exported.undocumented")
+    pure <|
+      hasSubstr html "Introductory prose before the imported declaration." &&
+      hasSubstr html "Connecting prose between declarations." &&
+      hasSubstr html "Concluding prose after the imported declarations." &&
+      hasSubstr html "Exported theorem used to verify" &&
+      hasSubstr html "bp_attribute_node_anchor" &&
+      hasSubstr html "exportedTheorem" &&
+      hasSubstr html "exportedUndocumentedDefinition" &&
+      !hasSubstr html "Blueprint node not found" &&
+      !hasSubstr html "Blueprint node has no cached content" &&
+      (Informal.PreviewManifest.findTraversalBlockEntry? state theoremKey).isSome &&
+      (Informal.PreviewManifest.findTraversalBlockEntry? state undocumentedKey).isSome
+
+/- A regular imported Lean module can become a source-ordered Verso part. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (html, state) ← renderManualDocHtmlStringAndState manualImpls includedAttributeModuleDoc
+    let hasIncludedTitle :=
+      includedAttributeModuleDoc.toPart.subParts.any
+        (·.titleString == "Imported attribute declarations")
+    let labels := #[
+      "attr.exported.theorem",
+      "attr.exported.definition",
+      "attr.exported.inductive",
+      "attr.exported.undocumented"
+    ]
+    let hasAnchor := hasSubstr html "bp_attribute_node_anchor"
+    let ordered := substringsInOrder html [
+        "exportedTheorem",
+        "exportedDefinition",
+        "exportedInductive",
+        "exportedUndocumentedDefinition"
+      ]
+    let hasEntries := labels.all fun label =>
+        let key := Informal.PreviewCache.statementKey (Name.mkSimple label)
+        (Informal.PreviewManifest.findTraversalBlockEntry? state key).isSome
+    pure <| hasIncludedTitle && hasAnchor && ordered && hasEntries
+
+/- Generated module nodes honor non-default Blueprint numbering options. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (_html, state) ←
+      renderManualDocHtmlStringAndState manualImpls globallyNumberedAttributeModuleDoc
+    let theoremLabel := Name.mkSimple "attr.exported.theorem"
+    let definitionLabel := Name.mkSimple "attr.exported.definition"
+    let some theoremData := Informal.TraversalIndex.Nodes.data? state theoremLabel
+      | return false
+    let some definitionData := Informal.TraversalIndex.Nodes.data? state definitionLabel
+      | return false
+    pure <|
+      theoremData.numberingMode == .global &&
+      theoremData.globalCount == some 1 &&
+      theoremData.displayNumber state == "1" &&
+      definitionData.numberingMode == .global &&
+      definitionData.globalCount == some 2 &&
+      definitionData.displayNumber state == "2"
+
+/- Persisted Manual bodies, Verso docstrings, and repeated labels share the module path. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (html, state) ← renderManualDocHtmlStringAndState manualImpls includedHybridAttributeModuleDoc
+    let labels := #[
+      "attr.hybrid.body",
+      "attr.hybrid.verso_docstring",
+      "attr.hybrid.shared"
+    ]
+    let hasEntries := labels.all fun label =>
+      let key := Informal.PreviewCache.statementKey (Name.mkSimple label)
+      (Informal.PreviewManifest.findTraversalBlockEntry? state key).isSome
+    pure <|
+      hasSubstr html "Hybrid statement body persisted as already elaborated Manual blocks." &&
+      hasSubstr html "A Verso docstring body that survives Blueprint conversion." &&
+      hasSubstr html "hybridSharedFirst" &&
+      hasSubstr html "hybridSharedSecond" &&
+      !hasSubstr html "bp_code_only_preview_body" &&
+      hasEntries
+
+/- Attribute-owned, code-only nodes remain available in the manifest/cache pair. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let files ← buildManualPreviewDataFiles manualImpls placedAttributeDoc
+    let key := Informal.PreviewCache.statementKey (Name.mkSimple "attr.exported.undocumented")
+    let some entry := files.manifest.previews.find? (·.key == key)
+      | return false
+    let some body := files.htmlCache.findHtml? key
+      | return false
+    pure <|
+      body.contains "bp_code_only_preview_body" &&
+      !entry.leanCodePreviewKeys.isEmpty &&
+      entry.kind == some .definition &&
+      (files.htmlCache.codeHtmlBodies entry |>.any (·.contains "exportedUndocumentedDefinition"))
 
 end Verso.VersoBlueprintTests.BlueprintAttribute

--- a/tests/VersoBlueprintTests/BlueprintAttribute.lean
+++ b/tests/VersoBlueprintTests/BlueprintAttribute.lean
@@ -530,6 +530,7 @@ private def importedStatementExportOk (node : Informal.Data.Node) : Bool :=
     let renderedAsExpected (html : String) : Bool :=
       countSubstr html "<strong>qualified default-label theorem</strong>" == 2 &&
       countSubstr html "<code class=\"bp_math inline\">3 + 4 = 7</code>" == 2 &&
+      countSubstr html "<code class=\"bp_math display\">3 + 5 = 8</code>" == 2 &&
       2 ≤ countSubstr html "First qualified-label list item." &&
       hasSubstr html "class=\"bp_code_block bp_code_panel\"" &&
       hasSubstr html "qualifiedDefaultLabel" &&

--- a/tests/VersoBlueprintTests/BlueprintAttribute/DefaultLabelProvider.lean
+++ b/tests/VersoBlueprintTests/BlueprintAttribute/DefaultLabelProvider.lean
@@ -13,6 +13,9 @@ set_option doc.verso true in
 A *qualified default-label theorem* whose structural external panel preserves
 inline mathematics $`3 + 4 = 7`.
 
+It also preserves display mathematics:
+$$`3 + 5 = 8`
+
 * First qualified-label list item.
 * Second qualified-label list item.
 -/

--- a/tests/VersoBlueprintTests/BlueprintAttribute/DefaultLabelProvider.lean
+++ b/tests/VersoBlueprintTests/BlueprintAttribute/DefaultLabelProvider.lean
@@ -16,8 +16,17 @@ inline mathematics $`3 + 4 = 7`.
 It also preserves display mathematics:
 $$`3 + 5 = 8`
 
+A [structural docstring link](https://example.com/qualified-docstring) remains
+clickable.
+
+> A quoted structural docstring paragraph.
+
 * First qualified-label list item.
 * Second qualified-label list item.
+
+# Qualified structural subsection
+
+Subsection content remains part of the imported statement.
 -/
 @[blueprint (uses := ["attr.exported.theorem"])]
 theorem qualifiedDefaultLabel : True := by

--- a/tests/VersoBlueprintTests/BlueprintAttribute/DefaultLabelProvider.lean
+++ b/tests/VersoBlueprintTests/BlueprintAttribute/DefaultLabelProvider.lean
@@ -1,0 +1,26 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoBlueprintTests.BlueprintAttribute.Provider
+
+namespace Verso.VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider
+
+set_option doc.verso true in
+/--
+A *qualified default-label theorem* whose structural external panel preserves
+inline mathematics $`3 + 4 = 7`.
+
+* First qualified-label list item.
+* Second qualified-label list item.
+-/
+@[blueprint (uses := ["attr.exported.theorem"])]
+theorem qualifiedDefaultLabel : True := by
+  trivial
+
+@[blueprint]
+def qualifiedDefaultDefinition : Nat := 23
+
+end Verso.VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider

--- a/tests/VersoBlueprintTests/BlueprintAttribute/HybridProvider.lean
+++ b/tests/VersoBlueprintTests/BlueprintAttribute/HybridProvider.lean
@@ -19,12 +19,23 @@ theorem hybridBodyTheorem : True := by
 #docs (Genre.Manual) hybridBodySourceDoc "Hybrid attribute body source" :=
 :::::::
 :::theorem "attr.hybrid.body"
-Hybrid statement body persisted as already elaborated Manual blocks.
+Hybrid statement body persisted with *structural emphasis*, inline mathematics
+$`1 + 1 = 2`, and already elaborated Manual blocks.
+
+* First persisted Manual list item.
+* Second persisted Manual list item.
 :::
 :::::::
 
 set_option doc.verso true in
-/-- A Verso docstring body that survives Blueprint conversion. -/
+/--
+A *structurally emphasized Verso docstring body* that survives Blueprint
+conversion. It keeps the child content of the {name}`Nat.succ`
+extension and inline mathematics $`2 + 2 = 4`.
+
+* First imported docstring list item.
+* Second imported docstring list item.
+-/
 @[blueprint "attr.hybrid.verso_docstring"]
 def hybridVersoDocstring : Nat := 13
 

--- a/tests/VersoBlueprintTests/BlueprintAttribute/HybridProvider.lean
+++ b/tests/VersoBlueprintTests/BlueprintAttribute/HybridProvider.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoBlueprint
+
+open Verso
+open Verso.Genre.Manual
+open Informal
+
+namespace Verso.VersoBlueprintTests.BlueprintAttribute.HybridProvider
+
+@[blueprint "attr.hybrid.body"]
+theorem hybridBodyTheorem : True := by
+  trivial
+
+#docs (Genre.Manual) hybridBodySourceDoc "Hybrid attribute body source" :=
+:::::::
+:::theorem "attr.hybrid.body"
+Hybrid statement body persisted as already elaborated Manual blocks.
+:::
+:::::::
+
+set_option doc.verso true in
+/-- A Verso docstring body that survives Blueprint conversion. -/
+@[blueprint "attr.hybrid.verso_docstring"]
+def hybridVersoDocstring : Nat := 13
+
+@[blueprint "attr.hybrid.shared"]
+def hybridSharedFirst : Nat := 17
+
+@[blueprint "attr.hybrid.shared"]
+def hybridSharedSecond : Nat := 19
+
+end Verso.VersoBlueprintTests.BlueprintAttribute.HybridProvider

--- a/tests/VersoBlueprintTests/BlueprintAttribute/HybridProvider.lean
+++ b/tests/VersoBlueprintTests/BlueprintAttribute/HybridProvider.lean
@@ -12,7 +12,9 @@ open Informal
 
 namespace Verso.VersoBlueprintTests.BlueprintAttribute.HybridProvider
 
-@[blueprint "attr.hybrid.body"]
+@[blueprint "attr.hybrid.body"
+  (uses := ["attr.hybrid.verso_docstring"])
+  (proofUses := ["attr.hybrid.shared"])]
 theorem hybridBodyTheorem : True := by
   trivial
 

--- a/tests/VersoBlueprintTests/BlueprintAttributeRendering.lean
+++ b/tests/VersoBlueprintTests/BlueprintAttributeRendering.lean
@@ -1,0 +1,392 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+
+import VersoBlueprintTests.BlueprintAttribute
+import VersoBlueprintTests.Blueprint.Support
+
+open Lean
+open Informal
+
+namespace Verso.VersoBlueprintTests.BlueprintAttributeRendering
+
+open Verso
+open Verso.Genre.Manual
+open Verso.VersoBlueprintTests.Blueprint.Support
+
+private def manualImpls : ExtensionImpls := extension_impls%
+
+#docs (Genre.Manual) placedAttributeDoc "Placed attribute-owned nodes" :=
+:::::::
+Introductory prose before the imported declaration.
+
+{blueprint_node "attr.exported.theorem"}
+
+Connecting prose between declarations.
+
+{blueprint_node "attr.exported.undocumented"}
+
+Concluding prose after the imported declarations.
+:::::::
+
+#docs (Genre.Manual) includedAttributeModuleDoc "Attribute module inclusion" :=
+:::::::
+{includeBlueprintModule 0 VersoBlueprintTests.BlueprintAttribute.Provider (title := "Imported attribute declarations")}
+:::::::
+
+#docs (Genre.Manual) includedAttributeModuleDefaultDoc "Default attribute module inclusion" :=
+:::::::
+{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.Provider}
+:::::::
+
+#docs (Genre.Manual) includedHybridAttributeModuleDoc "Hybrid attribute module inclusion" :=
+:::::::
+{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.HybridProvider}
+:::::::
+
+set_option verso.blueprint.foldCodeBlocks true
+
+#docs (Genre.Manual) placedDefaultLabelDoc "Placed default-label declaration" :=
+:::::::
+{blueprint_node "Verso.VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider.qualifiedDefaultLabel"}
+:::::::
+
+#docs (Genre.Manual) includedDefaultLabelModuleDoc "Default-label module inclusion" :=
+:::::::
+{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider}
+:::::::
+
+set_option verso.blueprint.foldCodeBlocks false
+
+set_option verso.blueprint.numbering "global" in
+#docs (Genre.Manual) globallyNumberedAttributeModuleDoc "Globally numbered attribute module" :=
+:::::::
+{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.Provider}
+:::::::
+
+set_option verso.blueprint.numbering "global" in
+#docs (Genre.Manual) repeatedAttributePlacementDoc "Repeated attribute placement" :=
+:::::::
+{blueprint_node "attr.exported.theorem"}
+
+Intervening prose between two placements of the same declaration.
+
+{blueprint_node "attr.exported.theorem"}
+:::::::
+
+set_option verso.blueprint.numbering "local" in
+#docs (Genre.Manual) interleavedLocalAttributePlacementDoc "Interleaved local attribute placement" :=
+:::::::
+:::definition "attr.consumer.before.placement"
+A consumer-authored node before an imported attribute placement.
+:::
+
+{blueprint_node "attr.exported.theorem"}
+
+:::definition "attr.consumer.after.placement"
+A consumer-authored node after an imported attribute placement.
+:::
+:::::::
+
+set_option verso.blueprint.numbering "local" in
+#docs (Genre.Manual) locallyNumberedHybridAttributeModuleDoc "Locally numbered hybrid module" :=
+:::::::
+:::definition "attr.consumer.before.module"
+A consumer-authored node that precedes the imported attribute module.
+:::
+
+{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.HybridProvider}
+:::::::
+
+/--
+error: Blueprint module include: imported module 'VersoBlueprintTests.BlueprintAttribute.Reexport' has no declarations registered with `@[blueprint]`
+-/
+#guard_msgs in
+#docs (Genre.Manual) rejectedEmptyAttributeModuleDoc "Rejected empty attribute module" :=
+:::::::
+{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.Reexport}
+:::::::
+
+/--
+error: Blueprint module include: module 'NotImported.BlueprintModule' is not available through this Lean module's imports; add `import NotImported.BlueprintModule`
+-/
+#guard_msgs in
+#docs (Genre.Manual) rejectedUnimportedAttributeModuleDoc "Rejected unimported attribute module" :=
+:::::::
+{includeBlueprintModule NotImported.BlueprintModule}
+:::::::
+
+/--
+error: Blueprint module include is only available in Manual documents
+-/
+#guard_msgs in
+#docs (VersoSlides.Slides) rejectedSlidesAttributeModuleDoc "Rejected Slides module include" :=
+:::::::
+{includeBlueprintModule VersoBlueprintTests.BlueprintAttribute.Provider}
+:::::::
+
+private def substringsInOrder (text : String) : List String → Bool
+  | [] => true
+  | needle :: rest =>
+    match text.splitOn needle with
+    | _before :: after =>
+      if after.isEmpty then
+        false
+      else
+        substringsInOrder (String.intercalate needle after) rest
+    | _ => false
+
+/- The no-level form creates a child part and derives its title from the module name. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    includedAttributeModuleDefaultDoc.toPart.subParts.any fun part =>
+      part.titleString == "Provider" && part.content.size == 4
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (html, state) ← renderManualDocHtmlStringAndState manualImpls placedAttributeDoc
+    let theoremKey := Informal.PreviewCache.statementKey (Name.mkSimple "attr.exported.theorem")
+    let undocumentedKey :=
+      Informal.PreviewCache.statementKey (Name.mkSimple "attr.exported.undocumented")
+    pure <|
+      hasSubstr html "Introductory prose before the imported declaration." &&
+      hasSubstr html "Connecting prose between declarations." &&
+      hasSubstr html "Concluding prose after the imported declarations." &&
+      hasSubstr html "Exported theorem used to verify" &&
+      hasSubstr html "bp_attribute_node_anchor" &&
+      hasSubstr html "exportedTheorem" &&
+      hasSubstr html "exportedUndocumentedDefinition" &&
+      !hasSubstr html "Blueprint node not found" &&
+      !hasSubstr html "Blueprint node has no cached content" &&
+      (Informal.PreviewManifest.findTraversalBlockEntry? state theoremKey).isSome &&
+      (Informal.PreviewManifest.findTraversalBlockEntry? state undocumentedKey).isSome
+
+/- A regular imported Lean module can become a source-ordered Verso part. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (html, state) ← renderManualDocHtmlStringAndState manualImpls includedAttributeModuleDoc
+    let hasIncludedTitle :=
+      includedAttributeModuleDoc.toPart.subParts.any
+        (·.titleString == "Imported attribute declarations")
+    let labels := #[
+      "attr.exported.theorem",
+      "attr.exported.definition",
+      "attr.exported.inductive",
+      "attr.exported.undocumented"
+    ]
+    let hasAnchor := hasSubstr html "bp_attribute_node_anchor"
+    let ordered := substringsInOrder html [
+        "exportedTheorem",
+        "exportedDefinition",
+        "exportedInductive",
+        "exportedUndocumentedDefinition"
+      ]
+    let hasEntries := labels.all fun label =>
+        let key := Informal.PreviewCache.statementKey (Name.mkSimple label)
+        (Informal.PreviewManifest.findTraversalBlockEntry? state key).isSome
+    pure <| hasIncludedTitle && hasAnchor && ordered && hasEntries
+
+/- Generated module nodes honor non-default Blueprint numbering options. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (_html, state) ←
+      renderManualDocHtmlStringAndState manualImpls globallyNumberedAttributeModuleDoc
+    let theoremLabel := Name.mkSimple "attr.exported.theorem"
+    let definitionLabel := Name.mkSimple "attr.exported.definition"
+    let some theoremData := Informal.TraversalIndex.Nodes.data? state theoremLabel
+      | return false
+    let some definitionData := Informal.TraversalIndex.Nodes.data? state definitionLabel
+      | return false
+    pure <|
+      theoremData.numberingMode == .global &&
+      theoremData.globalCount == some 1 &&
+      theoremData.count == 1 &&
+      theoremData.displayNumber state == "1" &&
+      definitionData.numberingMode == .global &&
+      definitionData.globalCount == some 2 &&
+      definitionData.count == 2 &&
+      definitionData.displayNumber state == "2"
+
+/- Repeated placements keep the first number and canonical traversal anchors. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (html, state) ←
+      renderManualDocHtmlStringAndState manualImpls repeatedAttributePlacementDoc
+    let label := Name.mkSimple "attr.exported.theorem"
+    let previewKey := Informal.PreviewCache.statementKey label
+    let some data := Informal.TraversalIndex.Nodes.data? state label
+      | return false
+    let some nodeObject := Informal.TraversalIndex.Nodes.object? state label
+      | return false
+    let some previewObject :=
+        Informal.TraversalIndex.TraversalPreviews.object? state previewKey
+      | return false
+    pure <|
+      data.numberingMode == .global &&
+      data.globalCount == some 1 &&
+      data.count == 1 &&
+      Informal.nextGlobalBlockNumber state == 2 &&
+      nodeObject.ids.toArray.size == 1 &&
+      previewObject.ids.toArray.size == 1 &&
+      (html.splitOn "class=\"bp_graft_node bp_graft_manifest_node\"").length == 3
+
+/- Generated placements cannot reuse a later authored block's source-local count. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (_html, state) ←
+      renderManualDocHtmlStringAndState manualImpls interleavedLocalAttributePlacementDoc
+    let some beforeData :=
+        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.consumer.before.placement")
+      | return false
+    let some attributeData :=
+        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.exported.theorem")
+      | return false
+    let some afterData :=
+        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.consumer.after.placement")
+      | return false
+    pure <|
+      beforeData.numberingMode == .local &&
+      attributeData.numberingMode == .local &&
+      afterData.numberingMode == .local &&
+      beforeData.count + 1 == attributeData.count &&
+      attributeData.count + 1 == afterData.count &&
+      beforeData.globalCount == some 1 &&
+      attributeData.globalCount == some 2 &&
+      afterData.globalCount == some 3
+
+/- Imported placements receive source-local numbers in consumer traversal order. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (_html, state) ←
+      renderManualDocHtmlStringAndState manualImpls locallyNumberedHybridAttributeModuleDoc
+    let some consumerData :=
+        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.consumer.before.module")
+      | return false
+    let some bodyData :=
+        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.hybrid.body")
+      | return false
+    let some versoDocstringData :=
+        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.hybrid.verso_docstring")
+      | return false
+    let some sharedData :=
+        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.hybrid.shared")
+      | return false
+    pure <|
+      consumerData.numberingMode == .local &&
+      bodyData.numberingMode == .local &&
+      consumerData.count + 1 == bodyData.count &&
+      bodyData.count + 1 == versoDocstringData.count &&
+      versoDocstringData.count + 1 == sharedData.count &&
+      consumerData.globalCount == some 1 &&
+      bodyData.globalCount == some 2 &&
+      versoDocstringData.globalCount == some 3 &&
+      sharedData.globalCount == some 4
+
+/- Persisted Manual bodies, Verso docstrings, and repeated labels share the module path. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let (html, state) ← renderManualDocHtmlStringAndState manualImpls includedHybridAttributeModuleDoc
+    let labels := #[
+      "attr.hybrid.body",
+      "attr.hybrid.verso_docstring",
+      "attr.hybrid.shared"
+    ]
+    let hasEntries := labels.all fun label =>
+      let key := Informal.PreviewCache.statementKey (Name.mkSimple label)
+      (Informal.PreviewManifest.findTraversalBlockEntry? state key).isSome
+    let some bodyData :=
+        Informal.TraversalIndex.Nodes.data? state (Name.mkSimple "attr.hybrid.body")
+      | return false
+    pure <|
+      hasSubstr html "<strong>structural emphasis</strong>" &&
+      hasSubstr html "First persisted Manual list item." &&
+      hasSubstr html "Second persisted Manual list item." &&
+      hasSubstr html "<strong>structurally emphasized Verso docstring body</strong>" &&
+      hasSubstr html "<code>Nat.succ</code>" &&
+      hasSubstr html "First imported docstring list item." &&
+      hasSubstr html "Second imported docstring list item." &&
+      3 ≤ (html.splitOn "<ul>").length &&
+      hasSubstr html "<code class=\"bp_math inline\">1 + 1 = 2</code>" &&
+      hasSubstr html "<code class=\"bp_math inline\">2 + 2 = 4</code>" &&
+      hasSubstr html "hybridSharedFirst" &&
+      hasSubstr html "hybridSharedSecond" &&
+      bodyData.statementUses.map (·.label) ==
+        #[Name.mkSimple "attr.hybrid.verso_docstring"] &&
+      bodyData.proofUses.map (·.label) == #[Name.mkSimple "attr.hybrid.shared"] &&
+      hasEntries
+
+/- This is the final-HTML regression behind the attribute-first authoring
+   feedback: an imported bare attribute, a structural Verso docstring, both
+   placement paths, and consumer-side code folding. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let label := Name.mkSimple
+      "Verso.VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider.qualifiedDefaultLabel"
+    let (placedHtml, placedState) ←
+      renderManualDocHtmlStringAndState manualImpls placedDefaultLabelDoc
+    let (moduleHtml, moduleState) ←
+      renderManualDocHtmlStringAndState manualImpls includedDefaultLabelModuleDoc
+    let key := Informal.PreviewCache.statementKey label
+    let renderedAsExpected (html : String) : Bool :=
+      countSubstr html "<strong>qualified default-label theorem</strong>" == 2 &&
+      countSubstr html "<code class=\"bp_math inline\">3 + 4 = 7</code>" == 2 &&
+      countSubstr html "<code class=\"bp_math display\">3 + 5 = 8</code>" == 2 &&
+      countSubstr html
+          "href=\"https://example.com/qualified-docstring\"" == 2 &&
+      countSubstr html "<blockquote>" == 2 &&
+      2 ≤ countSubstr html "First qualified-label list item." &&
+      countSubstr html "<strong>Qualified structural subsection</strong>" == 2 &&
+      2 ≤ countSubstr html
+          "Subsection content remains part of the imported statement." &&
+      hasSubstr html "class=\"bp_code_block bp_code_panel\"" &&
+      hasSubstr html "qualifiedDefaultLabel" &&
+      !hasSubstr html "open=\"open\""
+    pure <|
+      (Informal.PreviewManifest.findTraversalBlockEntry? placedState key).isSome &&
+      (Informal.PreviewManifest.findTraversalBlockEntry? moduleState key).isSome &&
+      (Informal.PreviewManifest.findTraversalBlockEntry? placedState key).map
+          (·.2.foldCodeBlock) == some true &&
+      (Informal.PreviewManifest.findTraversalBlockEntry? moduleState key).map
+          (·.2.foldCodeBlock) == some true &&
+      renderedAsExpected placedHtml &&
+      renderedAsExpected moduleHtml &&
+      hasSubstr moduleHtml "qualifiedDefaultDefinition"
+
+/- Attribute-owned, code-only nodes remain available in the manifest/cache pair. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let files ← buildManualPreviewDataFiles manualImpls placedAttributeDoc
+    let key := Informal.PreviewCache.statementKey (Name.mkSimple "attr.exported.undocumented")
+    let some entry := files.manifest.previews.find? (·.key == key)
+      | return false
+    let some body := files.htmlCache.findHtml? key
+      | return false
+    pure <|
+      body.contains "bp_code_only_preview_body" &&
+      !entry.leanCodePreviewKeys.isEmpty &&
+      entry.kind == some .definition &&
+      (files.htmlCache.codeHtmlBodies entry |>.any (·.contains "exportedUndocumentedDefinition"))
+
+end Verso.VersoBlueprintTests.BlueprintAttributeRendering

--- a/tests/VersoBlueprintTests/BlueprintAttributeRendering.lean
+++ b/tests/VersoBlueprintTests/BlueprintAttributeRendering.lean
@@ -4,7 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Emilio J. Gallego Arias
 -/
 
-import VersoBlueprintTests.BlueprintAttribute
+import VersoBlueprintTests.BlueprintAttribute.Provider
+import VersoBlueprintTests.BlueprintAttribute.Reexport
+import VersoBlueprintTests.BlueprintAttribute.HybridProvider
+import VersoBlueprintTests.BlueprintAttribute.DefaultLabelProvider
 import VersoBlueprintTests.Blueprint.Support
 
 open Lean
@@ -298,7 +301,8 @@ private def substringsInOrder (text : String) : List String → Bool
       versoDocstringData.globalCount == some 3 &&
       sharedData.globalCount == some 4
 
-/- Persisted Manual bodies, Verso docstrings, and repeated labels share the module path. -/
+/- Persisted Manual bodies, Verso docstrings, flattened extension children, and
+   repeated labels share the module path. -/
 /-- info: true -/
 #guard_msgs in
 #eval
@@ -320,7 +324,7 @@ private def substringsInOrder (text : String) : List String → Bool
       hasSubstr html "First persisted Manual list item." &&
       hasSubstr html "Second persisted Manual list item." &&
       hasSubstr html "<strong>structurally emphasized Verso docstring body</strong>" &&
-      hasSubstr html "<code>Nat.succ</code>" &&
+      countSubstr html "<code>Nat.succ</code>" == 2 &&
       hasSubstr html "First imported docstring list item." &&
       hasSubstr html "Second imported docstring list item." &&
       3 ≤ (html.splitOn "<ul>").length &&

--- a/tests/VersoBlueprintTests/BlueprintBlockFolding.lean
+++ b/tests/VersoBlueprintTests/BlueprintBlockFolding.lean
@@ -57,6 +57,8 @@ Folded proof statement.
 :::proof "folding.folded.proof"
 Folded proof body.
 :::
+
+{blueprint_node "folding.folded.proof" (facet := "proof")}
 :::::::
 
 set_option verso.blueprint.foldProofBlocks false
@@ -122,7 +124,8 @@ set_option verso.blueprint.foldCodeBlocks false
 #eval! do
   let out ← renderManualDocHtmlString manualImpls foldedProofBlockDoc
   pure <|
-    hasSubstr out "<details class=\"bp_wrapper bp_kind_proof_wrapper" &&
+    countSubstr out "<details class=\"bp_wrapper bp_kind_proof_wrapper" == 2 &&
+    hasSubstr out "class=\"bp_graft_node_blueprint\"" &&
     hasSubstr out "<summary class=\"bp_heading bp_kind_proof_heading" &&
     hasSubstr out "Folded proof body."
 

--- a/tests/VersoBlueprintTests/BlueprintImportedDuplicates/Direct.lean
+++ b/tests/VersoBlueprintTests/BlueprintImportedDuplicates/Direct.lean
@@ -28,7 +28,7 @@ error: Duplicate imported blueprint author id '«dup.imported.author»'
 #guard_msgs in
 #docs (Genre.Manual) directImportedDuplicateDoc "Direct Imported Duplicates" :=
 :::::::
-{blueprint_summary}
+{blueprint_node "dup.imported.node"}
 :::::::
 
 /-- info: true -/

--- a/tests/VersoBlueprintTests/BlueprintPreviewSchema.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewSchema.lean
@@ -67,6 +67,9 @@ open Informal.PreviewManifest
       let leanCodePreviewKeysDesc? := do
         let leanCodePreviewKeysJson ← entryProps.get? "leanCodePreviewKeys"
         leanCodePreviewKeysJson.getObjValAs? String "description" |>.toOption
+      let foldCodeBlockDesc? := do
+        let foldCodeBlockJson ← entryProps.get? "foldCodeBlock"
+        foldCodeBlockJson.getObjValAs? String "description" |>.toOption
       let sourceLocationDesc? := do
         let sourceLocationJson ← entryProps.get? "sourceLocation"
         sourceLocationJson.getObjValAs? String "description" |>.toOption
@@ -119,6 +122,8 @@ open Informal.PreviewManifest
         !useRefProps.contains "intents" &&
         entryProps.contains "leanCodePreviewKeys" &&
         entryProps.contains "codeData" &&
+        entryProps.contains "foldProofBlock" &&
+        entryProps.contains "foldCodeBlock" &&
         entryProps.contains "externalMarkup" &&
         entryProps.contains "sources" &&
         !entryProps.contains "source" &&
@@ -137,6 +142,7 @@ open Informal.PreviewManifest
         proofUsesDesc? == some "Structured proof use metadata, preserving origin and intent tags." &&
         displayCaptionDesc? == some "Structured heading caption for renderers that need to lay out the title." &&
         leanCodePreviewKeysDesc? == some "Manifest/cache-backed preview keys for Lean code previews associated with this entry." &&
+        foldCodeBlockDesc? == some "Whether an associated Lean code panel is collapsed for this rendered occurrence." &&
         (internalSchemaDesc?.getD "").contains "not a public" &&
         (internalSchemaDesc?.getD "").contains "compatibility promise" &&
         sourceLocationDesc? == some "Source location lookup result for this manifest entry." &&

--- a/tests/VersoBlueprintTests/BlueprintPreviewSchema.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewSchema.lean
@@ -70,6 +70,9 @@ open Informal.PreviewManifest
       let foldCodeBlockDesc? := do
         let foldCodeBlockJson ← entryProps.get? "foldCodeBlock"
         foldCodeBlockJson.getObjValAs? String "description" |>.toOption
+      let foldProofBlockDesc? := do
+        let foldProofBlockJson ← entryProps.get? "foldProofBlock"
+        foldProofBlockJson.getObjValAs? String "description" |>.toOption
       let sourceLocationDesc? := do
         let sourceLocationJson ← entryProps.get? "sourceLocation"
         sourceLocationJson.getObjValAs? String "description" |>.toOption
@@ -142,7 +145,10 @@ open Informal.PreviewManifest
         proofUsesDesc? == some "Structured proof use metadata, preserving origin and intent tags." &&
         displayCaptionDesc? == some "Structured heading caption for renderers that need to lay out the title." &&
         leanCodePreviewKeysDesc? == some "Manifest/cache-backed preview keys for Lean code previews associated with this entry." &&
-        foldCodeBlockDesc? == some "Whether an associated Lean code panel is collapsed for this rendered occurrence." &&
+        foldProofBlockDesc? ==
+          some "Whether the canonical proof shell is collapsed when this is a proof entry." &&
+        foldCodeBlockDesc? ==
+          some "Whether the associated Lean code panel is collapsed for this canonical traversal entry." &&
         (internalSchemaDesc?.getD "").contains "not a public" &&
         (internalSchemaDesc?.getD "").contains "compatibility promise" &&
         sourceLocationDesc? == some "Source location lookup result for this manifest entry." &&

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -112,6 +112,10 @@ class TestPreviewRuntimeRegressions:
         expect(verso_math).to_contain_text("6 + 1 = 7")
         expect(verso_math).to_have_attribute("data-bp-math-rendered", "1")
         expect(verso_math.locator(".katex")).to_have_count(1)
+        verso_display_math = verso_doc.locator("code.bp_math.display").first
+        expect(verso_display_math).to_contain_text("6 + 2 = 8")
+        expect(verso_display_math).to_have_attribute("data-bp-math-rendered", "1")
+        expect(verso_display_math.locator(".katex-display")).to_have_count(1)
         expect(verso_def.locator(".bp_external_decl_body > pre.docstring")).to_have_count(0)
 
         verso_structure = page.locator(

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -101,6 +101,32 @@ class TestPreviewRuntimeRegressions:
         expect(fun_doc).to_contain_text("Adds a small preview offset")
         expect(fun_doc.locator("code").first).to_contain_text("n")
 
+        verso_def = page.locator(
+            '[data-decl="PreviewRuntimeShowcase.CodePanelDecls.previewVersoDocstringedDefinition"]'
+        ).first
+        expect(verso_def).to_have_count(1)
+        verso_doc = verso_def.locator(".bp_external_decl_body > div.docstring").first
+        expect(verso_doc.locator("strong")).to_contain_text("structural external-panel docstring")
+        expect(verso_doc.locator("li")).to_have_count(2)
+        verso_math = verso_doc.locator("code.bp_math.inline").first
+        expect(verso_math).to_contain_text("6 + 1 = 7")
+        expect(verso_math).to_have_attribute("data-bp-math-rendered", "1")
+        expect(verso_math.locator(".katex")).to_have_count(1)
+        expect(verso_def.locator(".bp_external_decl_body > pre.docstring")).to_have_count(0)
+
+        verso_structure = page.locator(
+            '[data-decl="PreviewRuntimeShowcase.CodePanelDecls.PreviewVersoDocstringedStructure"]'
+        ).first
+        expect(verso_structure).to_have_count(1)
+        expect(verso_structure.locator(".bp_external_decl_body > div.docstring strong")).to_contain_text(
+            "structural container docstring"
+        )
+        field_doc = verso_structure.locator(".subdocs div.docstring").first
+        expect(field_doc.locator("strong")).to_contain_text("structural field docstring")
+        field_math = field_doc.locator("code.bp_math.inline").first
+        expect(field_math).to_contain_text("8 + 1 = 9")
+        expect(field_math).to_have_attribute("data-bp-math-rendered", "1")
+
         decl = page.locator(
             '[data-decl="PreviewRuntimeShowcase.CodePanelDecls.PreviewFreyPackage.ofCounterexample"]'
         ).first

--- a/tests/harness/preview_runtime_showcase/check_blueprint_code_panels.py
+++ b/tests/harness/preview_runtime_showcase/check_blueprint_code_panels.py
@@ -285,6 +285,10 @@ def main() -> int:
         fail("missing in-module documented external definition showcase declaration")
     if "PreviewRuntimeShowcase.CodePanelDecls.previewDocstringedFunction" not in code_panels:
         fail("missing in-module documented external function showcase declaration")
+    if "PreviewRuntimeShowcase.CodePanelDecls.previewVersoDocstringedDefinition" not in code_panels:
+        fail("missing in-module Verso-docstring external definition showcase declaration")
+    if "PreviewRuntimeShowcase.CodePanelDecls.PreviewVersoDocstringedStructure" not in code_panels:
+        fail("missing in-module Verso-docstring external structure showcase declaration")
     if "PreviewRuntimeShowcase.CodePanelDecls.previewExternalTheorem" not in code_panels:
         fail("missing in-module external theorem showcase declaration")
     if "PreviewRuntimeShowcase.CodePanelDecls.previewDocstringedTheorem" not in code_panels:
@@ -367,6 +371,44 @@ def main() -> int:
         fail("documented multi-definition panel missing second definition docstring")
     if docstringed_defs_panel.count('data-kind="def"') < 2:
         fail("documented multi-definition panel missing def kind markers")
+
+    verso_docstring_panel = next(
+        (
+            p
+            for p in external_panels
+            if 'data-decl="PreviewRuntimeShowcase.CodePanelDecls.previewVersoDocstringedDefinition"'
+            in p
+        ),
+        None,
+    )
+    if verso_docstring_panel is None:
+        fail("missing Verso-docstring external code panel")
+    if "<strong>structural external-panel docstring</strong>" not in verso_docstring_panel:
+        fail("Verso-docstring panel missing structural emphasis")
+    if '<code class="bp_math inline">6 + 1 = 7</code>' not in verso_docstring_panel:
+        fail("Verso-docstring panel missing structural inline mathematics")
+    if verso_docstring_panel.count("structural panel item") < 2:
+        fail("Verso-docstring panel missing structural list items")
+    if '<pre class="docstring">' in verso_docstring_panel:
+        fail("Verso-docstring panel was flattened to a plain docstring")
+
+    verso_structure_panel = next(
+        (
+            p
+            for p in external_panels
+            if 'data-decl="PreviewRuntimeShowcase.CodePanelDecls.PreviewVersoDocstringedStructure"'
+            in p
+        ),
+        None,
+    )
+    if verso_structure_panel is None:
+        fail("missing Verso-docstring external structure panel")
+    if "<strong>structural container docstring</strong>" not in verso_structure_panel:
+        fail("Verso structure panel missing structural declaration emphasis")
+    if "<strong>structural field docstring</strong>" not in verso_structure_panel:
+        fail("Verso structure panel missing structural field emphasis")
+    if '<code class="bp_math inline">8 + 1 = 9</code>' not in verso_structure_panel:
+        fail("Verso structure panel missing structural field mathematics")
 
     theorem_docstring_panel = next(
         (

--- a/tests/harness/preview_runtime_showcase/check_blueprint_code_panels.py
+++ b/tests/harness/preview_runtime_showcase/check_blueprint_code_panels.py
@@ -387,6 +387,8 @@ def main() -> int:
         fail("Verso-docstring panel missing structural emphasis")
     if '<code class="bp_math inline">6 + 1 = 7</code>' not in verso_docstring_panel:
         fail("Verso-docstring panel missing structural inline mathematics")
+    if '<code class="bp_math display">6 + 2 = 8</code>' not in verso_docstring_panel:
+        fail("Verso-docstring panel missing structural display mathematics")
     if verso_docstring_panel.count("structural panel item") < 2:
         fail("Verso-docstring panel missing structural list items")
     if '<pre class="docstring">' in verso_docstring_panel:

--- a/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/CodePanels.lean
+++ b/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/CodePanels.lean
@@ -33,6 +33,9 @@ set_option doc.verso true in
 A *structural external-panel docstring* with inline mathematics
 $`6 + 1 = 7`.
 
+A display equation follows:
+$$`6 + 2 = 8`
+
 * First structural panel item.
 * Second structural panel item.
 -/

--- a/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/CodePanels.lean
+++ b/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/CodePanels.lean
@@ -28,6 +28,26 @@ definitions appear in the same code panel.
 -/
 def previewDocstringedFunction (n : Nat) : Nat := n + 1
 
+set_option doc.verso true in
+/--
+A *structural external-panel docstring* with inline mathematics
+$`6 + 1 = 7`.
+
+* First structural panel item.
+* Second structural panel item.
+-/
+def previewVersoDocstringedDefinition : Nat := 7
+
+set_option doc.verso true in
+/--
+A *structural container docstring* for a field-docstring regression.
+-/
+structure PreviewVersoDocstringedStructure where
+  /--
+  A *structural field docstring* with inline mathematics $`8 + 1 = 9`.
+  -/
+  value : Nat
+
 theorem previewExternalTheorem : True := by
   trivial
 
@@ -302,4 +322,12 @@ class PanelInlineMixedFold (α : Type) where
 
 :::definition "panel_no_code"
 Statement without associated Lean code.
+:::
+
+:::definition "panel_external_verso_docstring" (lean := "PreviewRuntimeShowcase.CodePanelDecls.previewVersoDocstringedDefinition")
+External definition panel sample with a structural Verso docstring.
+:::
+
+:::definition "panel_external_verso_structure_docstring" (lean := "PreviewRuntimeShowcase.CodePanelDecls.PreviewVersoDocstringedStructure")
+External structure panel sample with structural declaration and field docstrings.
 :::


### PR DESCRIPTION
## Summary
Backport #350 to `v4.31.0`.

## Primary Review
- Primary review: #350
- Keep review comments on #350 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.31.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.