### PR TITLE
fix: treat the reference catalog as release metadata

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -109,9 +109,12 @@ Do those upstream write actions only when they are explicitly requested.
   reason. New-release branch-start PRs instead use the machine-checked
   `release-line bootstrap` status for every resulting required line.
 - Exemptions are limited to changes whose files are all documentation or
-  repository metadata. Source, scripts, tests, templates, package
-  configuration, and runtime assets require paired backports so maintenance
-  lines remain structurally aligned for future cherry-picks.
+  repository metadata. The release-specific reference catalog at
+  `tests/harness/projects.json` is metadata: moving a project to its intended
+  current release must not recreate that target on older release branches.
+  Source, scripts, other tests, templates, package configuration, and runtime
+  assets require paired backports so maintenance lines remain structurally
+  aligned for future cherry-picks.
 - `release-line bootstrap` is not a general exemption. CI accepts it only when
   every resulting required line uses that status and the PR demonstrably
   advances the Lean toolchain and default-development branch. The previous

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -312,6 +312,12 @@ Each paired backport PR should carry the scaffolded release label, such as
 `backport-v4.32.0`, so release-specific queues remain visible when several
 maintenance lines are active.
 
+A change limited to `tests/harness/projects.json` updates release-specific
+catalog metadata and may use an explicit backport exemption; do not recreate
+that catalog target on older release branches. If the same PR changes scripts,
+other tests, templates, or runtime files, it still requires the normal paired
+backport.
+
 Land reviewed local work from the clean root checkout:
 
 ```bash

--- a/scripts/blueprint_harness_backports.py
+++ b/scripts/blueprint_harness_backports.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 
-EXEMPT_FILE_NAMES = frozenset(
+EXEMPT_PATHS = frozenset(
     {
         ".gitattributes",
         ".gitignore",
@@ -24,7 +24,7 @@ def backport_exemption_violations(paths: Iterable[str]) -> tuple[str, ...]:
         path = raw_path.removeprefix("./")
         exempt = (
             path.endswith(".md")
-            or path in EXEMPT_FILE_NAMES
+            or path in EXEMPT_PATHS
             or path.startswith(EXEMPT_PATH_PREFIXES)
         )
         if not exempt:

--- a/scripts/blueprint_harness_backports.py
+++ b/scripts/blueprint_harness_backports.py
@@ -9,6 +9,7 @@ EXEMPT_FILE_NAMES = frozenset(
         ".gitignore",
         "branch-policy.json",
         "LICENSE",
+        "tests/harness/projects.json",
     }
 )
 EXEMPT_PATH_PREFIXES = (".github/", "doc/", "LICENSES/")

--- a/tests/harness/test_backport_pr_check.py
+++ b/tests/harness/test_backport_pr_check.py
@@ -266,7 +266,7 @@ Backport v4.24.0: release-line retirement
             with self.assertRaisesRegex(backport_mod.BackportCheckError, "pending backport entries are not allowed"):
                 backport_mod.run(str(event_path), token=None)
 
-    def test_run_accepts_ready_docs_only_exemptions(self) -> None:
+    def test_run_accepts_ready_documentation_and_catalog_exemptions(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             event_path = Path(tmp) / "event.json"
             write_pull_request_event(
@@ -274,7 +274,9 @@ Backport v4.24.0: release-line retirement
                 draft=False,
                 body=required_backport_body("exempt: docs-only change"),
             )
-            api = FakeGitHubApi(pull_request_files={11: ["doc/API.md", "README.md"]})
+            api = FakeGitHubApi(
+                pull_request_files={11: ["doc/API.md", "README.md", "tests/harness/projects.json"]}
+            )
             with patch.object(backport_mod, "GitHubApi", return_value=api):
                 self.assertEqual(backport_mod.run(str(event_path), token="token"), 0)
 

--- a/tests/harness/test_backport_pr_check.py
+++ b/tests/harness/test_backport_pr_check.py
@@ -266,7 +266,7 @@ Backport v4.24.0: release-line retirement
             with self.assertRaisesRegex(backport_mod.BackportCheckError, "pending backport entries are not allowed"):
                 backport_mod.run(str(event_path), token=None)
 
-    def test_run_accepts_ready_documentation_and_catalog_exemptions(self) -> None:
+    def test_run_accepts_ready_documentation_exemptions(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             event_path = Path(tmp) / "event.json"
             write_pull_request_event(
@@ -274,9 +274,19 @@ Backport v4.24.0: release-line retirement
                 draft=False,
                 body=required_backport_body("exempt: docs-only change"),
             )
-            api = FakeGitHubApi(
-                pull_request_files={11: ["doc/API.md", "README.md", "tests/harness/projects.json"]}
+            api = FakeGitHubApi(pull_request_files={11: ["doc/API.md", "README.md"]})
+            with patch.object(backport_mod, "GitHubApi", return_value=api):
+                self.assertEqual(backport_mod.run(str(event_path), token="token"), 0)
+
+    def test_run_accepts_ready_catalog_exemptions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            event_path = Path(tmp) / "event.json"
+            write_pull_request_event(
+                event_path,
+                draft=False,
+                body=required_backport_body("exempt: release-specific reference catalog"),
             )
+            api = FakeGitHubApi(pull_request_files={11: ["tests/harness/projects.json"]})
             with patch.object(backport_mod, "GitHubApi", return_value=api):
                 self.assertEqual(backport_mod.run(str(event_path), token="token"), 0)
 

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -144,11 +144,12 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
     def assert_single_current_release_target(
         self,
         project: HarnessProject,
-        release_id: str,
+        release_ids: set[str],
         *,
         publish_reference: bool | None = None,
     ) -> None:
-        self.assertEqual([target.release for target in project.targets], [release_id])
+        self.assertEqual(len(project.targets), 1)
+        self.assertIn(project.targets[0].release, release_ids)
         if publish_reference is not None:
             self.assertEqual(project.targets[0].publish_reference, publish_reference)
 
@@ -173,6 +174,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         )
         self.assertEqual(catalog.release_targets, branch_policy.release_targets)
         release_ids = [target.release_id for target in branch_policy.release_targets]
+        release_id_set = set(release_ids)
         self.assertIn(branch_policy.default_dev_branch, release_ids)
         self.assertNotIn(branch_policy.default_dev_branch, branch_policy.required_backport_branches)
         self.assertEqual(
@@ -204,47 +206,20 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(current_release.release_verso_ref, current_release.verso_ref)
         if current_release.deploy_pages:
             self.assertTrue(resolve_projects_for_release(catalog, current_release.release_id, None))
-        expected_external_releases = {
-            "noperthedron": "v4.32.0",
-            "spherepackingblueprint": "v4.32.0",
-            "verso-flt": "v4.32.0",
-            "verso-carleson": "v4.32.0",
+        expected_external_repositories = {
+            "noperthedron": "https://github.com/ejgallego/verso-noperthedron.git",
+            "spherepackingblueprint": "https://github.com/ejgallego/verso-sphere-packing.git",
+            "verso-flt": "https://github.com/ejgallego/verso-flt.git",
+            "verso-carleson": "https://github.com/ejgallego/verso-carleson.git",
         }
-        self.assertTrue(projects[1].git_checkout)
-        self.assertEqual(projects[1].repository, "https://github.com/ejgallego/verso-noperthedron.git")
-        self.assert_single_current_release_target(
-            projects[1], expected_external_releases[projects[1].project_id], publish_reference=True
-        )
-        self.assertIsNone(projects[1].targets[0].rc)
-        self.assertIsNone(projects[1].targets[0].toolchain)
-        self.assertIsNone(projects[1].build_command)
-        self.assertEqual(projects[1].generate_command, VBP_BUILD_OUTPUT_COMMAND)
+        for project in projects[1:]:
+            self.assertTrue(project.git_checkout)
+            self.assertEqual(project.repository, expected_external_repositories[project.project_id])
+            self.assert_single_current_release_target(project, release_id_set, publish_reference=True)
+            self.assertIsNone(project.build_command)
+            self.assertEqual(project.generate_command, VBP_BUILD_OUTPUT_COMMAND)
         self.assertEqual(projects[1].browser_tests_path, None)
         self.assertEqual(projects[1].panel_regression_script, None)
-        self.assertEqual(projects[2].repository, "https://github.com/ejgallego/verso-sphere-packing.git")
-        self.assert_single_current_release_target(
-            projects[2], expected_external_releases[projects[2].project_id], publish_reference=True
-        )
-        self.assertIsNone(projects[2].targets[0].rc)
-        self.assertIsNone(projects[2].targets[0].toolchain)
-        self.assertIsNone(projects[2].build_command)
-        self.assertEqual(projects[2].generate_command, VBP_BUILD_OUTPUT_COMMAND)
-        self.assertEqual(projects[3].repository, "https://github.com/ejgallego/verso-flt.git")
-        self.assert_single_current_release_target(
-            projects[3], expected_external_releases[projects[3].project_id], publish_reference=True
-        )
-        self.assertIsNone(projects[3].targets[0].rc)
-        self.assertIsNone(projects[3].targets[0].toolchain)
-        self.assertIsNone(projects[3].build_command)
-        self.assertEqual(projects[3].generate_command, VBP_BUILD_OUTPUT_COMMAND)
-        self.assertEqual(projects[4].repository, "https://github.com/ejgallego/verso-carleson.git")
-        self.assert_single_current_release_target(
-            projects[4], expected_external_releases[projects[4].project_id], publish_reference=True
-        )
-        self.assertIsNone(projects[4].targets[0].rc)
-        self.assertIsNone(projects[4].targets[0].toolchain)
-        self.assertIsNone(projects[4].build_command)
-        self.assertEqual(projects[4].generate_command, VBP_BUILD_OUTPUT_COMMAND)
 
     def test_selected_project_toolchain_requires_resolved_release_metadata(self) -> None:
         catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
@@ -755,18 +730,19 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             (entry["release_id"], entry["project_id"]): entry
             for entry in matrix["include"]
         }
-        self.assertEqual(
-            set(rows),
-            {
-                ("v4.32.0", "noperthedron"),
-                ("v4.32.0", "spherepackingblueprint"),
-                ("v4.32.0", "verso-flt"),
-                ("v4.32.0", "verso-carleson"),
-            },
-        )
-        for entry in rows.values():
-            self.assertFalse(entry["publish_pdf"])
-            self.assertNotIn("--pdf", entry["project_manifest"]["projects"][0]["generate_command"])
+        expected_rows = {
+            (target.release_id, project.project_id)
+            for target in deployable_targets
+            for project in catalog.projects
+            if (project_target := project.target_for_release(target.release_id)) is not None
+            and project_target.publish_reference
+        }
+        self.assertEqual(set(rows), expected_rows)
+        for (release_id, _project_id), entry in rows.items():
+            expected_pdf = release_id == branch_policy.default_dev_branch
+            self.assertEqual(entry["publish_pdf"], expected_pdf)
+            generate_command = entry["project_manifest"]["projects"][0]["generate_command"]
+            self.assertEqual("--pdf" in generate_command, expected_pdf)
 
         current_release_projects = [
             entry

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -219,15 +219,12 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             self.assertIsNone(project.build_command)
             self.assertEqual(project.generate_command, VBP_BUILD_OUTPUT_COMMAND)
 
-    def test_selected_project_toolchain_requires_resolved_release_metadata(self) -> None:
-        catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))
-        noperthedron = resolve_projects_for_release(catalog, "v4.32.0", ["noperthedron"])[0]
-        spherepacking = resolve_projects_for_release(catalog, "v4.32.0", ["spherepackingblueprint"])[0]
+    def test_selected_project_toolchain_uses_selected_release(self) -> None:
+        project = external_project(selected_release="v4.29.0")
 
-        self.assertEqual(selected_project_toolchain(noperthedron), "v4.32.0")
-        self.assertEqual(selected_project_toolchain(spherepacking), "v4.32.0")
+        self.assertEqual(selected_project_toolchain(project), "v4.29.0")
         with self.assertRaisesRegex(ValueError, "has no selected release target"):
-            selected_project_toolchain(catalog.projects[1])
+            selected_project_toolchain(external_project())
 
     def test_selected_project_toolchain_prefers_compiler_only_override(self) -> None:
         project = external_project(

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -141,7 +141,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             if expected_ref is not None:
                 self.assertEqual(project.ref, expected_ref)
 
-    def assert_single_current_release_target(
+    def assert_single_maintained_release_target(
         self,
         project: HarnessProject,
         release_ids: set[str],
@@ -215,11 +215,9 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         for project in projects[1:]:
             self.assertTrue(project.git_checkout)
             self.assertEqual(project.repository, expected_external_repositories[project.project_id])
-            self.assert_single_current_release_target(project, release_id_set, publish_reference=True)
+            self.assert_single_maintained_release_target(project, release_id_set, publish_reference=True)
             self.assertIsNone(project.build_command)
             self.assertEqual(project.generate_command, VBP_BUILD_OUTPUT_COMMAND)
-        self.assertEqual(projects[1].browser_tests_path, None)
-        self.assertEqual(projects[1].panel_regression_script, None)
 
     def test_selected_project_toolchain_requires_resolved_release_metadata(self) -> None:
         catalog = load_project_catalog(default_project_manifest(PACKAGE_ROOT))


### PR DESCRIPTION
This PR treats the external reference project catalog as release-specific repository metadata, so moving a Blueprint to its intended current release does not require recreating obsolete targets on maintenance branches. Catalog tests validate maintained-release and deploy-matrix invariants without duplicating the exact version table, and the maintainer guide documents the exemption boundary.

Backport v4.32.0: #377