### PR TITLE
chore: retire Lean 4.31 support from v4.32

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,8 +7,8 @@
   or discussions are not a substitute for the summary.
 - Put questions, local notes, and extra review coordination in comments rather
   than the PR description.
-- Keep the required `Backport ...` lines below. Draft PRs may use `pending`;
-  ready PRs must use `#<pr>` or `exempt: <reason>` for each line.
+- When branch policy requires `Backport ...` lines, draft PRs may use
+  `pending`; ready PRs must use `#<pr>` or `exempt: <reason>` for each line.
 - If the PR requires paired backports, prefer a merge commit when landing so
   cherry-pick source commits remain in default-dev history. Squash is fine for
   PRs with all backports exempt.
@@ -21,5 +21,3 @@ This PR <short summary of the problem solved and useful outcome>.
 
 <Optional: one short paragraph or a few bullets with the main behavior or
 maintainer-visible changes. Avoid module-by-module implementation inventory.>
-
-Backport v4.31.0: pending

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,8 @@
   than the PR description.
 - When branch policy requires `Backport ...` lines, draft PRs may use
   `pending`; ready PRs must use `#<pr>` or `exempt: <reason>` for each line.
+  PRs retiring the oldest maintained lines use `release-line retirement` for
+  those lines.
 - If the PR requires paired backports, prefer a merge commit when landing so
   cherry-pick source commits remain in default-dev history. Squash is fine for
   PRs with all backports exempt.

--- a/README.md
+++ b/README.md
@@ -384,19 +384,19 @@ reference projects publish on each Lean release line. Maintainers can inspect
 the current checkout's selected projects with
 `python3 -m scripts.blueprint_reference_harness projects`.
 
-Each external Blueprint is published only for its intended current release:
-Noperthedron and FLT on `v4.32.0`, and Sphere Packing and Carleson on
-`v4.31.0`. The in-repo starter template is a CI fixture rather than a public
-reference entry; it continues to validate every maintained release line.
+Each external Blueprint is published only for its intended current release,
+currently `v4.32.0`. The in-repo starter template is a CI fixture rather than a
+public reference entry; it continues to validate every maintained release
+line.
 
 - [`ejgallego/verso-noperthedron`](https://github.com/ejgallego/verso-noperthedron),
   [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/noperthedron/)
 - [`ejgallego/verso-sphere-packing`](https://github.com/ejgallego/verso-sphere-packing),
-  [rendered site for v4.31.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.31.0/spherepackingblueprint/)
+  [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/spherepackingblueprint/)
 - [`ejgallego/verso-flt`](https://github.com/ejgallego/verso-flt),
   [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/verso-flt/)
 - [`ejgallego/verso-carleson`](https://github.com/ejgallego/verso-carleson),
-  [rendered site for v4.31.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.31.0/verso-carleson/)
+  [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/verso-carleson/)
 
 ## Rendered Test Blueprints
 

--- a/branch-policy.json
+++ b/branch-policy.json
@@ -1,17 +1,8 @@
 {
   "version": 2,
   "default_dev_branch": "v4.32.0",
-  "required_backport_branches": [
-    "v4.31.0"
-  ],
+  "required_backport_branches": [],
   "release_targets": [
-    {
-      "id": "v4.31.0",
-      "toolchain": "v4.31.0",
-      "verso_ref": "v4.31.0",
-      "branch": "v4.31.0",
-      "deploy_pages": true
-    },
     {
       "id": "v4.32.0",
       "toolchain": "v4.32.0",

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -111,6 +111,10 @@ Do those upstream write actions only when they are explicitly requested.
   repository metadata. Source, scripts, tests, templates, package
   configuration, and runtime assets require paired backports so maintenance
   lines remain structurally aligned for future cherry-picks.
+- `release-line retirement` is machine-checked rather than exempt. CI accepts
+  it only when the default Lean line stays fixed, the oldest contiguous suffix
+  of required backports is removed, and every remaining release target is
+  unchanged.
 - Backported default-development PRs should normally be landed with a merge
   commit rather than squash or rebase, so the source commits recorded by
   `git cherry-pick -x` remain present in default-dev history.
@@ -128,6 +132,8 @@ Do those upstream write actions only when they are explicitly requested.
   - keep the default-development PR in draft while the change is still converging
   - run `python3 -m scripts.blueprint_harness prepare-pr` and use the emitted
     public title/body scaffold
+  - for a maintenance-line retirement, replace the retiring
+    `Backport ...: pending` lines with `Backport ...: release-line retirement`
   - use `python3 -m scripts.blueprint_harness prepare-backports` only when you
     need to refresh just the backport plan lines in an existing PR body
   - once it is ready for review, open the paired backport PRs

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -394,6 +394,14 @@ Commit that metadata-only change separately on each older branch that still
 carries `branch-policy.json`, such as `v4.31.0`. Preserve their own Lean
 toolchain pins.
 
+When retiring old maintenance lines from an existing release branch, use
+`Backport ...: release-line retirement` for each removed line. The check
+accepts this only when the default Lean toolchain and branch stay fixed, the
+removed branches are the oldest contiguous suffix of the maintenance sequence,
+and all remaining release targets are unchanged. This makes the policy
+transition self-validating without constructing obsolete backport projects
+solely to satisfy the policy being removed.
+
 To remove stale harness-managed reference caches and orphaned local clones:
 
 ```bash

--- a/scripts/blueprint_harness_branches.py
+++ b/scripts/blueprint_harness_branches.py
@@ -124,41 +124,49 @@ def load_branch_policy(checkout_root: Path) -> BranchPolicy:
             source_path=path,
         )
 
+    return load_branch_policy_text(path.read_text(encoding="utf-8"), source_path=path)
+
+
+def load_branch_policy_text(text: str, *, source_path: Path) -> BranchPolicy:
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
+        data = json.loads(text)
     except json.JSONDecodeError as err:
-        raise SystemExit(f"[blueprint-harness] invalid branch policy file `{path}`: {err}") from err
+        raise SystemExit(f"[blueprint-harness] invalid branch policy file `{source_path}`: {err}") from err
 
     if not isinstance(data, dict):
-        raise SystemExit(f"[blueprint-harness] invalid branch policy file `{path}`: expected a JSON object")
+        raise SystemExit(f"[blueprint-harness] invalid branch policy file `{source_path}`: expected a JSON object")
 
     raw_default = data.get("default_dev_branch")
     if not isinstance(raw_default, str):
-        raise SystemExit(f"[blueprint-harness] invalid branch policy file `{path}`: missing string `default_dev_branch`")
+        raise SystemExit(
+            f"[blueprint-harness] invalid branch policy file `{source_path}`: missing string `default_dev_branch`"
+        )
 
     raw_backports = data.get("required_backport_branches", [])
     if not isinstance(raw_backports, list) or not all(isinstance(item, str) for item in raw_backports):
         raise SystemExit(
-            f"[blueprint-harness] invalid branch policy file `{path}`: "
+            f"[blueprint-harness] invalid branch policy file `{source_path}`: "
             "`required_backport_branches` must be a list of strings"
         )
 
     raw_version = data.get("version", 1)
     if not isinstance(raw_version, int):
-        raise SystemExit(f"[blueprint-harness] invalid branch policy file `{path}`: `version` must be an integer")
+        raise SystemExit(
+            f"[blueprint-harness] invalid branch policy file `{source_path}`: `version` must be an integer"
+        )
 
-    release_targets = load_branch_policy_release_targets(data, path)
+    release_targets = load_branch_policy_release_targets(data, source_path)
     release_ids = {target.release_id for target in release_targets}
     if release_ids and release_branch_from_lean_ref(raw_default) not in release_ids:
         raise SystemExit(
-            f"[blueprint-harness] invalid branch policy file `{path}`: "
+            f"[blueprint-harness] invalid branch policy file `{source_path}`: "
             f"default development branch `{release_branch_from_lean_ref(raw_default)}` is not a release target"
         )
     for branch in raw_backports:
         normalized = release_branch_from_lean_ref(branch)
         if release_ids and normalized not in release_ids:
             raise SystemExit(
-                f"[blueprint-harness] invalid branch policy file `{path}`: "
+                f"[blueprint-harness] invalid branch policy file `{source_path}`: "
                 f"required backport branch `{normalized}` is not a release target"
             )
 
@@ -167,7 +175,7 @@ def load_branch_policy(checkout_root: Path) -> BranchPolicy:
         default_dev_branch=release_branch_from_lean_ref(raw_default),
         required_backport_branches=tuple(release_branch_from_lean_ref(item) for item in raw_backports),
         release_targets=release_targets,
-        source_path=path,
+        source_path=source_path,
     )
 
 

--- a/scripts/check_backport_pr.py
+++ b/scripts/check_backport_pr.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 from dataclasses import dataclass
 import os
@@ -9,13 +10,15 @@ import re
 import sys
 from typing import Any
 from urllib.error import HTTPError
+from urllib.parse import quote
 from urllib.request import Request, urlopen
 
 if str(Path(__file__).resolve().parents[1]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scripts.blueprint_harness_branches import load_branch_policy
+from scripts.blueprint_harness_branches import BranchPolicy, load_branch_policy, load_branch_policy_text
 from scripts.blueprint_harness_backports import backport_exemption_violations
+from scripts.blueprint_harness_releases import release_branch_from_lean_ref
 
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
@@ -24,6 +27,8 @@ API_VERSION = "2022-11-28"
 BACKPORT_LINE_RE = re.compile(r"(?mi)^Backport\s+([^\s:]+)\s*:\s*(.+)\s*$")
 BACKPORT_PR_RE = re.compile(r"(?:#|/pull/)(\d+)\b")
 CHERRY_PICK_SOURCE_RE = re.compile(r"(?mi)^\(cherry picked from commit ([0-9a-f]{40})\)\s*$")
+RELEASE_LINE_BOOTSTRAP_STATUS = "release-line bootstrap"
+RELEASE_LINE_RETIREMENT_STATUS = "release-line retirement"
 
 
 @dataclass(frozen=True)
@@ -33,6 +38,8 @@ class BackportEntry:
     exempt_reason: str | None = None
     pending: bool = False
     pending_note: str | None = None
+    release_line_bootstrap: bool = False
+    release_line_retirement: bool = False
 
 
 @dataclass(frozen=True)
@@ -111,6 +118,17 @@ class GitHubApi:
                 return files
             page += 1
 
+    def file_text(self, path: str, ref: str) -> str:
+        encoded_path = quote(path, safe="/")
+        encoded_ref = quote(ref, safe="")
+        data = self.get_json(f"/repos/{self.repo_full_name}/contents/{encoded_path}?ref={encoded_ref}")
+        if not isinstance(data, dict) or data.get("encoding") != "base64" or not isinstance(data.get("content"), str):
+            raise BackportCheckError(f"Unexpected repository file payload for `{path}` at `{ref}`")
+        try:
+            return base64.b64decode(data["content"], validate=False).decode("utf-8")
+        except (ValueError, UnicodeDecodeError) as err:
+            raise BackportCheckError(f"Unable to decode repository file `{path}` at `{ref}`") from err
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -159,11 +177,18 @@ def parse_backport_entries(body: str) -> dict[str, BackportEntry]:
             note = value[len("pending") :].lstrip(" :-()")
             entries[branch] = BackportEntry(branch=branch, pending=True, pending_note=note or None)
             continue
+        if lower == RELEASE_LINE_BOOTSTRAP_STATUS:
+            entries[branch] = BackportEntry(branch=branch, release_line_bootstrap=True)
+            continue
+        if lower == RELEASE_LINE_RETIREMENT_STATUS:
+            entries[branch] = BackportEntry(branch=branch, release_line_retirement=True)
+            continue
 
         pr_match = BACKPORT_PR_RE.search(value)
         if pr_match is None:
             raise BackportCheckError(
-                f"Backport {branch}: expected `#<pr>`, `pending`, or `exempt: <reason>`, got `{value}`"
+                f"Backport {branch}: expected `#<pr>`, `pending`, `exempt: <reason>`, or "
+                f"`{RELEASE_LINE_BOOTSTRAP_STATUS}`/`{RELEASE_LINE_RETIREMENT_STATUS}`, got `{value}`"
             )
         entries[branch] = BackportEntry(branch=branch, pr_number=int(pr_match.group(1)))
     return entries
@@ -186,7 +211,9 @@ def validate_backport_entries(
         raise BackportCheckError(
             "missing paired backport metadata for "
             + ", ".join(missing)
-            + f". Add lines like {example} or `Backport {example_branch}: exempt: <reason>`"
+            + f". Add lines like {example}, `Backport {example_branch}: exempt: <reason>`, or "
+            + f"`Backport {example_branch}: {RELEASE_LINE_BOOTSTRAP_STATUS}`/"
+            + f"`Backport {example_branch}: {RELEASE_LINE_RETIREMENT_STATUS}`"
         )
 
     if allow_pending:
@@ -197,9 +224,138 @@ def validate_backport_entries(
         raise BackportCheckError(
             "pending backport entries are not allowed once the default-dev PR is ready for review: "
             + ", ".join(pending)
-            + ". Replace each `pending` entry with `#<pr>` or `exempt: <reason>`"
+            + f". Replace each `pending` entry with `#<pr>`, `exempt: <reason>`, or "
+            + f"`{RELEASE_LINE_BOOTSTRAP_STATUS}`/`{RELEASE_LINE_RETIREMENT_STATUS}` "
+            + "for a machine-checked release-policy transition"
         )
     return entries
+
+
+def dedupe_release_branches(branches: tuple[str, ...]) -> tuple[str, ...]:
+    result: list[str] = []
+    for branch in branches:
+        normalized = release_branch_from_lean_ref(branch)
+        if normalized not in result:
+            result.append(normalized)
+    return tuple(result)
+
+
+def verify_release_line_bootstrap(
+    api: GitHubApi,
+    source_pr_number: int,
+    pull_request: dict[str, Any],
+    base_policy: BranchPolicy,
+) -> BranchPolicy:
+    base = pull_request.get("base")
+    base_sha = str(base.get("sha") or "") if isinstance(base, dict) else ""
+    head = pull_request.get("head")
+    head_sha = str(head.get("sha") or "") if isinstance(head, dict) else ""
+    if not base_sha:
+        raise BackportCheckError("release-line bootstrap validation requires pull_request.base.sha")
+    if not head_sha:
+        raise BackportCheckError("release-line bootstrap validation requires pull_request.head.sha")
+
+    try:
+        head_policy = load_branch_policy_text(
+            api.file_text("branch-policy.json", head_sha),
+            source_path=Path(f"github-head-{head_sha[:12]}-branch-policy.json"),
+        )
+    except SystemExit as err:
+        raise BackportCheckError(str(err)) from err
+    base_toolchain_release = release_branch_from_lean_ref(api.file_text("lean-toolchain", base_sha).strip())
+    head_toolchain_release = release_branch_from_lean_ref(api.file_text("lean-toolchain", head_sha).strip())
+
+    if base_toolchain_release != base_policy.default_dev_branch:
+        raise BackportCheckError(
+            "release-line bootstrap base is internally inconsistent: its Lean toolchain does not match its default branch"
+        )
+    if head_toolchain_release != head_policy.default_dev_branch:
+        raise BackportCheckError(
+            "release-line bootstrap head is internally inconsistent: its Lean toolchain does not match its default branch"
+        )
+    if head_policy.default_dev_branch == base_policy.default_dev_branch:
+        raise BackportCheckError("release-line bootstrap status requires advancing the default development release line")
+
+    expected_backports = tuple(
+        branch
+        for branch in dedupe_release_branches(
+            (base_policy.default_dev_branch, *base_policy.required_backport_branches)
+        )
+        if branch != head_policy.default_dev_branch
+    )
+    if head_policy.required_backport_branches != expected_backports:
+        raise BackportCheckError(
+            "release-line bootstrap must inherit the previous default branch and required backport sequence; expected "
+            + ", ".join(expected_backports)
+        )
+
+    changed_files = set(api.pull_request_files(source_pr_number))
+    missing_files = sorted({"branch-policy.json", "lean-toolchain"} - changed_files)
+    if missing_files:
+        raise BackportCheckError(
+            "release-line bootstrap must change both release identity files; missing " + ", ".join(missing_files)
+        )
+    return head_policy
+
+
+def verify_release_line_retirement(
+    api: GitHubApi,
+    source_pr_number: int,
+    pull_request: dict[str, Any],
+    base_policy: BranchPolicy,
+) -> tuple[BranchPolicy, tuple[str, ...]]:
+    base = pull_request.get("base")
+    base_sha = str(base.get("sha") or "") if isinstance(base, dict) else ""
+    head = pull_request.get("head")
+    head_sha = str(head.get("sha") or "") if isinstance(head, dict) else ""
+    if not base_sha:
+        raise BackportCheckError("release-line retirement validation requires pull_request.base.sha")
+    if not head_sha:
+        raise BackportCheckError("release-line retirement validation requires pull_request.head.sha")
+
+    try:
+        head_policy = load_branch_policy_text(
+            api.file_text("branch-policy.json", head_sha),
+            source_path=Path(f"github-head-{head_sha[:12]}-branch-policy.json"),
+        )
+    except SystemExit as err:
+        raise BackportCheckError(str(err)) from err
+    base_toolchain_release = release_branch_from_lean_ref(api.file_text("lean-toolchain", base_sha).strip())
+    head_toolchain_release = release_branch_from_lean_ref(api.file_text("lean-toolchain", head_sha).strip())
+
+    if head_policy.default_dev_branch != base_policy.default_dev_branch:
+        raise BackportCheckError("release-line retirement must preserve the default development release line")
+    if base_toolchain_release != base_policy.default_dev_branch:
+        raise BackportCheckError(
+            "release-line retirement base is internally inconsistent: its Lean toolchain does not match its default branch"
+        )
+    if head_toolchain_release != head_policy.default_dev_branch:
+        raise BackportCheckError(
+            "release-line retirement head is internally inconsistent: its Lean toolchain does not match its default branch"
+        )
+
+    retained_count = len(head_policy.required_backport_branches)
+    if retained_count >= len(base_policy.required_backport_branches):
+        raise BackportCheckError("release-line retirement status requires removing at least one backport branch")
+    if base_policy.required_backport_branches[:retained_count] != head_policy.required_backport_branches:
+        raise BackportCheckError(
+            "release-line retirement may remove only the oldest contiguous suffix of required backport branches"
+        )
+    retired_branches = base_policy.required_backport_branches[retained_count:]
+
+    retired_set = set(retired_branches)
+    expected_targets = tuple(
+        target for target in base_policy.release_targets if target.release_id not in retired_set
+    )
+    if head_policy.release_targets != expected_targets:
+        raise BackportCheckError(
+            "release-line retirement must remove exactly the retired release targets and preserve every remaining target"
+        )
+
+    changed_files = set(api.pull_request_files(source_pr_number))
+    if "branch-policy.json" not in changed_files:
+        raise BackportCheckError("release-line retirement must change branch-policy.json")
+    return head_policy, retired_branches
 
 
 def parse_cherry_pick_source(message: str) -> str | None:
@@ -297,7 +453,20 @@ def event_pull_request(event: dict[str, Any]) -> dict[str, Any]:
     return pull_request
 
 
-def should_enforce(pull_request: dict[str, Any], default_dev_branch: str, required_backports: tuple[str, ...]) -> bool:
+def should_enforce(
+    pull_request: dict[str, Any],
+    default_dev_branch: str,
+    required_backports: tuple[str, ...],
+    *,
+    release_line_bootstrap: bool = False,
+    release_line_retirement: bool = False,
+) -> bool:
+    if release_line_bootstrap:
+        print("[backport-check] release-line bootstrap plan declared; validating the base-to-head policy transition")
+        return True
+    if release_line_retirement:
+        print("[backport-check] release-line retirement plan declared; validating the base-to-head policy transition")
+        return True
     if not required_backports:
         print("[backport-check] no required backport branches configured; skipping")
         return False
@@ -313,39 +482,96 @@ def should_enforce(pull_request: dict[str, Any], default_dev_branch: str, requir
 def run(event_path: str | None, token: str | None) -> int:
     event = load_event(event_path)
     pull_request = event_pull_request(event)
-    policy = load_branch_policy(PACKAGE_ROOT)
+    base_policy = load_branch_policy(PACKAGE_ROOT)
+    body = str(pull_request.get("body") or "")
+    release_line_bootstrap = any(
+        value.strip().lower() == RELEASE_LINE_BOOTSTRAP_STATUS for _, value in BACKPORT_LINE_RE.findall(body)
+    )
+    release_line_retirement = any(
+        value.strip().lower() == RELEASE_LINE_RETIREMENT_STATUS for _, value in BACKPORT_LINE_RE.findall(body)
+    )
+    if release_line_bootstrap and release_line_retirement:
+        raise BackportCheckError("release-line bootstrap and retirement plans cannot be mixed")
 
-    if not should_enforce(pull_request, policy.default_dev_branch, policy.required_backport_branches):
+    if not should_enforce(
+        pull_request,
+        base_policy.default_dev_branch,
+        base_policy.required_backport_branches,
+        release_line_bootstrap=release_line_bootstrap,
+        release_line_retirement=release_line_retirement,
+    ):
         return 0
 
     draft = bool(pull_request.get("draft"))
-    body = str(pull_request.get("body") or "")
-    entries = validate_backport_entries(body, policy.required_backport_branches, allow_pending=draft)
-    entries_to_verify = [entries[branch] for branch in policy.required_backport_branches if entries[branch].pr_number is not None]
-    exemptions_to_verify = [entries[branch] for branch in policy.required_backport_branches if entries[branch].exempt_reason is not None]
-    needs_api = bool(exemptions_to_verify or (not draft and entries_to_verify))
-    if needs_api:
-        repository = event.get("repository")
+    repository = event.get("repository")
+    source_pr_number_raw = pull_request.get("number", event.get("number"))
+    try:
+        source_pr_number = int(source_pr_number_raw)
+    except (TypeError, ValueError) as err:
+        raise BackportCheckError("event payload is missing the default-development PR number") from err
+
+    api = None
+    if release_line_bootstrap or release_line_retirement:
         if not isinstance(repository, dict) or not isinstance(repository.get("full_name"), str):
             raise BackportCheckError("event payload is missing repository.full_name")
-        source_pr_number_raw = pull_request.get("number", event.get("number"))
-        try:
-            source_pr_number = int(source_pr_number_raw)
-        except (TypeError, ValueError) as err:
-            raise BackportCheckError("event payload is missing the default-development PR number") from err
         if not token:
             raise BackportCheckError("missing GitHub token; pass --token or set GITHUB_TOKEN")
         api = GitHubApi(repository["full_name"], token)
-        verify_backport_exemptions(api, source_pr_number, entries)
+        if release_line_bootstrap:
+            policy = verify_release_line_bootstrap(api, source_pr_number, pull_request, base_policy)
+            plan_branches = policy.required_backport_branches
+        else:
+            policy, plan_branches = verify_release_line_retirement(
+                api, source_pr_number, pull_request, base_policy
+            )
     else:
-        source_pr_number = 0
-        api = None
+        policy = base_policy
+        plan_branches = policy.required_backport_branches
+
+    entries = validate_backport_entries(body, plan_branches, allow_pending=draft)
+    if release_line_bootstrap:
+        non_bootstrap = [
+            branch for branch in policy.required_backport_branches if not entries[branch].release_line_bootstrap
+        ]
+        if non_bootstrap:
+            raise BackportCheckError(
+                "release-line bootstrap status must be used for every required backport branch; mixed plans are invalid"
+            )
+    if release_line_retirement:
+        retirement_branches = {
+            branch for branch, entry in entries.items() if entry.release_line_retirement
+        }
+        if retirement_branches != set(plan_branches):
+            raise BackportCheckError(
+                "release-line retirement status must name exactly the retired backport branches"
+            )
+    entries_to_verify = [entries[branch] for branch in plan_branches if entries[branch].pr_number is not None]
+    exemptions_to_verify = [entries[branch] for branch in plan_branches if entries[branch].exempt_reason is not None]
+    bootstraps_to_verify = [
+        entries[branch] for branch in plan_branches if entries[branch].release_line_bootstrap
+    ]
+    retirements_to_verify = [entries[branch] for branch in plan_branches if entries[branch].release_line_retirement]
+    needs_api = bool(
+        exemptions_to_verify or bootstraps_to_verify or retirements_to_verify or (not draft and entries_to_verify)
+    )
+    if needs_api and api is None:
+        if not isinstance(repository, dict) or not isinstance(repository.get("full_name"), str):
+            raise BackportCheckError("event payload is missing repository.full_name")
+        if not token:
+            raise BackportCheckError("missing GitHub token; pass --token or set GITHUB_TOKEN")
+        api = GitHubApi(repository["full_name"], token)
+    if api is not None:
+        verify_backport_exemptions(api, source_pr_number, entries)
     if draft:
         print("[backport-check] draft PR; enforcing declared backport plan only")
-        for branch in policy.required_backport_branches:
+        for branch in plan_branches:
             entry = entries[branch]
             if entry.exempt_reason is not None:
                 print(f"[backport-check] {branch}: exempt ({entry.exempt_reason})")
+            elif entry.release_line_bootstrap:
+                print(f"[backport-check] {branch}: release-line bootstrap verified")
+            elif entry.release_line_retirement:
+                print(f"[backport-check] {branch}: release-line retirement verified")
             elif entry.pending:
                 note_suffix = f" ({entry.pending_note})" if entry.pending_note else ""
                 print(f"[backport-check] {branch}: pending{note_suffix}")
@@ -356,10 +582,16 @@ def run(event_path: str | None, token: str | None) -> int:
                 )
         return 0
 
-    for branch in policy.required_backport_branches:
+    for branch in plan_branches:
         entry = entries[branch]
         if entry.exempt_reason is not None:
             print(f"[backport-check] {branch}: exempt ({entry.exempt_reason})")
+            continue
+        if entry.release_line_bootstrap:
+            print(f"[backport-check] {branch}: release-line bootstrap verified")
+            continue
+        if entry.release_line_retirement:
+            print(f"[backport-check] {branch}: release-line retirement verified")
             continue
         if api is None:
             raise BackportCheckError(f"Backport {branch}: internal error; paired PR verification is unavailable")

--- a/src/VersoBlueprint/Informal/Block/relation-panel.mjs
+++ b/src/VersoBlueprint/Informal/Block/relation-panel.mjs
@@ -169,6 +169,9 @@
       const dataScript = list.querySelector("script.bp-relation-entries");
       if (dataScript instanceof Element) dataScript.remove();
       list.appendChild(fragment);
+      if (typeof previewUtils.hydrate === "function") {
+        previewUtils.hydrate(list, { renderMath: false });
+      }
       if (!items.some(function (item) {
         return item instanceof Element && item.classList.contains("bp_relation_item_active");
       }) && items[0] instanceof Element) {

--- a/tests/browser/test_blueprint_slides_runtime.py
+++ b/tests/browser/test_blueprint_slides_runtime.py
@@ -172,7 +172,17 @@ class TestBlueprintSlidesRuntime:
             "multiplication_spec",
         }
         assert [entry["label"] for entry in collatz_entry["usedBy"]] == ["collatz_conjecture"]
-        assert collatz_entry["group"]["label"] == "collatz_core"
+        collatz_group = next(
+            group for group in manifest["groups"] if group["label"] == "collatz_core"
+        )
+        assert collatz_group["declared"]
+        assert [entry["label"] for entry in collatz_group["entries"]] == [
+            "collatz_step",
+            "collatz_conjecture",
+        ]
+        assert collatz_entry["parent"] == collatz_group["label"]
+        assert collatz_entry["parentTitle"] == collatz_group["title"]
+        assert "group" not in collatz_entry
         assert collatz_entry["leanCodePreviewKeys"] == [
             "Informal.LeanCodePreview.Inline.collatz_step"
         ]
@@ -326,12 +336,14 @@ class TestBlueprintSlidesRuntime:
             "Multiplication/#--informal-preview-multiplication_spec--statement",
             "/blueprint/Multiplication/#--informal-preview-multiplication_spec--statement",
         )
+        node.locator(".bp_extra_slot_group .bp_relation_chip").hover()
         expect_slide_link(
             page,
             ".bp_extra_slot_group .bp_relation_target",
             COLLATZ_CONJECTURE_HREF,
             COLLATZ_CONJECTURE_REWRITTEN,
         )
+        node.locator(".bp_extra_slot_used_by .bp_relation_chip").hover()
         expect_slide_link(
             page,
             ".bp_extra_slot_used_by .bp_relation_target",

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -27,7 +27,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "2c90f00890fdd502a601c441cf871b79c000fd94",
+          "ref": "4cba921642592f7380591e9d162116b1aa9f5171",
           "publish_reference": true
         }
       ],
@@ -45,7 +45,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "f00c5f67d8db934e9eca73c7bdcf12659ef8b55d",
+          "ref": "1235792325409218b6a628c5150a5aa50e30b4a5",
           "publish_reference": true
         }
       ],
@@ -63,7 +63,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "6985175a05cbb13605680681c79944eec89b69a5",
+          "ref": "4135d74a05e049094bba5b689d5f76b9e6a6e99a",
           "publish_reference": true
         }
       ],
@@ -81,7 +81,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "facefe765429123292df596fb47468e6d5f9745c",
+          "ref": "d5f1c2b9db447ba8acac08c93a37b3138d89581f",
           "publish_reference": true
         }
       ],

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -27,7 +27,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "4cba921642592f7380591e9d162116b1aa9f5171",
+          "ref": "50252fcd705f47c69e1643d6e55c362da273bec1",
           "publish_reference": true
         }
       ],
@@ -45,7 +45,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "1235792325409218b6a628c5150a5aa50e30b4a5",
+          "ref": "7f7fb9eb8770497625d5155af52921281093fe2b",
           "publish_reference": true
         }
       ],
@@ -63,7 +63,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "4135d74a05e049094bba5b689d5f76b9e6a6e99a",
+          "ref": "bc09f1e5ce35d6418173386b5f134b51a81e6c17",
           "publish_reference": true
         }
       ],
@@ -81,7 +81,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "d5f1c2b9db447ba8acac08c93a37b3138d89581f",
+          "ref": "e89a585c13d05c965d9d28d307517da0bfe13960",
           "publish_reference": true
         }
       ],

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -10,23 +10,10 @@
       },
       "targets": [
         {
-          "release": "v4.31.0"
-        },
-        {
           "release": "v4.32.0"
         }
       ],
-      "build_command": ["lake", "build", "ProjectTemplate"],
-      "generate_command": [
-        "lake",
-        "lean",
-        "ProjectTemplateMain.lean",
-        "--",
-        "--run",
-        "ProjectTemplateMain.lean",
-        "--output",
-        "{output_dir}"
-      ],
+      "generate_command": ["lake", "exe", "vbp", "build", "--output", "{output_dir}"],
       "site_subdir": "html-multi"
     },
     {
@@ -40,9 +27,8 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "ad062f0d06b891fa53db1cfcdc7e39be05c39204",
-          "publish_reference": true,
-          "rc": "4.32-rc1"
+          "ref": "2c90f00890fdd502a601c441cf871b79c000fd94",
+          "publish_reference": true
         }
       ],
       "generate_command": ["lake", "exe", "vbp", "build", "--output", "{output_dir}"],
@@ -58,8 +44,8 @@
       },
       "targets": [
         {
-          "release": "v4.31.0",
-          "ref": "4cbb43d6401ff2ca8d4495b82fea99df59b633bd",
+          "release": "v4.32.0",
+          "ref": "f00c5f67d8db934e9eca73c7bdcf12659ef8b55d",
           "publish_reference": true
         }
       ],
@@ -77,9 +63,8 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "1695b7cb937a8022dacd2742b969a272b7d57d1e",
-          "publish_reference": true,
-          "rc": "4.32-rc1"
+          "ref": "6985175a05cbb13605680681c79944eec89b69a5",
+          "publish_reference": true
         }
       ],
       "generate_command": ["lake", "exe", "vbp", "build", "--output", "{output_dir}"],
@@ -95,8 +80,8 @@
       },
       "targets": [
         {
-          "release": "v4.31.0",
-          "ref": "5b34f5d43ba50bca0680b2c139b2b994857902f4",
+          "release": "v4.32.0",
+          "ref": "facefe765429123292df596fb47468e6d5f9745c",
           "publish_reference": true
         }
       ],

--- a/tests/harness/test_backport_pr_check.py
+++ b/tests/harness/test_backport_pr_check.py
@@ -13,6 +13,9 @@ from tests.harness.release_fixtures import (
     SAMPLE_DEFAULT_RELEASE,
     SAMPLE_PREVIOUS_RELEASE,
     backport_line,
+    branch_policy_json,
+    lean_toolchain,
+    release_target,
 )
 
 
@@ -30,10 +33,12 @@ class FakeGitHubApi:
         pull_requests: dict[int, dict[str, object]] | None = None,
         pull_request_commits: dict[int, list[backport_mod.PullRequestCommit]] | None = None,
         pull_request_files: dict[int, list[str]] | None = None,
+        file_texts: dict[tuple[str, str], str] | None = None,
     ) -> None:
         self._pull_requests = pull_requests or {}
         self._pull_request_commits = pull_request_commits or {}
         self._pull_request_files = pull_request_files or {}
+        self._file_texts = file_texts or {}
 
     def pull_request(self, number: int) -> dict[str, object]:
         return self._pull_requests[number]
@@ -44,6 +49,9 @@ class FakeGitHubApi:
     def pull_request_files(self, number: int) -> list[str]:
         return self._pull_request_files[number]
 
+    def file_text(self, path: str, ref: str) -> str:
+        return self._file_texts[(path, ref)]
+
 
 def write_pull_request_event(path: Path, *, draft: bool, body: str) -> None:
     path.write_text(
@@ -52,7 +60,8 @@ def write_pull_request_event(path: Path, *, draft: bool, body: str) -> None:
                 "repository": {"full_name": "leanprover/verso-blueprint"},
                 "pull_request": {
                     "number": 11,
-                    "base": {"ref": DEFAULT_DEV_RELEASE},
+                    "base": {"ref": DEFAULT_DEV_RELEASE, "sha": "base-sha"},
+                    "head": {"sha": "head-sha"},
                     "draft": draft,
                     "body": body,
                 },
@@ -87,12 +96,16 @@ class BackportPrCheckTests(unittest.TestCase):
 Backport v4.28.0: #42
 Backport v4.27.0: pending
 Backport v4.26.0: exempt: no longer maintained
+Backport v4.25.0: release-line bootstrap
+Backport v4.24.0: release-line retirement
 """
         entries = backport_mod.parse_backport_entries(body)
         self.assertEqual(entries["v4.28.0"].pr_number, 42)
         self.assertIsNone(entries["v4.28.0"].exempt_reason)
         self.assertTrue(entries["v4.27.0"].pending)
         self.assertEqual(entries["v4.26.0"].exempt_reason, "no longer maintained")
+        self.assertTrue(entries["v4.25.0"].release_line_bootstrap)
+        self.assertTrue(entries["v4.24.0"].release_line_retirement)
 
     def test_parse_backport_entries_accepts_pull_request_url(self) -> None:
         body = "Backport v4.28.0: https://github.com/leanprover/verso-blueprint/pull/123\n"
@@ -240,6 +253,96 @@ Backport v4.26.0: exempt: no longer maintained
             )
             with self.assertRaisesRegex(backport_mod.BackportCheckError, "missing GitHub token"):
                 run_with_required_backport(event_path, token=None)
+
+    def test_run_accepts_machine_checked_release_line_retirement(self) -> None:
+        retired = SAMPLE_PREVIOUS_RELEASE
+        base_targets = [release_target(retired), release_target(DEFAULT_DEV_RELEASE)]
+        head_targets = [release_target(DEFAULT_DEV_RELEASE)]
+        with tempfile.TemporaryDirectory() as tmp:
+            package_root = Path(tmp) / "package"
+            package_root.mkdir()
+            (package_root / "branch-policy.json").write_text(
+                branch_policy_json(
+                    default_dev=DEFAULT_DEV_RELEASE,
+                    required_backports=(retired,),
+                    release_targets=base_targets,
+                ),
+                encoding="utf-8",
+            )
+            (package_root / "lean-toolchain").write_text(
+                f"{lean_toolchain(DEFAULT_DEV_RELEASE)}\n",
+                encoding="utf-8",
+            )
+            event_path = Path(tmp) / "event.json"
+            write_pull_request_event(
+                event_path,
+                draft=False,
+                body=backport_line(retired, backport_mod.RELEASE_LINE_RETIREMENT_STATUS),
+            )
+            api = FakeGitHubApi(
+                pull_request_files={11: ["branch-policy.json", "tests/harness/projects.json"]},
+                file_texts={
+                    ("branch-policy.json", "head-sha"): branch_policy_json(
+                        default_dev=DEFAULT_DEV_RELEASE,
+                        release_targets=head_targets,
+                    ),
+                    ("lean-toolchain", "base-sha"): f"{lean_toolchain(DEFAULT_DEV_RELEASE)}\n",
+                    ("lean-toolchain", "head-sha"): f"{lean_toolchain(DEFAULT_DEV_RELEASE)}\n",
+                },
+            )
+            with (
+                patch.object(backport_mod, "GitHubApi", return_value=api),
+                patch.object(backport_mod, "PACKAGE_ROOT", package_root),
+            ):
+                self.assertEqual(backport_mod.run(str(event_path), token="token"), 0)
+
+    def test_run_rejects_retiring_a_non_oldest_backport(self) -> None:
+        newest = "v4.31.0"
+        oldest = "v4.30.0"
+        base_targets = [
+            release_target(oldest),
+            release_target(newest),
+            release_target(DEFAULT_DEV_RELEASE),
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            package_root = Path(tmp) / "package"
+            package_root.mkdir()
+            (package_root / "branch-policy.json").write_text(
+                branch_policy_json(
+                    default_dev=DEFAULT_DEV_RELEASE,
+                    required_backports=(newest, oldest),
+                    release_targets=base_targets,
+                ),
+                encoding="utf-8",
+            )
+            (package_root / "lean-toolchain").write_text(
+                f"{lean_toolchain(DEFAULT_DEV_RELEASE)}\n",
+                encoding="utf-8",
+            )
+            event_path = Path(tmp) / "event.json"
+            write_pull_request_event(
+                event_path,
+                draft=False,
+                body=backport_line(newest, backport_mod.RELEASE_LINE_RETIREMENT_STATUS),
+            )
+            api = FakeGitHubApi(
+                pull_request_files={11: ["branch-policy.json"]},
+                file_texts={
+                    ("branch-policy.json", "head-sha"): branch_policy_json(
+                        default_dev=DEFAULT_DEV_RELEASE,
+                        required_backports=(oldest,),
+                        release_targets=[release_target(oldest), release_target(DEFAULT_DEV_RELEASE)],
+                    ),
+                    ("lean-toolchain", "base-sha"): f"{lean_toolchain(DEFAULT_DEV_RELEASE)}\n",
+                    ("lean-toolchain", "head-sha"): f"{lean_toolchain(DEFAULT_DEV_RELEASE)}\n",
+                },
+            )
+            with (
+                patch.object(backport_mod, "GitHubApi", return_value=api),
+                patch.object(backport_mod, "PACKAGE_ROOT", package_root),
+            ):
+                with self.assertRaisesRegex(backport_mod.BackportCheckError, "oldest contiguous suffix"):
+                    backport_mod.run(str(event_path), token="token")
 
 
 if __name__ == "__main__":

--- a/tests/harness/test_backport_pr_check.py
+++ b/tests/harness/test_backport_pr_check.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import tempfile
 import unittest
+from dataclasses import replace
 from unittest.mock import patch
 from pathlib import Path
 
@@ -19,6 +20,7 @@ PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 BRANCH_POLICY = load_branch_policy(PACKAGE_ROOT)
 DEFAULT_DEV_RELEASE = BRANCH_POLICY.default_dev_branch
 REQUIRED_BACKPORT_RELEASES = BRANCH_POLICY.required_backport_branches
+RUN_REQUIRED_BACKPORT_RELEASES = (SAMPLE_PREVIOUS_RELEASE,)
 
 
 class FakeGitHubApi:
@@ -62,7 +64,13 @@ def write_pull_request_event(path: Path, *, draft: bool, body: str) -> None:
 
 
 def required_backport_body(status: str) -> str:
-    return "".join(f"{backport_line(branch, status)}\n" for branch in REQUIRED_BACKPORT_RELEASES)
+    return "".join(f"{backport_line(branch, status)}\n" for branch in RUN_REQUIRED_BACKPORT_RELEASES)
+
+
+def run_with_required_backport(event_path: Path, *, token: str | None) -> int:
+    policy = replace(BRANCH_POLICY, required_backport_branches=RUN_REQUIRED_BACKPORT_RELEASES)
+    with patch.object(backport_mod, "load_branch_policy", return_value=policy):
+        return backport_mod.run(str(event_path), token=token)
 
 
 class BackportPrCheckTests(unittest.TestCase):
@@ -108,7 +116,7 @@ Backport v4.26.0: exempt: no longer maintained
             event_path = Path(tmp) / "event.json"
             write_pull_request_event(event_path, draft=True, body="")
             with self.assertRaisesRegex(backport_mod.BackportCheckError, "missing paired backport metadata"):
-                backport_mod.run(str(event_path), token=None)
+                run_with_required_backport(event_path, token=None)
 
     def test_run_accepts_pending_entries_for_draft_default_dev_prs(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -118,7 +126,7 @@ Backport v4.26.0: exempt: no longer maintained
                 draft=True,
                 body=required_backport_body("pending"),
             )
-            self.assertEqual(backport_mod.run(str(event_path), token=None), 0)
+            self.assertEqual(run_with_required_backport(event_path, token=None), 0)
 
     def test_verify_backport_commit_series_accepts_matching_cherry_picks(self) -> None:
         api = FakeGitHubApi(
@@ -195,7 +203,7 @@ Backport v4.26.0: exempt: no longer maintained
                 body=required_backport_body("pending"),
             )
             with self.assertRaisesRegex(backport_mod.BackportCheckError, "pending backport entries are not allowed"):
-                backport_mod.run(str(event_path), token=None)
+                run_with_required_backport(event_path, token=None)
 
     def test_run_accepts_ready_docs_only_exemptions(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -207,7 +215,7 @@ Backport v4.26.0: exempt: no longer maintained
             )
             api = FakeGitHubApi(pull_request_files={11: ["doc/API.md", "README.md"]})
             with patch.object(backport_mod, "GitHubApi", return_value=api):
-                self.assertEqual(backport_mod.run(str(event_path), token="token"), 0)
+                self.assertEqual(run_with_required_backport(event_path, token="token"), 0)
 
     def test_run_rejects_source_change_exemptions(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -220,7 +228,7 @@ Backport v4.26.0: exempt: no longer maintained
             api = FakeGitHubApi(pull_request_files={11: ["src/VersoBlueprint/GraphApi.lean", "doc/API.md"]})
             with patch.object(backport_mod, "GitHubApi", return_value=api):
                 with self.assertRaisesRegex(backport_mod.BackportCheckError, "paired backports are required"):
-                    backport_mod.run(str(event_path), token="token")
+                    run_with_required_backport(event_path, token="token")
 
     def test_run_requires_token_to_validate_exemptions(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -231,7 +239,7 @@ Backport v4.26.0: exempt: no longer maintained
                 body=required_backport_body("exempt: docs-only change"),
             )
             with self.assertRaisesRegex(backport_mod.BackportCheckError, "missing GitHub token"):
-                backport_mod.run(str(event_path), token=None)
+                run_with_required_backport(event_path, token=None)
 
 
 if __name__ == "__main__":

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -146,51 +146,39 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             ],
         )
         self.assertEqual(catalog.release_targets, branch_policy.release_targets)
-        self.assertEqual(branch_policy.required_backport_branches, ("v4.31.0",))
+        self.assertEqual(branch_policy.required_backport_branches, ())
         self.assertEqual(
             [target.release_id for target in branch_policy.release_targets],
-            ["v4.31.0", "v4.32.0"],
+            ["v4.32.0"],
         )
         self.assertTrue(projects[0].in_repo_project)
         self.assertTrue(projects[0].in_repo_command_project)
         self.assertEqual(projects[0].project_root, "project_template")
-        self.assertEqual(projects[0].build_command, ("lake", "build", "ProjectTemplate"))
-        self.assertEqual(
-            projects[0].generate_command,
-            (
-                "lake",
-                "lean",
-                "ProjectTemplateMain.lean",
-                "--",
-                "--run",
-                "ProjectTemplateMain.lean",
-                "--output",
-                "{output_dir}",
-            ),
-        )
+        self.assertIsNone(projects[0].build_command)
+        self.assertEqual(projects[0].generate_command, VBP_BUILD_OUTPUT_COMMAND)
         expected_template_targets = [target.release_id for target in branch_policy.release_targets]
         self.assertEqual([target.release for target in projects[0].targets], expected_template_targets)
         default_template_target = projects[0].target_for_release(branch_policy.default_dev_branch)
         self.assertIsNotNone(default_template_target)
         self.assertFalse(default_template_target.publish_reference)
         self.assertFalse(any(target.publish_reference for target in projects[0].targets))
-        self.assertTrue(catalog.release_target("v4.31.0").deploy_pages)
+        self.assertTrue(catalog.release_target("v4.32.0").deploy_pages)
         self.assertEqual(current_release.release_toolchain, current_release.toolchain)
         self.assertEqual(current_release.release_verso_ref, current_release.verso_ref)
         if current_release.deploy_pages:
             self.assertTrue(resolve_projects_for_release(catalog, current_release.release_id, None))
         expected_external_releases = {
             "noperthedron": "v4.32.0",
-            "spherepackingblueprint": "v4.31.0",
+            "spherepackingblueprint": "v4.32.0",
             "verso-flt": "v4.32.0",
-            "verso-carleson": "v4.31.0",
+            "verso-carleson": "v4.32.0",
         }
         self.assertTrue(projects[1].git_checkout)
         self.assertEqual(projects[1].repository, "https://github.com/ejgallego/verso-noperthedron.git")
         self.assert_single_current_release_target(
             projects[1], expected_external_releases[projects[1].project_id], publish_reference=True
         )
-        self.assertEqual(projects[1].targets[0].rc, "4.32-rc1")
+        self.assertIsNone(projects[1].targets[0].rc)
         self.assertIsNone(projects[1].build_command)
         self.assertEqual(projects[1].generate_command, VBP_BUILD_OUTPUT_COMMAND)
         self.assertEqual(projects[1].browser_tests_path, None)
@@ -206,7 +194,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assert_single_current_release_target(
             projects[3], expected_external_releases[projects[3].project_id], publish_reference=True
         )
-        self.assertEqual(projects[3].targets[0].rc, "4.32-rc1")
+        self.assertIsNone(projects[3].targets[0].rc)
         self.assertIsNone(projects[3].build_command)
         self.assertEqual(projects[3].generate_command, VBP_BUILD_OUTPUT_COMMAND)
         self.assertEqual(projects[4].repository, "https://github.com/ejgallego/verso-carleson.git")
@@ -220,10 +208,10 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
     def test_selected_project_toolchain_requires_resolved_release_metadata(self) -> None:
         catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
         noperthedron = resolve_projects_for_release(catalog, "v4.32.0", ["noperthedron"])[0]
-        spherepacking = resolve_projects_for_release(catalog, "v4.31.0", ["spherepackingblueprint"])[0]
+        spherepacking = resolve_projects_for_release(catalog, "v4.32.0", ["spherepackingblueprint"])[0]
 
-        self.assertEqual(selected_project_toolchain(noperthedron), "v4.32.0-rc1")
-        self.assertEqual(selected_project_toolchain(spherepacking), "v4.31.0")
+        self.assertEqual(selected_project_toolchain(noperthedron), "v4.32.0")
+        self.assertEqual(selected_project_toolchain(spherepacking), "v4.32.0")
         with self.assertRaisesRegex(ValueError, "has no selected release target"):
             selected_project_toolchain(catalog.projects[1])
 
@@ -817,22 +805,15 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(
             set(rows),
             {
-                ("v4.31.0", "spherepackingblueprint"),
-                ("v4.31.0", "verso-carleson"),
                 ("v4.32.0", "noperthedron"),
+                ("v4.32.0", "spherepackingblueprint"),
                 ("v4.32.0", "verso-flt"),
+                ("v4.32.0", "verso-carleson"),
             },
         )
-        self.assertFalse(rows[("v4.31.0", "spherepackingblueprint")]["publish_pdf"])
-        self.assertFalse(rows[("v4.31.0", "verso-carleson")]["publish_pdf"])
-        self.assertNotIn(
-            "--pdf",
-            rows[("v4.31.0", "spherepackingblueprint")]["project_manifest"]["projects"][0]["generate_command"],
-        )
-        self.assertNotIn(
-            "--pdf",
-            rows[("v4.31.0", "verso-carleson")]["project_manifest"]["projects"][0]["generate_command"],
-        )
+        for entry in rows.values():
+            self.assertTrue(entry["publish_pdf"])
+            self.assertIn("--pdf", entry["project_manifest"]["projects"][0]["generate_command"])
 
         current_release_projects = [
             entry
@@ -930,7 +911,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(projects[0].generate_command, VBP_BUILD_OUTPUT_COMMAND)
 
     def test_resolve_projects_for_release_filters_to_matching_targets(self) -> None:
-        self.assert_resolved_projects_match_manifest("v4.31.0")
+        self.assert_resolved_projects_match_manifest("v4.32.0")
 
     def test_resolve_projects_for_default_release_uses_matching_targets(self) -> None:
         self.assert_resolved_projects_match_manifest(load_branch_policy(PACKAGE_ROOT).default_dev_branch)


### PR DESCRIPTION
This PR retires Lean 4.31 support from the v4.32 maintenance line and pins the public reference catalog to the final Lean 4.32 wrapper revisions.

- Remove v4.31 from branch policy, release targets, templates, and reference publication.
- Keep the shared slide-relation hydration fix while omitting the v4.33-only toolchain and manifest changes from #356.
- Add a machine-checked release-line retirement status so this policy transition does not require constructing an obsolete v4.31 backport.
- Build every retained reference through the supported `lake exe vbp build` catalog path; no v4.31 Blueprint is created or built.

This is the v4.32 maintenance companion to #356, whose v4.33 branch start uses the separate release-line bootstrap path.

Backport v4.31.0: release-line retirement