### PR TITLE
[backport v4.32.0] fix: validate combined release transitions

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -26,9 +26,9 @@ This repository keeps local parallel work simple:
   default-dev slug with a release marker in front of it.
   Examples:
   - default-dev branch: `fix/backport-discipline`
-  - paired `v4.31.0` backport branch: `fix/backport-v431-backport-discipline`
+  - paired `v4.32.0` backport branch: `fix/backport-v432-backport-discipline`
   - default-dev docs branch: `docs/manual-cleanup`
-  - paired `v4.31.0` docs backport branch: `docs/backport-v431-manual-cleanup`
+  - paired `v4.32.0` docs backport branch: `docs/backport-v432-manual-cleanup`
 
 Prefer short, descriptive slugs over opaque branch names.
 
@@ -137,8 +137,9 @@ Do those upstream write actions only when they are explicitly requested.
   - use `python3 -m scripts.blueprint_harness prepare-backports` only when you
     need to refresh just the backport plan lines in an existing PR body
   - once it is ready for review, open the paired backport PRs
-  - use `python3 -m scripts.blueprint_harness prepare-backport-pr v4.31.0 --main-pr <pr>` to scaffold one paired backport PR branch name, title, and body
-  - apply the scaffolded release label, for example `backport-v4.31.0`, to the
+  - use `python3 -m scripts.blueprint_harness prepare-backport-pr v4.32.0 --main-pr <pr>`
+    to scaffold one paired backport PR branch name, title, and body
+  - apply the scaffolded release label, for example `backport-v4.32.0`, to the
     paired backport PR
   - when several releases are required, use `python3 -m scripts.blueprint_harness prepare-backport-pr --all-required --main-pr <pr>` to emit one scaffold block per release, then let the agent apply the `git cherry-pick -x` series and resolve conflicts in each backport worktree
   - replace each `Backport ...: pending` line with `Backport ...: #<pr>`, or
@@ -152,9 +153,9 @@ Do those upstream write actions only when they are explicitly requested.
 - Record the pairing in the PR body using plain lines like:
 
 ```text
-Backport v4.31.0: pending
-Backport v4.31.0: #122
-Backport v4.31.0: exempt: docs-only change
+Backport v4.32.0: pending
+Backport v4.32.0: #122
+Backport v4.32.0: exempt: docs-only change
 ```
 
 See the repository PR template for the preferred structure.

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -296,7 +296,7 @@ Use the harness to generate public PR/backport scaffolds:
 ```bash
 python3 -m scripts.blueprint_harness prepare-pr
 python3 -m scripts.blueprint_harness prepare-backports
-python3 -m scripts.blueprint_harness prepare-backport-pr v4.31.0 --main-pr <pr>
+python3 -m scripts.blueprint_harness prepare-backport-pr v4.32.0 --main-pr <pr>
 python3 -m scripts.blueprint_harness prepare-backport-pr --all-required --main-pr <pr>
 ```
 
@@ -306,7 +306,7 @@ check intentionally does not require patch-id equality, because release-line
 conflict resolution often changes the exact diff while preserving provenance.
 
 Each paired backport PR should carry the scaffolded release label, such as
-`backport-v4.31.0`, so release-specific queues remain visible when several
+`backport-v4.32.0`, so release-specific queues remain visible when several
 maintenance lines are active.
 
 Land reviewed local work from the clean root checkout:
@@ -331,8 +331,8 @@ fixtures, and pin the matching `verso` release or release candidate in the root
 package:
 
 ```bash
-python3 -m scripts.blueprint_harness bump-toolchain 4.31-rc2
-python3 -m scripts.blueprint_harness bump-toolchain v4.31.0 --skip-validation
+python3 -m scripts.blueprint_harness bump-toolchain 4.32-rc2
+python3 -m scripts.blueprint_harness bump-toolchain v4.32.0 --skip-validation
 ```
 
 That command rewrites the managed `lean-toolchain` files, rewrites the root
@@ -342,8 +342,8 @@ root package, `project_template`, and
 build/test validation pass that maintainers would otherwise do manually. It
 also synchronizes the current release target's RC metadata for in-repo
 reference projects; external project RC overrides remain explicit. Release
-candidates use the official short RC name, for example `4.31-rc2`; the harness
-writes the corresponding Lean and `verso` tag ref, such as `v4.31.0-rc2`.
+candidates use the official short RC name, for example `4.32-rc2`; the harness
+writes the corresponding Lean and `verso` tag ref, such as `v4.32.0-rc2`.
 The requested toolchain must belong to the checkout's current release line.
 Pass `--verso-ref <tag>` only when the Lean toolchain ref and upstream `verso`
 release tag need to differ.
@@ -355,10 +355,10 @@ default-development branch, then let the harness do the branch-local release
 setup:
 
 ```bash
-python3 -m scripts.blueprint_harness start-release-line 4.31-rc2
+python3 -m scripts.blueprint_harness start-release-line 4.33-rc2
 ```
 
-Run this from the new local branch, for example `v4.31.0`. The command:
+Run this from the new local branch, for example `v4.33.0`. The command:
 
 - rewrites the managed `lean-toolchain` files, the root `verso` pin, and the
   committed manifests for the root package, `project_template`, and the
@@ -371,14 +371,14 @@ Run this from the new local branch, for example `v4.31.0`. The command:
   a release candidate; fixtures remain explicitly selectable for validation
   but are not added to the public reference catalog
 
-For release candidates, use the official short RC name such as `4.31-rc2`.
-The branch name remains the stable release branch, for example `v4.31.0`, while
-the command pins the managed root-package files to `v4.31.0-rc2`.
+For release candidates, use the official short RC name such as `4.33-rc2`.
+The branch name remains the stable release branch, for example `v4.33.0`, while
+the command pins the managed root-package files to `v4.33.0-rc2`.
 
 External reference projects are not auto-pinned for a new release line. Add
 their release-target refs only after those repositories have been updated and
 validated on the new Lean release. If one project target still needs a release
-candidate, put the short RC name, for example `"rc": "4.31-rc2"`, on that
+candidate, put the short RC name, for example `"rc": "4.33-rc2"`, on that
 specific project target in `tests/harness/projects.json`.
 
 Do not backport the branch-start commit to older release lines: that commit
@@ -391,7 +391,7 @@ python3 -m scripts.blueprint_harness set-default-dev-branch v4.32.0
 ```
 
 Commit that metadata-only change separately on each older branch that still
-carries `branch-policy.json`, such as `v4.31.0`. Preserve their own Lean
+carries `branch-policy.json`, such as `v4.32.0`. Preserve their own Lean
 toolchain pins.
 
 When retiring old maintenance lines from an existing release branch, use
@@ -446,7 +446,7 @@ python3 -m scripts.blueprint_harness create-worktree <name>
 After `git worktree add`, that command syncs the root checkout's `.lake/` and
 prepares the shared and per-worktree reference blueprint clones without running
 external reference project builds. New worktrees now base off the branch policy's
-preferred default-development ref, typically something like `origin/v4.31.0`.
+preferred default-development ref, typically something like `origin/v4.32.0`.
 Pass `--base <release-ref>` explicitly for backport-only work.
 
 If you want to verify that the root checkout has not drifted before branching
@@ -490,11 +490,11 @@ an exemption is acceptable.
 To create one paired backport scaffold, run:
 
 ```bash
-python3 -m scripts.blueprint_harness prepare-backport-pr v4.31.0 --main-pr <pr>
+python3 -m scripts.blueprint_harness prepare-backport-pr v4.32.0 --main-pr <pr>
 ```
 
 That helper prints a standardized paired branch name, a title of the form
-`[backport v4.31.0] ...`, a `backport-v4.31.0` release label, and a PR body
+`[backport v4.32.0] ...`, a `backport-v4.32.0` release label, and a PR body
 that points back to the primary default-development review. By default the
 title after the backport prefix is read from the GitHub title of `--main-pr`,
 which keeps multi-commit backports from inheriting the last local commit

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,8 +8,8 @@ generator entry point, not the Python harness here. CI and Mathlib-heavy
 projects can run
 `lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean --output ...`
 after building `+<BlueprintLibrary>:olean`. Keep the explicit OLean facet so
-generation cannot trigger native C builds of Mathlib dependencies. Start with the top-level
-[`README.md`](../README.md) and [`doc/MANUAL.md`](../doc/MANUAL.md).
+generation cannot trigger native C builds of Mathlib dependencies. Start with
+the top-level [`README.md`](../README.md) and [`doc/MANUAL.md`](../doc/MANUAL.md).
 
 For repository maintenance, the canonical workflow document is
 [`doc/MAINTAINER_GUIDE.md`](../doc/MAINTAINER_GUIDE.md). This README is
@@ -51,8 +51,8 @@ Common starting points:
 python3 -m scripts.blueprint_harness create-worktree <name> --owner codex --lock --priority P1 --summary "short description"
 python3 -m scripts.blueprint_harness create-worktree <name> --lightweight  # docs/Python-only work
 python3 -m scripts.blueprint_harness release-status --require-sync
-python3 -m scripts.blueprint_harness start-release-line 4.31-rc2
-python3 -m scripts.blueprint_harness set-default-dev-branch v4.31.0
+python3 -m scripts.blueprint_harness start-release-line 4.33-rc2
+python3 -m scripts.blueprint_harness set-default-dev-branch v4.33.0
 python3 -m scripts.blueprint_harness paths
 python3 -m scripts.blueprint_reference_harness compose /path/to/source --project-root blueprint
 python3 -m scripts.blueprint_reference_harness projects

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -19,6 +19,7 @@ from scripts.blueprint_harness_branches import (
     default_dev_branch,
     checkout_is_backport_only,
     current_branch_name,
+    dedupe_release_branches,
     is_ancestor,
     load_branch_policy,
     local_release_ref,
@@ -475,17 +476,6 @@ def command_bump_toolchain(args: argparse.Namespace) -> int:
     print(f"project_manifest={manifest_path}")
     print(f"validated={str(not args.skip_validation).lower()}")
     return 0
-
-
-def dedupe_release_branches(branches: list[str] | tuple[str, ...]) -> tuple[str, ...]:
-    result: list[str] = []
-    seen: set[str] = set()
-    for branch in branches:
-        normalized = release_branch_from_lean_ref(branch)
-        if normalized not in seen:
-            result.append(normalized)
-            seen.add(normalized)
-    return tuple(result)
 
 
 def write_json(path: Path, data: object) -> None:

--- a/scripts/blueprint_harness_backports.py
+++ b/scripts/blueprint_harness_backports.py
@@ -12,6 +12,8 @@ EXEMPT_FILE_NAMES = frozenset(
     }
 )
 EXEMPT_PATH_PREFIXES = (".github/", "doc/", "LICENSES/")
+RELEASE_LINE_BOOTSTRAP_STATUS = "release-line bootstrap"
+RELEASE_LINE_RETIREMENT_STATUS = "release-line retirement"
 
 
 def backport_exemption_violations(paths: Iterable[str]) -> tuple[str, ...]:

--- a/scripts/blueprint_harness_branches.py
+++ b/scripts/blueprint_harness_branches.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 import json
 from dataclasses import dataclass
 import subprocess
@@ -16,6 +17,18 @@ ROOT_WORKTREE_NAME = "root"
 CHECKOUT_ROLE_DEFAULT_DEV = "default_dev"
 CHECKOUT_ROLE_BACKPORT = "backport"
 CHECKOUT_ROLE_CHOICES = (CHECKOUT_ROLE_DEFAULT_DEV, CHECKOUT_ROLE_BACKPORT)
+
+
+def dedupe_release_branches(branches: Iterable[str]) -> tuple[str, ...]:
+    """Normalize release branches while preserving their first-seen order."""
+    result: list[str] = []
+    seen: set[str] = set()
+    for branch in branches:
+        normalized = release_branch_from_lean_ref(branch)
+        if normalized not in seen:
+            result.append(normalized)
+            seen.add(normalized)
+    return tuple(result)
 
 
 @dataclass(frozen=True)

--- a/scripts/blueprint_harness_releases.py
+++ b/scripts/blueprint_harness_releases.py
@@ -70,6 +70,15 @@ def release_branch_from_lean_ref(raw_ref: str) -> str:
     return ref
 
 
+def release_branch_version(raw_ref: str) -> tuple[int, int, int]:
+    """Return the comparable numeric version of a stable or RC release branch."""
+    branch = release_branch_from_lean_ref(raw_ref)
+    if NUMERIC_LEAN_RELEASE_PATTERN.fullmatch(branch) is None:
+        raise SystemExit(f"[blueprint-harness] expected a numeric Lean release branch, got `{branch}`")
+    major, minor, patch = branch.removeprefix("v").split(".")
+    return int(major), int(minor), int(patch)
+
+
 def lean_toolchain_spec(lean_ref: str) -> str:
     return f"{LEAN_TOOLCHAIN_PREFIX}{lean_ref}"
 

--- a/scripts/check_backport_pr.py
+++ b/scripts/check_backport_pr.py
@@ -16,9 +16,18 @@ from urllib.request import Request, urlopen
 if str(Path(__file__).resolve().parents[1]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scripts.blueprint_harness_branches import BranchPolicy, load_branch_policy, load_branch_policy_text
-from scripts.blueprint_harness_backports import backport_exemption_violations
-from scripts.blueprint_harness_releases import release_branch_from_lean_ref
+from scripts.blueprint_harness_branches import (
+    BranchPolicy,
+    dedupe_release_branches,
+    load_branch_policy,
+    load_branch_policy_text,
+)
+from scripts.blueprint_harness_backports import (
+    RELEASE_LINE_BOOTSTRAP_STATUS,
+    RELEASE_LINE_RETIREMENT_STATUS,
+    backport_exemption_violations,
+)
+from scripts.blueprint_harness_releases import release_branch_from_lean_ref, release_branch_version
 
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
@@ -27,8 +36,6 @@ API_VERSION = "2022-11-28"
 BACKPORT_LINE_RE = re.compile(r"(?mi)^Backport\s+([^\s:]+)\s*:\s*(.+)\s*$")
 BACKPORT_PR_RE = re.compile(r"(?:#|/pull/)(\d+)\b")
 CHERRY_PICK_SOURCE_RE = re.compile(r"(?mi)^\(cherry picked from commit ([0-9a-f]{40})\)\s*$")
-RELEASE_LINE_BOOTSTRAP_STATUS = "release-line bootstrap"
-RELEASE_LINE_RETIREMENT_STATUS = "release-line retirement"
 
 
 @dataclass(frozen=True)
@@ -231,13 +238,43 @@ def validate_backport_entries(
     return entries
 
 
-def dedupe_release_branches(branches: tuple[str, ...]) -> tuple[str, ...]:
-    result: list[str] = []
-    for branch in branches:
-        normalized = release_branch_from_lean_ref(branch)
-        if normalized not in result:
-            result.append(normalized)
-    return tuple(result)
+def load_release_transition_head_policy(
+    api: GitHubApi,
+    pull_request: dict[str, Any],
+    base_policy: BranchPolicy,
+    *,
+    transition_name: str,
+) -> BranchPolicy:
+    base = pull_request.get("base")
+    base_sha = str(base.get("sha") or "") if isinstance(base, dict) else ""
+    head = pull_request.get("head")
+    head_sha = str(head.get("sha") or "") if isinstance(head, dict) else ""
+    if not base_sha:
+        raise BackportCheckError(f"{transition_name} validation requires pull_request.base.sha")
+    if not head_sha:
+        raise BackportCheckError(f"{transition_name} validation requires pull_request.head.sha")
+
+    try:
+        head_policy = load_branch_policy_text(
+            api.file_text("branch-policy.json", head_sha),
+            source_path=Path(f"github-head-{head_sha[:12]}-branch-policy.json"),
+        )
+        base_toolchain_release = release_branch_from_lean_ref(api.file_text("lean-toolchain", base_sha).strip())
+        head_toolchain_release = release_branch_from_lean_ref(api.file_text("lean-toolchain", head_sha).strip())
+    except SystemExit as err:
+        raise BackportCheckError(str(err)) from err
+
+    if base_toolchain_release != base_policy.default_dev_branch:
+        raise BackportCheckError(
+            f"{transition_name} base is internally inconsistent: "
+            "its Lean toolchain does not match its default branch"
+        )
+    if head_toolchain_release != head_policy.default_dev_branch:
+        raise BackportCheckError(
+            f"{transition_name} head is internally inconsistent: "
+            "its Lean toolchain does not match its default branch"
+        )
+    return head_policy
 
 
 def verify_release_line_bootstrap(
@@ -246,48 +283,62 @@ def verify_release_line_bootstrap(
     pull_request: dict[str, Any],
     base_policy: BranchPolicy,
 ) -> BranchPolicy:
-    base = pull_request.get("base")
-    base_sha = str(base.get("sha") or "") if isinstance(base, dict) else ""
-    head = pull_request.get("head")
-    head_sha = str(head.get("sha") or "") if isinstance(head, dict) else ""
-    if not base_sha:
-        raise BackportCheckError("release-line bootstrap validation requires pull_request.base.sha")
-    if not head_sha:
-        raise BackportCheckError("release-line bootstrap validation requires pull_request.head.sha")
-
+    head_policy = load_release_transition_head_policy(
+        api,
+        pull_request,
+        base_policy,
+        transition_name="release-line bootstrap",
+    )
     try:
-        head_policy = load_branch_policy_text(
-            api.file_text("branch-policy.json", head_sha),
-            source_path=Path(f"github-head-{head_sha[:12]}-branch-policy.json"),
-        )
+        base_version = release_branch_version(base_policy.default_dev_branch)
+        head_version = release_branch_version(head_policy.default_dev_branch)
     except SystemExit as err:
         raise BackportCheckError(str(err)) from err
-    base_toolchain_release = release_branch_from_lean_ref(api.file_text("lean-toolchain", base_sha).strip())
-    head_toolchain_release = release_branch_from_lean_ref(api.file_text("lean-toolchain", head_sha).strip())
-
-    if base_toolchain_release != base_policy.default_dev_branch:
+    if head_version <= base_version:
         raise BackportCheckError(
-            "release-line bootstrap base is internally inconsistent: its Lean toolchain does not match its default branch"
+            "release-line bootstrap status requires a newer default development release line"
         )
-    if head_toolchain_release != head_policy.default_dev_branch:
-        raise BackportCheckError(
-            "release-line bootstrap head is internally inconsistent: its Lean toolchain does not match its default branch"
-        )
-    if head_policy.default_dev_branch == base_policy.default_dev_branch:
-        raise BackportCheckError("release-line bootstrap status requires advancing the default development release line")
 
-    expected_backports = tuple(
-        branch
-        for branch in dedupe_release_branches(
-            (base_policy.default_dev_branch, *base_policy.required_backport_branches)
-        )
-        if branch != head_policy.default_dev_branch
+    inherited_backports = dedupe_release_branches(
+        (base_policy.default_dev_branch, *base_policy.required_backport_branches)
     )
-    if head_policy.required_backport_branches != expected_backports:
+    retained_count = len(head_policy.required_backport_branches)
+    if (
+        retained_count == 0
+        or retained_count > len(inherited_backports)
+        or inherited_backports[:retained_count] != head_policy.required_backport_branches
+    ):
         raise BackportCheckError(
-            "release-line bootstrap must inherit the previous default branch and required backport sequence; expected "
-            + ", ".join(expected_backports)
+            "release-line bootstrap must retain the previous default branch followed by an ordered prefix of "
+            "the previous backport sequence; only the oldest contiguous suffix may retire"
         )
+    retired_branches = inherited_backports[retained_count:]
+
+    if base_policy.release_targets or head_policy.release_targets:
+        retired_set = set(retired_branches)
+        retained_targets = tuple(
+            target for target in base_policy.release_targets if target.release_id not in retired_set
+        )
+        new_targets = tuple(
+            target
+            for target in head_policy.release_targets
+            if target.release_id == head_policy.default_dev_branch
+        )
+        if len(new_targets) != 1 or head_policy.release_targets != (*retained_targets, new_targets[0]):
+            raise BackportCheckError(
+                "release-line bootstrap must preserve retained release targets, remove only retired targets, "
+                "and append exactly one target for the new default line"
+            )
+        new_target = new_targets[0]
+        if (
+            release_branch_from_lean_ref(new_target.release_toolchain) != head_policy.default_dev_branch
+            or release_branch_from_lean_ref(new_target.release_verso_ref) != head_policy.default_dev_branch
+            or new_target.branch != head_policy.default_dev_branch
+        ):
+            raise BackportCheckError(
+                "release-line bootstrap target must use the new default release line for its toolchain, "
+                "Verso ref, and branch"
+            )
 
     changed_files = set(api.pull_request_files(source_pr_number))
     missing_files = sorted({"branch-policy.json", "lean-toolchain"} - changed_files)
@@ -304,35 +355,15 @@ def verify_release_line_retirement(
     pull_request: dict[str, Any],
     base_policy: BranchPolicy,
 ) -> tuple[BranchPolicy, tuple[str, ...]]:
-    base = pull_request.get("base")
-    base_sha = str(base.get("sha") or "") if isinstance(base, dict) else ""
-    head = pull_request.get("head")
-    head_sha = str(head.get("sha") or "") if isinstance(head, dict) else ""
-    if not base_sha:
-        raise BackportCheckError("release-line retirement validation requires pull_request.base.sha")
-    if not head_sha:
-        raise BackportCheckError("release-line retirement validation requires pull_request.head.sha")
-
-    try:
-        head_policy = load_branch_policy_text(
-            api.file_text("branch-policy.json", head_sha),
-            source_path=Path(f"github-head-{head_sha[:12]}-branch-policy.json"),
-        )
-    except SystemExit as err:
-        raise BackportCheckError(str(err)) from err
-    base_toolchain_release = release_branch_from_lean_ref(api.file_text("lean-toolchain", base_sha).strip())
-    head_toolchain_release = release_branch_from_lean_ref(api.file_text("lean-toolchain", head_sha).strip())
+    head_policy = load_release_transition_head_policy(
+        api,
+        pull_request,
+        base_policy,
+        transition_name="release-line retirement",
+    )
 
     if head_policy.default_dev_branch != base_policy.default_dev_branch:
         raise BackportCheckError("release-line retirement must preserve the default development release line")
-    if base_toolchain_release != base_policy.default_dev_branch:
-        raise BackportCheckError(
-            "release-line retirement base is internally inconsistent: its Lean toolchain does not match its default branch"
-        )
-    if head_toolchain_release != head_policy.default_dev_branch:
-        raise BackportCheckError(
-            "release-line retirement head is internally inconsistent: its Lean toolchain does not match its default branch"
-        )
 
     retained_count = len(head_policy.required_backport_branches)
     if retained_count >= len(base_policy.required_backport_branches):

--- a/tests/harness/test_backport_pr_check.py
+++ b/tests/harness/test_backport_pr_check.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 import tempfile
 import unittest
@@ -82,7 +83,62 @@ def run_with_required_backport(event_path: Path, *, token: str | None) -> int:
         return backport_mod.run(str(event_path), token=token)
 
 
+def run_release_transition(
+    *,
+    body: str,
+    base_default: str,
+    base_backports: tuple[str, ...],
+    head_default: str,
+    head_backports: tuple[str, ...],
+    changed_files: tuple[str, ...],
+    base_targets: list[dict[str, object]] | None = None,
+    head_targets: list[dict[str, object]] | None = None,
+    base_toolchain: str | None = None,
+    head_toolchain: str | None = None,
+) -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        package_root = Path(tmp) / "package"
+        package_root.mkdir()
+        (package_root / "branch-policy.json").write_text(
+            branch_policy_json(
+                default_dev=base_default,
+                required_backports=base_backports,
+                release_targets=base_targets,
+            ),
+            encoding="utf-8",
+        )
+        (package_root / "lean-toolchain").write_text(
+            f"{lean_toolchain(base_toolchain or base_default)}\n",
+            encoding="utf-8",
+        )
+        event_path = Path(tmp) / "event.json"
+        write_pull_request_event(event_path, draft=False, body=body)
+        api = FakeGitHubApi(
+            pull_request_files={11: list(changed_files)},
+            file_texts={
+                ("lean-toolchain", "base-sha"): f"{lean_toolchain(base_toolchain or base_default)}\n",
+                ("branch-policy.json", "head-sha"): branch_policy_json(
+                    default_dev=head_default,
+                    required_backports=head_backports,
+                    release_targets=head_targets,
+                ),
+                ("lean-toolchain", "head-sha"): f"{lean_toolchain(head_toolchain or head_default)}\n",
+            },
+        )
+        with (
+            patch.object(backport_mod, "GitHubApi", return_value=api),
+            patch.object(backport_mod, "PACKAGE_ROOT", package_root),
+        ):
+            return backport_mod.run(str(event_path), token="token")
+
+
 class BackportPrCheckTests(unittest.TestCase):
+    def test_github_api_decodes_repository_file_contents(self) -> None:
+        api = backport_mod.GitHubApi("leanprover/verso-blueprint", "token")
+        encoded = base64.b64encode(b"release policy\n").decode("ascii")
+        with patch.object(api, "get_json", return_value={"encoding": "base64", "content": encoded}):
+            self.assertEqual(api.file_text("branch-policy.json", "head-sha"), "release policy\n")
+
     def test_pr_template_backport_placeholder_is_safe_for_drafts(self) -> None:
         template = Path(__file__).resolve().parents[2] / ".github" / "PULL_REQUEST_TEMPLATE.md"
         entries = backport_mod.parse_backport_entries(template.read_text(encoding="utf-8"))
@@ -254,47 +310,106 @@ Backport v4.24.0: release-line retirement
             with self.assertRaisesRegex(backport_mod.BackportCheckError, "missing GitHub token"):
                 run_with_required_backport(event_path, token=None)
 
+    def test_run_accepts_machine_checked_release_line_bootstrap(self) -> None:
+        self.assertEqual(
+            run_release_transition(
+                body=backport_line("v4.32.0", backport_mod.RELEASE_LINE_BOOTSTRAP_STATUS),
+                base_default="v4.32.0",
+                base_backports=(),
+                head_default="v4.33.0",
+                head_backports=("v4.32.0",),
+                changed_files=("branch-policy.json", "lean-toolchain", "scripts/release.py"),
+            ),
+            0,
+        )
+
+    def test_run_accepts_bootstrap_that_retires_oldest_backport(self) -> None:
+        base_targets = [release_target("v4.31.0"), release_target("v4.32.0")]
+        head_targets = [
+            release_target("v4.32.0"),
+            release_target("v4.33.0", deploy_pages=False),
+        ]
+        self.assertEqual(
+            run_release_transition(
+                body=backport_line("v4.32.0", backport_mod.RELEASE_LINE_BOOTSTRAP_STATUS),
+                base_default="v4.32.0",
+                base_backports=("v4.31.0",),
+                head_default="v4.33.0",
+                head_backports=("v4.32.0",),
+                changed_files=("branch-policy.json", "lean-toolchain", "tests/harness/projects.json"),
+                base_targets=base_targets,
+                head_targets=head_targets,
+            ),
+            0,
+        )
+
+    def test_run_rejects_backward_release_line_bootstrap(self) -> None:
+        with self.assertRaisesRegex(backport_mod.BackportCheckError, "newer default development release line"):
+            run_release_transition(
+                body=backport_line("v4.32.0", backport_mod.RELEASE_LINE_BOOTSTRAP_STATUS),
+                base_default="v4.32.0",
+                base_backports=(),
+                head_default="v4.31.0",
+                head_backports=("v4.32.0",),
+                changed_files=("branch-policy.json", "lean-toolchain"),
+            )
+
+    def test_run_rejects_bootstrap_that_changes_a_retained_target(self) -> None:
+        with self.assertRaisesRegex(backport_mod.BackportCheckError, "preserve retained release targets"):
+            run_release_transition(
+                body=backport_line("v4.32.0", backport_mod.RELEASE_LINE_BOOTSTRAP_STATUS),
+                base_default="v4.32.0",
+                base_backports=("v4.31.0",),
+                head_default="v4.33.0",
+                head_backports=("v4.32.0",),
+                changed_files=("branch-policy.json", "lean-toolchain"),
+                base_targets=[release_target("v4.31.0"), release_target("v4.32.0")],
+                head_targets=[
+                    release_target("v4.32.0", deploy_pages=False),
+                    release_target("v4.33.0", deploy_pages=False),
+                ],
+            )
+
+    def test_run_rejects_bootstrap_with_mismatched_head_toolchain(self) -> None:
+        with self.assertRaisesRegex(backport_mod.BackportCheckError, "head is internally inconsistent"):
+            run_release_transition(
+                body=backport_line("v4.32.0", backport_mod.RELEASE_LINE_BOOTSTRAP_STATUS),
+                base_default="v4.32.0",
+                base_backports=(),
+                head_default="v4.33.0",
+                head_backports=("v4.32.0",),
+                changed_files=("branch-policy.json", "lean-toolchain"),
+                head_toolchain="v4.34.0",
+            )
+
+    def test_run_rejects_release_line_bootstrap_without_release_identity_changes(self) -> None:
+        with self.assertRaisesRegex(backport_mod.BackportCheckError, "missing lean-toolchain"):
+            run_release_transition(
+                body=backport_line("v4.32.0", backport_mod.RELEASE_LINE_BOOTSTRAP_STATUS),
+                base_default="v4.32.0",
+                base_backports=(),
+                head_default="v4.33.0",
+                head_backports=("v4.32.0",),
+                changed_files=("branch-policy.json",),
+            )
+
     def test_run_accepts_machine_checked_release_line_retirement(self) -> None:
         retired = SAMPLE_PREVIOUS_RELEASE
         base_targets = [release_target(retired), release_target(DEFAULT_DEV_RELEASE)]
-        head_targets = [release_target(DEFAULT_DEV_RELEASE)]
-        with tempfile.TemporaryDirectory() as tmp:
-            package_root = Path(tmp) / "package"
-            package_root.mkdir()
-            (package_root / "branch-policy.json").write_text(
-                branch_policy_json(
-                    default_dev=DEFAULT_DEV_RELEASE,
-                    required_backports=(retired,),
-                    release_targets=base_targets,
-                ),
-                encoding="utf-8",
-            )
-            (package_root / "lean-toolchain").write_text(
-                f"{lean_toolchain(DEFAULT_DEV_RELEASE)}\n",
-                encoding="utf-8",
-            )
-            event_path = Path(tmp) / "event.json"
-            write_pull_request_event(
-                event_path,
-                draft=False,
+        head_targets = [target for target in base_targets if target["id"] != retired]
+        self.assertEqual(
+            run_release_transition(
                 body=backport_line(retired, backport_mod.RELEASE_LINE_RETIREMENT_STATUS),
-            )
-            api = FakeGitHubApi(
-                pull_request_files={11: ["branch-policy.json", "tests/harness/projects.json"]},
-                file_texts={
-                    ("branch-policy.json", "head-sha"): branch_policy_json(
-                        default_dev=DEFAULT_DEV_RELEASE,
-                        release_targets=head_targets,
-                    ),
-                    ("lean-toolchain", "base-sha"): f"{lean_toolchain(DEFAULT_DEV_RELEASE)}\n",
-                    ("lean-toolchain", "head-sha"): f"{lean_toolchain(DEFAULT_DEV_RELEASE)}\n",
-                },
-            )
-            with (
-                patch.object(backport_mod, "GitHubApi", return_value=api),
-                patch.object(backport_mod, "PACKAGE_ROOT", package_root),
-            ):
-                self.assertEqual(backport_mod.run(str(event_path), token="token"), 0)
+                base_default=DEFAULT_DEV_RELEASE,
+                base_backports=(retired,),
+                head_default=DEFAULT_DEV_RELEASE,
+                head_backports=(),
+                changed_files=("branch-policy.json", "tests/harness/projects.json"),
+                base_targets=base_targets,
+                head_targets=head_targets,
+            ),
+            0,
+        )
 
     def test_run_rejects_retiring_a_non_oldest_backport(self) -> None:
         newest = "v4.31.0"
@@ -304,45 +419,17 @@ Backport v4.24.0: release-line retirement
             release_target(newest),
             release_target(DEFAULT_DEV_RELEASE),
         ]
-        with tempfile.TemporaryDirectory() as tmp:
-            package_root = Path(tmp) / "package"
-            package_root.mkdir()
-            (package_root / "branch-policy.json").write_text(
-                branch_policy_json(
-                    default_dev=DEFAULT_DEV_RELEASE,
-                    required_backports=(newest, oldest),
-                    release_targets=base_targets,
-                ),
-                encoding="utf-8",
-            )
-            (package_root / "lean-toolchain").write_text(
-                f"{lean_toolchain(DEFAULT_DEV_RELEASE)}\n",
-                encoding="utf-8",
-            )
-            event_path = Path(tmp) / "event.json"
-            write_pull_request_event(
-                event_path,
-                draft=False,
+        with self.assertRaisesRegex(backport_mod.BackportCheckError, "oldest contiguous suffix"):
+            run_release_transition(
                 body=backport_line(newest, backport_mod.RELEASE_LINE_RETIREMENT_STATUS),
+                base_default=DEFAULT_DEV_RELEASE,
+                base_backports=(newest, oldest),
+                head_default=DEFAULT_DEV_RELEASE,
+                head_backports=(oldest,),
+                changed_files=("branch-policy.json",),
+                base_targets=base_targets,
+                head_targets=[release_target(oldest), release_target(DEFAULT_DEV_RELEASE)],
             )
-            api = FakeGitHubApi(
-                pull_request_files={11: ["branch-policy.json"]},
-                file_texts={
-                    ("branch-policy.json", "head-sha"): branch_policy_json(
-                        default_dev=DEFAULT_DEV_RELEASE,
-                        required_backports=(oldest,),
-                        release_targets=[release_target(oldest), release_target(DEFAULT_DEV_RELEASE)],
-                    ),
-                    ("lean-toolchain", "base-sha"): f"{lean_toolchain(DEFAULT_DEV_RELEASE)}\n",
-                    ("lean-toolchain", "head-sha"): f"{lean_toolchain(DEFAULT_DEV_RELEASE)}\n",
-                },
-            )
-            with (
-                patch.object(backport_mod, "GitHubApi", return_value=api),
-                patch.object(backport_mod, "PACKAGE_ROOT", package_root),
-            ):
-                with self.assertRaisesRegex(backport_mod.BackportCheckError, "oldest contiguous suffix"):
-                    backport_mod.run(str(event_path), token="token")
 
 
 if __name__ == "__main__":

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -162,7 +162,8 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertIsNotNone(default_template_target)
         self.assertFalse(default_template_target.publish_reference)
         self.assertFalse(any(target.publish_reference for target in projects[0].targets))
-        self.assertTrue(catalog.release_target("v4.32.0").deploy_pages)
+        for release_id in branch_policy.required_backport_branches:
+            self.assertTrue(catalog.release_target(release_id).deploy_pages)
         self.assertEqual(current_release.release_toolchain, current_release.toolchain)
         self.assertEqual(current_release.release_verso_ref, current_release.verso_ref)
         if current_release.deploy_pages:

--- a/tests/harness/test_blueprint_harness_releases.py
+++ b/tests/harness/test_blueprint_harness_releases.py
@@ -28,6 +28,18 @@ class BlueprintHarnessReleaseHelperTests(unittest.TestCase):
         self.assertEqual(releases_mod.normalize_lean_release_ref(SAMPLE_NEXT_RC), SAMPLE_NEXT_RC_REF)
         self.assertEqual(releases_mod.release_branch_from_lean_ref(lean_toolchain(SAMPLE_NEXT_RC_REF)), SAMPLE_NEXT_RELEASE)
 
+    def test_release_branch_versions_are_comparable_across_stable_and_rc_refs(self) -> None:
+        self.assertEqual(releases_mod.release_branch_version("v4.33.0"), (4, 33, 0))
+        self.assertEqual(releases_mod.release_branch_version("4.33-rc2"), (4, 33, 0))
+        self.assertGreater(
+            releases_mod.release_branch_version("v4.33.0"),
+            releases_mod.release_branch_version("v4.32.1"),
+        )
+
+    def test_release_branch_version_rejects_non_numeric_refs(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "expected a numeric Lean release branch"):
+            releases_mod.release_branch_version("main")
+
     def test_rewrite_lean_toolchain_preserves_existing_final_newline_style(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
Backport #366 to `v4.32.0`.

## Primary Review
- Primary review: #366
- Keep review comments on #366 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.32.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- Preserve v4.32-specific toolchain/Verso documentation and adapt transition fixtures to branch-independent sample releases.
- Production checker and shared-helper changes otherwise match #366.