### PR TITLE
[backport v4.32.0] perf: streamline generated preview data

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -173,9 +173,16 @@ Generator-side data flow is source-to-traversal-to-public JSON. During Manual
 traversal, Blueprint records preview identities, rendered bodies, Lean-code
 associations, citations, graph data, and external-markup witnesses in traversal
 state and traversal domains. `Informal.PreviewManifest.buildPreviewDataFiles`
-then normalizes those phase-local records into the semantic manifest and the
-rendered-fragment cache. Generated ESM APIs load those two files; they do not
-rerun traversal and should not recover semantics by scraping cached HTML.
+then assembles a `PreviewDataModel` and crosses its `finish` boundary into the
+emission-ready semantic manifest/rendered-fragment-cache `Files` pair. The
+final type has a private constructor, so unresolved candidate references cannot
+enter the normal emission path. Generated ESM APIs load those two files; they
+do not rerun traversal and should not recover semantics by scraping cached HTML.
+
+Persisted or externally supplied manifest/cache pairs enter maintainer audits
+as `PreviewManifest.PersistedFiles`, not as emission-ready `Files`. Parsing each
+file cannot by itself establish their cross-artifact reference invariants;
+`vbp check` reports violations without repairing or promoting the decoded pair.
 
 Source-provenance data also lives in the manifest. Declared source documents
 are exported as `sourceDocuments`. Each manifest entry carries a `sources` array
@@ -438,7 +445,7 @@ or DOT variant that disagrees with the authoritative nodes.
 Topology finalization and preview-artifact resolution are separate boundaries.
 `GraphModel.finish` fixes topology and DOT exactly once. Later, after the
 manifest and rendered-fragment cache are both known,
-`PreviewManifest.Files.finalizePreviewReferences` may use
+`PreviewManifest.PreviewDataModel.finish` may use
 `GraphData.filterPreviewReferences` to remove unavailable preview keys from nodes
 and their variant lookup entries together. That synchronized post-pass cannot
 change nodes' dependencies or parents, derived edges or children, or DOT, and

--- a/doc/API.md
+++ b/doc/API.md
@@ -438,7 +438,7 @@ or DOT variant that disagrees with the authoritative nodes.
 Topology finalization and preview-artifact resolution are separate boundaries.
 `GraphModel.finish` fixes topology and DOT exactly once. Later, after the
 manifest and rendered-fragment cache are both known,
-`PreviewManifest.File.finalizePreviewReferences` may use
+`PreviewManifest.Files.finalizePreviewReferences` may use
 `GraphData.filterPreviewReferences` to remove unavailable preview keys from nodes
 and their variant lookup entries together. That synchronized post-pass cannot
 change nodes' dependencies or parents, derived edges or children, or DOT, and

--- a/doc/API.md
+++ b/doc/API.md
@@ -445,7 +445,7 @@ or DOT variant that disagrees with the authoritative nodes.
 Topology finalization and preview-artifact resolution are separate boundaries.
 `GraphModel.finish` fixes topology and DOT exactly once. Later, after the
 manifest and rendered-fragment cache are both known,
-`PreviewManifest.PreviewDataModel.finish` may use
+`PreviewManifest.PreviewDataModel.finish` uses
 `GraphData.filterPreviewReferences` to remove unavailable preview keys from nodes
 and their variant lookup entries together. That synchronized post-pass cannot
 change nodes' dependencies or parents, derived edges or children, or DOT, and

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -327,9 +327,17 @@ edges, group children, or DOT. It accepts only a retention predicate, so this
 post-pass cannot rewrite preview identities. Thus topology still crosses one
 finalization boundary even though manifest emission later prunes preview
 candidates that did not produce both a manifest entry and a rendered cache
-body. `PreviewManifest.Files.finalizePreviewReferences` owns that post-pass on
-the paired manifest/cache value, so production construction, indexing, and
-finalization pass one explicit pair instead of repeatedly selecting artifacts.
+body. `PreviewManifest.PreviewDataModel.finish` owns that post-pass on the paired
+manifest/cache candidate and returns `PreviewManifest.Files`, whose private
+constructor makes the phase transition concrete. Production construction,
+indexing, and finalization therefore pass one explicit pair instead of
+repeatedly selecting artifacts, and finalized files cannot be finalized again.
+
+For `m` manifest entries, `c` rendered-cache entries, `r` non-graph preview
+references, `n` graph nodes, and `v` graph-variant preview mappings, `finish`
+runs in expected `O(m + c + r + n + v)` time under hash-map operations. Its
+auxiliary indexes use `O(m + c)` space; the finalized arrays it returns are
+linear in the candidate output size. Graph topology and DOT are not rebuilt.
 
 Generated-data readers preserve the same boundary without charging every
 semantic query for projections it cannot consume. The general manifest reader
@@ -338,7 +346,9 @@ rejects mismatches; `vbp check` and the graph-backed `work-queue` selector use
 that reader. Other `vbp query` selectors remove the top-level graph array before
 decoding because they do not consume graph projections. They still validate the
 manifest schema and decode all queryable semantic data, while avoiding graph and
-DOT rematerialization on graph-free planning-data paths.
+DOT rematerialization on graph-free planning-data paths. The manifest/cache pair
+read by `vbp check` is represented as `PreviewManifest.PersistedFiles`, because
+successful local decoding does not imply that cross-file references agree.
 
 ### Render Path Inventory
 

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -327,7 +327,9 @@ edges, group children, or DOT. It accepts only a retention predicate, so this
 post-pass cannot rewrite preview identities. Thus topology still crosses one
 finalization boundary even though manifest emission later prunes preview
 candidates that did not produce both a manifest entry and a rendered cache
-body.
+body. `PreviewManifest.Files.finalizePreviewReferences` owns that post-pass on
+the paired manifest/cache value, so production construction, indexing, and
+finalization pass one explicit pair instead of repeatedly selecting artifacts.
 
 ### Render Path Inventory
 

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -333,11 +333,12 @@ constructor makes the phase transition concrete. Production construction,
 indexing, and finalization therefore pass one explicit pair instead of
 repeatedly selecting artifacts, and finalized files cannot be finalized again.
 
-For `m` manifest entries, `c` rendered-cache entries, `r` non-graph preview
-references, `n` graph nodes, and `v` graph-variant preview mappings, `finish`
-runs in expected `O(m + c + r + n + v)` time under hash-map operations. Its
-auxiliary indexes use `O(m + c)` space; the finalized arrays it returns are
-linear in the candidate output size. Graph topology and DOT are not rebuilt.
+For `m` manifest preview/group records, `c` rendered-cache entries, `r`
+non-graph preview references, `n` graph nodes, and `v` graph-variant
+records/mappings, `finish` runs in expected `O(m + c + r + n + v)` time under
+hash-map operations. Its auxiliary indexes use `O(m + c)` space; the finalized
+arrays it returns are linear in the candidate output size. Graph topology and
+DOT are not rebuilt.
 
 Generated-data readers preserve the same boundary without charging every
 semantic query for projections it cannot consume. The general manifest reader

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -331,6 +331,15 @@ body. `PreviewManifest.Files.finalizePreviewReferences` owns that post-pass on
 the paired manifest/cache value, so production construction, indexing, and
 finalization pass one explicit pair instead of repeatedly selecting artifacts.
 
+Generated-data readers preserve the same boundary without charging every
+semantic query for projections it cannot consume. The general manifest reader
+strictly reconstructs graph topology and DOT variants from semantic nodes and
+rejects mismatches; `vbp check` and the graph-backed `work-queue` selector use
+that reader. Other `vbp query` selectors remove the top-level graph array before
+decoding because they do not consume graph projections. They still validate the
+manifest schema and decode all queryable semantic data, while avoiding graph and
+DOT rematerialization on graph-free planning-data paths.
+
 ### Render Path Inventory
 
 There are several Blueprint render callers, but only a few true assembly

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -58,6 +58,15 @@ queries. End-user docs should present `lake exe vbp build` as the normal
 rendering workflow; it discovers the project generator entry point and invokes
 it internally.
 
+`lake exe vbp check` is an audit of an already-generated artifact boundary, not
+a repair phase or a required second half of normal generation. Production
+generation constructs the manifest and rendered-fragment cache together and
+finalizes their preview references before emission. Use `check` when validating
+persisted, copied, or externally supplied output; it deliberately performs
+stricter cross-artifact and graph-projection checks than ordinary semantic
+queries. The graph-backed `work-queue` selector also retains strict graph
+decoding; graph-free selectors avoid materializing graph projections.
+
 Treat `vbp` JSON as fully unstable. It may change within this repository as
 agent workflows evolve, and is not part of the documented integration API.
 Prefer in-band discovery through `lake exe vbp --help`,

--- a/skills/verso-blueprint/SKILL.md
+++ b/skills/verso-blueprint/SKILL.md
@@ -25,9 +25,9 @@ Read `references/authoring-patterns.md` before editing Blueprint source, adding 
 1. Run `lake exe vbp discover` first to identify the package, generator, top-level Blueprint module, output paths, and chapter candidates.
 2. Build with `lake exe vbp build` before querying unless generated output already exists and the user only asks to inspect it.
 3. Query with `lake exe vbp query ...`; do not ask users to inspect manifest/cache files directly for normal tasks.
-4. Use `lake exe vbp query all <label>` when you need the full agent bundle for one Blueprint node.
+4. Use `lake exe vbp query node <label>` when you need the complete record for one Blueprint node.
 5. Edit source conservatively when requested. Preserve stable labels, use existing chapter/module patterns, and keep dependency intent clear.
-6. Rebuild or run `lake exe vbp check` after edits. Report changed labels, changed dependency edges, and remaining diagnostics.
+6. Rebuild after source edits. Use `lake exe vbp check` when auditing persisted, copied, or externally supplied generated output. Report changed labels, changed dependency edges, and remaining diagnostics.
 
 ## Guardrails
 

--- a/skills/verso-blueprint/SKILL.md
+++ b/skills/verso-blueprint/SKILL.md
@@ -13,7 +13,6 @@ Prefer the project-local helper:
 lake exe vbp discover
 lake exe vbp build
 lake exe vbp query labels
-lake exe vbp check
 ```
 
 Read `references/vbp.md` when you need exact command behavior, JSON shapes, serve behavior, or fallback commands.

--- a/skills/verso-blueprint/references/authoring-patterns.md
+++ b/skills/verso-blueprint/references/authoring-patterns.md
@@ -118,7 +118,9 @@ Before editing, inspect the neighboring chapter and top-level Blueprint module. 
 
 ```bash
 lake exe vbp build
-lake exe vbp check
 ```
 
-When reporting changes, name the labels changed, dependency edges added or removed, and any remaining build/check diagnostics.
+`vbp build` is the correctness boundary for normal source edits. Use
+`lake exe vbp check` separately when auditing persisted, copied, or externally
+supplied generated output. When reporting changes, name the labels changed,
+dependency edges added or removed, and any remaining diagnostics.

--- a/skills/verso-blueprint/references/vbp.md
+++ b/skills/verso-blueprint/references/vbp.md
@@ -19,7 +19,6 @@ Query selectors:
 selectors
 labels
 node <label>
-all <label>
 uses <label>
 used-by <label>
 group <label>
@@ -79,8 +78,7 @@ All query commands print compact JSON for agent consumption. The JSON shape is f
 
 - `selectors`: query selector forms supported by this `vbp` binary. This selector does not require generated Blueprint data.
 - `labels`: statement-level Blueprint block summaries.
-- `node <label>`: one block entry with title, kind, href, parent/group, owner/tags/priority/effort, statement/proof uses, reverse uses, and Lean preview keys.
-- `all <label>`: one-stop agent bundle for a node, including the node, statement/proof uses, reverse uses, and group data.
+- `node <label>`: one complete block entry with title, kind, href, parent/group, owner/tags/priority/effort, statement/proof uses, reverse uses, group data, and Lean preview keys.
 - `uses <label>`: statement/proof dependencies and resolved related entries for one label.
 - `used-by <label>`: reverse dependencies for one label.
 - `group <label>`: group metadata and sibling entries for one label, when present.
@@ -98,7 +96,7 @@ If generated data is missing, run `lake exe vbp build` first. If a label is unkn
 
 ## Check
 
-`lake exe vbp check` is a post-build generated-data health check. It does not replace `build`: build catches Lean/Lake compilation, elaboration, generator, and rendering failures. `check` parses generated data and verifies that semantic entries, Lean preview keys, relation previews, and group previews have corresponding rendered HTML cache entries. It prints:
+`lake exe vbp check` audits an already-generated artifact boundary. It is not a repair phase or a required second step after normal generation: `build` catches Lean/Lake compilation, elaboration, generator, and rendering failures, and production generation constructs and finalizes the manifest/cache pair together. Use `check` for persisted, copied, or externally supplied output. It strictly parses generated graph projections and verifies that semantic entries, Lean preview keys, relation previews, and group previews have corresponding rendered HTML cache entries. It prints:
 
 ```json
 {"apiStability":"unstable","ok":true,"manifestEntries":0,"htmlCacheEntries":0,"errors":[]}

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -1626,6 +1626,22 @@ def readFile (path : System.FilePath) : IO File := do
   | .ok () => decodeJsonAs path "Blueprint manifest" json
   | .error err => throw <| IO.userError s!"could not decode Blueprint manifest {path}: {err}"
 
+/--
+Read the semantic projection consumed by graph-free `vbp query` selectors
+without materializing graph render projections they do not read.
+
+The manifest schema and every non-graph field are decoded normally. Use
+`readFile` for artifact audits: its strict `GraphData` decoder reconstructs and
+checks derived edges, groups, preview mappings, and DOT variants.
+-/
+def readFileWithoutGraphs (path : System.FilePath) : IO File := do
+  let json ← readJsonFile path "Blueprint manifest"
+  match checkManifestInternalSchema json with
+  | .ok () =>
+      decodeJsonAs path "Blueprint manifest" <|
+        json.setObjVal! "graphs" (Json.arr #[])
+  | .error err => throw <| IO.userError s!"could not decode Blueprint manifest {path}: {err}"
+
 private structure SchemaState where
   seen : Std.HashSet Name := {}
   defs : Array (String × Json) := #[]

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -1194,8 +1194,17 @@ def readFile (path : System.FilePath) : IO File := do
 
 end HtmlCache
 
-/-- Paired preview-data outputs emitted for a generated Blueprint site. -/
-structure Files where
+/--
+Assembled preview-data candidates before rendered-preview references are
+resolved against the paired manifest and HTML cache.
+-/
+structure PreviewDataModel where
+  manifest : File := {}
+  htmlCache : HtmlCache.File := {}
+deriving Inhabited, Repr
+
+/-- Paired, emission-ready preview-data outputs for a generated Blueprint site. -/
+structure Files where private mk ::
   /--
   Semantic preview data. This is the public source of truth for labels, hrefs,
   relationship topology, Lean-code associations, external-markup metadata, and
@@ -1206,6 +1215,19 @@ structure Files where
   Opaque rendered fragments and their hover payload side table. Consumers join
   this cache with `manifest` by preview key when they need presentation data.
   -/
+  htmlCache : HtmlCache.File := {}
+deriving Repr
+
+/--
+Manifest/cache files decoded from persisted or externally supplied output.
+
+Parsing establishes each file's local schema but does not establish the
+cross-artifact invariants enforced during production construction. Consumers
+such as `vbp check` audit this value rather than treating it as emission-ready
+`Files`.
+-/
+structure PersistedFiles where
+  manifest : File := {}
   htmlCache : HtmlCache.File := {}
 deriving Inhabited, Repr
 
@@ -1254,10 +1276,17 @@ structure PreviewArtifactIndex where
   manifestIndex : Index := {}
   htmlCacheIndex : HtmlCache.Index := {}
 
-def PreviewArtifactIndex.ofFiles (files : Files) : PreviewArtifactIndex := {
-  manifestIndex := files.manifest.index
-  htmlCacheIndex := files.htmlCache.index
+private def PreviewArtifactIndex.ofArtifacts
+    (manifest : File) (htmlCache : HtmlCache.File) : PreviewArtifactIndex := {
+  manifestIndex := manifest.index
+  htmlCacheIndex := htmlCache.index
 }
+
+def PreviewArtifactIndex.ofModel (model : PreviewDataModel) : PreviewArtifactIndex :=
+  PreviewArtifactIndex.ofArtifacts model.manifest model.htmlCache
+
+def PreviewArtifactIndex.ofPersistedFiles (files : PersistedFiles) : PreviewArtifactIndex :=
+  PreviewArtifactIndex.ofArtifacts files.manifest files.htmlCache
 
 def PreviewArtifactIndex.hasManifestKey
     (index : PreviewArtifactIndex) (key : String) : Bool :=
@@ -1316,13 +1345,13 @@ fragment cache body. Relations and graph nodes that fail that join remain
 present but lose their `previewKey`; Lean-code keys and graph-variant mappings
 are removed so generated JSON does not point at an unavailable preview body.
 
-Keeping finalization on `Files` makes the manifest/cache pair explicit at the
-construction boundary and prevents argument drift between index construction
-and the returned value.
+The phase-changing result type makes the manifest/cache pair explicit at the
+construction boundary: unresolved candidates cannot be emitted as `Files`, and
+emission-ready files cannot be finalized a second time.
 -/
-def Files.finalizePreviewReferences (files : Files) : Files :=
-  let index := PreviewArtifactIndex.ofFiles files
-  { files with manifest := files.manifest.finalizePreviewReferences index }
+def PreviewDataModel.finish (model : PreviewDataModel) : Files :=
+  let index := PreviewArtifactIndex.ofModel model
+  Files.mk (model.manifest.finalizePreviewReferences index) model.htmlCache
 
 /-- Manifest metadata that was present during traversal but is absent from export. -/
 structure PreviewMetadataLoss where
@@ -2509,11 +2538,11 @@ def buildPreviewDataFiles
     entries := htmlEntries
     hoverDocs := HtmlCache.HoverDoc.ofDedup hoverState.dedup
   }
-  let files : Files := {
+  let model : PreviewDataModel := {
     manifest := { previews, groups, graphs, sourceDocuments }
     htmlCache
   }
-  pure files.finalizePreviewReferences
+  pure model.finish
 
 private def dumpManifest
     (text : Part Manual)

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -1254,10 +1254,9 @@ structure PreviewArtifactIndex where
   manifestIndex : Index := {}
   htmlCacheIndex : HtmlCache.Index := {}
 
-def PreviewArtifactIndex.ofFiles (manifest : File) (htmlCache : HtmlCache.File) :
-    PreviewArtifactIndex := {
-  manifestIndex := manifest.index
-  htmlCacheIndex := htmlCache.index
+def PreviewArtifactIndex.ofFiles (files : Files) : PreviewArtifactIndex := {
+  manifestIndex := files.manifest.index
+  htmlCacheIndex := files.htmlCache.index
 }
 
 def PreviewArtifactIndex.hasManifestKey
@@ -1299,23 +1298,31 @@ private def graphFinalizePreviewReferences
     Informal.Graph.GraphData :=
   graph.filterPreviewReferences fun key => index.resolves key.value
 
-/--
-Finalize traversal-derived preview references against the manifest/cache pair.
-
-Generated relation, group, Lean-code, and graph preview references are only
-advertised when the target key has both a semantic manifest entry and a rendered
-fragment cache body. Relations and graph nodes that fail that join remain
-present but lose their `previewKey`; Lean-code keys and graph-variant mappings
-are removed so generated JSON does not point at an unavailable preview body.
--/
-def File.finalizePreviewReferences (file : File) (htmlCache : HtmlCache.File) : File :=
-  let index := PreviewArtifactIndex.ofFiles file htmlCache
+private def File.finalizePreviewReferences
+    (file : File) (index : PreviewArtifactIndex) : File :=
   {
     file with
       previews := file.previews.map (Entry.finalizePreviewReferences index)
       groups := file.groups.map (GroupRelation.finalizePreviewReferences index)
       graphs := file.graphs.map (graphFinalizePreviewReferences index)
   }
+
+/--
+Finalize traversal-derived preview references against a paired manifest/cache value.
+
+Generated relation, group, Lean-code, and graph preview references are only
+advertised when the target key has both a semantic manifest entry and a rendered
+fragment cache body. Relations and graph nodes that fail that join remain
+present but lose their `previewKey`; Lean-code keys and graph-variant mappings
+are removed so generated JSON does not point at an unavailable preview body.
+
+Keeping finalization on `Files` makes the manifest/cache pair explicit at the
+construction boundary and prevents argument drift between index construction
+and the returned value.
+-/
+def Files.finalizePreviewReferences (files : Files) : Files :=
+  let index := PreviewArtifactIndex.ofFiles files
+  { files with manifest := files.manifest.finalizePreviewReferences index }
 
 /-- Manifest metadata that was present during traversal but is absent from export. -/
 structure PreviewMetadataLoss where
@@ -2486,8 +2493,11 @@ def buildPreviewDataFiles
     entries := htmlEntries
     hoverDocs := HtmlCache.HoverDoc.ofDedup hoverState.dedup
   }
-  let manifest : File := { previews, groups, graphs, sourceDocuments }
-  pure { manifest := manifest.finalizePreviewReferences htmlCache, htmlCache }
+  let files : Files := {
+    manifest := { previews, groups, graphs, sourceDocuments }
+    htmlCache
+  }
+  pure files.finalizePreviewReferences
 
 private def dumpManifest
     (text : Part Manual)

--- a/src/VersoBlueprint/Vbp.lean
+++ b/src/VersoBlueprint/Vbp.lean
@@ -19,7 +19,7 @@ abbrev RelatedEntry := Informal.PreviewManifest.RelatedEntry
 abbrev GroupRelation := Informal.PreviewManifest.GroupRelation
 abbrev RelationAxis := Informal.PreviewManifest.RelationAxis
 abbrev PreviewArtifactIndex := Informal.PreviewManifest.PreviewArtifactIndex
-abbrev GeneratedData := Informal.PreviewManifest.Files
+abbrev GeneratedData := Informal.PreviewManifest.PersistedFiles
 abbrev WorkQueueItem := Informal.PreviewManifest.WorkQueueItem
 
 def defaultSite : FilePath := "_out" / "site"
@@ -463,7 +463,7 @@ private def checkManifestGroupIntegrity
 
 def checkGeneratedData (data : GeneratedData) : Array String :=
   let manifest := data.manifest
-  let index := Informal.PreviewManifest.PreviewArtifactIndex.ofFiles data
+  let index := Informal.PreviewManifest.PreviewArtifactIndex.ofPersistedFiles data
   let errors := manifest.previews.foldl
     (fun errors entry =>
       let errors :=

--- a/src/VersoBlueprint/Vbp.lean
+++ b/src/VersoBlueprint/Vbp.lean
@@ -285,9 +285,27 @@ private def readManifestWith
 def readManifestForSite (site : FilePath) : IO ManifestFile :=
   readManifestWith Informal.PreviewManifest.readFile site
 
+/--
+Whether a query must use the strict manifest reader that reconstructs graph data.
+
+Graph-free loading is an explicit allowlist. Unknown or newly added selector
+shapes default to strict loading so they cannot silently observe an empty graph
+projection when their read mode has not yet been classified.
+-/
 def queryNeedsGraphData : List String → Bool
-  | ["work-queue"] => true
-  | _ => false
+  | ["selectors"]
+  | ["labels"]
+  | ["node", _]
+  | ["uses", _]
+  | ["used-by", _]
+  | ["group", _]
+  | ["owners"]
+  | ["tags"]
+  | ["metadata"]
+  | ["search", _]
+  | ["code", _]
+  | ["stats"] => false
+  | _ => true
 
 def readManifestForQuery (site : FilePath) (selector : List String) : IO ManifestFile := do
   if queryNeedsGraphData selector then

--- a/src/VersoBlueprint/Vbp.lean
+++ b/src/VersoBlueprint/Vbp.lean
@@ -19,7 +19,7 @@ abbrev RelatedEntry := Informal.PreviewManifest.RelatedEntry
 abbrev GroupRelation := Informal.PreviewManifest.GroupRelation
 abbrev RelationAxis := Informal.PreviewManifest.RelationAxis
 abbrev PreviewArtifactIndex := Informal.PreviewManifest.PreviewArtifactIndex
-abbrev GeneratedData := Informal.PreviewManifest.PersistedFiles
+abbrev PersistedGeneratedData := Informal.PreviewManifest.PersistedFiles
 abbrev WorkQueueItem := Informal.PreviewManifest.WorkQueueItem
 
 def defaultSite : FilePath := "_out" / "site"
@@ -319,7 +319,7 @@ def readHtmlCacheForSite (site : FilePath) : IO HtmlCacheFile := do
     throw <| IO.userError s!"missing Blueprint HTML cache at {htmlCachePath}; run `lake exe vbp build` first"
   Informal.PreviewManifest.HtmlCache.readFile htmlCachePath
 
-def readGeneratedData (site : FilePath) : IO GeneratedData := do
+def readPersistedGeneratedData (site : FilePath) : IO PersistedGeneratedData := do
   let manifest ← readManifestForSite site
   let htmlCache ← readHtmlCacheForSite site
   pure { manifest, htmlCache }
@@ -461,7 +461,7 @@ private def checkManifestGroupIntegrity
           s!"{Informal.PreviewManifest.labelString member} has no matching manifest entry"
   return errors
 
-def checkGeneratedData (data : GeneratedData) : Array String :=
+def checkGeneratedData (data : PersistedGeneratedData) : Array String :=
   let manifest := data.manifest
   let index := Informal.PreviewManifest.PreviewArtifactIndex.ofPersistedFiles data
   let errors := manifest.previews.foldl
@@ -492,7 +492,7 @@ def checkGeneratedData (data : GeneratedData) : Array String :=
   let errors := checkManifestGroupIntegrity manifest errors
   manifest.graphs.foldl (fun errors graph => checkGraphPreviewKeys index graph errors) errors
 
-def checkJsonFromErrors (data : GeneratedData) (errors : Array String) : Json :=
+def checkJsonFromErrors (data : PersistedGeneratedData) (errors : Array String) : Json :=
   responseJson [
     ("ok", Json.bool errors.isEmpty),
     ("manifestEntries", Json.num data.manifest.previews.size),
@@ -500,7 +500,7 @@ def checkJsonFromErrors (data : GeneratedData) (errors : Array String) : Json :=
     ("errors", Json.arr (errors.map Json.str))
   ]
 
-def checkJson (data : GeneratedData) : Json :=
+def checkJson (data : PersistedGeneratedData) : Json :=
   checkJsonFromErrors data (checkGeneratedData data)
 
 end VersoBlueprint.Vbp

--- a/src/VersoBlueprint/Vbp.lean
+++ b/src/VersoBlueprint/Vbp.lean
@@ -32,7 +32,6 @@ def querySelectorLines : List String := [
   "selectors",
   "labels",
   "node <label>",
-  "all <label>",
   "uses <label>",
   "used-by <label>",
   "group <label>",
@@ -173,23 +172,8 @@ private def entryDetailFields
     ("effort", optionStringJson entry.effort)
   ]
 
-def entryJson (entry : Entry) (group? : Option GroupRelation := none) : Json :=
-  Json.mkObj (entryDetailFields entry group?)
-
 private def entryResponseJson (manifest : ManifestFile) (entry : Entry) : Json :=
   responseJson (entryDetailFields entry (manifest.groupForEntry? entry))
-
-private def entryAllJson (manifest : ManifestFile) (label : String) (entry : Entry) : Json :=
-  let group? := manifest.groupForEntry? entry
-  responseJson [
-    ("label", Json.str label),
-    ("node", entryJson entry group?),
-    ("statementUses", Json.arr (entry.statementUses.map useRefJson)),
-    ("proofUses", Json.arr (entry.proofUses.map useRefJson)),
-    ("uses", Json.arr (entry.uses.map relatedEntryJson)),
-    ("usedBy", Json.arr (entry.usedBy.map relatedEntryJson)),
-    ("group", group?.map groupRelationJson |>.getD Json.null)
-  ]
 
 private def incrementCount (counts : Array (String × Nat)) (key : String) : Array (String × Nat) :=
   let rec go (seen : Bool) (acc : Array (String × Nat)) : List (String × Nat) → Array (String × Nat)
@@ -244,8 +228,6 @@ def queryJson (manifest : ManifestFile) (args : List String) : Except String Jso
       ]
   | ["node", label] =>
       withPrimaryEntry manifest label (entryResponseJson manifest)
-  | ["all", label] =>
-      withPrimaryEntry manifest label (entryAllJson manifest label)
   | ["uses", label] =>
       withPrimaryEntry manifest label fun entry =>
         responseJson [
@@ -293,11 +275,25 @@ def queryJson (manifest : ManifestFile) (args : List String) : Except String Jso
   | [] => .error "missing query selector"
   | selector :: _ => .error s!"unknown query selector '{selector}'"
 
-def readManifestForSite (site : FilePath) : IO ManifestFile := do
+private def readManifestWith
+    (read : FilePath → IO ManifestFile) (site : FilePath) : IO ManifestFile := do
   let manifestPath ← manifestPathForSite site
   unless ← manifestPath.pathExists do
     throw <| IO.userError s!"missing Blueprint manifest at {manifestPath}; run `lake exe vbp build` first"
-  Informal.PreviewManifest.readFile manifestPath
+  read manifestPath
+
+def readManifestForSite (site : FilePath) : IO ManifestFile :=
+  readManifestWith Informal.PreviewManifest.readFile site
+
+def queryNeedsGraphData : List String → Bool
+  | ["work-queue"] => true
+  | _ => false
+
+def readManifestForQuery (site : FilePath) (selector : List String) : IO ManifestFile := do
+  if queryNeedsGraphData selector then
+    readManifestForSite site
+  else
+    readManifestWith Informal.PreviewManifest.readFileWithoutGraphs site
 
 def readHtmlCacheForSite (site : FilePath) : IO HtmlCacheFile := do
   let htmlCachePath ← htmlCachePathForSite site
@@ -354,24 +350,10 @@ private def checkGraphNodePreviewKey
         s!"graph {graphKey} node {Informal.PreviewManifest.labelString node.label}"
         key.value errors
 
-private def checkGraphVariantPreviewKeys
-    (index : PreviewArtifactIndex) (graphKey : String)
-    (variant : Informal.Graph.GraphRenderVariant) (errors : Array String) : Array String :=
-  variant.previewKeyByNodeId.foldl
-    (fun errors (nodeId, key) =>
-      checkPreviewReference index
-        s!"graph {graphKey} variant {variant.key} node {nodeId}"
-        key errors)
-    errors
-
 private def checkGraphPreviewKeys
     (index : PreviewArtifactIndex) (graph : Informal.Graph.GraphData)
     (errors : Array String) : Array String :=
-  let errors :=
-    graph.nodes.foldl (fun errors node => checkGraphNodePreviewKey index graph.key node errors) errors
-  graph.variants.foldl
-    (fun errors variant => checkGraphVariantPreviewKeys index graph.key variant errors)
-    errors
+  graph.nodes.foldl (fun errors node => checkGraphNodePreviewKey index graph.key node errors) errors
 
 private def checkManifestGroupIntegrity
     (manifest : ManifestFile) (errors : Array String) : Array String := Id.run do

--- a/src/VersoBlueprint/Vbp.lean
+++ b/src/VersoBlueprint/Vbp.lean
@@ -19,6 +19,7 @@ abbrev RelatedEntry := Informal.PreviewManifest.RelatedEntry
 abbrev GroupRelation := Informal.PreviewManifest.GroupRelation
 abbrev RelationAxis := Informal.PreviewManifest.RelationAxis
 abbrev PreviewArtifactIndex := Informal.PreviewManifest.PreviewArtifactIndex
+abbrev GeneratedData := Informal.PreviewManifest.Files
 abbrev WorkQueueItem := Informal.PreviewManifest.WorkQueueItem
 
 def defaultSite : FilePath := "_out" / "site"
@@ -292,10 +293,6 @@ def queryJson (manifest : ManifestFile) (args : List String) : Except String Jso
   | [] => .error "missing query selector"
   | selector :: _ => .error s!"unknown query selector '{selector}'"
 
-structure GeneratedData where
-  manifest : ManifestFile
-  htmlCache : HtmlCacheFile
-
 def readManifestForSite (site : FilePath) : IO ManifestFile := do
   let manifestPath ← manifestPathForSite site
   unless ← manifestPath.pathExists do
@@ -464,8 +461,9 @@ private def checkManifestGroupIntegrity
           s!"{Informal.PreviewManifest.labelString member} has no matching manifest entry"
   return errors
 
-def checkGeneratedData (manifest : ManifestFile) (htmlCache : HtmlCacheFile) : Array String :=
-  let index := Informal.PreviewManifest.PreviewArtifactIndex.ofFiles manifest htmlCache
+def checkGeneratedData (data : GeneratedData) : Array String :=
+  let manifest := data.manifest
+  let index := Informal.PreviewManifest.PreviewArtifactIndex.ofFiles data
   let errors := manifest.previews.foldl
     (fun errors entry =>
       let errors :=
@@ -494,16 +492,15 @@ def checkGeneratedData (manifest : ManifestFile) (htmlCache : HtmlCacheFile) : A
   let errors := checkManifestGroupIntegrity manifest errors
   manifest.graphs.foldl (fun errors graph => checkGraphPreviewKeys index graph errors) errors
 
-def checkJsonFromErrors
-    (manifest : ManifestFile) (htmlCache : HtmlCacheFile) (errors : Array String) : Json :=
+def checkJsonFromErrors (data : GeneratedData) (errors : Array String) : Json :=
   responseJson [
     ("ok", Json.bool errors.isEmpty),
-    ("manifestEntries", Json.num manifest.previews.size),
-    ("htmlCacheEntries", Json.num htmlCache.entries.size),
+    ("manifestEntries", Json.num data.manifest.previews.size),
+    ("htmlCacheEntries", Json.num data.htmlCache.entries.size),
     ("errors", Json.arr (errors.map Json.str))
   ]
 
-def checkJson (manifest : ManifestFile) (htmlCache : HtmlCacheFile) : Json :=
-  checkJsonFromErrors manifest htmlCache (checkGeneratedData manifest htmlCache)
+def checkJson (data : GeneratedData) : Json :=
+  checkJsonFromErrors data (checkGeneratedData data)
 
 end VersoBlueprint.Vbp

--- a/src/VersoBlueprint/VbpMain.lean
+++ b/src/VersoBlueprint/VbpMain.lean
@@ -463,7 +463,7 @@ def query (args : List String) : IO UInt32 := do
           pure 0
       | _ =>
           try
-            let manifest ← VersoBlueprint.Vbp.readManifestForSite opts.site
+            let manifest ← VersoBlueprint.Vbp.readManifestForQuery opts.site opts.rest
             match VersoBlueprint.Vbp.queryJson manifest opts.rest with
             | .ok json =>
                 printJson json

--- a/src/VersoBlueprint/VbpMain.lean
+++ b/src/VersoBlueprint/VbpMain.lean
@@ -483,8 +483,8 @@ def check (args : List String) : IO UInt32 := do
   | .ok opts =>
       try
         let data ← VersoBlueprint.Vbp.readGeneratedData opts.site
-        let errors := VersoBlueprint.Vbp.checkGeneratedData data.manifest data.htmlCache
-        printJson (VersoBlueprint.Vbp.checkJsonFromErrors data.manifest data.htmlCache errors)
+        let errors := VersoBlueprint.Vbp.checkGeneratedData data
+        printJson (VersoBlueprint.Vbp.checkJsonFromErrors data errors)
         if errors.isEmpty then pure 0 else pure 1
       catch err =>
         IO.eprintln err.toString

--- a/src/VersoBlueprint/VbpMain.lean
+++ b/src/VersoBlueprint/VbpMain.lean
@@ -482,7 +482,7 @@ def check (args : List String) : IO UInt32 := do
       pure 2
   | .ok opts =>
       try
-        let data ← VersoBlueprint.Vbp.readGeneratedData opts.site
+        let data ← VersoBlueprint.Vbp.readPersistedGeneratedData opts.site
         let errors := VersoBlueprint.Vbp.checkGeneratedData data
         printJson (VersoBlueprint.Vbp.checkJsonFromErrors data errors)
         if errors.isEmpty then pure 0 else pure 1

--- a/tests/VersoBlueprintTests/BlueprintGraph/Topology.lean
+++ b/tests/VersoBlueprintTests/BlueprintGraph/Topology.lean
@@ -48,6 +48,30 @@ private def topologyNode
   | .error _ => true
   | .ok _ => false
 
+/- A variant preview mapping cannot disagree with its authoritative node. -/
+/-- info: true -/
+#guard_msgs in
+#eval
+  let previewKey := "informal:variant_preview_source:statement"
+  let source := {
+    topologyNode `variant_preview_source with
+      previewKey := PreviewKey.ofString? previewKey
+  }
+  let finalized := ({ nodes := #[source] } : GraphModel).finish "inconsistent-preview" {}
+  match finalized.variants[0]? with
+  | none => false
+  | some variant =>
+      let corrupted := {
+        variant with
+          previewKeyByNodeId :=
+            #[(graphNodeSvgId `variant_preview_source, "informal:wrong_preview:statement")]
+      }
+      let variants := finalized.variants.set! 0 corrupted
+      let inconsistent := (toJson finalized).setObjVal! "variants" (toJson variants)
+      match fromJson? (α := GraphData) inconsistent with
+      | .error _ => true
+      | .ok _ => false
+
 /- Repeated live/disk-equivalent refs collapse to one semantic mixed-axis edge. -/
 /-- info: true -/
 #guard_msgs in

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -8,11 +8,12 @@ open Informal.Graph
 
 abbrev ManifestFile := Informal.PreviewManifest.File
 abbrev HtmlCacheFile := Informal.PreviewManifest.HtmlCache.File
-abbrev PreviewDataFiles := Informal.PreviewManifest.Files
+abbrev PreviewDataModel := Informal.PreviewManifest.PreviewDataModel
+abbrev PersistedFiles := Informal.PreviewManifest.PersistedFiles
 abbrev RelatedEntry := Informal.PreviewManifest.RelatedEntry
 
-private def previewData (manifest : ManifestFile) (htmlCache : HtmlCacheFile) :
-    PreviewDataFiles :=
+private def persistedFiles (manifest : ManifestFile) (htmlCache : HtmlCacheFile) :
+    PersistedFiles :=
   { manifest, htmlCache }
 
 private def label (value : String) : Name :=
@@ -618,9 +619,11 @@ private def graphNodePreviewKeys
 #guard_msgs in
 #eval
   show Bool from
-    let finalizedFiles :=
-      Informal.PreviewManifest.Files.finalizePreviewReferences <|
-        previewData sampleUnfinalizedReferenceManifest sampleUnfinalizedReferenceCache
+    let model : PreviewDataModel := {
+      manifest := sampleUnfinalizedReferenceManifest
+      htmlCache := sampleUnfinalizedReferenceCache
+    }
+    let finalizedFiles := model.finish
     let finalized := finalizedFiles.manifest
     match finalized.findEntry? "informal:reference_source:statement",
         finalized.graphs.find? (fun graph => graph.key == "reference-finalization") with
@@ -1005,21 +1008,21 @@ private def queryReadModeExamples : List (String × List String × Bool) := [
 #guard_msgs in
 #eval
   show Bool from
-    VersoBlueprint.Vbp.checkGeneratedData (previewData sampleManifest sampleCache) |>.isEmpty
+    VersoBlueprint.Vbp.checkGeneratedData (persistedFiles sampleManifest sampleCache) |>.isEmpty
 
 /-- info: true -/
 #guard_msgs in
 #eval
   show Bool from
     VersoBlueprint.Vbp.checkGeneratedData
-      (previewData sampleGroupManifest sampleGroupCache) |>.isEmpty
+      (persistedFiles sampleGroupManifest sampleGroupCache) |>.isEmpty
 
 /-- info: true -/
 #guard_msgs in
 #eval
   show Bool from
     VersoBlueprint.Vbp.checkGeneratedData
-      (previewData sampleExternalGroupManifest sampleExternalGroupCache) |>.isEmpty
+      (persistedFiles sampleExternalGroupManifest sampleExternalGroupCache) |>.isEmpty
 
 /-- info: true -/
 #guard_msgs in
@@ -1113,7 +1116,7 @@ private def queryReadModeExamples : List (String × List String × Bool) := [
             entry
     }
     let checkGroups manifest :=
-      VersoBlueprint.Vbp.checkGeneratedData (previewData manifest sampleGroupCache)
+      VersoBlueprint.Vbp.checkGeneratedData (persistedFiles manifest sampleGroupCache)
     let orphanErrors := checkGroups orphanedManifest
     let duplicateGroupErrors := checkGroups duplicateGroupManifest
     let duplicateMemberErrors := checkGroups duplicateMemberManifest
@@ -1161,21 +1164,21 @@ private def queryReadModeExamples : List (String × List String × Bool) := [
 #eval
   show Bool from
     VersoBlueprint.Vbp.checkGeneratedData
-      (previewData sampleEmptyRelationManifest sampleEmptyRelationCache) |>.isEmpty
+      (persistedFiles sampleEmptyRelationManifest sampleEmptyRelationCache) |>.isEmpty
 
 /-- info: true -/
 #guard_msgs in
 #eval
   show Bool from
     VersoBlueprint.Vbp.checkGeneratedData
-      (previewData sampleSemanticOnlyExternalManifest sampleSemanticOnlyExternalCache) |>.isEmpty
+      (persistedFiles sampleSemanticOnlyExternalManifest sampleSemanticOnlyExternalCache) |>.isEmpty
 
 /-- info: true -/
 #guard_msgs in
 #eval
   show Bool from
     let errors := VersoBlueprint.Vbp.checkGeneratedData <|
-      previewData sampleCacheOnlyRelationManifest sampleCacheOnlyRelationCache
+      persistedFiles sampleCacheOnlyRelationManifest sampleCacheOnlyRelationCache
     errors.any (fun err =>
       err.contains "missing manifest entry for uses of informal:relation_source:statement relation cache_only_relation" &&
         err.contains "informal:cache_only_relation:statement") &&
@@ -1188,7 +1191,7 @@ private def queryReadModeExamples : List (String × List String × Bool) := [
 #eval
   show Bool from
     let errors := VersoBlueprint.Vbp.checkGeneratedData <|
-      previewData sampleGraphReferenceManifest sampleGraphReferenceCache
+      persistedFiles sampleGraphReferenceManifest sampleGraphReferenceCache
     errors.any (fun err =>
       err.contains "missing HTML cache entry for graph graph-fixture node semantic_graph_target" &&
         err.contains (Informal.PreviewManifest.externalMarkupEntryKey (label "semantic_graph_target"))) &&
@@ -1203,7 +1206,7 @@ private def queryReadModeExamples : List (String × List String × Bool) := [
 #guard_msgs in
 #eval
   show Bool from
-    let json := VersoBlueprint.Vbp.checkJson (previewData sampleManifest sampleCache)
+    let json := VersoBlueprint.Vbp.checkJson (persistedFiles sampleManifest sampleCache)
     jsonHasApiStability json &&
       jsonBoolField? json "ok" == some true &&
       jsonNatField? json "manifestEntries" == some 3 &&
@@ -1214,7 +1217,7 @@ private def queryReadModeExamples : List (String × List String × Bool) := [
 #eval
   show Bool from
     let json := VersoBlueprint.Vbp.checkJsonFromErrors
-      (previewData sampleManifest sampleCache) #["forced diagnostic"]
+      (persistedFiles sampleManifest sampleCache) #["forced diagnostic"]
     let errors := jsonArrayField? json "errors" |>.getD #[]
     jsonBoolField? json "ok" == some false &&
       jsonArrayContainsString errors "forced diagnostic"
@@ -1226,7 +1229,7 @@ private def queryReadModeExamples : List (String × List String × Bool) := [
     let brokenCache : HtmlCacheFile := {
       entries := sampleCache.entries.filter (fun entry => entry.key != "lean:Nat.add_assoc")
     }
-    VersoBlueprint.Vbp.checkGeneratedData (previewData sampleManifest brokenCache)
+    VersoBlueprint.Vbp.checkGeneratedData (persistedFiles sampleManifest brokenCache)
       |>.any (·.contains "lean:Nat.add_assoc")
 
 /-- info: true -/

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -8,7 +8,12 @@ open Informal.Graph
 
 abbrev ManifestFile := Informal.PreviewManifest.File
 abbrev HtmlCacheFile := Informal.PreviewManifest.HtmlCache.File
+abbrev PreviewDataFiles := Informal.PreviewManifest.Files
 abbrev RelatedEntry := Informal.PreviewManifest.RelatedEntry
+
+private def previewData (manifest : ManifestFile) (htmlCache : HtmlCacheFile) :
+    PreviewDataFiles :=
+  { manifest, htmlCache }
 
 private def label (value : String) : Name :=
   Name.mkSimple value
@@ -612,8 +617,10 @@ private def graphNodePreviewKeys
 #guard_msgs in
 #eval
   show Bool from
-    let finalized :=
-      sampleUnfinalizedReferenceManifest.finalizePreviewReferences sampleUnfinalizedReferenceCache
+    let finalizedFiles :=
+      Informal.PreviewManifest.Files.finalizePreviewReferences <|
+        previewData sampleUnfinalizedReferenceManifest sampleUnfinalizedReferenceCache
+    let finalized := finalizedFiles.manifest
     match finalized.findEntry? "informal:reference_source:statement",
         finalized.graphs.find? (fun graph => graph.key == "reference-finalization") with
     | some source, some graph =>
@@ -978,26 +985,21 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
 #guard_msgs in
 #eval
   show Bool from
-    VersoBlueprint.Vbp.checkGeneratedData sampleManifest sampleCache |>.isEmpty
-
-/-- info: true -/
-#guard_msgs in
-#eval
-  show Bool from
-    VersoBlueprint.Vbp.checkGeneratedData sampleEmptyRelationManifest sampleEmptyRelationCache |>.isEmpty
-
-/-- info: true -/
-#guard_msgs in
-#eval
-  show Bool from
-    VersoBlueprint.Vbp.checkGeneratedData sampleGroupManifest sampleGroupCache |>.isEmpty
+    VersoBlueprint.Vbp.checkGeneratedData (previewData sampleManifest sampleCache) |>.isEmpty
 
 /-- info: true -/
 #guard_msgs in
 #eval
   show Bool from
     VersoBlueprint.Vbp.checkGeneratedData
-      sampleExternalGroupManifest sampleExternalGroupCache |>.isEmpty
+      (previewData sampleGroupManifest sampleGroupCache) |>.isEmpty
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    VersoBlueprint.Vbp.checkGeneratedData
+      (previewData sampleExternalGroupManifest sampleExternalGroupCache) |>.isEmpty
 
 /-- info: true -/
 #guard_msgs in
@@ -1090,34 +1092,22 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
           else
             entry
     }
-    let orphanErrors :=
-      VersoBlueprint.Vbp.checkGeneratedData orphanedManifest sampleGroupCache
-    let duplicateGroupErrors :=
-      VersoBlueprint.Vbp.checkGeneratedData duplicateGroupManifest sampleGroupCache
-    let duplicateMemberErrors :=
-      VersoBlueprint.Vbp.checkGeneratedData duplicateMemberManifest sampleGroupCache
-    let crossGroupMemberErrors :=
-      VersoBlueprint.Vbp.checkGeneratedData crossGroupMemberManifest sampleGroupCache
-    let missingMemberErrors :=
-      VersoBlueprint.Vbp.checkGeneratedData missingMemberManifest sampleGroupCache
-    let orphanMemberErrors :=
-      VersoBlueprint.Vbp.checkGeneratedData orphanMemberManifest sampleGroupCache
-    let mismatchedParentErrors :=
-      VersoBlueprint.Vbp.checkGeneratedData mismatchedParentManifest sampleGroupCache
-    let mismatchedTitleErrors :=
-      VersoBlueprint.Vbp.checkGeneratedData mismatchedTitleManifest sampleGroupCache
-    let unparentedMemberErrors :=
-      VersoBlueprint.Vbp.checkGeneratedData unparentedMemberManifest sampleGroupCache
-    let emptyGroupLabelErrors :=
-      VersoBlueprint.Vbp.checkGeneratedData emptyGroupLabelManifest sampleGroupCache
-    let emptyGroupTitleErrors :=
-      VersoBlueprint.Vbp.checkGeneratedData emptyGroupTitleManifest sampleGroupCache
-    let emptyMemberLabelErrors :=
-      VersoBlueprint.Vbp.checkGeneratedData emptyMemberLabelManifest sampleGroupCache
-    let emptyEntryLabelErrors :=
-      VersoBlueprint.Vbp.checkGeneratedData emptyEntryLabelManifest sampleGroupCache
-    let invalidParentErrors :=
-      VersoBlueprint.Vbp.checkGeneratedData invalidParentManifest sampleGroupCache
+    let checkGroups manifest :=
+      VersoBlueprint.Vbp.checkGeneratedData (previewData manifest sampleGroupCache)
+    let orphanErrors := checkGroups orphanedManifest
+    let duplicateGroupErrors := checkGroups duplicateGroupManifest
+    let duplicateMemberErrors := checkGroups duplicateMemberManifest
+    let crossGroupMemberErrors := checkGroups crossGroupMemberManifest
+    let missingMemberErrors := checkGroups missingMemberManifest
+    let orphanMemberErrors := checkGroups orphanMemberManifest
+    let mismatchedParentErrors := checkGroups mismatchedParentManifest
+    let mismatchedTitleErrors := checkGroups mismatchedTitleManifest
+    let unparentedMemberErrors := checkGroups unparentedMemberManifest
+    let emptyGroupLabelErrors := checkGroups emptyGroupLabelManifest
+    let emptyGroupTitleErrors := checkGroups emptyGroupTitleManifest
+    let emptyMemberLabelErrors := checkGroups emptyMemberLabelManifest
+    let emptyEntryLabelErrors := checkGroups emptyEntryLabelManifest
+    let invalidParentErrors := checkGroups invalidParentManifest
     orphanErrors.any (fun err =>
       err == "entry informal:group_member:statement references missing manifest group: sample_group") &&
       duplicateGroupErrors.any (fun err =>
@@ -1151,14 +1141,21 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
 #eval
   show Bool from
     VersoBlueprint.Vbp.checkGeneratedData
-      sampleSemanticOnlyExternalManifest sampleSemanticOnlyExternalCache |>.isEmpty
+      (previewData sampleEmptyRelationManifest sampleEmptyRelationCache) |>.isEmpty
 
 /-- info: true -/
 #guard_msgs in
 #eval
   show Bool from
-    let errors := VersoBlueprint.Vbp.checkGeneratedData
-      sampleCacheOnlyRelationManifest sampleCacheOnlyRelationCache
+    VersoBlueprint.Vbp.checkGeneratedData
+      (previewData sampleSemanticOnlyExternalManifest sampleSemanticOnlyExternalCache) |>.isEmpty
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    let errors := VersoBlueprint.Vbp.checkGeneratedData <|
+      previewData sampleCacheOnlyRelationManifest sampleCacheOnlyRelationCache
     errors.any (fun err =>
       err.contains "missing manifest entry for uses of informal:relation_source:statement relation cache_only_relation" &&
         err.contains "informal:cache_only_relation:statement") &&
@@ -1170,8 +1167,8 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
 #guard_msgs in
 #eval
   show Bool from
-    let errors := VersoBlueprint.Vbp.checkGeneratedData
-      sampleGraphReferenceManifest sampleGraphReferenceCache
+    let errors := VersoBlueprint.Vbp.checkGeneratedData <|
+      previewData sampleGraphReferenceManifest sampleGraphReferenceCache
     errors.any (fun err =>
       err.contains "missing HTML cache entry for graph graph-fixture node semantic_graph_target" &&
         err.contains (Informal.PreviewManifest.externalMarkupEntryKey (label "semantic_graph_target"))) &&
@@ -1186,7 +1183,7 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
 #guard_msgs in
 #eval
   show Bool from
-    let json := VersoBlueprint.Vbp.checkJson sampleManifest sampleCache
+    let json := VersoBlueprint.Vbp.checkJson (previewData sampleManifest sampleCache)
     jsonHasApiStability json &&
       jsonBoolField? json "ok" == some true &&
       jsonNatField? json "manifestEntries" == some 3 &&
@@ -1196,7 +1193,8 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
 #guard_msgs in
 #eval
   show Bool from
-    let json := VersoBlueprint.Vbp.checkJsonFromErrors sampleManifest sampleCache #["forced diagnostic"]
+    let json := VersoBlueprint.Vbp.checkJsonFromErrors
+      (previewData sampleManifest sampleCache) #["forced diagnostic"]
     let errors := jsonArrayField? json "errors" |>.getD #[]
     jsonBoolField? json "ok" == some false &&
       jsonArrayContainsString errors "forced diagnostic"
@@ -1208,7 +1206,8 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
     let brokenCache : HtmlCacheFile := {
       entries := sampleCache.entries.filter (fun entry => entry.key != "lean:Nat.add_assoc")
     }
-    VersoBlueprint.Vbp.checkGeneratedData sampleManifest brokenCache |>.any (·.contains "lean:Nat.add_assoc")
+    VersoBlueprint.Vbp.checkGeneratedData (previewData sampleManifest brokenCache)
+      |>.any (·.contains "lean:Nat.add_assoc")
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -497,7 +497,8 @@ private def graphNodePreviewKeys
     text.contains "lake exe vbp query [--site <dir>] <selector>" &&
       text.contains "Query selectors:" &&
       text.contains "selectors" &&
-      text.contains "all <label>" &&
+      text.contains "node <label>" &&
+      !text.contains "all <label>" &&
       text.contains "search <text>" &&
       text.contains "lake exe vbp build [--output <dir>] [--pdf] [--verbose]" &&
       text.contains "--pdf builds _out/site/pdf/main.pdf" &&
@@ -699,7 +700,8 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
         | some selectors =>
             jsonHasApiStability json &&
               jsonArrayContainsString selectors "selectors" &&
-              jsonArrayContainsString selectors "all <label>" &&
+              jsonArrayContainsString selectors "node <label>" &&
+              !jsonArrayContainsString selectors "all <label>" &&
               jsonArrayContainsString selectors "work-queue" &&
               jsonArrayContainsString selectors "metadata" &&
               jsonArrayContainsString selectors "search <text>"
@@ -844,17 +846,8 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
 #eval
   show Bool from
     match VersoBlueprint.Vbp.queryJson sampleManifest ["all", "addition_assoc"] with
-    | .ok json =>
-        match jsonField? json "node", jsonArrayField? json "statementUses" with
-        | some node, some statementUses =>
-            jsonHasApiStability json &&
-              jsonStringField? json "label" == some "addition_assoc" &&
-              jsonStringField? node "label" == some "addition_assoc" &&
-              jsonStringField? node "authoredLabel" == some "addition_assoc" &&
-              jsonArrayHasStringField statementUses "label" "addition_spec" &&
-              (jsonArrayField? json "usedBy").isSome
-        | _, _ => false
-    | .error _ => false
+    | .ok _ => false
+    | .error err => err == "unknown query selector 'all'"
 
 /-- info: true -/
 #guard_msgs in
@@ -1173,10 +1166,10 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
       err.contains "missing HTML cache entry for graph graph-fixture node semantic_graph_target" &&
         err.contains (Informal.PreviewManifest.externalMarkupEntryKey (label "semantic_graph_target"))) &&
     errors.any (fun err =>
-        err.contains s!"missing manifest entry for graph graph-fixture variant full node {graphNodeSvgId (label "cache_only_graph")}" &&
+        err.contains "missing manifest entry for graph graph-fixture node cache_only_graph" &&
           err.contains "informal:cache_only_graph:statement") &&
       !errors.any (fun err =>
-        err.contains s!"missing HTML cache entry for graph graph-fixture variant full node {graphNodeSvgId (label "cache_only_graph")}" &&
+        err.contains "missing HTML cache entry for graph graph-fixture node cache_only_graph" &&
           err.contains "informal:cache_only_graph:statement")
 
 /-- info: true -/
@@ -1230,6 +1223,49 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
       pure <| message.contains "run `lake exe vbp build` first" &&
         !message.contains "vbp check"
   pure (queryOk && cacheMissing)
+
+/-- info: true -/
+#guard_msgs in
+#eval do
+  let site ← freshVbpFixtureRoot
+  writeRawManifestOnlySite site (toJson sampleGraphReferenceManifest)
+  let strictManifest ← VersoBlueprint.Vbp.readManifestForSite site
+  let queryManifest ← VersoBlueprint.Vbp.readManifestForQuery site ["labels"]
+  let workQueueManifest ← VersoBlueprint.Vbp.readManifestForQuery site ["work-queue"]
+  pure <|
+    strictManifest.graphs.size == 1 &&
+      queryManifest.graphs.isEmpty &&
+      workQueueManifest.graphs.size == 1 &&
+      queryManifest.previews.map
+          (fun entry : Informal.PreviewManifest.Entry => entry.key) ==
+        sampleGraphReferenceManifest.previews.map
+          (fun entry : Informal.PreviewManifest.Entry => entry.key)
+
+/-- info: true -/
+#guard_msgs in
+#eval do
+  let site ← freshVbpFixtureRoot
+  let malformedGraphManifest :=
+    (toJson sampleManifest).setObjVal! "graphs" (Json.arr #[Json.str "malformed"])
+  writeRawManifestOnlySite site malformedGraphManifest
+  let queryManifest ← VersoBlueprint.Vbp.readManifestForQuery site ["labels"]
+  let strictRejected ←
+    try
+      let _ ← VersoBlueprint.Vbp.readManifestForSite site
+      pure false
+    catch _ =>
+      pure true
+  let workQueueRejected ←
+    try
+      let _ ← VersoBlueprint.Vbp.readManifestForQuery site ["work-queue"]
+      pure false
+    catch _ =>
+      pure true
+  pure <|
+    queryManifest.previews.size == sampleManifest.previews.size &&
+      queryManifest.graphs.isEmpty &&
+      strictRejected &&
+      workQueueRejected
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -671,6 +671,33 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
     (dataDir / Informal.PreviewManifest.manifestFilename)
     manifestJson.compress
 
+private def queryReadModeExamples : List (String × List String × Bool) := [
+  ("selectors", ["selectors"], false),
+  ("labels", ["labels"], false),
+  ("node <label>", ["node", "addition_assoc"], false),
+  ("uses <label>", ["uses", "addition_assoc"], false),
+  ("used-by <label>", ["used-by", "addition_assoc"], false),
+  ("group <label>", ["group", "addition_assoc"], false),
+  ("owners", ["owners"], false),
+  ("tags", ["tags"], false),
+  ("work-queue", ["work-queue"], true),
+  ("metadata", ["metadata"], false),
+  ("search <text>", ["search", "addition"], false),
+  ("code <decl>", ["code", "Nat.add"], false),
+  ("stats", ["stats"], false)
+]
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    queryReadModeExamples.map (fun (selector, _, _) => selector) ==
+        VersoBlueprint.Vbp.querySelectorLines &&
+      (queryReadModeExamples.all fun (_, args, needsGraphData) =>
+        VersoBlueprint.Vbp.queryNeedsGraphData args == needsGraphData) &&
+      VersoBlueprint.Vbp.queryNeedsGraphData ["future-selector"] &&
+      VersoBlueprint.Vbp.queryNeedsGraphData ["node"]
+
 /-- info: true -/
 #guard_msgs in
 #eval
@@ -1230,16 +1257,23 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
   let site ← freshVbpFixtureRoot
   writeRawManifestOnlySite site (toJson sampleGraphReferenceManifest)
   let strictManifest ← VersoBlueprint.Vbp.readManifestForSite site
-  let queryManifest ← VersoBlueprint.Vbp.readManifestForQuery site ["labels"]
-  let workQueueManifest ← VersoBlueprint.Vbp.readManifestForQuery site ["work-queue"]
+  let queryManifests ← queryReadModeExamples.mapM
+      (fun (queryMode : String × List String × Bool) => do
+        let args := queryMode.2.1
+        let needsGraphData := queryMode.2.2
+        let manifest ← VersoBlueprint.Vbp.readManifestForQuery site args
+        pure (manifest, needsGraphData))
+  let unknownManifest ←
+    VersoBlueprint.Vbp.readManifestForQuery site ["future-selector"]
   pure <|
     strictManifest.graphs.size == 1 &&
-      queryManifest.graphs.isEmpty &&
-      workQueueManifest.graphs.size == 1 &&
-      queryManifest.previews.map
-          (fun entry : Informal.PreviewManifest.Entry => entry.key) ==
-        sampleGraphReferenceManifest.previews.map
-          (fun entry : Informal.PreviewManifest.Entry => entry.key)
+      queryManifests.all (fun (manifest, needsGraphData) =>
+        manifest.graphs.isEmpty == !needsGraphData &&
+          manifest.previews.map
+              (fun entry : Informal.PreviewManifest.Entry => entry.key) ==
+            sampleGraphReferenceManifest.previews.map
+              (fun entry : Informal.PreviewManifest.Entry => entry.key)) &&
+      unknownManifest.graphs.size == 1
 
 /-- info: true -/
 #guard_msgs in
@@ -1248,7 +1282,14 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
   let malformedGraphManifest :=
     (toJson sampleManifest).setObjVal! "graphs" (Json.arr #[Json.str "malformed"])
   writeRawManifestOnlySite site malformedGraphManifest
-  let queryManifest ← VersoBlueprint.Vbp.readManifestForQuery site ["labels"]
+  let graphFreeManifests ← queryReadModeExamples.filterMapM
+      (fun (queryMode : String × List String × Bool) =>
+        let args := queryMode.2.1
+        let needsGraphData := queryMode.2.2
+        if needsGraphData then
+          pure none
+        else
+          some <$> VersoBlueprint.Vbp.readManifestForQuery site args)
   let strictRejected ←
     try
       let _ ← VersoBlueprint.Vbp.readManifestForSite site
@@ -1261,11 +1302,18 @@ private def writeRawManifestOnlySite (site : System.FilePath) (manifestJson : Js
       pure false
     catch _ =>
       pure true
+  let unknownRejected ←
+    try
+      let _ ← VersoBlueprint.Vbp.readManifestForQuery site ["future-selector"]
+      pure false
+    catch _ =>
+      pure true
   pure <|
-    queryManifest.previews.size == sampleManifest.previews.size &&
-      queryManifest.graphs.isEmpty &&
+    graphFreeManifests.all (fun manifest =>
+      manifest.previews.size == sampleManifest.previews.size && manifest.graphs.isEmpty) &&
       strictRejected &&
-      workQueueRejected
+      workQueueRejected &&
+      unknownRejected
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/harness/test_verso_blueprint_skill.py
+++ b/tests/harness/test_verso_blueprint_skill.py
@@ -20,6 +20,14 @@ class VersoBlueprintSkillTests(unittest.TestCase):
         self.assertIn("JSON shapes as unstable", text)
         self.assertNotIn("TODO", text)
 
+    def test_quick_start_does_not_present_check_as_a_routine_build_step(self) -> None:
+        text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+        quick_start = text.split("## Quick Start", 1)[1].split("Read `references/vbp.md`", 1)[0]
+        self.assertIn("lake exe vbp build", quick_start)
+        self.assertIn("lake exe vbp query labels", quick_start)
+        self.assertNotIn("lake exe vbp check", quick_start)
+        self.assertIn("Use `lake exe vbp check` when auditing", text)
+
     def test_vbp_reference_documents_public_surface(self) -> None:
         text = (SKILL_ROOT / "references" / "vbp.md").read_text(encoding="utf-8")
         self.assertIn("lake exe vbp build [--output <dir>] [--pdf] [--verbose] [--serve] [--port <n>]", text)

--- a/tests/harness/test_verso_blueprint_skill.py
+++ b/tests/harness/test_verso_blueprint_skill.py
@@ -31,7 +31,8 @@ class VersoBlueprintSkillTests(unittest.TestCase):
         self.assertIn("lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean --output <output>", text)
         self.assertIn("selectors`: query selector forms", text)
         self.assertIn("does not require generated Blueprint data", text)
-        self.assertIn("all <label>", text)
+        self.assertIn("node <label>", text)
+        self.assertNotIn("all <label>", text)
         self.assertIn("search <text>", text)
         self.assertIn("case-insensitively", text)
         self.assertIn("code <decl>", text)
@@ -52,8 +53,9 @@ class VersoBlueprintSkillTests(unittest.TestCase):
 
     def test_vbp_reference_documents_build_check_boundary(self) -> None:
         text = (SKILL_ROOT / "references" / "vbp.md").read_text(encoding="utf-8")
-        self.assertIn("post-build generated-data health check", text)
-        self.assertIn("does not replace `build`", text)
+        self.assertIn("audits an already-generated artifact boundary", text)
+        self.assertIn("not a repair phase or a required second step", text)
+        self.assertIn("constructs and finalizes the manifest/cache pair together", text)
         self.assertIn("Lean/Lake compilation", text)
 
     def test_vbp_reference_documents_adoption_boundary(self) -> None:


### PR DESCRIPTION
## Summary
Backport #371 to `v4.32.0`.

## Primary Review
- Primary review: #371
- Keep review comments on #371 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.32.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.