### PR TITLE
chore: publish current v4.33 reference blueprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,19 +384,19 @@ reference projects publish on each Lean release line. Maintainers can inspect
 the current checkout's selected projects with
 `python3 -m scripts.blueprint_reference_harness projects`.
 
-Each external Blueprint is published only for its intended current release,
-currently `v4.32.0`. The in-repo starter template is a CI fixture rather than a
-public reference entry; it continues to validate every maintained release
-line.
+Each external Blueprint is published only for its intended current release.
+Noperthedron and Sphere Packing currently target `v4.32.0`; FLT and Carleson
+target `v4.33.0`. The in-repo starter template is a CI fixture rather than a
+public reference entry; it continues to validate every maintained release line.
 
 - [`ejgallego/verso-noperthedron`](https://github.com/ejgallego/verso-noperthedron),
   [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/noperthedron/)
 - [`ejgallego/verso-sphere-packing`](https://github.com/ejgallego/verso-sphere-packing),
   [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/spherepackingblueprint/)
 - [`ejgallego/verso-flt`](https://github.com/ejgallego/verso-flt),
-  [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/verso-flt/)
+  [rendered site for v4.33.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.33.0/verso-flt/)
 - [`ejgallego/verso-carleson`](https://github.com/ejgallego/verso-carleson),
-  [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/verso-carleson/)
+  [rendered site for v4.33.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.33.0/verso-carleson/)
 
 ## Rendered Test Blueprints
 

--- a/branch-policy.json
+++ b/branch-policy.json
@@ -17,7 +17,7 @@
       "toolchain": "v4.33.0",
       "verso_ref": "v4.33.0",
       "branch": "v4.33.0",
-      "deploy_pages": false
+      "deploy_pages": true
     }
   ]
 }

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -87,9 +87,10 @@
       },
       "targets": [
         {
-          "release": "v4.32.0",
-          "ref": "bc09f1e5ce35d6418173386b5f134b51a81e6c17",
-          "publish_reference": true
+          "release": "v4.33.0",
+          "ref": "e4f15950fc128b024fc1872d7178d30b29094e64",
+          "publish_reference": true,
+          "reference_toolchain": "v4.33.0-rc1"
         }
       ],
       "generate_command": [
@@ -112,9 +113,10 @@
       },
       "targets": [
         {
-          "release": "v4.32.0",
-          "ref": "e89a585c13d05c965d9d28d307517da0bfe13960",
-          "publish_reference": true
+          "release": "v4.33.0",
+          "ref": "275d7562958693065a012a74026432b3bd6598b7",
+          "publish_reference": true,
+          "reference_toolchain": "v4.33.0-rc1"
         }
       ],
       "generate_command": [


### PR DESCRIPTION
This PR moves FLT and Carleson to their intended v4.33 catalog targets while preserving each reference project's exact v4.33.0-rc1 toolchain. VBP and Verso remain on v4.33.0.

- Enable v4.33 reference Pages publication and update the public catalog links.

Backport v4.32.0: exempt: release-specific reference catalog and v4.33 publication metadata
