### PR TITLE
fix: preserve explicit wrapper toolchain overrides

### DIFF
--- a/.github/workflows/blueprint-pages.yml
+++ b/.github/workflows/blueprint-pages.yml
@@ -93,7 +93,7 @@ jobs:
               lake exe cache get || true
             )
           fi
-      - if: ${{ inputs.harness_enabled }}
+      - if: ${{ inputs.harness_enabled && steps.harness.outputs.use_formalization_toolchain == 'true' }}
         name: Select harness Lean toolchain
         run: |
           formalization_toolchain="${{ steps.harness.outputs.formalization_path }}/lean-toolchain"

--- a/project_template/.github/workflows/blueprint-pages.yml
+++ b/project_template/.github/workflows/blueprint-pages.yml
@@ -93,7 +93,7 @@ jobs:
               lake exe cache get || true
             )
           fi
-      - if: ${{ inputs.harness_enabled }}
+      - if: ${{ inputs.harness_enabled && steps.harness.outputs.use_formalization_toolchain == 'true' }}
         name: Select harness Lean toolchain
         run: |
           formalization_toolchain="${{ steps.harness.outputs.formalization_path }}/lean-toolchain"


### PR DESCRIPTION
This PR keeps the checked-in wrapper Lean toolchain during reference Blueprint CI when the shared harness declares an exact compatibility override.

- Gate formalization-toolchain copying on the shared harness CI export.
- Keep the root workflow synchronized with the project-template copy.

Backport v4.32.0: #367