### PR TITLE
chore: bootstrap Lean 4.31 retirement policy

### DIFF
--- a/branch-policy.json
+++ b/branch-policy.json
@@ -1,9 +1,7 @@
 {
   "version": 2,
   "default_dev_branch": "v4.32.0",
-  "required_backport_branches": [
-    "v4.31.0"
-  ],
+  "required_backport_branches": [],
   "release_targets": [
     {
       "id": "v4.31.0",


### PR DESCRIPTION
This PR removes the v4.31 backport requirement from the v4.32 release line before the full v4.31 retirement backport lands.

- Stop requiring new v4.31 backports from v4.32 maintenance PRs.

Backport v4.31.0: exempt: branch-policy bootstrap retires this requirement