### PR TITLE
chore: mark v4.33 as default development

### DIFF
--- a/branch-policy.json
+++ b/branch-policy.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "default_dev_branch": "v4.32.0",
+  "default_dev_branch": "v4.33.0",
   "required_backport_branches": [],
   "release_targets": [
     {
@@ -9,6 +9,13 @@
       "verso_ref": "v4.32.0",
       "branch": "v4.32.0",
       "deploy_pages": true
+    },
+    {
+      "id": "v4.33.0",
+      "toolchain": "v4.33.0",
+      "verso_ref": "v4.33.0",
+      "branch": "v4.33.0",
+      "deploy_pages": false
     }
   ]
 }

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -11,6 +11,10 @@
       "targets": [
         {
           "release": "v4.32.0"
+        },
+        {
+          "release": "v4.33.0",
+          "rc": "4.33-rc2"
         }
       ],
       "generate_command": ["lake", "exe", "vbp", "build", "--output", "{output_dir}"],

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -175,7 +175,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(branch_policy.required_backport_branches, ())
         self.assertEqual(
             [target.release_id for target in branch_policy.release_targets],
-            ["v4.32.0"],
+            ["v4.32.0", "v4.33.0"],
         )
         self.assertTrue(projects[0].in_repo_project)
         self.assertTrue(projects[0].in_repo_command_project)
@@ -755,15 +755,15 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             },
         )
         for entry in rows.values():
-            self.assertTrue(entry["publish_pdf"])
-            self.assertIn("--pdf", entry["project_manifest"]["projects"][0]["generate_command"])
+            self.assertFalse(entry["publish_pdf"])
+            self.assertNotIn("--pdf", entry["project_manifest"]["projects"][0]["generate_command"])
 
         current_release_projects = [
             entry
             for (release_id, _project_id), entry in rows.items()
             if release_id == branch_policy.default_dev_branch
         ]
-        self.assertTrue(current_release_projects)
+        self.assertFalse(current_release_projects)
         for entry in current_release_projects:
             self.assertTrue(entry["publish_pdf"])
             self.assertIn("--pdf", entry["project_manifest"]["projects"][0]["generate_command"])


### PR DESCRIPTION
This updates the maintained v4.32 branch metadata after v4.33 became the default development line.

It:
- marks v4.32 as backport-only by tracking v4.33 as the default development branch;
- records the v4.33 baseline release target and matching project-template RC metadata;
- updates branch-local harness expectations so archived v4.32 deployment artifacts no longer receive default-development PDFs.

The v4.32 Lean toolchain and published external reference catalog remain unchanged.