### PR TITLE
fix: decouple reference project compiler selection

### DIFF
--- a/.github/workflows/blueprint-pages.yml
+++ b/.github/workflows/blueprint-pages.yml
@@ -93,7 +93,7 @@ jobs:
               lake exe cache get || true
             )
           fi
-      - if: ${{ inputs.harness_enabled && steps.harness.outputs.use_formalization_toolchain == 'true' }}
+      - if: ${{ inputs.harness_enabled }}
         name: Select harness Lean toolchain
         run: |
           formalization_toolchain="${{ steps.harness.outputs.formalization_path }}/lean-toolchain"

--- a/.github/workflows/reference-blueprints-deploy.yml
+++ b/.github/workflows/reference-blueprints-deploy.yml
@@ -98,7 +98,7 @@ jobs:
           path: ${{ matrix.artifact_path }}
           key: ${{ runner.os }}-reference-site-v1-${{ steps.artifact-identity.outputs.sha256 }}
       - name: Match reference target toolchain
-        if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' && matrix.rc != '' }}
+        if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' }}
         run: printf 'leanprover/lean4:${{ matrix.toolchain }}\n' > lean-toolchain
       - name: Install elan
         if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/reference-blueprints.yml
+++ b/.github/workflows/reference-blueprints.yml
@@ -50,7 +50,6 @@ jobs:
           echo "hash=${{ matrix.hash }}"
           echo "reference_source_identity=${{ matrix.reference_source_identity }}"
       - name: Match reference target toolchain
-        if: ${{ matrix.rc != '' }}
         run: printf 'leanprover/lean4:${{ matrix.toolchain }}\n' > lean-toolchain
       - name: Report disk usage before cache restore
         run: ./scripts/report-ci-disk-usage.sh "before cache restore" --reference-source-identity "${{ matrix.reference_source_identity }}" --artifact-path "${{ matrix.artifact_path }}"

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -82,9 +82,12 @@ Reference release metadata has two tracked sources of truth. `branch-policy.json
 owns release ids, branch names, baseline Lean toolchain refs, baseline `verso`
 refs, default-development/backport policy, and the release-level Pages deploy
 flag. `tests/harness/projects.json` owns project ids, external repository refs,
-the `publish_reference` flag, and any per-project `rc` override. Matrix emitter
-scripts derive effective per-project `toolchain` and `verso_ref` values from
-those two files; release targets themselves do not carry `rc` metadata.
+the `publish_reference` flag, and any per-project compiler or RC override.
+Matrix emitter scripts derive effective per-project `toolchain` and `verso_ref`
+values from those two files; release targets themselves do not carry `rc`
+metadata. A project-target `rc` changes both values for legacy RC lockstep,
+while a project-target `toolchain` changes only the compiler and leaves the
+release target's VBP/Verso ref intact.
 
 ## Everyday Workflows
 
@@ -769,9 +772,10 @@ the project id, release, pinned ref, and publication flag. For each deploy
 matrix entry, the workflow writes a small one-project manifest from that
 default-development catalog and passes it to the release-branch harness with
 `--manifest`; the deploy job therefore does not rely on stale branch-local
-`projects.json` refs. The per-project target entry also owns any RC override,
-so two projects in the same release line can deploy against different release
-candidate tags when needed. Deploy one-project manifests append `--pdf` to the
+`projects.json` refs. The per-project target entry also owns any RC or
+compiler-only override, so two projects in the same release line can use
+different compilers when needed without necessarily selecting different
+VBP/Verso refs. Deploy one-project manifests append `--pdf` to the
 selected generator command only for the default-development release target, so
 the current published catalog includes PDFs while archived release targets stay
 HTML-only unless their deploy policy is deliberately expanded.
@@ -886,6 +890,10 @@ project target records `"rc": "4.32-rc1"`. That row then builds with
 `leanprover/lean4:v4.32.0-rc1` and pins `verso` to `v4.32.0-rc1`, while another
 project target on the same release id can use a different RC or the final
 release tag.
+
+Use `"toolchain": "v4.32.0-rc1"` instead when only the external project's
+compiler must remain on that RC while VBP/Verso use the release target's normal
+ref. Do not combine `rc` and `toolchain` on one project target.
 
 Minimal external catalog entry shape:
 

--- a/project_template/.github/workflows/blueprint-pages.yml
+++ b/project_template/.github/workflows/blueprint-pages.yml
@@ -93,7 +93,7 @@ jobs:
               lake exe cache get || true
             )
           fi
-      - if: ${{ inputs.harness_enabled && steps.harness.outputs.use_formalization_toolchain == 'true' }}
+      - if: ${{ inputs.harness_enabled }}
         name: Select harness Lean toolchain
         run: |
           formalization_toolchain="${{ steps.harness.outputs.formalization_path }}/lean-toolchain"

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -40,6 +40,7 @@ class HarnessProjectTarget:
     ref: str | None
     publish_reference: bool = False
     rc: str | None = None
+    toolchain: str | None = None
 
 
 @dataclass(frozen=True)
@@ -73,6 +74,7 @@ class HarnessProject:
     targets: tuple[HarnessProjectTarget, ...] = ()
     selected_release: str | None = None
     selected_rc: str | None = None
+    selected_toolchain: str | None = None
 
     @property
     def in_repo_project(self) -> bool:
@@ -109,6 +111,8 @@ def short_git_ref(ref: str) -> str:
 
 
 def selected_project_toolchain(project: HarnessProject) -> str:
+    if project.selected_toolchain is not None:
+        return project.selected_toolchain
     if project.selected_rc is not None:
         return release_candidate_ref(project.selected_rc)
     if project.selected_release is not None:
@@ -251,12 +255,26 @@ def _load_project_targets(
             rc = normalize_release_candidate_name(rc)
             if release_branch_from_lean_ref(rc) != release:
                 raise ValueError(f"{target_context}: `rc` `{rc}` does not belong to release `{release}`")
+        toolchain = _optional_string(raw_target, "toolchain", context=target_context)
+        if toolchain is not None:
+            toolchain = normalize_lean_release_ref(toolchain)
+            if release_branch_from_lean_ref(toolchain) != release:
+                raise ValueError(
+                    f"{target_context}: `toolchain` `{toolchain}` does not belong to release `{release}`"
+                )
+            if rc is not None:
+                raise ValueError(
+                    f"{target_context}: `rc` and `toolchain` are mutually exclusive; "
+                    "use `rc` to override both compiler and Verso ref, or `toolchain` "
+                    "to override only the compiler"
+                )
         targets.append(
             HarnessProjectTarget(
                 release=release,
                 ref=ref,
                 publish_reference=_optional_bool(raw_target, "publish_reference", default=False, context=target_context),
                 rc=rc,
+                toolchain=toolchain,
             )
         )
     return tuple(targets)
@@ -439,6 +457,7 @@ def resolve_projects_for_release(
                 ref=target.ref,
                 selected_release=release,
                 selected_rc=target.rc,
+                selected_toolchain=target.toolchain,
             )
         )
     return resolved
@@ -475,6 +494,8 @@ def project_target_rc(project: HarnessProject) -> str:
 
 
 def project_target_toolchain(release_target: HarnessReleaseTarget, project: HarnessProject) -> str:
+    if project.selected_toolchain is not None:
+        return project.selected_toolchain
     return release_candidate_ref(project.selected_rc) if project.selected_rc is not None else release_target.toolchain
 
 
@@ -591,6 +612,8 @@ def project_manifest_entry(project: HarnessProject, *, include_pdf: bool = False
         target["ref"] = project.ref
     if project.selected_rc is not None:
         target["rc"] = project.selected_rc
+    if project.selected_toolchain is not None:
+        target["toolchain"] = project.selected_toolchain
 
     entry: dict[str, object] = {
         "id": project.project_id,

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -120,6 +120,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         expected_projects: list[str] = []
         expected_refs: dict[str, str | None] = {}
         expected_rcs: dict[str, str | None] = {}
+        expected_toolchains: dict[str, str | None] = {}
         expected_targets = [
             (project, target)
             for project in catalog.projects
@@ -129,11 +130,13 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             expected_projects.append(project.project_id)
             expected_refs[project.project_id] = target.ref
             expected_rcs[project.project_id] = target.rc
+            expected_toolchains[project.project_id] = target.toolchain
 
         self.assertEqual([project.project_id for project in projects], expected_projects)
         for project in projects:
             self.assertEqual(project.selected_release, release.release_id)
             self.assertEqual(project.selected_rc, expected_rcs[project.project_id])
+            self.assertEqual(project.selected_toolchain, expected_toolchains[project.project_id])
             expected_ref = expected_refs[project.project_id]
             if expected_ref is not None:
                 self.assertEqual(project.ref, expected_ref)
@@ -213,6 +216,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             projects[1], expected_external_releases[projects[1].project_id], publish_reference=True
         )
         self.assertIsNone(projects[1].targets[0].rc)
+        self.assertIsNone(projects[1].targets[0].toolchain)
         self.assertIsNone(projects[1].build_command)
         self.assertEqual(projects[1].generate_command, VBP_BUILD_OUTPUT_COMMAND)
         self.assertEqual(projects[1].browser_tests_path, None)
@@ -222,6 +226,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             projects[2], expected_external_releases[projects[2].project_id], publish_reference=True
         )
         self.assertIsNone(projects[2].targets[0].rc)
+        self.assertIsNone(projects[2].targets[0].toolchain)
         self.assertIsNone(projects[2].build_command)
         self.assertEqual(projects[2].generate_command, VBP_BUILD_OUTPUT_COMMAND)
         self.assertEqual(projects[3].repository, "https://github.com/ejgallego/verso-flt.git")
@@ -229,6 +234,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             projects[3], expected_external_releases[projects[3].project_id], publish_reference=True
         )
         self.assertIsNone(projects[3].targets[0].rc)
+        self.assertIsNone(projects[3].targets[0].toolchain)
         self.assertIsNone(projects[3].build_command)
         self.assertEqual(projects[3].generate_command, VBP_BUILD_OUTPUT_COMMAND)
         self.assertEqual(projects[4].repository, "https://github.com/ejgallego/verso-carleson.git")
@@ -236,6 +242,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             projects[4], expected_external_releases[projects[4].project_id], publish_reference=True
         )
         self.assertIsNone(projects[4].targets[0].rc)
+        self.assertIsNone(projects[4].targets[0].toolchain)
         self.assertIsNone(projects[4].build_command)
         self.assertEqual(projects[4].generate_command, VBP_BUILD_OUTPUT_COMMAND)
 
@@ -248,6 +255,15 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(selected_project_toolchain(spherepacking), "v4.32.0")
         with self.assertRaisesRegex(ValueError, "has no selected release target"):
             selected_project_toolchain(catalog.projects[1])
+
+    def test_selected_project_toolchain_prefers_compiler_only_override(self) -> None:
+        project = external_project(
+            selected_release="v4.33.0",
+            selected_rc=None,
+            selected_toolchain="v4.33.0-rc1",
+        )
+
+        self.assertEqual(selected_project_toolchain(project), "v4.33.0-rc1")
 
     def test_project_catalog_requires_json_object(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -553,7 +569,13 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(set(rows), {project.project_id for project, _target in expected_targets})
         for project, target in expected_targets:
             row = rows[project.project_id]
-            expected_toolchain = release_candidate_ref(target.rc) if target.rc is not None else release.toolchain
+            expected_toolchain = (
+                target.toolchain
+                if target.toolchain is not None
+                else release_candidate_ref(target.rc)
+                if target.rc is not None
+                else release.toolchain
+            )
             expected_verso_ref = release_candidate_ref(target.rc) if target.rc is not None else release.verso_ref
             self.assertEqual(row["rc"], target.rc or "")
             self.assertEqual(row["toolchain"], expected_toolchain)
@@ -639,7 +661,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                                 {
                                     "release": "v4.29.0",
                                     "ref": "new-second-controller-ref",
-                                    "rc": "v4.29.0-rc2",
+                                    "toolchain": "v4.29.0-rc2",
                                     "publish_reference": True,
                                 }
                             ],
@@ -707,16 +729,16 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(matrix_by_project["new-release-project"]["verso_ref"], "v4.29.0-rc1")
         self.assertEqual(
             manifest_by_project["new-release-second-project"]["projects"][0]["targets"],
-            [{"release": "v4.29.0", "ref": "new-second-controller-ref", "rc": "4.29-rc2"}],
+            [{"release": "v4.29.0", "ref": "new-second-controller-ref", "toolchain": "v4.29.0-rc2"}],
         )
         self.assertEqual(
             manifest_by_project["new-release-second-project"]["projects"][0]["generate_command"],
             list(VBP_BUILD_PDF_COMMAND),
         )
         self.assertTrue(matrix_by_project["new-release-second-project"]["publish_pdf"])
-        self.assertEqual(matrix_by_project["new-release-second-project"]["rc"], "4.29-rc2")
+        self.assertEqual(matrix_by_project["new-release-second-project"]["rc"], "")
         self.assertEqual(matrix_by_project["new-release-second-project"]["toolchain"], "v4.29.0-rc2")
-        self.assertEqual(matrix_by_project["new-release-second-project"]["verso_ref"], "v4.29.0-rc2")
+        self.assertEqual(matrix_by_project["new-release-second-project"]["verso_ref"], "v4.29.0")
 
     def test_default_deploy_matrix_publishes_pdfs_only_for_default_dev_release(self) -> None:
         catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
@@ -783,6 +805,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                         {
                             "release": "v4.29.0",
                             "ref": "main",
+                            "toolchain": "v4.29.0-rc1",
                         }
                     ],
                     "build_command": ["lake", "build"],
@@ -800,6 +823,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(len(projects), 1)
         self.assertTrue(projects[0].git_checkout)
         self.assertEqual(projects[0].generate_command, VBP_BUILD_OUTPUT_COMMAND)
+        self.assertEqual(projects[0].targets[0].toolchain, "v4.29.0-rc1")
 
     def test_in_repo_command_project_is_supported(self) -> None:
         manifest_data = {


### PR DESCRIPTION
This PR separates an external reference project compiler from the VBP/Verso release tooling selected for its catalog release.

- add a compiler-only project target toolchain override while retaining legacy rc lockstep semantics
- always apply the resolved project compiler in reference build and deploy workflows
- remove the reusable Pages workflow escape hatch that skipped the formalization toolchain

Backport v4.32.0: #374
