### PR TITLE
fix: delegate slide asset emission

### DIFF
--- a/src/VersoBlueprint/Slides.lean
+++ b/src/VersoBlueprint/Slides.lean
@@ -62,7 +62,7 @@ private def slidesMainWithBlueprintRenderer
     (htmlCache? : Option Informal.PreviewManifest.HtmlCache.File)
     (doc : Verso.Doc.Part VersoSlides.Slides)
     (quiet : Bool := false) : IO UInt32 := do
-  let assetPlan ← collectSlideAssets config
+  config.validateFilenames
   let hasError ← IO.mkRef false
   let logError (msg : String) : IO Unit := do
     hasError.set true
@@ -105,7 +105,7 @@ private def slidesMainWithBlueprintRenderer
   IO.FS.writeFile indexPath ("<!doctype html>\n" ++ fullHtml.asString)
   IO.FS.writeFile (dir / "-verso-docs.json") (toString hoverState.dedup.docJson)
   VersoSlides.writeVendoredAssets dir config.theme
-  writeSlideAssets dir assetPlan
+  config.writeAssets dir
   writeSlideImages dir traverseState.imageFiles
   unless quiet do
     IO.println s!"Slides written to {indexPath}"

--- a/src/VersoBlueprint/Slides/Assets.lean
+++ b/src/VersoBlueprint/Slides/Assets.lean
@@ -61,56 +61,6 @@ private def writeBinFileWithDirs (path : System.FilePath) (content : ByteArray) 
   ensureParentDir path
   IO.FS.writeBinFile path content
 
-inductive SlideAssetPayload where
-  | text (body : String)
-  | binary (bytes : ByteArray)
-
-private def SlideAssetPayload.equal : SlideAssetPayload → SlideAssetPayload → Bool
-  | .text a, .text b => a == b
-  | .binary a, .binary b => a == b
-  | _, _ => false
-
-private def SlideAssetPayload.kind : SlideAssetPayload → String
-  | .text _ => "text"
-  | .binary _ => "binary"
-
-structure SlideAssetPlan where
-  assets : Std.HashMap String (String × SlideAssetPayload) := {}
-
-private def recordSlideAsset
-    (seen : Std.HashMap String (String × SlideAssetPayload))
-    (filename source : String) (payload : SlideAssetPayload) :
-    IO (Std.HashMap String (String × SlideAssetPayload)) := do
-  match seen.get? filename with
-  | none => pure <| seen.insert filename (source, payload)
-  | some (prevSource, prev) =>
-    if prev.equal payload then
-      pure seen
-    else
-      throw <| IO.userError
-        s!"Filename collision in config: \"{filename}\" is claimed by {prevSource} ({prev.kind}) and {source} ({payload.kind}) with different contents."
-
-def collectSlideAssets (config : VersoSlides.Config) : IO SlideAssetPlan := do
-  let mut seen : Std.HashMap String (String × SlideAssetPayload) := {}
-  if let .custom theme := config.theme then
-    seen ← recordSlideAsset seen theme.stylesheet.filename
-      "theme stylesheet" (.text theme.stylesheet.contents.css)
-    for asset in theme.assets do
-      seen ← recordSlideAsset seen asset.filename
-        "theme asset" (.binary asset.contents)
-  seen ← recordSlideAsset seen config.highlightTheme.filename
-    "highlight.js theme" (.text config.highlightTheme.contents.css)
-  for css in config.extraCss do
-    seen ← recordSlideAsset seen css.filename
-      "extraCss" (.text css.contents.css)
-  pure { assets := seen }
-
-def writeSlideAssets (outputDir : System.FilePath) (plan : SlideAssetPlan) : IO Unit := do
-  for (filename, _source, payload) in plan.assets.toList do
-    match payload with
-    | .text body => writeTextFileWithDirs (outputDir / filename) body
-    | .binary bytes => writeBinFileWithDirs (outputDir / filename) bytes
-
 def writeSlideImages
     (outputDir : System.FilePath)
     (imageFiles : Std.HashMap String String) : IO Unit := do

--- a/tests/VersoBlueprintTests/BlueprintSlides.lean
+++ b/tests/VersoBlueprintTests/BlueprintSlides.lean
@@ -95,6 +95,10 @@ private def dummySlidesCss (filename body : String) : VersoSlides.CssFile where
   filename
   contents := ⟨body⟩
 
+private def dummySlidesJs (filename body : String) : VersoSlides.JsModule where
+  filename
+  contents := ⟨body⟩
+
 private partial def freshSlidesSmokeRoot : IO System.FilePath := do
   let suffix ← IO.rand 0 1000000000000
   let root :=
@@ -433,9 +437,11 @@ private def writeSlidesPreviewDataFiles
     let files ← buildPreviewDataFor leanCodeLinkPreviewDoc
     let root ← freshSlidesSmokeRoot
     let outDir := root / "slides"
+    let jsModule := dummySlidesJs "js/blueprint-wrapper-probe.mjs"
+      "document.documentElement.dataset.blueprintWrapperProbe = 'loaded';\n"
     let manifestPath ← writeSlidesPreviewDataFiles root files
     let rc ← Informal.Slides.slidesMainWithBlueprintPreviews
-      { outputDir := outDir }
+      { outputDir := outDir, extraJsModules := #[jsModule] }
       (previewManifest? := some manifestPath)
       staticBlueprintNodeSlideFixture.toPart
       (quiet := true)
@@ -450,6 +456,10 @@ private def writeSlidesPreviewDataFiles
     let normalizedKey := Informal.PreviewCache.statementKey (Lean.Name.mkSimple "def:code.preview")
     let slideRuntimePath := outDir / "-verso-data" / Informal.Slides.blueprintSlideRuntimeModuleFilename
     let slideRuntimeModulePath := outDir / "-verso-data" / Informal.Slides.blueprintSlidesModulePath
+    let jsModulePath := outDir / jsModule.filename
+    if !(← jsModulePath.pathExists) then
+      return false
+    let jsModuleContents ← IO.FS.readFile jsModulePath
     pure <|
       (← copiedManifest.pathExists) &&
         (← copiedHtmlCache.pathExists) &&
@@ -461,6 +471,8 @@ private def writeSlidesPreviewDataFiles
         hasSubstr index s!"data-bp-preview-key=\"{normalizedKey}\"" &&
         hasSubstr index "data-bp-site-base=\"blueprint\"" &&
         hasSubstr index s!"src=\"{Informal.Slides.blueprintSlideRuntimeModulePath}\"" &&
+        hasSubstr index s!"<script type=\"module\" src=\"{jsModule.filename}\"></script>" &&
+        jsModuleContents == jsModule.contents.js &&
         !hasSubstr index "blueprint-slides.js" &&
         hasSubstr index "href=\"#--informal-preview" &&
         !hasSubstr index "Loading Blueprint node"


### PR DESCRIPTION
This PR delegates Blueprint slide asset emission to Verso Slides' public `Config.writeAssets` hook, so bundled JavaScript modules and other slide assets use the same validation and deduplication path as standalone decks.

Backport v4.31.0: pending
