### PR TITLE
fix: update linkify-it to 5.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -219,9 +219,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
This PR updates the development-only transitive `linkify-it` dependency from 5.0.1 to 5.0.2, fixing GHSA-v245-v573-v5vm's quadratic-complexity denial of service in `mailto:` validation used through JSDoc and Markdown-It.

The package manifest is unchanged; only the resolved lockfile version and integrity are refreshed.

Backport v4.32.0: #370
