### PR TITLE
[backport v4.32.0] refactor: simplify reference cache ownership

### DIFF
--- a/.github/workflows/reference-blueprints-deploy.yml
+++ b/.github/workflows/reference-blueprints-deploy.yml
@@ -62,7 +62,7 @@ jobs:
           echo "branch=${{ matrix.branch }}"
           echo "project_id=${{ matrix.project_id }}"
           echo "hash=${{ matrix.hash }}"
-          echo "reference_cache_key=${{ matrix.reference_cache_key }}"
+          echo "reference_source_identity=${{ matrix.reference_source_identity }}"
           echo "publish_pdf=${{ matrix.publish_pdf }}"
       - name: Write deploy project manifest
         env:
@@ -90,7 +90,7 @@ jobs:
             --output _out/deploy-projects/${{ matrix.project_id }}.identity.json \
             --github-output >> "$GITHUB_OUTPUT"
       - name: Report disk usage before cache restore
-        run: ./scripts/report-ci-disk-usage.sh "before cache restore" --reference-cache-key "${{ matrix.reference_cache_key }}" --artifact-path "${{ matrix.artifact_path }}"
+        run: ./scripts/report-ci-disk-usage.sh "before cache restore" --reference-source-identity "${{ matrix.reference_source_identity }}" --artifact-path "${{ matrix.artifact_path }}"
       - name: Restore exact generated reference site
         id: generated-site-cache
         uses: actions/cache/restore@v5
@@ -140,20 +140,20 @@ jobs:
             ${{ runner.os }}-reference-deploy-lake-deps-
       - name: Report disk usage after Lake cache restore
         if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' }}
-        run: ./scripts/report-ci-disk-usage.sh "after Lake cache restore" --reference-cache-key "${{ matrix.reference_cache_key }}" --artifact-path "${{ matrix.artifact_path }}"
+        run: ./scripts/report-ci-disk-usage.sh "after Lake cache restore" --reference-source-identity "${{ matrix.reference_source_identity }}" --artifact-path "${{ matrix.artifact_path }}"
       - name: Restore external reference dependency cache
-        if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' && matrix.reference_cache_key != '' }}
+        if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' && matrix.reference_source_identity != '' }}
         uses: actions/cache@v5
         with:
           path: |
-            .worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/packages
-            .worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/path-builds
-          key: ${{ runner.os }}-reference-deploy-deps-v2-${{ matrix.reference_cache_key }}
+            .worktrees/_reference-blueprints/deps/${{ matrix.reference_source_identity }}/packages
+            .worktrees/_reference-blueprints/deps/${{ matrix.reference_source_identity }}/path-builds
+          key: ${{ runner.os }}-reference-deploy-deps-v2-${{ matrix.reference_source_identity }}
           restore-keys: |
             ${{ runner.os }}-reference-deploy-deps-v2-${{ matrix.project_id }}-
       - name: Report disk usage after reference cache restore
         if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' }}
-        run: ./scripts/report-ci-disk-usage.sh "after reference cache restore" --reference-cache-key "${{ matrix.reference_cache_key }}" --artifact-path "${{ matrix.artifact_path }}"
+        run: ./scripts/report-ci-disk-usage.sh "after reference cache restore" --reference-source-identity "${{ matrix.reference_source_identity }}" --artifact-path "${{ matrix.artifact_path }}"
       - name: Show tool versions
         if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' }}
         run: |
@@ -172,12 +172,11 @@ jobs:
             --project ${{ matrix.project_id }} \
             --allow-unsafe-root-release \
             --allow-local-build \
-            --reference-package-mode move \
             --serial \
             _out/reference-blueprints/${{ matrix.release_id }}
       - name: Report disk usage after reference generation
         if: ${{ always() }}
-        run: ./scripts/report-ci-disk-usage.sh "after reference generation" --reference-cache-key "${{ matrix.reference_cache_key }}" --artifact-path "${{ matrix.artifact_path }}"
+        run: ./scripts/report-ci-disk-usage.sh "after reference generation" --reference-source-identity "${{ matrix.reference_source_identity }}" --artifact-path "${{ matrix.artifact_path }}"
       - name: Install exact reference artifact identity
         if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' }}
         run: |

--- a/.github/workflows/reference-blueprints-deploy.yml
+++ b/.github/workflows/reference-blueprints-deploy.yml
@@ -146,8 +146,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            .worktrees/_reference-blueprints/deps/${{ matrix.reference_source_identity }}/packages
-            .worktrees/_reference-blueprints/deps/${{ matrix.reference_source_identity }}/path-builds
+            ${{ matrix.reference_dependency_packages_path }}
+            ${{ matrix.reference_dependency_path_builds_path }}
           key: ${{ runner.os }}-reference-deploy-deps-v2-${{ matrix.reference_source_identity }}
           restore-keys: |
             ${{ runner.os }}-reference-deploy-deps-v2-${{ matrix.project_id }}-

--- a/.github/workflows/reference-blueprints.yml
+++ b/.github/workflows/reference-blueprints.yml
@@ -95,8 +95,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            .worktrees/_reference-blueprints/deps/${{ matrix.reference_source_identity }}/packages
-            .worktrees/_reference-blueprints/deps/${{ matrix.reference_source_identity }}/path-builds
+            ${{ matrix.reference_dependency_packages_path }}
+            ${{ matrix.reference_dependency_path_builds_path }}
           key: ${{ runner.os }}-reference-deps-v2-${{ matrix.reference_source_identity }}
           restore-keys: |
             ${{ runner.os }}-reference-deps-v2-${{ matrix.project_id }}-

--- a/.github/workflows/reference-blueprints.yml
+++ b/.github/workflows/reference-blueprints.yml
@@ -48,12 +48,12 @@ jobs:
           echo "verso_ref=${{ matrix.verso_ref }}"
           echo "blueprint=${{ matrix.project_id }}"
           echo "hash=${{ matrix.hash }}"
-          echo "reference_cache_key=${{ matrix.reference_cache_key }}"
+          echo "reference_source_identity=${{ matrix.reference_source_identity }}"
       - name: Match reference target toolchain
         if: ${{ matrix.rc != '' }}
         run: printf 'leanprover/lean4:${{ matrix.toolchain }}\n' > lean-toolchain
       - name: Report disk usage before cache restore
-        run: ./scripts/report-ci-disk-usage.sh "before cache restore" --reference-cache-key "${{ matrix.reference_cache_key }}" --artifact-path "${{ matrix.artifact_path }}"
+        run: ./scripts/report-ci-disk-usage.sh "before cache restore" --reference-source-identity "${{ matrix.reference_source_identity }}" --artifact-path "${{ matrix.artifact_path }}"
       - name: Install elan
         run: |
           curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
@@ -89,19 +89,19 @@ jobs:
             ${{ runner.os }}-lake-deps-${{ matrix.toolchain }}-
             ${{ runner.os }}-lake-deps-
       - name: Report disk usage after Lake cache restore
-        run: ./scripts/report-ci-disk-usage.sh "after Lake cache restore" --reference-cache-key "${{ matrix.reference_cache_key }}" --artifact-path "${{ matrix.artifact_path }}"
+        run: ./scripts/report-ci-disk-usage.sh "after Lake cache restore" --reference-source-identity "${{ matrix.reference_source_identity }}" --artifact-path "${{ matrix.artifact_path }}"
       - name: Restore external reference dependency cache
-        if: ${{ matrix.reference_cache_key != '' }}
+        if: ${{ matrix.reference_source_identity != '' }}
         uses: actions/cache@v5
         with:
           path: |
-            .worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/packages
-            .worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/path-builds
-          key: ${{ runner.os }}-reference-deps-v2-${{ matrix.reference_cache_key }}
+            .worktrees/_reference-blueprints/deps/${{ matrix.reference_source_identity }}/packages
+            .worktrees/_reference-blueprints/deps/${{ matrix.reference_source_identity }}/path-builds
+          key: ${{ runner.os }}-reference-deps-v2-${{ matrix.reference_source_identity }}
           restore-keys: |
             ${{ runner.os }}-reference-deps-v2-${{ matrix.project_id }}-
       - name: Report disk usage after reference cache restore
-        run: ./scripts/report-ci-disk-usage.sh "after reference cache restore" --reference-cache-key "${{ matrix.reference_cache_key }}" --artifact-path "${{ matrix.artifact_path }}"
+        run: ./scripts/report-ci-disk-usage.sh "after reference cache restore" --reference-source-identity "${{ matrix.reference_source_identity }}" --artifact-path "${{ matrix.artifact_path }}"
       - name: Show tool versions
         run: |
           lean --version
@@ -109,10 +109,10 @@ jobs:
           lualatex --version | head -n 1
           python3 --version
       - name: Generate reference blueprint with PDF
-        run: ./scripts/generate-reference-blueprints.sh --allow-unsafe-root-release --reference-package-mode move --pdf --project ${{ matrix.project_id }}
+        run: ./scripts/generate-reference-blueprints.sh --allow-unsafe-root-release --pdf --project ${{ matrix.project_id }}
       - name: Report disk usage after reference generation
         if: ${{ always() }}
-        run: ./scripts/report-ci-disk-usage.sh "after reference generation" --reference-cache-key "${{ matrix.reference_cache_key }}" --artifact-path "${{ matrix.artifact_path }}"
+        run: ./scripts/report-ci-disk-usage.sh "after reference generation" --reference-source-identity "${{ matrix.reference_source_identity }}" --artifact-path "${{ matrix.artifact_path }}"
       - name: Upload reference blueprint artifact
         uses: actions/upload-artifact@v7
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,12 +196,14 @@
 - Default test-blueprint output in a linked worktree:
   - `_out/<worktree>/test-blueprints/{<slug>,preview_runtime_showcase,state-showcase}/`
 - Shared warmed source checkout cache for external git-checkout projects:
-  - `.worktrees/_reference-blueprints/cache/<source-ref-key>/`
+  - `.worktrees/_reference-blueprints/cache/<source-identity>/`
 - Shared warmed dependency cache for external git-checkout projects:
-  - `.worktrees/_reference-blueprints/deps/<source-ref-key>/packages/`
-  - `.worktrees/_reference-blueprints/deps/<source-ref-key>/path-builds/`
+  - `.worktrees/_reference-blueprints/deps/<source-identity>/packages/`
+  - `.worktrees/_reference-blueprints/deps/<source-identity>/path-builds/`
 - Current-checkout local reference blueprint clones for external git-checkout projects:
-  - `.worktrees/_reference-blueprints/by-worktree/<checkout>/<source-ref-key>/`
+  - `.worktrees/_reference-blueprints/by-worktree/<checkout>/<source-identity>/`
+- The canonical ownership rules for these paths live in
+  `doc/MAINTAINER_GUIDE.md#external-reference-cache-ownership`.
 
 ## Mathlib and Worktree Reuse
 

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -434,6 +434,38 @@ locations used by the harness.
 It also prints the shared reference checkout cache root, dependency package
 cache root, and the current checkout's local clone root.
 
+## External Reference Cache Ownership
+
+Every external git-checkout project has one `reference_source_identity`. Its
+readable prefix comes from the catalog project id, and its digest is derived
+from the repository URL, project root, and selected source ref. The identity
+intentionally does not include the current Verso Blueprint checkout or release
+label: all paths below represent the same pinned external source. The reference
+and deploy CI matrices serialize this same identity so local and CI cache
+layouts agree.
+
+| Role | Path | Ownership |
+| --- | --- | --- |
+| Disposable source checkout | `.worktrees/_reference-blueprints/cache/<source-identity>/` | Shared; refreshed by `sync` and safe to prune |
+| Warmed dependencies | `.worktrees/_reference-blueprints/deps/<source-identity>/{packages,path-builds}/` | Shared; remains resident while consumers are seeded |
+| Validation checkout | `.worktrees/_reference-blueprints/by-worktree/<checkout>/<source-identity>/` | Owned by one root checkout or linked worktree |
+| Generated site | `_out/.../reference-blueprints/<project-id>/` | Output artifact; never stored in a dependency cache |
+
+Dependency packages and path-dependency build trees are copied from the shared
+cache into each validation checkout. The harness never moves them or lends
+their ownership to a consumer. Consequently, multiple worktrees can seed from
+one warmed cache, and a failed or interrupted generation does not have to move
+packages back to make the cache usable again. Cache warm-up may refresh shared
+contents with `rsync`; this ownership rule does not yet provide transactional
+publication for simultaneous writers.
+
+After warm-up, the disposable source checkout's duplicate `.lake/packages/`
+tree is removed once it has been copied into the dependency cache. This deletes
+only the source checkout's copy, not the shared dependency cache. CI likewise
+keeps the shared dependency tree resident while a per-job checkout uses its own
+copy. The additional peak disk use is an intentional tradeoff for predictable
+ownership and failure behavior.
+
 ## Working from Linked Worktrees
 
 For implementation work, create a linked worktree under `.worktrees/` and keep
@@ -541,17 +573,9 @@ The harness is worktree-aware:
 - in a linked worktree it writes artifacts to `_out/<worktree>/...`
 - by default it prefers reusing the root checkout's prepared package `.lake`
   artifacts and binaries
-- it also keeps shared warmed reference dependency caches under
-  `.worktrees/_reference-blueprints/deps/<source-ref-key>/`, with downloaded
-  Lake packages under `packages/` and external path-dependency build trees under
-  `path-builds/`
-- those shared caches are keyed by external repository, project root, and
-  selected project ref; they preserve expensive pinned dependency state such as
-  Mathlib package builds, not generated Blueprint site artifacts
-- disposable source checkouts for those refs live separately under
-  `.worktrees/_reference-blueprints/cache/<source-ref-key>/`
-- each checkout uses its own local reference blueprint clones under
-  `.worktrees/_reference-blueprints/by-worktree/<checkout>/<source-ref-key>/`
+- external reference projects follow the shared-source and per-worktree
+  ownership model described in
+  [External Reference Cache Ownership](#external-reference-cache-ownership)
 - the reference CLI avoids local `lake build` and `lake test` in a linked
   worktree by default to avoid unnecessary dependency rebuilds
 
@@ -636,19 +660,8 @@ python3 -m scripts.blueprint_harness worktree-retire <name> --merged-pr <number>
 - the default validation catalog mixes in-repo projects with external reference
   blueprints; the larger published reference blueprints live in external
   repositories
-- the harness warms shared reference dependency caches under
-  `.worktrees/_reference-blueprints/deps/<source-ref-key>/`, including Lake
-  packages and `.lake/build` trees for external path dependencies such as
-  formalization submodules
-- the cache key is derived from the external repository URL, project root, and
-  selected project ref, so one project can keep separate caches for different
-  Lean/mathlib release pins
-- disposable source checkouts for those keyed refs live under
-  `.worktrees/_reference-blueprints/cache/<source-ref-key>/`
-- each checkout gets its own local clone under
-  `.worktrees/_reference-blueprints/by-worktree/<checkout>/<source-ref-key>/`,
-  seeded from the dependency cache so transitive package and path-dependency
-  build artifacts stay warm across worktrees
+- shared cache and validation-checkout paths obey
+  [External Reference Cache Ownership](#external-reference-cache-ownership)
 - editable reference-project clones live separately under
   `.worktrees/_reference-blueprints/edit/<checkout>/` and are not touched by
   `sync`, `generate`, or `prune`
@@ -726,12 +739,9 @@ pushes to release branches named like `v4.32.0`, and manual dispatch, it:
 - stages a branch-local site artifact under `_site/` only when the selected
   release target has `deploy_pages: true`
 - uploads that assembled site as a normal workflow artifact
-- generates external references from per-job local clones seeded by the keyed
-  dependency cache
-- restores and saves external reference dependency caches by the same
-  repository/project-root/ref key used locally, caching the external project's
-  `.lake/packages/` tree and `.lake/build` trees for external path dependencies
-  rather than the source checkout or generated Blueprint site's own output
+- generates external references from per-job local clones using the same
+  [source identity and ownership model](#external-reference-cache-ownership)
+  as local worktrees
 
 `reference-blueprints-deploy.yml` is the deployment workflow. It runs after a
 successful `reference-blueprints.yml` run on a release branch named like

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -436,13 +436,14 @@ cache root, and the current checkout's local clone root.
 
 ## External Reference Cache Ownership
 
-Every external git-checkout project has one `reference_source_identity`. Its
-readable prefix comes from the catalog project id, and its digest is derived
-from the repository URL, project root, and selected source ref. The identity
+Every selected external git-checkout project source has one
+`reference_source_identity`. Its readable prefix comes from the catalog project
+id, and its digest is derived from the repository URL, project root, and
+selected source ref. The identity
 intentionally does not include the current Verso Blueprint checkout or release
 label: all paths below represent the same pinned external source. The reference
-and deploy CI matrices serialize this same identity so local and CI cache
-layouts agree.
+and deploy CI matrices serialize this identity together with its canonical
+dependency paths so local and CI cache layouts agree.
 
 | Role | Path | Ownership |
 | --- | --- | --- |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -122,12 +122,13 @@ script map, not a second command reference.
   Project-manifest loader and schema checks for
   [`tests/harness/projects.json`](../tests/harness/projects.json), including
   branch-policy release-target inheritance, per-project RC resolution, shared
-  reference/deploy matrix serialization, and the external reference
-  dependency-cache key.
+  reference/deploy matrix serialization, and the external project's shared
+  source identity.
 - `blueprint_harness_references.py`
   Reference-blueprint checkout, editable-clone setup, local override,
-  dependency package/path-build cache warm-up, and prune helpers shared by the
-  reference CLI.
+  copy-owned dependency package/path-build cache warm-up, and prune helpers
+  shared by the reference CLI. The canonical path and ownership model is in
+  [the maintainer guide](../doc/MAINTAINER_GUIDE.md#external-reference-cache-ownership).
 - `blueprint_harness_utils.py`
   Shared process-launch helpers used by the harness modules.
 - `blueprint_harness_validation.py`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -122,8 +122,8 @@ script map, not a second command reference.
   Project-manifest loader and schema checks for
   [`tests/harness/projects.json`](../tests/harness/projects.json), including
   branch-policy release-target inheritance, per-project RC resolution, shared
-  reference/deploy matrix serialization, and the external project's shared
-  source identity.
+  reference/deploy matrix serialization, and each external project's shared
+  source identity and canonical CI dependency paths.
 - `blueprint_harness_references.py`
   Reference-blueprint checkout, editable-clone setup, local override,
   copy-owned dependency package/path-build cache warm-up, and prune helpers
@@ -135,7 +135,7 @@ script map, not a second command reference.
   Shared panel/browser regression command builders.
 - `blueprint_harness_paths.py`
   Worktree-aware path resolution for `_out/` and reference-blueprint
-  directories.
+  directories, including the shared relative roots consumed by CI matrices.
 - `blueprint_harness_worktrees.py`
   Local worktree-coordination helpers for ignored metadata under `.worktrees/`.
 - `prepare_reference_blueprints_pages.py`

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -51,8 +51,8 @@ from scripts.blueprint_harness_projects import (
     resolve_release_target,
 )
 from scripts.blueprint_harness_references import (
-    reference_dependency_cache_keys,
     reference_prune_plan,
+    reference_source_identities,
     sync_reference_blueprints,
 )
 from scripts.blueprint_harness_toolchains import bump_toolchain_checkout
@@ -1232,10 +1232,10 @@ def command_worktree_retire(args: argparse.Namespace) -> int:
         for candidate in git_worktrees(layout.repo_root)
         if candidate.name != name and candidate.path.exists()
     }
-    cache_keys = reference_dependency_cache_keys(projects)
+    source_identities = reference_source_identities(projects)
     removals = reference_prune_plan(
         active_names,
-        cache_keys,
+        source_identities,
         layout.reference_source_cache_root,
         layout.reference_project_root / "by-worktree",
         layout.reference_dependency_cache_root,

--- a/scripts/blueprint_harness_paths.py
+++ b/scripts/blueprint_harness_paths.py
@@ -6,6 +6,10 @@ from pathlib import Path
 from scripts.blueprint_harness_branches import root_checkout_namespace
 
 
+REFERENCE_PROJECT_RELATIVE_ROOT = Path(".worktrees") / "_reference-blueprints"
+REFERENCE_DEPENDENCY_CACHE_RELATIVE_ROOT = REFERENCE_PROJECT_RELATIVE_ROOT / "deps"
+
+
 @dataclass(frozen=True)
 class HarnessLayout:
     package_root: Path
@@ -27,7 +31,7 @@ class HarnessLayout:
 
     @property
     def reference_project_root(self) -> Path:
-        return self.repo_root / ".worktrees" / "_reference-blueprints"
+        return self.repo_root / REFERENCE_PROJECT_RELATIVE_ROOT
 
     @property
     def reference_source_cache_root(self) -> Path:

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -30,7 +30,7 @@ from scripts.blueprint_harness_manifest import (
 
 IN_REPO_PROJECT_SOURCE_KIND = "in_repo_project"
 GIT_CHECKOUT_SOURCE_KIND = "git_checkout"
-REFERENCE_CACHE_KEY_DIGEST_LENGTH = 12
+REFERENCE_SOURCE_IDENTITY_DIGEST_LENGTH = 12
 
 
 @dataclass(frozen=True)
@@ -96,12 +96,12 @@ class HarnessProject:
         return None
 
 
-def _reference_cache_key_slug(value: str, *, max_length: int) -> str:
+def _reference_source_identity_slug(value: str, *, max_length: int) -> str:
     slug = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip(".-_")
     return (slug or "unknown")[:max_length].strip(".-_") or "unknown"
 
 
-def _short_reference_cache_ref(ref: str) -> str:
+def _short_reference_source_ref(ref: str) -> str:
     if len(ref) == 40 and all(char in "0123456789abcdefABCDEF" for char in ref):
         return ref[:12]
     return ref
@@ -115,13 +115,15 @@ def selected_project_toolchain(project: HarnessProject) -> str:
     raise ValueError(f"project `{project.project_id}` has no selected release target")
 
 
-def reference_dependency_cache_key(project: HarnessProject) -> str:
-    """Key dependency cache state for one external project source ref.
+def reference_source_identity(project: HarnessProject) -> str:
+    """Identify one external project source checkout.
 
-    The key intentionally ignores the selected release and local package root:
-    the expensive state being reused is the external project's pinned Lake
-    dependency packages, not the generated Blueprint site or local checkout
-    build output.
+    The identity is shared by source checkouts, dependency caches, and local
+    worktree clones. Its readable prefix includes the catalog project id, while
+    its digest covers the repository, project root, and selected source ref. It
+    intentionally ignores the selected release and local package root.
+    Generated Blueprint sites have a separate identity and never use this value
+    as their cache key.
     """
     if not project.git_checkout:
         raise ValueError(f"project `{project.project_id}` is not an external git checkout project")
@@ -139,9 +141,9 @@ def reference_dependency_cache_key(project: HarnessProject) -> str:
         sort_keys=True,
         separators=(",", ":"),
     )
-    digest = hashlib.sha256(key_material.encode("utf-8")).hexdigest()[:REFERENCE_CACHE_KEY_DIGEST_LENGTH]
-    project_slug = _reference_cache_key_slug(project.project_id, max_length=48)
-    ref_slug = _reference_cache_key_slug(_short_reference_cache_ref(project.ref), max_length=40)
+    digest = hashlib.sha256(key_material.encode("utf-8")).hexdigest()[:REFERENCE_SOURCE_IDENTITY_DIGEST_LENGTH]
+    project_slug = _reference_source_identity_slug(project.project_id, max_length=48)
+    ref_slug = _reference_source_identity_slug(_short_reference_source_ref(project.ref), max_length=40)
     return f"{project_slug}-{ref_slug}-{digest}"
 
 
@@ -485,7 +487,7 @@ def reference_project_target_fields(
         "verso_ref": project_target_verso_ref(release_target, project),
         "project_root": project.project_root,
         "hash": project.ref,
-        "reference_cache_key": reference_dependency_cache_key(project) if project.git_checkout else "",
+        "reference_source_identity": reference_source_identity(project) if project.git_checkout else "",
     }
 
 
@@ -649,7 +651,7 @@ def deploy_matrix_from_controller_catalog(
                     "project_id": fields["project_id"],
                     "project_root": fields["project_root"],
                     "hash": fields["hash"],
-                    "reference_cache_key": fields["reference_cache_key"],
+                    "reference_source_identity": fields["reference_source_identity"],
                     "artifact_name": deploy_project_artifact_name(project),
                     "artifact_path": deploy_project_artifact_path(project),
                     "publish_pdf": publish_pdf,

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -26,6 +26,7 @@ from scripts.blueprint_harness_manifest import (
     require_string as _require_string,
     resolve_manifest_path as resolve_manifest_file_path,
 )
+from scripts.blueprint_harness_paths import REFERENCE_DEPENDENCY_CACHE_RELATIVE_ROOT
 
 
 IN_REPO_PROJECT_SOURCE_KIND = "in_repo_project"
@@ -101,7 +102,7 @@ def _reference_source_identity_slug(value: str, *, max_length: int) -> str:
     return (slug or "unknown")[:max_length].strip(".-_") or "unknown"
 
 
-def _short_reference_source_ref(ref: str) -> str:
+def short_git_ref(ref: str) -> str:
     if len(ref) == 40 and all(char in "0123456789abcdefABCDEF" for char in ref):
         return ref[:12]
     return ref
@@ -143,8 +144,13 @@ def reference_source_identity(project: HarnessProject) -> str:
     )
     digest = hashlib.sha256(key_material.encode("utf-8")).hexdigest()[:REFERENCE_SOURCE_IDENTITY_DIGEST_LENGTH]
     project_slug = _reference_source_identity_slug(project.project_id, max_length=48)
-    ref_slug = _reference_source_identity_slug(_short_reference_source_ref(project.ref), max_length=40)
+    ref_slug = _reference_source_identity_slug(short_git_ref(project.ref), max_length=40)
     return f"{project_slug}-{ref_slug}-{digest}"
+
+
+def reference_dependency_cache_paths(source_identity: str) -> tuple[str, str]:
+    root = REFERENCE_DEPENDENCY_CACHE_RELATIVE_ROOT / source_identity
+    return (root / "packages").as_posix(), (root / "path-builds").as_posix()
 
 
 def default_project_manifest(package_root: Path) -> Path:
@@ -480,6 +486,10 @@ def reference_project_target_fields(
     project: HarnessProject,
     release_target: HarnessReleaseTarget,
 ) -> dict[str, object]:
+    source_identity = reference_source_identity(project) if project.git_checkout else ""
+    dependency_packages_path, dependency_path_builds_path = (
+        reference_dependency_cache_paths(source_identity) if source_identity else ("", "")
+    )
     return {
         "project_id": project.project_id,
         "rc": project_target_rc(project),
@@ -487,7 +497,9 @@ def reference_project_target_fields(
         "verso_ref": project_target_verso_ref(release_target, project),
         "project_root": project.project_root,
         "hash": project.ref,
-        "reference_source_identity": reference_source_identity(project) if project.git_checkout else "",
+        "reference_source_identity": source_identity,
+        "reference_dependency_packages_path": dependency_packages_path,
+        "reference_dependency_path_builds_path": dependency_path_builds_path,
     }
 
 
@@ -652,6 +664,8 @@ def deploy_matrix_from_controller_catalog(
                     "project_root": fields["project_root"],
                     "hash": fields["hash"],
                     "reference_source_identity": fields["reference_source_identity"],
+                    "reference_dependency_packages_path": fields["reference_dependency_packages_path"],
+                    "reference_dependency_path_builds_path": fields["reference_dependency_path_builds_path"],
                     "artifact_name": deploy_project_artifact_name(project),
                     "artifact_path": deploy_project_artifact_path(project),
                     "publish_pdf": publish_pdf,

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -15,7 +15,7 @@ from scripts.blueprint_harness_releases import (
 from scripts.blueprint_harness_projects import (
     HarnessProject,
     command_with_pdf,
-    reference_dependency_cache_key,
+    reference_source_identity,
     selected_project_toolchain,
 )
 from scripts.blueprint_harness_project_commands import (
@@ -34,9 +34,6 @@ from scripts.blueprint_harness_utils import format_command, lean_low_priority_co
 
 
 COMMIT_HASH_PATTERN = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
-REFERENCE_PACKAGE_MODE_COPY = "copy"
-REFERENCE_PACKAGE_MODE_MOVE = "move"
-REFERENCE_PACKAGE_MODES = (REFERENCE_PACKAGE_MODE_COPY, REFERENCE_PACKAGE_MODE_MOVE)
 GITHUB_SUBMODULE_URL_REWRITE_ARGS = (
     "-c",
     "url.https://github.com/.insteadOf=git@github.com:",
@@ -83,6 +80,16 @@ class ReferenceToolchain:
     release_branch: str
 
 
+@dataclass(frozen=True)
+class ReferenceSourcePaths:
+    identity: str
+    source_checkout: Path
+    dependency_cache: Path
+    dependency_packages: Path
+    dependency_path_builds: Path
+    local_checkout: Path
+
+
 def output_dir_for(project: HarnessProject, output_root: Path) -> Path:
     return output_root / project.project_id
 
@@ -91,46 +98,39 @@ def site_dir_for(project: HarnessProject, output_root: Path) -> Path:
     return output_dir_for(project, output_root) / project.site_subdir
 
 
-def reference_source_cache_checkout_dir(layout, project: HarnessProject) -> Path:
-    return layout.reference_source_cache_root / reference_dependency_cache_key(project)
-
-
-def reference_dependency_cache_dir(layout, project: HarnessProject) -> Path:
-    return layout.reference_dependency_cache_root / reference_dependency_cache_key(project)
-
-
-def reference_dependency_packages_dir(layout, project: HarnessProject) -> Path:
-    return reference_dependency_cache_dir(layout, project) / "packages"
-
-
-def reference_dependency_path_builds_dir(layout, project: HarnessProject) -> Path:
-    return reference_dependency_cache_dir(layout, project) / "path-builds"
-
-
-def reference_local_checkout_dir(layout, project: HarnessProject) -> Path:
-    return layout.reference_project_checkout_root / reference_dependency_cache_key(project)
+def reference_source_paths(layout, project: HarnessProject) -> ReferenceSourcePaths:
+    identity = reference_source_identity(project)
+    dependency_cache = layout.reference_dependency_cache_root / identity
+    return ReferenceSourcePaths(
+        identity=identity,
+        source_checkout=layout.reference_source_cache_root / identity,
+        dependency_cache=dependency_cache,
+        dependency_packages=dependency_cache / "packages",
+        dependency_path_builds=dependency_cache / "path-builds",
+        local_checkout=layout.reference_project_checkout_root / identity,
+    )
 
 
 def reference_edit_checkout_dir(layout, project: HarnessProject) -> Path:
     return layout.reference_project_edit_root / project.project_id
 
 
-def reference_dependency_cache_keys(projects: tuple[HarnessProject, ...] | list[HarnessProject]) -> set[str]:
-    keys: set[str] = set()
+def reference_source_identities(projects: tuple[HarnessProject, ...] | list[HarnessProject]) -> set[str]:
+    identities: set[str] = set()
     for project in projects:
         if not project.git_checkout:
             continue
         if project.ref is not None:
-            keys.add(reference_dependency_cache_key(project))
+            identities.add(reference_source_identity(project))
         for target in project.targets:
             if target.ref is None:
                 continue
-            keys.add(
-                reference_dependency_cache_key(
+            identities.add(
+                reference_source_identity(
                     replace(project, ref=target.ref, selected_release=target.release)
                 )
             )
-    return keys
+    return identities
 
 
 def lake_packages_dir(project_dir: Path) -> Path:
@@ -199,34 +199,15 @@ def validate_external_reference_toolchain(
     return project_toolchain.lean_ref
 
 
-def validate_reference_package_mode(mode: str) -> str:
-    if mode not in REFERENCE_PACKAGE_MODES:
-        expected = ", ".join(REFERENCE_PACKAGE_MODES)
-        raise ValueError(f"unknown reference package mode `{mode}`; expected one of: {expected}")
-    return mode
-
-
 def seed_lake_packages_from_dependency_cache(
     layout,
     project: HarnessProject,
     project_dir: Path,
-    *,
-    package_mode: str = REFERENCE_PACKAGE_MODE_COPY,
 ) -> Path | None:
-    package_mode = validate_reference_package_mode(package_mode)
-    source_packages = reference_dependency_packages_dir(layout, project)
+    source_packages = reference_source_paths(layout, project).dependency_packages
     if not source_packages.exists():
         return None
     destination_packages = lake_packages_dir(project_dir)
-    if package_mode == REFERENCE_PACKAGE_MODE_MOVE:
-        discard_lake_packages(project_dir)
-        destination_packages.parent.mkdir(parents=True, exist_ok=True)
-        shutil.move(str(source_packages), str(destination_packages))
-        print(
-            "[blueprint-harness] moved reference dependency packages into "
-            f"{destination_packages}"
-        )
-        return source_packages
     destination_packages.mkdir(parents=True, exist_ok=True)
     run(["rsync", "-a", f"{source_packages}/", f"{destination_packages}/"], cwd=layout.package_root)
     return source_packages
@@ -236,27 +217,11 @@ def store_lake_packages_in_dependency_cache(
     layout,
     project: HarnessProject,
     project_dir: Path,
-    *,
-    package_mode: str = REFERENCE_PACKAGE_MODE_COPY,
 ) -> Path | None:
-    package_mode = validate_reference_package_mode(package_mode)
     source_packages = lake_packages_dir(project_dir)
     if not source_packages.exists():
         return None
-    destination_packages = reference_dependency_packages_dir(layout, project)
-    if package_mode == REFERENCE_PACKAGE_MODE_MOVE:
-        if destination_packages.exists() or destination_packages.is_symlink():
-            if destination_packages.is_symlink() or destination_packages.is_file():
-                destination_packages.unlink()
-            else:
-                shutil.rmtree(destination_packages)
-        destination_packages.parent.mkdir(parents=True, exist_ok=True)
-        shutil.move(str(source_packages), str(destination_packages))
-        print(
-            "[blueprint-harness] restored reference dependency packages to "
-            f"{destination_packages}"
-        )
-        return destination_packages
+    destination_packages = reference_source_paths(layout, project).dependency_packages
     destination_packages.mkdir(parents=True, exist_ok=True)
     run(["rsync", "-a", "--delete", f"{source_packages}/", f"{destination_packages}/"], cwd=layout.package_root)
     return destination_packages
@@ -312,7 +277,7 @@ def _relative_path_dependency_dirs(project_dir: Path, package_root: Path) -> lis
 
 
 def seed_lake_path_builds_from_dependency_cache(layout, project: HarnessProject, project_dir: Path) -> Path | None:
-    source_root = reference_dependency_path_builds_dir(layout, project)
+    source_root = reference_source_paths(layout, project).dependency_path_builds
     if not source_root.exists():
         return None
     copied = False
@@ -328,7 +293,7 @@ def seed_lake_path_builds_from_dependency_cache(layout, project: HarnessProject,
 
 
 def store_lake_path_builds_in_dependency_cache(layout, project: HarnessProject, project_dir: Path) -> Path | None:
-    destination_root = reference_dependency_path_builds_dir(layout, project)
+    destination_root = reference_source_paths(layout, project).dependency_path_builds
     copied = False
     for relative_dir in _relative_path_dependency_dirs(project_dir, layout.package_root):
         source_build = lake_build_dir(project_dir / relative_dir)
@@ -637,7 +602,8 @@ def seed_reference_edit_checkout_lake(layout, project: HarnessProject, edit_dir:
     if shutil.which("rsync") is None:
         return None
 
-    local_lake = reference_local_checkout_dir(layout, project) / project.project_root / ".lake"
+    paths = reference_source_paths(layout, project)
+    local_lake = paths.local_checkout / project.project_root / ".lake"
     if local_lake.exists():
         run(
             ["rsync", "-a", "--delete", f"{local_lake}/", f"{edit_dir / project.project_root / '.lake'}/"],
@@ -645,7 +611,7 @@ def seed_reference_edit_checkout_lake(layout, project: HarnessProject, edit_dir:
         )
         return local_lake
 
-    dependency_packages = reference_dependency_packages_dir(layout, project)
+    dependency_packages = paths.dependency_packages
     if dependency_packages.exists():
         edit_packages = edit_dir / project.project_root / ".lake" / "packages"
         edit_packages.mkdir(parents=True, exist_ok=True)
@@ -661,16 +627,13 @@ def seed_reference_edit_checkout_lake(layout, project: HarnessProject, edit_dir:
         )
         return dependency_packages
 
-    for source_dir in (
-        reference_source_cache_checkout_dir(layout, project),
-    ):
-        source_lake = source_dir / project.project_root / ".lake"
-        if source_lake.exists():
-            run(
-                ["rsync", "-a", "--delete", f"{source_lake}/", f"{edit_dir / project.project_root / '.lake'}/"],
-                cwd=layout.package_root,
-            )
-            return source_lake
+    source_lake = paths.source_checkout / project.project_root / ".lake"
+    if source_lake.exists():
+        run(
+            ["rsync", "-a", "--delete", f"{source_lake}/", f"{edit_dir / project.project_root / '.lake'}/"],
+            cwd=layout.package_root,
+        )
+        return source_lake
     return None
 
 
@@ -786,17 +749,15 @@ def reference_cache_warm_build_failure_message(
     command: list[str],
     err: subprocess.CalledProcessError,
 ) -> str:
-    cache_key = reference_dependency_cache_key(project)
-    source_cache = reference_source_cache_checkout_dir(layout, project)
-    dependency_cache = reference_dependency_packages_dir(layout, project)
+    paths = reference_source_paths(layout, project)
     return "\n".join(
         [
             (
                 f"[blueprint-harness] failed to warm reference cache for `{project.project_id}` "
-                f"({cache_key}); command exited with code {err.returncode}: {format_command(command)}"
+                f"({paths.identity}); command exited with code {err.returncode}: {format_command(command)}"
             ),
-            f"[blueprint-harness] source cache: {source_cache}",
-            f"[blueprint-harness] dependency package cache: {dependency_cache}",
+            f"[blueprint-harness] source cache: {paths.source_checkout}",
+            f"[blueprint-harness] dependency package cache: {paths.dependency_packages}",
             (
                 "[blueprint-harness] stale or cross-toolchain Lake build artifacts in the shared "
                 "reference cache can cause incompatible `.olean` header errors."
@@ -819,10 +780,8 @@ def sync_reference_cache_checkout(
     project: HarnessProject,
     *,
     warm_build: bool,
-    package_mode: str = REFERENCE_PACKAGE_MODE_COPY,
 ) -> Path:
-    package_mode = validate_reference_package_mode(package_mode)
-    cache_dir = reference_source_cache_checkout_dir(layout, project)
+    cache_dir = reference_source_paths(layout, project).source_checkout
     cache_dir.parent.mkdir(parents=True, exist_ok=True)
     if not cache_dir.exists():
         clone_git_project(project, cache_dir, cwd=layout.package_root)
@@ -834,35 +793,27 @@ def sync_reference_cache_checkout(
     project_dir = cache_dir / project.project_root
     discard_untracked_project_manifest(project_dir)
     bootstrap_reference_checkout(project_dir=project_dir)
-    borrowed_packages = (
-        seed_lake_packages_from_dependency_cache(layout, project, project_dir, package_mode=package_mode) is not None
-        and package_mode == REFERENCE_PACKAGE_MODE_MOVE
-    )
+    seed_lake_packages_from_dependency_cache(layout, project, project_dir)
     seed_lake_path_builds_from_dependency_cache(layout, project, project_dir)
-    try:
-        with local_blueprint_dependency_override(layout.package_root, project_dir, restore_lakefile=True):
-            run_external_reference_lake_update(
-                layout.package_root,
-                project_dir,
-                expected_project_toolchain=selected_project_toolchain(project),
-            )
-            seed_lake_path_builds_from_dependency_cache(layout, project, project_dir)
-            if warm_build and project.build_command is not None:
-                command = lean_low_priority_command(layout.package_root, *project.build_command)
-                try:
-                    run_with_heartbeat(command, cwd=project_dir, label=f"{project.project_id}: warm cache build")
-                except subprocess.CalledProcessError as err:
-                    raise SystemExit(reference_cache_warm_build_failure_message(layout, project, command, err)) from err
-            store_lake_path_builds_in_dependency_cache(layout, project, project_dir)
-            if store_lake_packages_in_dependency_cache(layout, project, project_dir, package_mode=package_mode) is not None:
-                # The dependency cache is now the source of truth. Drop the warmed
-                # cache checkout copy so large external projects do not keep two
-                # Mathlib package trees before the local checkout is prepared.
-                discard_lake_packages(project_dir)
-            borrowed_packages = False
-    finally:
-        if borrowed_packages:
-            store_lake_packages_in_dependency_cache(layout, project, project_dir, package_mode=package_mode)
+    with local_blueprint_dependency_override(layout.package_root, project_dir, restore_lakefile=True):
+        run_external_reference_lake_update(
+            layout.package_root,
+            project_dir,
+            expected_project_toolchain=selected_project_toolchain(project),
+        )
+        seed_lake_path_builds_from_dependency_cache(layout, project, project_dir)
+        if warm_build and project.build_command is not None:
+            command = lean_low_priority_command(layout.package_root, *project.build_command)
+            try:
+                run_with_heartbeat(command, cwd=project_dir, label=f"{project.project_id}: warm cache build")
+            except subprocess.CalledProcessError as err:
+                raise SystemExit(reference_cache_warm_build_failure_message(layout, project, command, err)) from err
+        store_lake_path_builds_in_dependency_cache(layout, project, project_dir)
+        if store_lake_packages_in_dependency_cache(layout, project, project_dir) is not None:
+            # The dependency cache is now the source of truth. Drop the warmed
+            # source-checkout copy so large external projects do not keep two
+            # Mathlib package trees before the local checkout is prepared.
+            discard_lake_packages(project_dir)
     return cache_dir
 
 
@@ -870,11 +821,9 @@ def sync_reference_local_checkout(
     layout,
     project: HarnessProject,
     cache_dir: Path,
-    *,
-    package_mode: str = REFERENCE_PACKAGE_MODE_COPY,
 ) -> Path:
-    package_mode = validate_reference_package_mode(package_mode)
-    local_dir = reference_local_checkout_dir(layout, project)
+    paths = reference_source_paths(layout, project)
+    local_dir = paths.local_checkout
     local_dir.parent.mkdir(parents=True, exist_ok=True)
     if not local_dir.exists():
         clone_git_project(project, local_dir, cwd=layout.package_root, source=str(cache_dir))
@@ -882,28 +831,19 @@ def sync_reference_local_checkout(
         update_git_checkout(project, local_dir)
     bootstrap_reference_checkout(project_dir=local_dir / project.project_root)
 
-    dependency_packages = reference_dependency_packages_dir(layout, project)
+    dependency_packages = paths.dependency_packages
     if dependency_packages.exists():
         local_packages = local_dir / project.project_root / ".lake" / "packages"
-        if package_mode == REFERENCE_PACKAGE_MODE_MOVE:
-            discard_lake_packages(local_dir / project.project_root)
-            local_packages.parent.mkdir(parents=True, exist_ok=True)
-            shutil.move(str(dependency_packages), str(local_packages))
-            print(
-                "[blueprint-harness] moved reference dependency packages into "
-                f"{local_packages}"
-            )
-        else:
-            local_packages.mkdir(parents=True, exist_ok=True)
-            run(
-                [
-                    "rsync",
-                    "-a",
-                    f"{dependency_packages}/",
-                    f"{local_packages}/",
-                ],
-                cwd=layout.package_root,
-            )
+        local_packages.mkdir(parents=True, exist_ok=True)
+        run(
+            [
+                "rsync",
+                "-a",
+                f"{dependency_packages}/",
+                f"{local_packages}/",
+            ],
+            cwd=layout.package_root,
+        )
     else:
         cache_lake = cache_dir / project.project_root / ".lake"
         if not cache_lake.exists():
@@ -975,54 +915,48 @@ def generate_git_project(
     project: HarnessProject,
     *,
     skip_build: bool,
-    package_mode: str = REFERENCE_PACKAGE_MODE_COPY,
     pdf: bool = False,
     verbose: bool = False,
 ) -> None:
-    package_mode = validate_reference_package_mode(package_mode)
     rebuild_and_log_embedded_asset_owners(layout.package_root)
-    cache_dir = sync_reference_cache_checkout(layout, project, warm_build=False, package_mode=package_mode)
-    checkout_root = sync_reference_local_checkout(layout, project, cache_dir, package_mode=package_mode)
+    cache_dir = sync_reference_cache_checkout(layout, project, warm_build=False)
+    checkout_root = sync_reference_local_checkout(layout, project, cache_dir)
     project_dir = checkout_root / project.project_root
-    borrowed_packages = package_mode == REFERENCE_PACKAGE_MODE_MOVE and lake_packages_dir(project_dir).exists()
-    try:
-        discard_untracked_project_manifest(project_dir)
-        output_dir = output_dir_for(project, output_root)
-        output_dir.mkdir(parents=True, exist_ok=True)
-        bootstrap_reference_checkout(project_dir=project_dir)
-        def update_reference_project() -> None:
-            run_external_reference_lake_update(
-                layout.package_root,
-                project_dir,
-                expected_project_toolchain=selected_project_toolchain(project),
-            )
-            seed_lake_path_builds_from_dependency_cache(layout, project, project_dir)
+    discard_untracked_project_manifest(project_dir)
+    output_dir = output_dir_for(project, output_root)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    bootstrap_reference_checkout(project_dir=project_dir)
 
-        with local_blueprint_dependency_override(layout.package_root, project_dir, restore_lakefile=False, log=True):
-            generate_command = reference_generation_command(project.generate_command or (), pdf=pdf, verbose=verbose)
-            run_project_update_build_generate(
-                layout.package_root,
-                project_dir,
-                update_project=update_reference_project,
-                build_command=project.build_command,
-                generate_command=generate_command,
-                format_command=lambda command: format_project_command(
-                    command,
-                    reference_command_placeholders(
-                        project,
-                        package_root=layout.package_root,
-                        checkout_root=checkout_root,
-                        project_dir=project_dir,
-                        output_dir=output_dir,
-                    ),
+    def update_reference_project() -> None:
+        run_external_reference_lake_update(
+            layout.package_root,
+            project_dir,
+            expected_project_toolchain=selected_project_toolchain(project),
+        )
+        seed_lake_path_builds_from_dependency_cache(layout, project, project_dir)
+
+    with local_blueprint_dependency_override(layout.package_root, project_dir, restore_lakefile=False, log=True):
+        generate_command = reference_generation_command(project.generate_command or (), pdf=pdf, verbose=verbose)
+        run_project_update_build_generate(
+            layout.package_root,
+            project_dir,
+            update_project=update_reference_project,
+            build_command=project.build_command,
+            generate_command=generate_command,
+            format_command=lambda command: format_project_command(
+                command,
+                reference_command_placeholders(
+                    project,
+                    package_root=layout.package_root,
+                    checkout_root=checkout_root,
+                    project_dir=project_dir,
+                    output_dir=output_dir,
                 ),
-                skip_build=skip_build,
-                project_id=project.project_id,
-            )
-            store_lake_path_builds_in_dependency_cache(layout, project, project_dir)
-    finally:
-        if borrowed_packages:
-            store_lake_packages_in_dependency_cache(layout, project, project_dir, package_mode=package_mode)
+            ),
+            skip_build=skip_build,
+            project_id=project.project_id,
+        )
+        store_lake_path_builds_in_dependency_cache(layout, project, project_dir)
 
 
 def sync_reference_blueprints(
@@ -1031,24 +965,22 @@ def sync_reference_blueprints(
     *,
     warm_build: bool,
     prepare_local_checkout: bool,
-    package_mode: str = REFERENCE_PACKAGE_MODE_COPY,
 ) -> None:
-    package_mode = validate_reference_package_mode(package_mode)
     git_projects = [project for project in projects if project.git_checkout]
     if not git_projects:
         return
     if shutil.which("rsync") is None:
         raise SystemExit("[blueprint-harness] `rsync` is required for reference dependency cache sync.")
     for project in git_projects:
-        cache_dir = sync_reference_cache_checkout(layout, project, warm_build=warm_build, package_mode=package_mode)
+        cache_dir = sync_reference_cache_checkout(layout, project, warm_build=warm_build)
         if prepare_local_checkout:
-            local_dir = sync_reference_local_checkout(layout, project, cache_dir, package_mode=package_mode)
+            local_dir = sync_reference_local_checkout(layout, project, cache_dir)
             print(f"[blueprint-harness] prepared local reference checkout: {local_dir}")
 
 
 def reference_prune_plan(
     active_worktree_names: set[str],
-    active_cache_keys: set[str],
+    active_source_identities: set[str],
     cache_root: Path,
     checkout_root: Path,
     dependency_cache_root: Path | None = None,
@@ -1056,11 +988,11 @@ def reference_prune_plan(
     removals: list[Path] = []
     if cache_root.exists():
         for path in sorted(child for child in cache_root.iterdir() if child.is_dir()):
-            if path.name not in active_cache_keys:
+            if path.name not in active_source_identities:
                 removals.append(path)
     if dependency_cache_root is not None and dependency_cache_root.exists():
         for path in sorted(child for child in dependency_cache_root.iterdir() if child.is_dir()):
-            if path.name not in active_cache_keys:
+            if path.name not in active_source_identities:
                 removals.append(path)
     if checkout_root.exists():
         for namespace_dir in sorted(child for child in checkout_root.iterdir() if child.is_dir()):
@@ -1068,6 +1000,6 @@ def reference_prune_plan(
                 removals.append(namespace_dir)
                 continue
             for project_dir in sorted(child for child in namespace_dir.iterdir() if child.is_dir()):
-                if project_dir.name not in active_cache_keys:
+                if project_dir.name not in active_source_identities:
                     removals.append(project_dir)
     return removals

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -17,6 +17,7 @@ from scripts.blueprint_harness_projects import (
     command_with_pdf,
     reference_source_identity,
     selected_project_toolchain,
+    short_git_ref,
 )
 from scripts.blueprint_harness_project_commands import (
     discard_untracked_project_manifest,
@@ -84,7 +85,6 @@ class ReferenceToolchain:
 class ReferenceSourcePaths:
     identity: str
     source_checkout: Path
-    dependency_cache: Path
     dependency_packages: Path
     dependency_path_builds: Path
     local_checkout: Path
@@ -104,7 +104,6 @@ def reference_source_paths(layout, project: HarnessProject) -> ReferenceSourcePa
     return ReferenceSourcePaths(
         identity=identity,
         source_checkout=layout.reference_source_cache_root / identity,
-        dependency_cache=dependency_cache,
         dependency_packages=dependency_cache / "packages",
         dependency_path_builds=dependency_cache / "path-builds",
         local_checkout=layout.reference_project_checkout_root / identity,
@@ -226,6 +225,7 @@ def store_lake_packages_in_dependency_cache(
     run(["rsync", "-a", "--delete", f"{source_packages}/", f"{destination_packages}/"], cwd=layout.package_root)
     return destination_packages
 
+
 def discard_lake_packages(project_dir: Path) -> Path | None:
     packages = lake_packages_dir(project_dir)
     if not packages.exists() and not packages.is_symlink():
@@ -304,10 +304,6 @@ def store_lake_path_builds_in_dependency_cache(layout, project: HarnessProject, 
         run(["rsync", "-a", "--delete", f"{source_build}/", f"{destination_build}/"], cwd=layout.package_root)
         copied = True
     return destination_root if copied else None
-
-
-def short_git_ref(ref: str) -> str:
-    return ref[:12] if COMMIT_HASH_PATTERN.fullmatch(ref) is not None else ref
 
 
 def default_reference_bump_branch(ref: str) -> str:
@@ -842,20 +838,6 @@ def sync_reference_local_checkout(
                 f"{dependency_packages}/",
                 f"{local_packages}/",
             ],
-            cwd=layout.package_root,
-        )
-    else:
-        cache_lake = cache_dir / project.project_root / ".lake"
-        if not cache_lake.exists():
-            return local_dir
-        # Fallback for caches produced before the dedicated dependency-package
-        # cache existed: seed dependency state from the shared checkout, but
-        # preserve the worktree-local project's own build products. Those
-        # artifacts are produced after rewriting the reference project to depend
-        # on the local VersoBlueprint checkout, so deleting them defeats the
-        # local cache.
-        run(
-            ["rsync", "-a", "--exclude", "/build/", f"{cache_lake}/", f"{local_dir / project.project_root / '.lake'}/"],
             cwd=layout.package_root,
         )
     seed_lake_path_builds_from_dependency_cache(layout, project, local_dir / project.project_root)

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -46,8 +46,6 @@ from scripts.blueprint_harness_projects import (
 )
 from scripts.blueprint_harness_project_commands import OFFICIAL_BLUEPRINT_URL_PATTERNS
 from scripts.blueprint_harness_references import (
-    REFERENCE_PACKAGE_MODE_COPY,
-    REFERENCE_PACKAGE_MODES,
     bump_reference_project,
     clone_git_project,
     generate_in_repo_command_project,
@@ -56,9 +54,9 @@ from scripts.blueprint_harness_references import (
     prepare_reference_edit_checkout,
     reference_generation_command,
     ref_is_commit_hash,
-    reference_dependency_cache_keys,
     reference_prune_plan,
-    reference_source_cache_checkout_dir,
+    reference_source_identities,
+    reference_source_paths,
     site_dir_for,
     sync_reference_blueprints,
 )
@@ -114,18 +112,6 @@ BLUEPRINT_REQUIRE_PATTERN = re.compile(
     re.MULTILINE | re.DOTALL,
 )
 REFERENCE_HARNESS_PREFIX = "[blueprint-reference-harness]"
-
-
-def add_reference_package_mode_argument(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument(
-        "--reference-package-mode",
-        choices=REFERENCE_PACKAGE_MODES,
-        default=REFERENCE_PACKAGE_MODE_COPY,
-        help=(
-            "How external reference projects receive warmed `.lake/packages` trees. "
-            "`copy` keeps the local default; `move` avoids duplicate package trees and is intended for CI."
-        ),
-    )
 
 
 def add_generation_verbose_argument(parser: argparse.ArgumentParser) -> None:
@@ -254,7 +240,7 @@ def refresh_reference_status_checkout(checkout_root: Path, project: HarnessProje
 
 
 def ensure_reference_status_checkout(layout, project: HarnessProject) -> Path:
-    checkout_root = reference_source_cache_checkout_dir(layout, project)
+    checkout_root = reference_source_paths(layout, project).source_checkout
     checkout_root.parent.mkdir(parents=True, exist_ok=True)
     if not checkout_root.exists():
         clone_git_project(project, checkout_root, cwd=layout.package_root, shallow=False)
@@ -698,7 +684,6 @@ def generate_projects(
     skip_build: bool,
     serial: bool,
     allow_local_build: bool,
-    reference_package_mode: str = REFERENCE_PACKAGE_MODE_COPY,
     pdf: bool = False,
     verbose: bool = False,
 ) -> None:
@@ -751,7 +736,6 @@ def generate_projects(
             output_root,
             project,
             skip_build=skip_build,
-            package_mode=reference_package_mode,
             pdf=pdf,
             verbose=verbose,
         )
@@ -771,7 +755,6 @@ def command_generate(args: argparse.Namespace) -> int:
         skip_build=args.skip_build,
         serial=args.serial,
         allow_local_build=args.allow_local_build,
-        reference_package_mode=getattr(args, "reference_package_mode", REFERENCE_PACKAGE_MODE_COPY),
         pdf=args.pdf,
         verbose=getattr(args, "verbose", False),
     )
@@ -860,7 +843,6 @@ def command_validate(args: argparse.Namespace) -> int:
             skip_build=False,
             serial=args.serial,
             allow_local_build=args.allow_local_build,
-            reference_package_mode=getattr(args, "reference_package_mode", REFERENCE_PACKAGE_MODE_COPY),
             verbose=getattr(args, "verbose", False),
         )
     except SystemExit as err:
@@ -1096,10 +1078,10 @@ def command_reference_prune(args: argparse.Namespace) -> int:
         root_checkout_namespace(layout.repo_root) if worktree.root_checkout else worktree.name
         for worktree in git_worktrees(layout.repo_root)
     }
-    cache_keys = reference_dependency_cache_keys(projects)
+    source_identities = reference_source_identities(projects)
     removals = reference_prune_plan(
         active_names,
-        cache_keys,
+        source_identities,
         layout.reference_source_cache_root,
         layout.reference_project_root / "by-worktree",
         layout.reference_dependency_cache_root,
@@ -1184,7 +1166,6 @@ def add_generation_commands(subparsers) -> None:
         generate,
         help_text="Permit `lake build` in a linked worktree instead of requiring synced root executables.",
     )
-    add_reference_package_mode_argument(generate)
     generate.set_defaults(func=command_generate)
 
     validate = subparsers.add_parser(
@@ -1228,7 +1209,6 @@ def add_generation_commands(subparsers) -> None:
         action="store_true",
         help="Stop validation as soon as one phase fails instead of collecting later failures.",
     )
-    add_reference_package_mode_argument(validate)
     validate.set_defaults(func=command_validate)
 
 

--- a/scripts/report-ci-disk-usage.sh
+++ b/scripts/report-ci-disk-usage.sh
@@ -9,14 +9,15 @@ Usage: scripts/report-ci-disk-usage.sh LABEL [options]
 Print a compact disk-usage report for CI reference blueprint jobs.
 
 Options:
-  --reference-cache-key KEY   Include per-reference cache paths for KEY.
+  --reference-source-identity ID
+                              Include per-reference paths for the source ID.
   --artifact-path PATH        Include the generated artifact path.
   -h, --help                  Show this help.
 EOF
 }
 
 label=""
-reference_cache_key=""
+reference_source_identity=""
 artifact_path=""
 
 while [[ $# -gt 0 ]]; do
@@ -25,12 +26,12 @@ while [[ $# -gt 0 ]]; do
       usage
       exit 0
       ;;
-    --reference-cache-key)
+    --reference-source-identity)
       if [[ $# -lt 2 ]]; then
-        echo "missing value for --reference-cache-key" >&2
+        echo "missing value for --reference-source-identity" >&2
         exit 2
       fi
-      reference_cache_key="$2"
+      reference_source_identity="$2"
       shift 2
       ;;
     --artifact-path)
@@ -107,15 +108,15 @@ report_du() {
     "_out/reference-blueprints"
   )
 
-  if [[ -n "$reference_cache_key" ]]; then
+  if [[ -n "$reference_source_identity" ]]; then
     paths+=(
-      ".worktrees/_reference-blueprints/cache/$reference_cache_key"
-      ".worktrees/_reference-blueprints/deps/$reference_cache_key"
-      ".worktrees/_reference-blueprints/deps/$reference_cache_key/packages"
+      ".worktrees/_reference-blueprints/cache/$reference_source_identity"
+      ".worktrees/_reference-blueprints/deps/$reference_source_identity"
+      ".worktrees/_reference-blueprints/deps/$reference_source_identity/packages"
     )
 
     shopt -s nullglob
-    local local_checkouts=(.worktrees/_reference-blueprints/by-worktree/*/"$reference_cache_key")
+    local local_checkouts=(.worktrees/_reference-blueprints/by-worktree/*/"$reference_source_identity")
     shopt -u nullglob
     paths+=("${local_checkouts[@]}")
   fi
@@ -141,10 +142,10 @@ report_reference_children() {
     du -sh "$root"/* 2>/dev/null | sort -h || true
   fi
 
-  if [[ -n "$reference_cache_key" ]]; then
-    local packages=".worktrees/_reference-blueprints/deps/$reference_cache_key/packages"
+  if [[ -n "$reference_source_identity" ]]; then
+    local packages=".worktrees/_reference-blueprints/deps/$reference_source_identity/packages"
     if [[ -d "$packages" ]]; then
-      printf '[ci-disk] packages for %s\n' "$reference_cache_key"
+      printf '[ci-disk] packages for %s\n' "$reference_source_identity"
       du -sh "$packages"/* 2>/dev/null | sort -h || true
     fi
   fi
@@ -152,8 +153,8 @@ report_reference_children() {
 
 begin_group "Disk usage: $label"
 printf '[ci-disk] label=%s\n' "$label"
-if [[ -n "$reference_cache_key" ]]; then
-  printf '[ci-disk] reference_cache_key=%s\n' "$reference_cache_key"
+if [[ -n "$reference_source_identity" ]]; then
+  printf '[ci-disk] reference_source_identity=%s\n' "$reference_source_identity"
 fi
 if [[ -n "$artifact_path" ]]; then
   printf '[ci-disk] artifact_path=%s\n' "$artifact_path"

--- a/scripts/report-ci-disk-usage.sh
+++ b/scripts/report-ci-disk-usage.sh
@@ -113,6 +113,7 @@ report_du() {
       ".worktrees/_reference-blueprints/cache/$reference_source_identity"
       ".worktrees/_reference-blueprints/deps/$reference_source_identity"
       ".worktrees/_reference-blueprints/deps/$reference_source_identity/packages"
+      ".worktrees/_reference-blueprints/deps/$reference_source_identity/path-builds"
     )
 
     shopt -s nullglob
@@ -147,6 +148,11 @@ report_reference_children() {
     if [[ -d "$packages" ]]; then
       printf '[ci-disk] packages for %s\n' "$reference_source_identity"
       du -sh "$packages"/* 2>/dev/null | sort -h || true
+    fi
+    local path_builds=".worktrees/_reference-blueprints/deps/$reference_source_identity/path-builds"
+    if [[ -d "$path_builds" ]]; then
+      printf '[ci-disk] path builds for %s\n' "$reference_source_identity"
+      du -sh "$path_builds"/* 2>/dev/null | sort -h || true
     fi
   fi
 }

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -173,12 +173,6 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertTrue(args.allow_unsafe_root_release)
         self.assertEqual(args.release, "v4.29.0")
 
-    def test_reference_commands_parse_package_mode(self) -> None:
-        parser = reference_harness_mod.build_parser()
-        self.assertEqual(parser.parse_args(["generate"]).reference_package_mode, "copy")
-        self.assertEqual(parser.parse_args(["generate", "--reference-package-mode", "move"]).reference_package_mode, "move")
-        self.assertEqual(parser.parse_args(["validate", "--reference-package-mode", "move"]).reference_package_mode, "move")
-
     def test_reference_generate_parses_pdf(self) -> None:
         parser = reference_harness_mod.build_parser()
         self.assertFalse(parser.parse_args(["generate"]).pdf)
@@ -2347,7 +2341,6 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 skip_build=False,
                 serial=False,
                 allow_local_build=False,
-                reference_package_mode="copy",
             )
 
     def test_validate_run_lean_tests_does_not_auto_sync_root_lake(self) -> None:

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 import json
 from pathlib import Path
 import subprocess
@@ -52,6 +53,26 @@ PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 VBP_BUILD_COMMAND = ("lake", "exe", "vbp", "build")
 VBP_BUILD_OUTPUT_COMMAND = (*VBP_BUILD_COMMAND, "--output", "{output_dir}")
 VBP_BUILD_PDF_COMMAND = (*VBP_BUILD_COMMAND, "--pdf")
+
+DEFAULT_EXTERNAL_PROJECT = HarnessProject(
+    project_id="external-blueprint",
+    source_kind="git_checkout",
+    project_root="nested/blueprint",
+    build_target=None,
+    generator=None,
+    repository="https://github.com/example/external-blueprint.git",
+    ref="main",
+    build_command=("lake", "build"),
+    generate_command=VBP_BUILD_COMMAND,
+    site_subdir="html-multi",
+    panel_regression_script=None,
+    browser_tests_path=None,
+    description=None,
+)
+
+
+def external_project(**changes) -> HarnessProject:
+    return replace(DEFAULT_EXTERNAL_PROJECT, **changes)
 
 
 def load_project_catalog_text(text: str, manifest_path: Path | str):
@@ -226,53 +247,14 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 load_project_catalog(manifest)
 
     def test_reference_source_identity_tracks_external_source(self) -> None:
-        base_project = HarnessProject(
-            project_id="external-blueprint",
-            source_kind="git_checkout",
-            project_root="nested/blueprint",
-            build_target=None,
-            generator=None,
-            repository="https://github.com/example/external-blueprint.git",
+        base_project = external_project(
             ref="0123456789abcdef0123456789abcdef01234567",
-            build_command=("lake", "build"),
-            generate_command=VBP_BUILD_COMMAND,
-            site_subdir="html-multi",
-            panel_regression_script=None,
-            browser_tests_path=None,
-            description=None,
             selected_release="v4.29.0",
         )
-        same_source_other_release = HarnessProject(
-            project_id="external-blueprint",
-            source_kind="git_checkout",
-            project_root="nested/blueprint",
-            build_target=None,
-            generator=None,
-            repository="https://github.com/example/external-blueprint.git",
-            ref="0123456789abcdef0123456789abcdef01234567",
-            build_command=("lake", "build"),
-            generate_command=VBP_BUILD_COMMAND,
-            site_subdir="html-multi",
-            panel_regression_script=None,
-            browser_tests_path=None,
-            description=None,
-            selected_release="v4.30.0",
-        )
-        changed_ref = HarnessProject(
-            project_id="external-blueprint",
-            source_kind="git_checkout",
-            project_root="nested/blueprint",
-            build_target=None,
-            generator=None,
-            repository="https://github.com/example/external-blueprint.git",
+        same_source_other_release = replace(base_project, selected_release="v4.30.0")
+        changed_ref = replace(
+            base_project,
             ref="fedcba9876543210fedcba9876543210fedcba98",
-            build_command=("lake", "build"),
-            generate_command=VBP_BUILD_COMMAND,
-            site_subdir="html-multi",
-            panel_regression_script=None,
-            browser_tests_path=None,
-            description=None,
-            selected_release="v4.29.0",
         )
 
         identity = reference_source_identity(base_project)
@@ -281,24 +263,8 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(identity, reference_source_identity(same_source_other_release))
         self.assertNotEqual(identity, reference_source_identity(changed_ref))
 
-    def test_reference_dependency_packages_seed_two_checkouts_without_transferring_ownership(self) -> None:
-        import scripts.blueprint_harness_references as refs_mod
-
-        project = HarnessProject(
-            project_id="external-blueprint",
-            source_kind="git_checkout",
-            project_root="nested/blueprint",
-            build_target=None,
-            generator=None,
-            repository="https://github.com/example/external-blueprint.git",
-            ref="main",
-            build_command=("lake", "build"),
-            generate_command=VBP_BUILD_COMMAND,
-            site_subdir="html-multi",
-            panel_regression_script=None,
-            browser_tests_path=None,
-            description=None,
-        )
+    def test_reference_dependency_packages_seed_independent_consumers(self) -> None:
+        project = external_project()
 
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -310,7 +276,6 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             shared_marker = dependency_packages / "mathlib" / ".lake" / "build" / "Mathlib.olean"
             shared_marker.parent.mkdir(parents=True)
             shared_marker.write_text("shared", encoding="utf-8")
-            (first_project_dir / ".lake" / "packages" / "mathlib").mkdir(parents=True)
             layout = SimpleNamespace(
                 package_root=root / "pkg",
                 reference_source_cache_root=root / "cache",
@@ -319,53 +284,53 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             )
             layout.package_root.mkdir()
 
-            original_run = refs_mod.run
-            commands: list[list[str]] = []
-            try:
-                refs_mod.run = lambda command, *, cwd: commands.append(command)
+            first_seed = seed_lake_packages_from_dependency_cache(layout, project, first_project_dir)
+            second_seed = seed_lake_packages_from_dependency_cache(layout, project, second_project_dir)
+            first_marker = first_project_dir / ".lake" / "packages" / "mathlib" / ".lake" / "build" / "Mathlib.olean"
+            second_marker = second_project_dir / ".lake" / "packages" / "mathlib" / ".lake" / "build" / "Mathlib.olean"
 
-                first_seed = seed_lake_packages_from_dependency_cache(layout, project, first_project_dir)
-                second_seed = seed_lake_packages_from_dependency_cache(layout, project, second_project_dir)
-                stored_to = store_lake_packages_in_dependency_cache(layout, project, first_project_dir)
-                shared_marker_text = shared_marker.read_text(encoding="utf-8")
-            finally:
-                refs_mod.run = original_run
+            self.assertEqual(first_seed, dependency_packages)
+            self.assertEqual(second_seed, dependency_packages)
+            self.assertEqual(first_marker.read_text(encoding="utf-8"), "shared")
+            self.assertEqual(second_marker.read_text(encoding="utf-8"), "shared")
 
-        self.assertEqual(first_seed, dependency_packages)
-        self.assertEqual(second_seed, dependency_packages)
-        self.assertEqual(stored_to, dependency_packages)
-        self.assertEqual(shared_marker_text, "shared")
-        self.assertEqual(
-            commands,
-            [
-                ["rsync", "-a", f"{dependency_packages}/", f"{first_project_dir / '.lake' / 'packages'}/"],
-                ["rsync", "-a", f"{dependency_packages}/", f"{second_project_dir / '.lake' / 'packages'}/"],
-                [
-                    "rsync",
-                    "-a",
-                    "--delete",
-                    f"{first_project_dir / '.lake' / 'packages'}/",
-                    f"{dependency_packages}/",
-                ],
-            ],
-        )
+            with self.assertRaisesRegex(RuntimeError, "consumer failed"):
+                first_marker.write_text("dirty consumer", encoding="utf-8")
+                raise RuntimeError("consumer failed")
+
+            self.assertEqual(shared_marker.read_text(encoding="utf-8"), "shared")
+            self.assertEqual(second_marker.read_text(encoding="utf-8"), "shared")
+
+    def test_reference_dependency_packages_refresh_shared_cache_by_copy(self) -> None:
+        project = external_project()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source_identity = reference_source_identity(project)
+            dependency_packages = root / "deps" / source_identity / "packages"
+            shared_marker = dependency_packages / "mathlib" / ".lake" / "build" / "Mathlib.olean"
+            shared_marker.parent.mkdir(parents=True)
+            shared_marker.write_text("old", encoding="utf-8")
+            project_dir = root / "checkout" / project.project_root
+            local_marker = project_dir / ".lake" / "packages" / "mathlib" / ".lake" / "build" / "Mathlib.olean"
+            local_marker.parent.mkdir(parents=True)
+            local_marker.write_text("warm", encoding="utf-8")
+            layout = SimpleNamespace(
+                package_root=root / "pkg",
+                reference_source_cache_root=root / "cache",
+                reference_dependency_cache_root=root / "deps",
+                reference_project_checkout_root=root / "checkouts",
+            )
+            layout.package_root.mkdir()
+
+            stored_to = store_lake_packages_in_dependency_cache(layout, project, project_dir)
+
+            self.assertEqual(stored_to, dependency_packages)
+            self.assertEqual(shared_marker.read_text(encoding="utf-8"), "warm")
+            self.assertEqual(local_marker.read_text(encoding="utf-8"), "warm")
 
     def test_reference_source_paths_share_one_identity_and_exclude_generated_output(self) -> None:
-        project = HarnessProject(
-            project_id="external-blueprint",
-            source_kind="git_checkout",
-            project_root="nested/blueprint",
-            build_target=None,
-            generator=None,
-            repository="https://github.com/example/external-blueprint.git",
-            ref="main",
-            build_command=("lake", "build"),
-            generate_command=VBP_BUILD_COMMAND,
-            site_subdir="html-multi",
-            panel_regression_script=None,
-            browser_tests_path=None,
-            description=None,
-        )
+        project = external_project()
         layout = SimpleNamespace(
             reference_source_cache_root=Path("/tmp/cache"),
             reference_dependency_cache_root=Path("/tmp/deps"),
@@ -377,12 +342,11 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
 
         self.assertEqual(paths.identity, reference_source_identity(project))
         self.assertEqual(paths.source_checkout, Path("/tmp/cache") / paths.identity)
-        self.assertEqual(paths.dependency_cache, Path("/tmp/deps") / paths.identity)
-        self.assertEqual(paths.dependency_packages, paths.dependency_cache / "packages")
-        self.assertEqual(paths.dependency_path_builds, paths.dependency_cache / "path-builds")
+        self.assertEqual(paths.dependency_packages, Path("/tmp/deps") / paths.identity / "packages")
+        self.assertEqual(paths.dependency_path_builds, Path("/tmp/deps") / paths.identity / "path-builds")
         self.assertEqual(paths.local_checkout, Path("/tmp/by-worktree/demo") / paths.identity)
         self.assertEqual(output, Path("/tmp/output/external-blueprint"))
-        for managed_path in (paths.source_checkout, paths.dependency_cache, paths.local_checkout):
+        for managed_path in (paths.source_checkout, paths.dependency_packages.parent, paths.local_checkout):
             self.assertFalse(output.is_relative_to(managed_path))
 
     def test_discard_lake_packages_prunes_warmed_checkout_copy(self) -> None:
@@ -404,21 +368,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
     def test_reference_dependency_path_build_cache_seeds_external_path_dependencies(self) -> None:
         import scripts.blueprint_harness_references as refs_mod
 
-        project = HarnessProject(
-            project_id="external-blueprint",
-            source_kind="git_checkout",
-            project_root="nested/blueprint",
-            build_target=None,
-            generator=None,
-            repository="https://github.com/example/external-blueprint.git",
-            ref="main",
-            build_command=("lake", "build"),
-            generate_command=VBP_BUILD_COMMAND,
-            site_subdir="html-multi",
-            panel_regression_script=None,
-            browser_tests_path=None,
-            description=None,
-        )
+        project = external_project()
 
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -512,17 +462,11 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertIn("texlive-fonts-extra", workflow_text)
         self.assertIn("texlive-plain-generic", workflow_text)
         self.assertIn("matrix.reference_source_identity", workflow_text)
-        self.assertIn(
-            ".worktrees/_reference-blueprints/deps/${{ matrix.reference_source_identity }}/packages", workflow_text
-        )
-        self.assertIn(
-            ".worktrees/_reference-blueprints/deps/${{ matrix.reference_source_identity }}/path-builds", workflow_text
-        )
+        self.assertIn("matrix.reference_dependency_packages_path", workflow_text)
+        self.assertIn("matrix.reference_dependency_path_builds_path", workflow_text)
         self.assertIn("reference-deps-v2-${{ matrix.reference_source_identity }}", workflow_text)
-        self.assertIn(
-            ".worktrees/_reference-blueprints/deps/${{ matrix.reference_source_identity }}/path-builds",
-            deploy_workflow_text,
-        )
+        self.assertIn("matrix.reference_dependency_packages_path", deploy_workflow_text)
+        self.assertIn("matrix.reference_dependency_path_builds_path", deploy_workflow_text)
         self.assertIn("reference-deploy-deps-v2-${{ matrix.reference_source_identity }}", deploy_workflow_text)
         self.assertIn(
             "group: ${{ github.repository }}-reference-blueprints-pages",
@@ -558,9 +502,20 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             self.assertEqual(entry["artifact_path"], f"_out/reference-blueprints/{entry['project_id']}")
             self.assertIn("project_root", entry)
             if entry["hash"] is not None:
-                self.assertTrue(entry["reference_source_identity"])
+                identity = entry["reference_source_identity"]
+                self.assertTrue(identity)
+                self.assertEqual(
+                    entry["reference_dependency_packages_path"],
+                    f".worktrees/_reference-blueprints/deps/{identity}/packages",
+                )
+                self.assertEqual(
+                    entry["reference_dependency_path_builds_path"],
+                    f".worktrees/_reference-blueprints/deps/{identity}/path-builds",
+                )
             else:
                 self.assertEqual(entry["reference_source_identity"], "")
+                self.assertEqual(entry["reference_dependency_packages_path"], "")
+                self.assertEqual(entry["reference_dependency_path_builds_path"], "")
 
     def test_reference_release_payload_uses_project_target_rcs(self) -> None:
         manifest = default_project_manifest(PACKAGE_ROOT)
@@ -1279,22 +1234,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         import scripts.blueprint_harness_project_commands as commands_mod
         import scripts.blueprint_harness_references as refs_mod
 
-        project = HarnessProject(
-            project_id="external-blueprint",
-            source_kind="git_checkout",
-            project_root="nested/blueprint",
-            build_target=None,
-            generator=None,
-            repository="https://github.com/example/external-blueprint.git",
-            ref="main",
-            build_command=("lake", "build"),
-            generate_command=VBP_BUILD_COMMAND,
-            site_subdir="html-multi",
-            panel_regression_script=None,
-            browser_tests_path=None,
-            description=None,
-            selected_release="v4.30.0",
-        )
+        project = external_project(selected_release="v4.30.0")
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             cache_dir = root / "cache" / reference_source_identity(project)
@@ -1349,20 +1289,9 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
     def test_reference_cache_checkout_rewrites_override_to_absolute_linked_worktree_path(self) -> None:
         import scripts.blueprint_harness_references as refs_mod
 
-        project = HarnessProject(
-            project_id="external-blueprint",
-            source_kind="git_checkout",
+        project = external_project(
             project_root=".",
-            build_target=None,
-            generator=None,
-            repository="https://github.com/example/external-blueprint.git",
-            ref="main",
             build_command=None,
-            generate_command=VBP_BUILD_COMMAND,
-            site_subdir="html-multi",
-            panel_regression_script=None,
-            browser_tests_path=None,
-            description=None,
             selected_release="v4.30.0",
         )
         with tempfile.TemporaryDirectory() as tmp:
@@ -1417,22 +1346,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
     def test_reference_cache_warm_build_failure_reports_recovery_hints(self) -> None:
         import scripts.blueprint_harness_references as refs_mod
 
-        project = HarnessProject(
-            project_id="external-blueprint",
-            source_kind="git_checkout",
-            project_root="nested/blueprint",
-            build_target=None,
-            generator=None,
-            repository="https://github.com/example/external-blueprint.git",
-            ref="main",
-            build_command=("lake", "build"),
-            generate_command=VBP_BUILD_COMMAND,
-            site_subdir="html-multi",
-            panel_regression_script=None,
-            browser_tests_path=None,
-            description=None,
-            selected_release="v4.30.0",
-        )
+        project = external_project(selected_release="v4.30.0")
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             source_identity = reference_source_identity(project)
@@ -1537,20 +1451,11 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             self.run_git(seed, "remote", "add", "origin", str(remote))
             self.run_git(seed, "push", "-u", "origin", "main")
 
-            project = HarnessProject(
-                project_id="external-blueprint",
-                source_kind="git_checkout",
+            project = external_project(
                 project_root=".",
-                build_target=None,
-                generator=None,
                 repository=str(remote),
                 ref=first,
                 build_command=None,
-                generate_command=VBP_BUILD_COMMAND,
-                site_subdir="html-multi",
-                panel_regression_script=None,
-                browser_tests_path=None,
-                description=None,
             )
 
             clone_git_project(project, checkout, cwd=root)
@@ -1565,20 +1470,9 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             self.assertEqual(head, first)
 
     def test_default_reference_edit_base_uses_detached_commit_for_sha_ref(self) -> None:
-        project = HarnessProject(
-            project_id="external-blueprint",
-            source_kind="git_checkout",
-            project_root="nested/blueprint",
-            build_target=None,
-            generator=None,
-            repository="https://github.com/example/external-blueprint.git",
+        project = external_project(
             ref="9b50e39c17434ee1a574fd27ed97006adfdc5dc1",
             build_command=None,
-            generate_command=VBP_BUILD_COMMAND,
-            site_subdir="html-multi",
-            panel_regression_script=None,
-            browser_tests_path=None,
-            description=None,
         )
 
         self.assertEqual(default_reference_edit_base(project), project.ref)
@@ -1608,20 +1502,11 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             target = self.commit(seed, "add manifest")
             self.run_git(seed, "push", "origin", "main")
 
-            project = HarnessProject(
-                project_id="external-blueprint",
-                source_kind="git_checkout",
+            project = external_project(
                 project_root=".",
-                build_target=None,
-                generator=None,
                 repository=str(remote),
                 ref=target,
                 build_command=None,
-                generate_command=VBP_BUILD_COMMAND,
-                site_subdir="html-multi",
-                panel_regression_script=None,
-                browser_tests_path=None,
-                description=None,
             )
 
             update_git_checkout(project, checkout)
@@ -1652,20 +1537,11 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             (checkout / "lakefile.lean").write_text('require VersoBlueprint from "../local"\n', encoding="utf-8")
             (checkout / "lake-manifest.json").write_text('{"version":"dirty"}\n', encoding="utf-8")
 
-            project = HarnessProject(
-                project_id="external-blueprint",
-                source_kind="git_checkout",
+            project = external_project(
                 project_root=".",
-                build_target=None,
-                generator=None,
                 repository=str(remote),
                 ref=target,
                 build_command=None,
-                generate_command=VBP_BUILD_COMMAND,
-                site_subdir="html-multi",
-                panel_regression_script=None,
-                browser_tests_path=None,
-                description=None,
             )
 
             update_git_checkout(project, checkout)
@@ -1685,20 +1561,9 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         import scripts.blueprint_harness_project_commands as commands_mod
         import scripts.blueprint_harness_references as refs_mod
 
-        project = HarnessProject(
-            project_id="external-blueprint",
-            source_kind="git_checkout",
+        project = external_project(
             project_root=".",
-            build_target=None,
-            generator=None,
-            repository="https://github.com/example/external-blueprint.git",
-            ref="main",
-            build_command=("lake", "build"),
             generate_command=VBP_BUILD_OUTPUT_COMMAND,
-            site_subdir="html-multi",
-            panel_regression_script=None,
-            browser_tests_path=None,
-            description=None,
             selected_release="v4.30.0",
         )
 
@@ -1797,72 +1662,6 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             )
         )
 
-    def test_generate_git_project_failure_leaves_shared_packages_usable(self) -> None:
-        import scripts.blueprint_harness_references as refs_mod
-
-        project = HarnessProject(
-            project_id="external-blueprint",
-            source_kind="git_checkout",
-            project_root=".",
-            build_target=None,
-            generator=None,
-            repository="https://github.com/example/external-blueprint.git",
-            ref="main",
-            build_command=("lake", "build"),
-            generate_command=VBP_BUILD_OUTPUT_COMMAND,
-            site_subdir="html-multi",
-            panel_regression_script=None,
-            browser_tests_path=None,
-            description=None,
-        )
-
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            cache_dir = root / "cache"
-            local_dir = root / "local"
-            output_root = root / "out"
-            dependency_packages = root / "deps" / reference_source_identity(project) / "packages"
-            shared_marker = dependency_packages / "mathlib" / ".lake" / "build" / "Mathlib.olean"
-            shared_marker.parent.mkdir(parents=True)
-            shared_marker.write_text("shared", encoding="utf-8")
-            local_marker = local_dir / ".lake" / "packages" / "mathlib" / ".lake" / "build" / "Mathlib.olean"
-            local_marker.parent.mkdir(parents=True)
-            local_marker.write_text("local", encoding="utf-8")
-            layout = SimpleNamespace(
-                package_root=root / "pkg",
-                repo_root=root / "repo",
-                reference_dependency_cache_root=root / "deps",
-            )
-            layout.package_root.mkdir()
-            layout.repo_root.mkdir()
-
-            originals = {
-                "rebuild_and_log_embedded_asset_owners": refs_mod.rebuild_and_log_embedded_asset_owners,
-                "sync_reference_cache_checkout": refs_mod.sync_reference_cache_checkout,
-                "sync_reference_local_checkout": refs_mod.sync_reference_local_checkout,
-                "bootstrap_reference_checkout": refs_mod.bootstrap_reference_checkout,
-            }
-            def fake_sync_reference_cache_checkout(_layout, _project, *, warm_build):
-                return cache_dir
-
-            def fake_sync_reference_local_checkout(_layout, _project, _cache_dir):
-                return local_dir
-
-            try:
-                refs_mod.rebuild_and_log_embedded_asset_owners = lambda _package_root: None
-                refs_mod.sync_reference_cache_checkout = fake_sync_reference_cache_checkout
-                refs_mod.sync_reference_local_checkout = fake_sync_reference_local_checkout
-                refs_mod.bootstrap_reference_checkout = lambda *, project_dir: (_ for _ in ()).throw(RuntimeError("boom"))
-
-                with self.assertRaisesRegex(RuntimeError, "boom"):
-                    generate_git_project(layout, output_root, project, skip_build=False)
-            finally:
-                for name, value in originals.items():
-                    setattr(refs_mod, name, value)
-
-            self.assertEqual(shared_marker.read_text(encoding="utf-8"), "shared")
-            self.assertEqual(local_marker.read_text(encoding="utf-8"), "local")
-
     def test_reference_submodule_update_skips_lfs_smudge(self) -> None:
         self.assertEqual(
             reference_submodule_update_command()[:3],
@@ -1915,20 +1714,9 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
     def test_bump_reference_project_commits_and_pushes_when_requested(self) -> None:
         import scripts.blueprint_harness_references as refs_mod
 
-        project = HarnessProject(
-            project_id="external-blueprint",
-            source_kind="git_checkout",
+        project = external_project(
             project_root=".",
-            build_target=None,
-            generator=None,
-            repository="https://github.com/example/external-blueprint.git",
-            ref="main",
-            build_command=("lake", "build"),
             generate_command=VBP_BUILD_OUTPUT_COMMAND,
-            site_subdir="html-multi",
-            panel_regression_script=None,
-            browser_tests_path=None,
-            description=None,
             selected_release="v4.30.0",
         )
         layout = SimpleNamespace(
@@ -2004,20 +1792,9 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
     def test_bump_reference_project_can_generate_review_output(self) -> None:
         import scripts.blueprint_harness_references as refs_mod
 
-        project = HarnessProject(
-            project_id="external-blueprint",
-            source_kind="git_checkout",
+        project = external_project(
             project_root=".",
-            build_target=None,
-            generator=None,
-            repository="https://github.com/example/external-blueprint.git",
-            ref="main",
-            build_command=("lake", "build"),
             generate_command=VBP_BUILD_OUTPUT_COMMAND,
-            site_subdir="html-multi",
-            panel_regression_script=None,
-            browser_tests_path=None,
-            description=None,
             selected_release="v4.30.0",
         )
 
@@ -2084,21 +1861,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
     def test_seed_reference_edit_checkout_lake_prefers_local_checkout(self) -> None:
         import scripts.blueprint_harness_references as refs_mod
 
-        project = HarnessProject(
-            project_id="external-blueprint",
-            source_kind="git_checkout",
-            project_root="nested/blueprint",
-            build_target=None,
-            generator=None,
-            repository="https://github.com/example/external-blueprint.git",
-            ref="main",
-            build_command=("lake", "build"),
-            generate_command=VBP_BUILD_COMMAND,
-            site_subdir="html-multi",
-            panel_regression_script=None,
-            browser_tests_path=None,
-            description=None,
-        )
+        project = external_project()
 
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -2144,75 +1907,6 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                     f"{edit_dir / 'nested' / 'blueprint' / '.lake'}/",
                 ]
             ],
-        )
-
-    def test_sync_reference_local_checkout_rsyncs_warmed_cache_lake(self) -> None:
-        import scripts.blueprint_harness_references as refs_mod
-
-        project = HarnessProject(
-            project_id="external-blueprint",
-            source_kind="git_checkout",
-            project_root="nested/blueprint",
-            build_target=None,
-            generator=None,
-            repository="https://github.com/example/external-blueprint.git",
-            ref="main",
-            build_command=("lake", "build"),
-            generate_command=VBP_BUILD_COMMAND,
-            site_subdir="html-multi",
-            panel_regression_script=None,
-            browser_tests_path=None,
-            description=None,
-        )
-
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            source_identity = reference_source_identity(project)
-            cache_dir = root / "cache" / source_identity
-            cache_dir.mkdir(parents=True)
-            (cache_dir / "nested" / "blueprint" / ".lake" / "packages" / "mathlib" / ".lake" / "build").mkdir(
-                parents=True
-            )
-            layout = SimpleNamespace(
-                package_root=root / "pkg",
-                reference_project_checkout_root=root / "checkouts",
-                reference_source_cache_root=root / "cache",
-                reference_dependency_cache_root=root / "deps",
-            )
-            layout.package_root.mkdir()
-
-            originals = {
-                "clone_git_project": refs_mod.clone_git_project,
-                "update_git_checkout": refs_mod.update_git_checkout,
-                "run": refs_mod.run,
-            }
-            commands: list[list[str]] = []
-            try:
-                refs_mod.clone_git_project = (
-                    lambda _project, destination, *, cwd, source=None, shallow=True: (
-                        destination / "nested" / "blueprint"
-                    ).mkdir(parents=True)
-                    or destination
-                )
-                refs_mod.update_git_checkout = lambda _project, _checkout_root: None
-                refs_mod.run = lambda command, *, cwd: commands.append(command)
-
-                local_dir = refs_mod.sync_reference_local_checkout(layout, project, cache_dir)
-            finally:
-                for name, value in originals.items():
-                    setattr(refs_mod, name, value)
-
-        self.assertEqual(local_dir, root / "checkouts" / source_identity)
-        self.assertIn(
-            [
-                "rsync",
-                "-a",
-                "--exclude",
-                "/build/",
-                f"{cache_dir / 'nested' / 'blueprint' / '.lake'}/",
-                f"{local_dir / 'nested' / 'blueprint' / '.lake'}/",
-            ],
-            commands,
         )
 
     def test_reference_prune_plan_finds_stale_cache_and_checkout_paths(self) -> None:

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -16,7 +16,7 @@ from scripts.blueprint_harness_projects import (
     load_project_catalog,
     load_project_catalog_data,
     reference_build_matrix,
-    reference_dependency_cache_key,
+    reference_source_identity,
     reference_release_payload,
     resolve_projects_for_release,
     resolve_release_target,
@@ -32,6 +32,8 @@ from scripts.blueprint_harness_references import (
     default_reference_bump_branch,
     default_reference_edit_base,
     generate_git_project,
+    output_dir_for,
+    reference_source_paths,
     reference_submodule_update_command,
     require_reference_harness_layout,
     run_external_reference_lake_update,
@@ -223,7 +225,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "expected JSON object"):
                 load_project_catalog(manifest)
 
-    def test_reference_dependency_cache_key_tracks_external_source_identity(self) -> None:
+    def test_reference_source_identity_tracks_external_source(self) -> None:
         base_project = HarnessProject(
             project_id="external-blueprint",
             source_kind="git_checkout",
@@ -273,13 +275,13 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             selected_release="v4.29.0",
         )
 
-        key = reference_dependency_cache_key(base_project)
+        identity = reference_source_identity(base_project)
 
-        self.assertTrue(key.startswith("external-blueprint-0123456789ab-"))
-        self.assertEqual(key, reference_dependency_cache_key(same_source_other_release))
-        self.assertNotEqual(key, reference_dependency_cache_key(changed_ref))
+        self.assertTrue(identity.startswith("external-blueprint-0123456789ab-"))
+        self.assertEqual(identity, reference_source_identity(same_source_other_release))
+        self.assertNotEqual(identity, reference_source_identity(changed_ref))
 
-    def test_reference_dependency_package_cache_is_separate_from_checkout_cache(self) -> None:
+    def test_reference_dependency_packages_seed_two_checkouts_without_transferring_ownership(self) -> None:
         import scripts.blueprint_harness_references as refs_mod
 
         project = HarnessProject(
@@ -300,14 +302,20 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            cache_key = reference_dependency_cache_key(project)
-            dependency_packages = root / "deps" / cache_key / "packages"
-            project_dir = root / "checkout" / "nested" / "blueprint"
+            source_identity = reference_source_identity(project)
+            dependency_packages = root / "deps" / source_identity / "packages"
+            first_project_dir = root / "first-checkout" / "nested" / "blueprint"
+            second_project_dir = root / "second-checkout" / "nested" / "blueprint"
             dependency_packages.mkdir(parents=True)
-            (project_dir / ".lake" / "packages" / "mathlib").mkdir(parents=True)
+            shared_marker = dependency_packages / "mathlib" / ".lake" / "build" / "Mathlib.olean"
+            shared_marker.parent.mkdir(parents=True)
+            shared_marker.write_text("shared", encoding="utf-8")
+            (first_project_dir / ".lake" / "packages" / "mathlib").mkdir(parents=True)
             layout = SimpleNamespace(
                 package_root=root / "pkg",
+                reference_source_cache_root=root / "cache",
                 reference_dependency_cache_root=root / "deps",
+                reference_project_checkout_root=root / "checkouts",
             )
             layout.package_root.mkdir()
 
@@ -316,22 +324,33 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             try:
                 refs_mod.run = lambda command, *, cwd: commands.append(command)
 
-                seeded_from = seed_lake_packages_from_dependency_cache(layout, project, project_dir)
-                stored_to = store_lake_packages_in_dependency_cache(layout, project, project_dir)
+                first_seed = seed_lake_packages_from_dependency_cache(layout, project, first_project_dir)
+                second_seed = seed_lake_packages_from_dependency_cache(layout, project, second_project_dir)
+                stored_to = store_lake_packages_in_dependency_cache(layout, project, first_project_dir)
+                shared_marker_text = shared_marker.read_text(encoding="utf-8")
             finally:
                 refs_mod.run = original_run
 
-        self.assertEqual(seeded_from, dependency_packages)
+        self.assertEqual(first_seed, dependency_packages)
+        self.assertEqual(second_seed, dependency_packages)
         self.assertEqual(stored_to, dependency_packages)
+        self.assertEqual(shared_marker_text, "shared")
         self.assertEqual(
             commands,
             [
-                ["rsync", "-a", f"{dependency_packages}/", f"{project_dir / '.lake' / 'packages'}/"],
-                ["rsync", "-a", "--delete", f"{project_dir / '.lake' / 'packages'}/", f"{dependency_packages}/"],
+                ["rsync", "-a", f"{dependency_packages}/", f"{first_project_dir / '.lake' / 'packages'}/"],
+                ["rsync", "-a", f"{dependency_packages}/", f"{second_project_dir / '.lake' / 'packages'}/"],
+                [
+                    "rsync",
+                    "-a",
+                    "--delete",
+                    f"{first_project_dir / '.lake' / 'packages'}/",
+                    f"{dependency_packages}/",
+                ],
             ],
         )
 
-    def test_reference_dependency_package_move_mode_moves_into_checkout(self) -> None:
+    def test_reference_source_paths_share_one_identity_and_exclude_generated_output(self) -> None:
         project = HarnessProject(
             project_id="external-blueprint",
             source_kind="git_checkout",
@@ -347,89 +366,24 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             browser_tests_path=None,
             description=None,
         )
-
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            cache_key = reference_dependency_cache_key(project)
-            dependency_packages = root / "deps" / cache_key / "packages"
-            project_dir = root / "checkout" / "nested" / "blueprint"
-            marker = dependency_packages / "mathlib" / ".lake" / "build" / "Mathlib.olean"
-            marker.parent.mkdir(parents=True)
-            marker.write_text("warm", encoding="utf-8")
-            old_local_marker = project_dir / ".lake" / "packages" / "old" / "stale"
-            old_local_marker.parent.mkdir(parents=True)
-            old_local_marker.write_text("stale", encoding="utf-8")
-            layout = SimpleNamespace(
-                package_root=root / "pkg",
-                reference_dependency_cache_root=root / "deps",
-            )
-            layout.package_root.mkdir()
-
-            seeded_from = seed_lake_packages_from_dependency_cache(
-                layout,
-                project,
-                project_dir,
-                package_mode="move",
-            )
-
-            self.assertEqual(seeded_from, dependency_packages)
-            self.assertFalse(dependency_packages.exists())
-            self.assertFalse(old_local_marker.exists())
-            self.assertEqual(
-                (project_dir / ".lake" / "packages" / "mathlib" / ".lake" / "build" / "Mathlib.olean").read_text(
-                    encoding="utf-8"
-                ),
-                "warm",
-            )
-
-    def test_reference_dependency_package_move_mode_restores_to_cache(self) -> None:
-        project = HarnessProject(
-            project_id="external-blueprint",
-            source_kind="git_checkout",
-            project_root="nested/blueprint",
-            build_target=None,
-            generator=None,
-            repository="https://github.com/example/external-blueprint.git",
-            ref="main",
-            build_command=("lake", "build"),
-            generate_command=VBP_BUILD_COMMAND,
-            site_subdir="html-multi",
-            panel_regression_script=None,
-            browser_tests_path=None,
-            description=None,
+        layout = SimpleNamespace(
+            reference_source_cache_root=Path("/tmp/cache"),
+            reference_dependency_cache_root=Path("/tmp/deps"),
+            reference_project_checkout_root=Path("/tmp/by-worktree/demo"),
         )
 
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            cache_key = reference_dependency_cache_key(project)
-            dependency_packages = root / "deps" / cache_key / "packages"
-            project_dir = root / "checkout" / "nested" / "blueprint"
-            marker = project_dir / ".lake" / "packages" / "mathlib" / ".lake" / "build" / "Mathlib.olean"
-            marker.parent.mkdir(parents=True)
-            marker.write_text("warm", encoding="utf-8")
-            old_cache_marker = dependency_packages / "old" / "stale"
-            old_cache_marker.parent.mkdir(parents=True)
-            old_cache_marker.write_text("stale", encoding="utf-8")
-            layout = SimpleNamespace(
-                package_root=root / "pkg",
-                reference_dependency_cache_root=root / "deps",
-            )
-            layout.package_root.mkdir()
+        paths = reference_source_paths(layout, project)
+        output = output_dir_for(project, Path("/tmp/output"))
 
-            stored_to = store_lake_packages_in_dependency_cache(
-                layout,
-                project,
-                project_dir,
-                package_mode="move",
-            )
-
-            self.assertEqual(stored_to, dependency_packages)
-            self.assertFalse((project_dir / ".lake" / "packages").exists())
-            self.assertFalse(old_cache_marker.exists())
-            self.assertEqual(
-                (dependency_packages / "mathlib" / ".lake" / "build" / "Mathlib.olean").read_text(encoding="utf-8"),
-                "warm",
-            )
+        self.assertEqual(paths.identity, reference_source_identity(project))
+        self.assertEqual(paths.source_checkout, Path("/tmp/cache") / paths.identity)
+        self.assertEqual(paths.dependency_cache, Path("/tmp/deps") / paths.identity)
+        self.assertEqual(paths.dependency_packages, paths.dependency_cache / "packages")
+        self.assertEqual(paths.dependency_path_builds, paths.dependency_cache / "path-builds")
+        self.assertEqual(paths.local_checkout, Path("/tmp/by-worktree/demo") / paths.identity)
+        self.assertEqual(output, Path("/tmp/output/external-blueprint"))
+        for managed_path in (paths.source_checkout, paths.dependency_cache, paths.local_checkout):
+            self.assertFalse(output.is_relative_to(managed_path))
 
     def test_discard_lake_packages_prunes_warmed_checkout_copy(self) -> None:
         import scripts.blueprint_harness_references as refs_mod
@@ -468,8 +422,8 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            cache_key = reference_dependency_cache_key(project)
-            path_builds = root / "deps" / cache_key / "path-builds"
+            source_identity = reference_source_identity(project)
+            path_builds = root / "deps" / source_identity / "path-builds"
             project_dir = root / "checkout" / "nested" / "blueprint"
             package_root = root / "pkg"
             project_dir.mkdir(parents=True)
@@ -497,7 +451,9 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             )
             layout = SimpleNamespace(
                 package_root=package_root,
+                reference_source_cache_root=root / "cache",
                 reference_dependency_cache_root=root / "deps",
+                reference_project_checkout_root=root / "checkouts",
             )
 
             original_run = refs_mod.run
@@ -555,12 +511,19 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertIn("lualatex --version", workflow_text)
         self.assertIn("texlive-fonts-extra", workflow_text)
         self.assertIn("texlive-plain-generic", workflow_text)
-        self.assertIn("matrix.reference_cache_key", workflow_text)
-        self.assertIn(".worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/packages", workflow_text)
-        self.assertIn(".worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/path-builds", workflow_text)
-        self.assertIn("reference-deps-v2-${{ matrix.reference_cache_key }}", workflow_text)
-        self.assertIn(".worktrees/_reference-blueprints/deps/${{ matrix.reference_cache_key }}/path-builds", deploy_workflow_text)
-        self.assertIn("reference-deploy-deps-v2-${{ matrix.reference_cache_key }}", deploy_workflow_text)
+        self.assertIn("matrix.reference_source_identity", workflow_text)
+        self.assertIn(
+            ".worktrees/_reference-blueprints/deps/${{ matrix.reference_source_identity }}/packages", workflow_text
+        )
+        self.assertIn(
+            ".worktrees/_reference-blueprints/deps/${{ matrix.reference_source_identity }}/path-builds", workflow_text
+        )
+        self.assertIn("reference-deps-v2-${{ matrix.reference_source_identity }}", workflow_text)
+        self.assertIn(
+            ".worktrees/_reference-blueprints/deps/${{ matrix.reference_source_identity }}/path-builds",
+            deploy_workflow_text,
+        )
+        self.assertIn("reference-deploy-deps-v2-${{ matrix.reference_source_identity }}", deploy_workflow_text)
         self.assertIn(
             "group: ${{ github.repository }}-reference-blueprints-pages",
             deploy_workflow_text,
@@ -595,9 +558,9 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             self.assertEqual(entry["artifact_path"], f"_out/reference-blueprints/{entry['project_id']}")
             self.assertIn("project_root", entry)
             if entry["hash"] is not None:
-                self.assertTrue(entry["reference_cache_key"])
+                self.assertTrue(entry["reference_source_identity"])
             else:
-                self.assertEqual(entry["reference_cache_key"], "")
+                self.assertEqual(entry["reference_source_identity"], "")
 
     def test_reference_release_payload_uses_project_target_rcs(self) -> None:
         manifest = default_project_manifest(PACKAGE_ROOT)
@@ -760,7 +723,9 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(matrix_by_project["old-release-project"]["project_root"], "old-controller")
         self.assertEqual(matrix_by_project["old-release-project"]["rc"], "")
         self.assertEqual(matrix_by_project["old-release-project"]["toolchain"], "v4.28.0")
-        self.assertTrue(matrix_by_project["old-release-project"]["reference_cache_key"].startswith("old-release-project-"))
+        self.assertTrue(
+            matrix_by_project["old-release-project"]["reference_source_identity"].startswith("old-release-project-")
+        )
         self.assertEqual(
             manifest_by_project["new-release-project"]["projects"][0]["targets"],
             [{"release": "v4.29.0", "ref": "new-controller-ref", "rc": "4.29-rc1"}],
@@ -1332,7 +1297,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            cache_dir = root / "cache" / reference_dependency_cache_key(project)
+            cache_dir = root / "cache" / reference_source_identity(project)
             project_dir = cache_dir / "nested" / "blueprint"
             project_dir.mkdir(parents=True)
             (cache_dir / ".git").mkdir()
@@ -1343,6 +1308,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 repo_root=root / "root",
                 reference_source_cache_root=root / "cache",
                 reference_dependency_cache_root=root / "deps",
+                reference_project_checkout_root=root / "checkouts",
             )
             layout.package_root.mkdir()
             layout.repo_root.mkdir()
@@ -1403,7 +1369,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             root = Path(tmp)
             worktrees_root = root / ".worktrees"
             package_root = worktrees_root / "docs-431-reference-catalog"
-            cache_dir = worktrees_root / "_reference-blueprints" / "cache" / reference_dependency_cache_key(project)
+            cache_dir = worktrees_root / "_reference-blueprints" / "cache" / reference_source_identity(project)
             cache_dir.mkdir(parents=True)
             (cache_dir / ".git").mkdir()
             lakefile = cache_dir / "lakefile.lean"
@@ -1414,6 +1380,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 repo_root=root,
                 reference_source_cache_root=worktrees_root / "_reference-blueprints" / "cache",
                 reference_dependency_cache_root=worktrees_root / "_reference-blueprints" / "deps",
+                reference_project_checkout_root=worktrees_root / "_reference-blueprints" / "by-worktree" / "demo",
             )
 
             originals = {
@@ -1468,8 +1435,8 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            cache_key = reference_dependency_cache_key(project)
-            cache_dir = root / "cache" / cache_key
+            source_identity = reference_source_identity(project)
+            cache_dir = root / "cache" / source_identity
             project_dir = cache_dir / "nested" / "blueprint"
             project_dir.mkdir(parents=True)
             (cache_dir / ".git").mkdir()
@@ -1480,6 +1447,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 repo_root=root / "root",
                 reference_source_cache_root=root / "cache",
                 reference_dependency_cache_root=root / "deps",
+                reference_project_checkout_root=root / "checkouts",
             )
             layout.package_root.mkdir()
             layout.repo_root.mkdir()
@@ -1517,9 +1485,9 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
 
             message = str(raised.exception)
             self.assertIn("failed to warm reference cache for `external-blueprint`", message)
-            self.assertIn(cache_key, message)
+            self.assertIn(source_identity, message)
             self.assertIn(str(cache_dir), message)
-            self.assertIn(str(root / "deps" / cache_key / "packages"), message)
+            self.assertIn(str(root / "deps" / source_identity / "packages"), message)
             self.assertIn("incompatible `.olean` header", message)
             self.assertIn("create-worktree <name> --lightweight", message)
             self.assertIn("blueprint_reference_harness prune --dry-run", message)
@@ -1760,7 +1728,9 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             layout = SimpleNamespace(
                 package_root=root / "pkg",
                 repo_root=root / "repo",
+                reference_source_cache_root=root / "cache",
                 reference_dependency_cache_root=root / "deps",
+                reference_project_checkout_root=root / "checkouts",
             )
             layout.package_root.mkdir()
             layout.repo_root.mkdir()
@@ -1777,15 +1747,12 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             }
             commands: list[list[str]] = []
             warm_build_values: list[bool] = []
-            package_modes: list[str] = []
 
-            def fake_sync_reference_cache_checkout(_layout, _project, *, warm_build, package_mode="copy"):
+            def fake_sync_reference_cache_checkout(_layout, _project, *, warm_build):
                 warm_build_values.append(warm_build)
-                package_modes.append(package_mode)
                 return cache_dir
 
-            def fake_sync_reference_local_checkout(_layout, _project, _cache_dir, *, package_mode="copy"):
-                package_modes.append(package_mode)
+            def fake_sync_reference_local_checkout(_layout, _project, _cache_dir):
                 return local_dir
 
             try:
@@ -1813,7 +1780,6 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                         setattr(refs_mod, name, value)
 
         self.assertEqual(warm_build_values, [False])
-        self.assertEqual(package_modes, ["copy", "copy"])
         self.assertEqual(commands[0], reference_submodule_update_command())
         self.assertIn(["lake", "update", "VersoBlueprint"], commands)
         self.assertTrue(any(command[1:] == ["lake", "build"] for command in commands))
@@ -1831,7 +1797,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             )
         )
 
-    def test_generate_git_project_move_mode_restores_packages_after_failure(self) -> None:
+    def test_generate_git_project_failure_leaves_shared_packages_usable(self) -> None:
         import scripts.blueprint_harness_references as refs_mod
 
         project = HarnessProject(
@@ -1855,9 +1821,13 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             cache_dir = root / "cache"
             local_dir = root / "local"
             output_root = root / "out"
-            marker = local_dir / ".lake" / "packages" / "mathlib" / ".lake" / "build" / "Mathlib.olean"
-            marker.parent.mkdir(parents=True)
-            marker.write_text("warm", encoding="utf-8")
+            dependency_packages = root / "deps" / reference_source_identity(project) / "packages"
+            shared_marker = dependency_packages / "mathlib" / ".lake" / "build" / "Mathlib.olean"
+            shared_marker.parent.mkdir(parents=True)
+            shared_marker.write_text("shared", encoding="utf-8")
+            local_marker = local_dir / ".lake" / "packages" / "mathlib" / ".lake" / "build" / "Mathlib.olean"
+            local_marker.parent.mkdir(parents=True)
+            local_marker.write_text("local", encoding="utf-8")
             layout = SimpleNamespace(
                 package_root=root / "pkg",
                 repo_root=root / "repo",
@@ -1872,14 +1842,10 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 "sync_reference_local_checkout": refs_mod.sync_reference_local_checkout,
                 "bootstrap_reference_checkout": refs_mod.bootstrap_reference_checkout,
             }
-            package_modes: list[str] = []
-
-            def fake_sync_reference_cache_checkout(_layout, _project, *, warm_build, package_mode="copy"):
-                package_modes.append(package_mode)
+            def fake_sync_reference_cache_checkout(_layout, _project, *, warm_build):
                 return cache_dir
 
-            def fake_sync_reference_local_checkout(_layout, _project, _cache_dir, *, package_mode="copy"):
-                package_modes.append(package_mode)
+            def fake_sync_reference_local_checkout(_layout, _project, _cache_dir):
                 return local_dir
 
             try:
@@ -1889,19 +1855,13 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 refs_mod.bootstrap_reference_checkout = lambda *, project_dir: (_ for _ in ()).throw(RuntimeError("boom"))
 
                 with self.assertRaisesRegex(RuntimeError, "boom"):
-                    generate_git_project(layout, output_root, project, skip_build=False, package_mode="move")
+                    generate_git_project(layout, output_root, project, skip_build=False)
             finally:
                 for name, value in originals.items():
                     setattr(refs_mod, name, value)
 
-            dependency_packages = root / "deps" / reference_dependency_cache_key(project) / "packages"
-
-            self.assertEqual(package_modes, ["move", "move"])
-            self.assertFalse((local_dir / ".lake" / "packages").exists())
-            self.assertEqual(
-                (dependency_packages / "mathlib" / ".lake" / "build" / "Mathlib.olean").read_text(encoding="utf-8"),
-                "warm",
-            )
+            self.assertEqual(shared_marker.read_text(encoding="utf-8"), "shared")
+            self.assertEqual(local_marker.read_text(encoding="utf-8"), "local")
 
     def test_reference_submodule_update_skips_lfs_smudge(self) -> None:
         self.assertEqual(
@@ -2142,9 +2102,9 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            cache_key = reference_dependency_cache_key(project)
-            local_dir = root / "local" / cache_key
-            cache_dir = root / "cache" / cache_key
+            source_identity = reference_source_identity(project)
+            local_dir = root / "local" / source_identity
+            cache_dir = root / "cache" / source_identity
             edit_dir = root / "edit" / project.project_id
             (local_dir / "nested" / "blueprint" / ".lake" / "packages").mkdir(parents=True)
             (cache_dir / "nested" / "blueprint" / ".lake" / "packages").mkdir(parents=True)
@@ -2207,8 +2167,8 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            cache_key = reference_dependency_cache_key(project)
-            cache_dir = root / "cache" / cache_key
+            source_identity = reference_source_identity(project)
+            cache_dir = root / "cache" / source_identity
             cache_dir.mkdir(parents=True)
             (cache_dir / "nested" / "blueprint" / ".lake" / "packages" / "mathlib" / ".lake" / "build").mkdir(
                 parents=True
@@ -2216,6 +2176,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             layout = SimpleNamespace(
                 package_root=root / "pkg",
                 reference_project_checkout_root=root / "checkouts",
+                reference_source_cache_root=root / "cache",
                 reference_dependency_cache_root=root / "deps",
             )
             layout.package_root.mkdir()
@@ -2241,7 +2202,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 for name, value in originals.items():
                     setattr(refs_mod, name, value)
 
-        self.assertEqual(local_dir, root / "checkouts" / cache_key)
+        self.assertEqual(local_dir, root / "checkouts" / source_identity)
         self.assertIn(
             [
                 "rsync",

--- a/tests/harness/test_harness_entrypoints.py
+++ b/tests/harness/test_harness_entrypoints.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 import subprocess
 import sys
+import tempfile
 import unittest
 
 
@@ -76,6 +77,38 @@ class HarnessEntrypointSmokeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("Print a compact disk-usage report", result.stdout)
         self.assertIn("--reference-source-identity", result.stdout)
+
+    def test_report_ci_disk_usage_includes_dependency_path_builds(self) -> None:
+        identity = "external-main-123456789abc"
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path_build = (
+                root
+                / ".worktrees"
+                / "_reference-blueprints"
+                / "deps"
+                / identity
+                / "path-builds"
+                / "Formalization"
+            )
+            path_build.mkdir(parents=True)
+            result = subprocess.run(
+                [
+                    "bash",
+                    str(PACKAGE_ROOT / "scripts" / "report-ci-disk-usage.sh"),
+                    "test",
+                    "--reference-source-identity",
+                    identity,
+                ],
+                cwd=root,
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn(f"[ci-disk] path builds for {identity}", result.stdout)
+        self.assertIn("path-builds/Formalization", result.stdout)
 
     def test_validate_reference_wrapper_help(self) -> None:
         result = self.run_command(["bash", "scripts/validate-reference-blueprints.sh", "--help"])

--- a/tests/harness/test_harness_entrypoints.py
+++ b/tests/harness/test_harness_entrypoints.py
@@ -75,7 +75,7 @@ class HarnessEntrypointSmokeTests(unittest.TestCase):
         result = self.run_command(["bash", "scripts/report-ci-disk-usage.sh", "--help"])
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("Print a compact disk-usage report", result.stdout)
-        self.assertIn("--reference-cache-key", result.stdout)
+        self.assertIn("--reference-source-identity", result.stdout)
 
     def test_validate_reference_wrapper_help(self) -> None:
         result = self.run_command(["bash", "scripts/validate-reference-blueprints.sh", "--help"])


### PR DESCRIPTION
## Summary
Backport #361 to `v4.32.0`.

## Primary Review
- Primary review: #361
- Keep review comments on #361 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.32.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.