### PR TITLE
[backport v4.32.0] fix: preserve explicit wrapper toolchain overrides

### DIFF
--- a/.github/workflows/blueprint-pages.yml
+++ b/.github/workflows/blueprint-pages.yml
@@ -93,7 +93,7 @@ jobs:
               lake exe cache get || true
             )
           fi
-      - if: ${{ inputs.harness_enabled }}
+      - if: ${{ inputs.harness_enabled && steps.harness.outputs.use_formalization_toolchain == 'true' }}
         name: Select harness Lean toolchain
         run: |
           formalization_toolchain="${{ steps.harness.outputs.formalization_path }}/lean-toolchain"

--- a/project_template/.github/workflows/blueprint-pages.yml
+++ b/project_template/.github/workflows/blueprint-pages.yml
@@ -93,7 +93,7 @@ jobs:
               lake exe cache get || true
             )
           fi
-      - if: ${{ inputs.harness_enabled }}
+      - if: ${{ inputs.harness_enabled && steps.harness.outputs.use_formalization_toolchain == 'true' }}
         name: Select harness Lean toolchain
         run: |
           formalization_toolchain="${{ steps.harness.outputs.formalization_path }}/lean-toolchain"


### PR DESCRIPTION
## Summary
Backport #365 to `v4.32.0`.

## Primary Review
- Primary review: #365
- Keep review comments on #365 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.32.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.