### PR TITLE
[backport v4.31.0] feat: distinguish original-source identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ source := {
   spans := #[
     {
       page := "12"
+      anchor := "lem:addition-right-identity"
+      citation := "Lemma 2.1(1)"
       pdf := some { path := "source/pages/page-12.pdf" }
     }
   ]
@@ -269,7 +271,10 @@ For every natural number $`n`, $`n + 0 = n`.
 ````
 
 Current behavior: source provenance is exported in the Blueprint manifest as
-`sourceDocuments` and per-entry `sources`, and kept hidden in rendered pages.
+`sourceDocuments` and per-entry `sources`. A sourced node shows a compact chip;
+when one source citation is available, the chip says, for example,
+`source: Lemma 2.1(1)` rather than presenting the citation as Blueprint's own
+generated number.
 Browser clients can resolve source-document ids with `loadSourceDocument`, load
 the complete catalog with `loadSourceDocuments`, or join entry source refs with
 declared documents using `resolveSourceMetadata` from `api/data.mjs` or

--- a/doc/API.md
+++ b/doc/API.md
@@ -1213,7 +1213,9 @@ a `reason` and `diagnosticHtml` suitable for insertion into the page.
 `resolveSourceMetadata` is data-only: it returns source metadata and failure
 reasons, but no rendered HTML. It also does not load source PDFs, extracted
 text, or page images; callers use the returned paths and spans in the source UI
-they own.
+they own. Each span may carry a source-native `anchor` (for example a TeX
+`\label`) and a human-readable `citation` (for example `Lemma 2.1(1)`) in
+addition to its optional page, text range, and PDF location.
 
 | Helper | Success shape | Failure shape |
 | --- | --- | --- |

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -1,6 +1,6 @@
 # Blueprint Design Rationale
 
-Last updated: 2026-06-20
+Last updated: 2026-07-17
 
 This document records the current architecture boundaries and the reasons the
 Blueprint implementation is shaped the way it is.
@@ -45,6 +45,22 @@ object, and what local formal/informal data belongs to it?" The
 traversal/rendering pass answers "how do these objects sit inside this rendered
 site?" Rendering and UI layers are expected to project from those two stages
 rather than invent parallel sources of truth.
+
+### Blueprint Identity and Original-Source Identity
+
+Blueprint labels and traversal-generated heading numbers identify nodes inside
+the Blueprint site. They must remain independent of identities inherited from
+an original TeX, PDF, or text source. A source span therefore records a stable
+source-native `anchor` and a human-facing `citation` alongside physical page,
+text, or PDF locations. For example, a node generated as `Lemma 2.2` can point
+to `itm: ib-first` and display `source: Lemma 2.1(1)` without changing its graph
+key, cross-references, or intrinsic numbering.
+
+The source anchor is machine identity; the citation is presentation. Neither is
+reconstructed from visible prose, and neither is used as a substitute for the
+Blueprint node label. This is particularly important for Blueprints generated
+from TeX, where definitions or split list items may consume different
+Blueprint counters than the source theorem environment.
 
 ### Command Split
 

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -646,6 +646,8 @@ source := {
   spans := #[
     {
       page := "12"
+      anchor := "lem:addition-right-identity"
+      citation := "Lemma 2.1(1)"
       text := some {
         path := "source/pages/page-12.md"
         startLine := 41
@@ -667,8 +669,48 @@ For every natural number $`n`, $`n + 0 = n`.
 The generated manifest exports declared documents in `sourceDocuments` and each
 manifest entry's original-source refs in `entry.sources`. Normal generated node
 shells also show a compact source chip when source provenance is present; open
-it to inspect the source document id, page summary, and recorded text/PDF span
-details.
+it to inspect the source document id, source-native anchor and citation, page
+summary, and recorded text/PDF span details.
+
+`anchor` is a stable identifier in the original source, such as a TeX
+`\label`; `citation` is the corresponding human-readable source identity, such
+as `Lemma 2.1(1)` or `Equation (2.4)`. These fields do not replace the
+Blueprint node's label or generated heading number. A node may therefore remain
+`Lemma 2.2` in the Blueprint while its source chip explicitly reads
+`source: Lemma 2.1(1)`. Keeping the identities separate avoids silently
+changing graph keys, Blueprint references, or site-local numbering to imitate
+the source document.
+
+For a text source such as the TeX input itself, omit `page` and use a source
+anchor, a text line range, or both:
+
+````md
+:::source_document "paper-tex"
+%%%
+title := "Representation Theory (TeX source)"
+kind := .text
+%%%
+:::
+
+:::lemma_ "addition_right_identity"
+%%%
+source := {
+  document := "paper-tex"
+  spans := #[{
+    anchor := "itm:addition-right-identity"
+    citation := "Lemma 2.1(1)"
+    text := some {
+      path := "paper.tex"
+      startLine := 439
+      endLine := 440
+    }
+  }]
+}
+%%%
+
+For every natural number $`n`, $`n + 0 = n`.
+:::
+````
 
 Manifest clients should read `entry.sources`; there is no singular
 `entry.source` field. Lean code preview entries may contain multiple refs when
@@ -684,8 +726,8 @@ read the complete catalog with `loadSourceDocuments`.
 
 Browser clients can call `resolveSourceMetadata` from `api/data.mjs` or
 `api/preview.mjs` to resolve source refs for a preview key, manifest entry, or
-render result. The API returns structured source-document metadata and recorded
-text/PDF spans.
+render result. The API returns structured source-document metadata, source
+identities, and text/PDF spans.
 Manifest entries also include `sourceLocation`, a lookup result for the authored
 Blueprint label/facet location or Lean declaration source. Browser clients that
 start from semantic names can call `resolveLabel`, or `resolveDeclaration` for

--- a/src/VersoBlueprint/Informal/Block/Render.lean
+++ b/src/VersoBlueprint/Informal/Block/Render.lean
@@ -372,8 +372,11 @@ private def sourceSpanPages (spans : Array Source.Span) : Array String :=
   spans.foldl
     (init := #[])
     fun pages span =>
-      let page := span.page.trimAscii.toString
-      if page.isEmpty then pages else pushUniqueString pages page
+      match span.page with
+      | none => pages
+      | some rawPage =>
+          let page := rawPage.trimAscii.toString
+          if page.isEmpty then pages else pushUniqueString pages page
 
 private def sourcePagesSummary (pages : Array String) : String :=
   match pages.toList with
@@ -395,9 +398,25 @@ private def sourcePdfSpanSummary (span : Source.PdfSpan) : String :=
   | Option.none => s!"pdf {span.path}"
 
 private def sourceSpanSummary (span : Source.Span) : String :=
-  let page := span.page.trimAscii.toString
-  let parts : Array String :=
-    if page.isEmpty then #[] else #[s!"page {page}"]
+  let parts : Array String := #[]
+  let parts :=
+    match span.citation with
+    | Option.some citation =>
+        let citation := citation.trimAscii.toString
+        if citation.isEmpty then parts else parts.push s!"citation {citation}"
+    | Option.none => parts
+  let parts :=
+    match span.anchor with
+    | Option.some anchor =>
+        let anchor := anchor.trimAscii.toString
+        if anchor.isEmpty then parts else parts.push s!"anchor {anchor}"
+    | Option.none => parts
+  let parts :=
+    match span.page with
+    | Option.some rawPage =>
+        let page := rawPage.trimAscii.toString
+        if page.isEmpty then parts else parts.push s!"page {page}"
+    | Option.none => parts
   let parts :=
     match span.text with
     | Option.some textRange => parts.push (sourceTextRangeSummary textRange)
@@ -407,6 +426,22 @@ private def sourceSpanSummary (span : Source.Span) : String :=
     | Option.some pdf => parts.push (sourcePdfSpanSummary pdf)
     | Option.none => parts
   String.intercalate "; " parts.toList
+
+private def sourceSpanCitations (spans : Array Source.Span) : Array String :=
+  spans.foldl
+    (init := #[])
+    fun citations span =>
+      match span.citation with
+      | none => citations
+      | some rawCitation =>
+          let citation := rawCitation.trimAscii.toString
+          if citation.isEmpty then citations else pushUniqueString citations citation
+
+private def sourceRefsCitations (sourceRefs : Array Source.Ref) : Array String :=
+  sourceRefs.foldl
+    (init := #[])
+    fun citations sourceRef =>
+      (sourceSpanCitations sourceRef.spans).foldl pushUniqueString citations
 
 private def sourceRefSummary (sourceRef : Source.Ref) : String :=
   let pages := sourceSpanPages sourceRef.spans
@@ -425,10 +460,13 @@ private def sourceRefTitle (sourceRef : Source.Ref) : String :=
     s!"Original source document {sourceRef.document}: {String.intercalate " | " spanSummary}"
 
 private def sourceRefsChipText (sourceRefs : Array Source.Ref) : String :=
-  if sourceRefs.size == 1 then
-    "source 1"
-  else
-    s!"sources {sourceRefs.size}"
+  match sourceRefsCitations sourceRefs |>.toList with
+  | [citation] => s!"source: {citation}"
+  | _ =>
+      if sourceRefs.size == 1 then
+        "source 1"
+      else
+        s!"sources {sourceRefs.size}"
 
 private def sourceRefsPanelTitle (sourceRefs : Array Source.Ref) : String :=
   if sourceRefs.size == 1 then
@@ -452,7 +490,7 @@ private def sourceRefsChipTitle (sourceRefs : Array Source.Ref) : String :=
 private def sourceSpanPreviewText (span : Source.Span) : String :=
   let summary := sourceSpanSummary span
   if summary.isEmpty then
-    "Source span recorded without page, text, or PDF location"
+    "Source span recorded without page, anchor, text, or PDF location"
   else
     summary
 

--- a/src/VersoBlueprint/Source/Data.lean
+++ b/src/VersoBlueprint/Source/Data.lean
@@ -70,7 +70,8 @@ def ValidationError.message : ValidationError → String
   | .pdfBoxInvalidYRange => "source PDF box yMin must be less than yMax"
   | .pdfBoxXMaxBeyondPageWidth => "source PDF box xMax must be within pageWidth"
   | .pdfBoxYMaxBeyondPageHeight => "source PDF box yMax must be within pageHeight"
-  | .spanMissingLocation => "source spans require text or PDF location data"
+  | .spanMissingLocation =>
+      "source spans require a page, source anchor, text range, or PDF location"
   | .refMissingSpan => "source metadata must include at least one source span"
 
 instance : ToString ValidationError where
@@ -160,14 +161,26 @@ def PdfSpan.validationErrors (span : PdfSpan) : Array ValidationError :=
 
 /-- One source span attached to a Blueprint node. -/
 structure Span where
-  page : String
+  /-- Optional source-local page identifier. Text sources do not need one. -/
+  page : Option String := none
+  /-- Stable source-native identifier, such as a TeX `\label`. -/
+  anchor : Option String := none
+  /-- Human-readable source-native reference, such as `Lemma 2.1(1)`. -/
+  citation : Option String := none
   text : Option TextRange := none
   pdf : Option PdfSpan := none
 deriving Inhabited, Repr, BEq, DecidableEq, FromJson, ToJson, Quote
 
 def Span.validationErrors (span : Span) : Array ValidationError :=
-  let errors := nonEmptyField "source span page" span.page
-  let errors := addIf errors (span.text.isNone && span.pdf.isNone) .spanMissingLocation
+  let errors : Array ValidationError := #[]
+  let errors := addOptional errors span.page (nonEmptyField "source span page")
+  let errors := addOptional errors span.anchor (nonEmptyField "source span anchor")
+  let errors := addOptional errors span.citation (nonEmptyField "source span citation")
+  let hasPage := span.page.any fun page => !page.trimAscii.isEmpty
+  let hasAnchor := span.anchor.any fun anchor => !anchor.trimAscii.isEmpty
+  let errors := addIf errors
+    (!hasPage && !hasAnchor && span.text.isNone && span.pdf.isNone)
+    .spanMissingLocation
   let errors := addOptional errors span.text TextRange.validationErrors
   addOptional errors span.pdf PdfSpan.validationErrors
 

--- a/src/VersoBlueprint/blueprint-api-types.mjs
+++ b/src/VersoBlueprint/blueprint-api-types.mjs
@@ -215,7 +215,9 @@
  * One original source span attached to a Blueprint node.
  *
  * @typedef {Object} BlueprintSourceSpan
- * @property {string} page Source-local page identifier.
+ * @property {string} [page] Optional source-local page identifier.
+ * @property {string} [anchor] Stable source-native identifier, such as a TeX `\\label`.
+ * @property {string} [citation] Human-readable source-native reference, such as `Lemma 2.1(1)`.
  * @property {BlueprintSourceTextRange} [text] Text location for this span.
  * @property {BlueprintSourcePdfSpan} [pdf] PDF/page-image location for this span.
  */

--- a/tests/VersoBlueprintTests/BlueprintExternalMarkup.lean
+++ b/tests/VersoBlueprintTests/BlueprintExternalMarkup.lean
@@ -48,7 +48,7 @@ private def entryHasSourcePage
     (entry : Informal.PreviewManifest.Entry) (document page : String) : Bool :=
   entry.sources.any fun sourceRef =>
     sourceRef.document == document &&
-      sourceRef.spans.any (fun span => span.page == page)
+      sourceRef.spans.any (fun span => span.page == some page)
 
 private def htmlHasSourcePreview (html document pageText : String) : Bool :=
   hasSubstr html "bp_extra_slot_source" &&

--- a/tests/VersoBlueprintTests/BlueprintPreviewSchema.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewSchema.lean
@@ -31,10 +31,38 @@ open Informal.PreviewManifest
         fromJson? (α := Array String) requiredJson |>.toOption
       let some relatedEntrySchema := defs.get? "Informal.PreviewManifest.RelatedEntry" | return false
       let some graphNodeSchema := defs.get? "Informal.Graph.NodeData" | return false
+      let some sourceSpanSchema := defs.get? "Informal.Source.Span" | return false
+      let Except.ok sourceSpanPropsJson := Json.getObjVal? sourceSpanSchema "properties" | return false
+      let Except.ok sourceSpanProps := sourceSpanPropsJson.getObj? | return false
+      let sourceSpanRequired? := do
+        let requiredJson ← sourceSpanSchema.getObjVal? "required" |>.toOption
+        fromJson? (α := Array String) requiredJson |>.toOption
       let schemaText := schema.compress
       let stringSchemaHasMinLengthOne (schema : Json) : Bool :=
         (schema.getObjValAs? String "type" |>.toOption) == some "string" &&
           (schema.getObjValAs? Nat "minLength" |>.toOption) == some 1
+      let stringSchema (schema : Json) : Bool :=
+        (schema.getObjValAs? String "type" |>.toOption) == some "string"
+      let schemaHasStringNull (schema : Json) : Bool :=
+        match Json.getObjVal? schema "anyOf" with
+        | Except.error _ => false
+        | Except.ok anyOfJson =>
+            match anyOfJson.getArr? with
+            | Except.error _ => false
+            | Except.ok schemas =>
+                schemas.any stringSchema &&
+                schemas.any (fun (schema : Json) =>
+                  (schema.getObjValAs? String "type" |>.toOption) == some "null")
+      let schemaHasNonEmptyStringNull (schema : Json) : Bool :=
+        match Json.getObjVal? schema "anyOf" with
+        | Except.error _ => false
+        | Except.ok anyOfJson =>
+            match anyOfJson.getArr? with
+            | Except.error _ => false
+            | Except.ok schemas =>
+                schemas.any stringSchemaHasMinLengthOne &&
+                schemas.any (fun (schema : Json) =>
+                  (schema.getObjValAs? String "type" |>.toOption) == some "null")
       let previewKeySchemaHasNonEmptyStringNull (schema : Json) : Bool :=
         match Json.getObjVal? schema "properties" with
         | Except.error _ => false
@@ -44,16 +72,7 @@ open Informal.PreviewManifest
             | Except.ok props =>
                 match props.get? "previewKey" with
                 | none => false
-                | some previewKeyJson =>
-                    match Json.getObjVal? previewKeyJson "anyOf" with
-                    | Except.error _ => false
-                    | Except.ok anyOfJson =>
-                        match anyOfJson.getArr? with
-                        | Except.error _ => false
-                        | Except.ok schemas =>
-                            schemas.any stringSchemaHasMinLengthOne &&
-                            schemas.any (fun (schema : Json) =>
-                              (schema.getObjValAs? String "type" |>.toOption) == some "null")
+                | some previewKeyJson => schemaHasNonEmptyStringNull previewKeyJson
       let internalSchemaDesc? := do
         let internalSchemaJson ← fileProps.get? "vbpInternalSchemaVersion"
         internalSchemaJson.getObjValAs? String "description" |>.toOption
@@ -81,6 +100,7 @@ open Informal.PreviewManifest
         authoredLabelJson.getObjValAs? String "description" |>.toOption
       let some fileRequired := fileRequired? | return false
       let some entryRequired := entryRequired? | return false
+      let some sourceSpanRequired := sourceSpanRequired? | return false
       let some useRefProps := useRefProps? | return false
       let displayCaptionDesc? := do
         let displayCaptionJson ← entryProps.get? "displayCaption"
@@ -160,6 +180,19 @@ open Informal.PreviewManifest
         defs.contains "Informal.Source.DocumentKind" &&
         defs.contains "Informal.Source.Ref" &&
         defs.contains "Informal.Source.Span" &&
+        sourceSpanProps.contains "page" &&
+        sourceSpanProps.contains "anchor" &&
+        sourceSpanProps.contains "citation" &&
+        sourceSpanProps.contains "text" &&
+        sourceSpanProps.contains "pdf" &&
+        sourceSpanRequired.contains "page" &&
+        sourceSpanRequired.contains "anchor" &&
+        sourceSpanRequired.contains "citation" &&
+        sourceSpanRequired.contains "text" &&
+        sourceSpanRequired.contains "pdf" &&
+        (sourceSpanProps.get? "page").any schemaHasStringNull &&
+        (sourceSpanProps.get? "anchor").any schemaHasStringNull &&
+        (sourceSpanProps.get? "citation").any schemaHasStringNull &&
         defs.contains "Informal.Source.TextRange" &&
         defs.contains "Informal.Source.PdfSpan" &&
         defs.contains "Informal.Source.PdfBox" &&

--- a/tests/VersoBlueprintTests/BlueprintSource.lean
+++ b/tests/VersoBlueprintTests/BlueprintSource.lean
@@ -20,7 +20,10 @@ private def sourcedLabel : Name := Name.mkSimple "source.lemma"
 private def secondSourcedLabel : Name := Name.mkSimple "source.second"
 
 private def sourceRefHasPage (document page : String) (sourceRef : Informal.Source.Ref) : Bool :=
-  sourceRef.document == document && sourceRef.spans.any (fun span => span.page == page)
+  sourceRef.document == document && sourceRef.spans.any (fun span => span.page == some page)
+
+private def sourceRefHasAnchor (document anchor : String) (sourceRef : Informal.Source.Ref) : Bool :=
+  sourceRef.document == document && sourceRef.spans.any (fun span => span.anchor == some anchor)
 
 private def entryHasSourcePage
     (document page : String) (entry : Informal.PreviewManifest.Entry) : Bool :=
@@ -30,11 +33,21 @@ private def entryOptionHasSourcePage
     (document page : String) (entry? : Option Informal.PreviewManifest.Entry) : Bool :=
   entry?.any fun entry => entryHasSourcePage document page entry
 
+private def entryHasSourceAnchor
+    (document anchor : String) (entry : Informal.PreviewManifest.Entry) : Bool :=
+  entry.hasSourceDocument document && entry.sources.any (sourceRefHasAnchor document anchor)
+
+private def entryOptionHasSourceAnchor
+    (document anchor : String) (entry? : Option Informal.PreviewManifest.Entry) : Bool :=
+  entry?.any fun entry => entryHasSourceAnchor document anchor entry
+
 private def sourceRefHasRepresentationTheorySpan (sourceRef : Informal.Source.Ref) : Bool :=
   sourceRef.document == "paper" &&
     sourceRef.spans.any fun span =>
       let boxXMax := (span.pdf.bind (·.box)).map (·.xMax)
-      span.page == "12" &&
+      span.page == some "12" &&
+        span.anchor == some "lem:representation" &&
+        span.citation == some "Lemma 4.2" &&
         span.text.map (·.path) == some "source/pages/page-12.md" &&
         span.text.map (·.startLine) == some 41 &&
         span.text.map (·.endLine) == some 45 &&
@@ -69,6 +82,8 @@ source := {
   spans := #[
     {
       page := "12"
+      anchor := "lem:representation"
+      citation := "Lemma 4.2"
       text := some {
         path := "source/pages/page-12.md"
         startLine := 41
@@ -101,9 +116,10 @@ source := {
   document := "notes"
   spans := #[
     {
-      page := "A"
+      anchor := "itm:addition-right-identity"
+      citation := "Lemma 2.1(1)"
       text := some {
-        path := "source/notes/addition.md"
+        path := "source/notes/addition.tex"
         startLine := 1
         endLine := 3
       }
@@ -250,13 +266,29 @@ Invalid source metadata.
     let refErrors :=
       Informal.Source.Ref.validationErrors
         ({ document := "paper" } : Informal.Source.Ref)
+    let citationOnlySpanErrors :=
+      Informal.Source.Span.validationErrors
+        ({ citation := "Lemma 2.1(1)" } : Informal.Source.Span)
+    let anchorOnlySpanErrors :=
+      Informal.Source.Span.validationErrors
+        ({ anchor := "itm:addition-right-identity" } : Informal.Source.Span)
+    let anchoredTextSpanErrors :=
+      Informal.Source.Span.validationErrors
+        ({
+          anchor := "itm:addition-right-identity"
+          citation := "Lemma 2.1(1)"
+          text := some { path := "source.tex", startLine := 1, endLine := 3 }
+        } : Informal.Source.Span)
     let expectedDocumentErrors : Array Informal.Source.ValidationError := #[
       .emptyField "source document id",
       .pdfDocumentMissingPath
     ]
     let expectedRefErrors : Array Informal.Source.ValidationError := #[.refMissingSpan]
     documentErrors == expectedDocumentErrors &&
-      refErrors == expectedRefErrors
+      refErrors == expectedRefErrors &&
+      citationOnlySpanErrors == #[.spanMissingLocation] &&
+      anchorOnlySpanErrors.isEmpty &&
+      anchoredTextSpanErrors.isEmpty
 
 /-- info: true -/
 #guard_msgs in
@@ -265,17 +297,21 @@ Invalid source metadata.
     let (html, st) ← renderManualDocHtmlStringAndState extension_impls% sourceProvenanceDoc
     let sourceDocument? := Informal.TraversalIndex.SourceDocuments.data? st "paper"
     let sourceRef? := Informal.TraversalIndex.SourceRefs.data? st sourcedLabel
+    let secondSourceRef? := Informal.TraversalIndex.SourceRefs.data? st secondSourcedLabel
     let storageOk :=
-      match sourceDocument?, sourceRef? with
-      | some sourceDocument, some sourceRef =>
+      match sourceDocument?, sourceRef?, secondSourceRef? with
+      | some sourceDocument, some sourceRef, some secondSourceRef =>
           sourceDocument.id == "paper" &&
             sourceDocument.title == "Representation Theory" &&
             sourceDocument.kind == .pdf &&
             sourceDocument.pdf == some "source/paper.pdf" &&
             sourceDocument.pageRoot == some "source/pages" &&
             sourceDocument.imageRoot == some "source/pages/images" &&
-            sourceRefHasRepresentationTheorySpan sourceRef
-      | _, _ => false
+            sourceRefHasRepresentationTheorySpan sourceRef &&
+            sourceRefHasAnchor "notes" "itm:addition-right-identity" secondSourceRef &&
+            secondSourceRef.spans.any (fun span =>
+              span.page.isNone && span.citation == some "Lemma 2.1(1)")
+      | _, _, _ => false
     pure <|
       hasSubstr html "A sourced statement." &&
       !hasSubstr html "source/paper.pdf" &&
@@ -312,9 +348,9 @@ Invalid source metadata.
         entry.targetKind == .leanDecl &&
           entry.sources.size == 2 &&
           entryHasSourcePage "paper" "12" entry &&
-          entryHasSourcePage "notes" "A" entry) &&
+          entryHasSourceAnchor "notes" "itm:addition-right-identity" entry) &&
       entryOptionHasSourcePage "paper" "12" entry? &&
-      entryOptionHasSourcePage "notes" "A" secondEntry?
+      entryOptionHasSourceAnchor "notes" "itm:addition-right-identity" secondEntry?
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/browser/test_preview_runtime_regressions.py
+++ b/tests/browser/test_preview_runtime_regressions.py
@@ -1513,6 +1513,8 @@ class TestPreviewRuntimeRegressions:
         assert entry["label"] == "custom_client_external_markdown_metadata"
         assert source_ref["document"] == "custom-client-paper"
         assert span["page"] == "42"
+        assert span["anchor"] == "thm:custom-client"
+        assert span["citation"] == "Theorem 4.2"
         assert span["text"]["path"] == "source/pages/page-42.md"
         assert span["text"]["startLine"] == 10
         assert span["text"]["endLine"] == 12
@@ -2168,7 +2170,7 @@ class TestPreviewRuntimeRegressions:
         ).first
         source_slot = statement.locator(".bp_extra_slot_source").first
         chip = source_slot.locator(".bp_source_ref_chip").first
-        expect(chip).to_have_text("source 1")
+        expect(chip).to_have_text("source: Theorem 4.2")
 
         uses_chip = statement.locator(".bp_extra_slot_uses .bp_relation_chip").first
         source_box = require_box(chip)
@@ -2190,6 +2192,8 @@ class TestPreviewRuntimeRegressions:
         body = preview.locator(".bp_source_ref_preview_body").first
         expect(body).to_contain_text("custom-client-paper")
         expect(body).to_contain_text("custom-client-paper p. 42")
+        expect(body).to_contain_text("citation Theorem 4.2")
+        expect(body).to_contain_text("anchor thm:custom-client")
         expect(body).to_contain_text("source/pages/page-42.md:10-12")
         expect(body).to_contain_text("source/pages/page-42.pdf")
 

--- a/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/CustomRenderClient.lean
+++ b/tests/test_blueprints/preview_runtime_showcase/PreviewRuntimeShowcase/Chapters/CustomRenderClient.lean
@@ -498,6 +498,8 @@ source := {
   spans := #[
     {
       page := "42"
+      anchor := "thm:custom-client"
+      citation := "Theorem 4.2"
       text := some {
         path := "source/pages/page-42.md"
         startLine := 10


### PR DESCRIPTION
## Summary
Backport #353 to `v4.31.0`.

## Primary Review
- Primary review: #353
- Keep review comments on #353 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.31.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.