### PR TITLE
[backport v4.32.0] refactor: tighten reference harness maintenance

### DIFF
--- a/.github/workflows/reference-blueprints-deploy.yml
+++ b/.github/workflows/reference-blueprints-deploy.yml
@@ -46,6 +46,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: resolve-deploy-releases
     if: ${{ needs.resolve-deploy-releases.outputs.deployable_project_count != '0' }}
+    env:
+      BP_REFERENCE_SOURCE_IDENTITY: ${{ matrix.reference_source_identity }}
+      BP_REFERENCE_DEPENDENCY_PACKAGES_PATH: ${{ matrix.reference_dependency_packages_path }}
+      BP_REFERENCE_DEPENDENCY_PATH_BUILDS_PATH: ${{ matrix.reference_dependency_path_builds_path }}
+      BP_REFERENCE_ARTIFACT_PATH: ${{ matrix.artifact_path }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.resolve-deploy-releases.outputs.deployable_project_matrix) }}
@@ -90,7 +95,7 @@ jobs:
             --output _out/deploy-projects/${{ matrix.project_id }}.identity.json \
             --github-output >> "$GITHUB_OUTPUT"
       - name: Report disk usage before cache restore
-        run: ./scripts/report-ci-disk-usage.sh "before cache restore" --reference-source-identity "${{ matrix.reference_source_identity }}" --artifact-path "${{ matrix.artifact_path }}"
+        run: ./scripts/report-ci-disk-usage.sh "before cache restore"
       - name: Restore exact generated reference site
         id: generated-site-cache
         uses: actions/cache/restore@v5
@@ -140,7 +145,7 @@ jobs:
             ${{ runner.os }}-reference-deploy-lake-deps-
       - name: Report disk usage after Lake cache restore
         if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' }}
-        run: ./scripts/report-ci-disk-usage.sh "after Lake cache restore" --reference-source-identity "${{ matrix.reference_source_identity }}" --artifact-path "${{ matrix.artifact_path }}"
+        run: ./scripts/report-ci-disk-usage.sh "after Lake cache restore"
       - name: Restore external reference dependency cache
         if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' && matrix.reference_source_identity != '' }}
         uses: actions/cache@v5
@@ -153,7 +158,7 @@ jobs:
             ${{ runner.os }}-reference-deploy-deps-v2-${{ matrix.project_id }}-
       - name: Report disk usage after reference cache restore
         if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' }}
-        run: ./scripts/report-ci-disk-usage.sh "after reference cache restore" --reference-source-identity "${{ matrix.reference_source_identity }}" --artifact-path "${{ matrix.artifact_path }}"
+        run: ./scripts/report-ci-disk-usage.sh "after reference cache restore"
       - name: Show tool versions
         if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' }}
         run: |
@@ -176,7 +181,7 @@ jobs:
             _out/reference-blueprints/${{ matrix.release_id }}
       - name: Report disk usage after reference generation
         if: ${{ always() }}
-        run: ./scripts/report-ci-disk-usage.sh "after reference generation" --reference-source-identity "${{ matrix.reference_source_identity }}" --artifact-path "${{ matrix.artifact_path }}"
+        run: ./scripts/report-ci-disk-usage.sh "after reference generation"
       - name: Install exact reference artifact identity
         if: ${{ steps.generated-site-cache.outputs.cache-hit != 'true' }}
         run: |

--- a/.github/workflows/reference-blueprints.yml
+++ b/.github/workflows/reference-blueprints.yml
@@ -35,6 +35,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: resolve-reference-release
     if: ${{ needs.resolve-reference-release.outputs.reference_project_count != '0' }}
+    env:
+      BP_REFERENCE_SOURCE_IDENTITY: ${{ matrix.reference_source_identity }}
+      BP_REFERENCE_DEPENDENCY_PACKAGES_PATH: ${{ matrix.reference_dependency_packages_path }}
+      BP_REFERENCE_DEPENDENCY_PATH_BUILDS_PATH: ${{ matrix.reference_dependency_path_builds_path }}
+      BP_REFERENCE_ARTIFACT_PATH: ${{ matrix.artifact_path }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.resolve-reference-release.outputs.reference_matrix) }}
@@ -52,7 +57,7 @@ jobs:
       - name: Match reference target toolchain
         run: printf 'leanprover/lean4:${{ matrix.toolchain }}\n' > lean-toolchain
       - name: Report disk usage before cache restore
-        run: ./scripts/report-ci-disk-usage.sh "before cache restore" --reference-source-identity "${{ matrix.reference_source_identity }}" --artifact-path "${{ matrix.artifact_path }}"
+        run: ./scripts/report-ci-disk-usage.sh "before cache restore"
       - name: Install elan
         run: |
           curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
@@ -88,7 +93,7 @@ jobs:
             ${{ runner.os }}-lake-deps-${{ matrix.toolchain }}-
             ${{ runner.os }}-lake-deps-
       - name: Report disk usage after Lake cache restore
-        run: ./scripts/report-ci-disk-usage.sh "after Lake cache restore" --reference-source-identity "${{ matrix.reference_source_identity }}" --artifact-path "${{ matrix.artifact_path }}"
+        run: ./scripts/report-ci-disk-usage.sh "after Lake cache restore"
       - name: Restore external reference dependency cache
         if: ${{ matrix.reference_source_identity != '' }}
         uses: actions/cache@v5
@@ -100,7 +105,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-reference-deps-v2-${{ matrix.project_id }}-
       - name: Report disk usage after reference cache restore
-        run: ./scripts/report-ci-disk-usage.sh "after reference cache restore" --reference-source-identity "${{ matrix.reference_source_identity }}" --artifact-path "${{ matrix.artifact_path }}"
+        run: ./scripts/report-ci-disk-usage.sh "after reference cache restore"
       - name: Show tool versions
         run: |
           lean --version
@@ -111,7 +116,7 @@ jobs:
         run: ./scripts/generate-reference-blueprints.sh --allow-unsafe-root-release --pdf --project ${{ matrix.project_id }}
       - name: Report disk usage after reference generation
         if: ${{ always() }}
-        run: ./scripts/report-ci-disk-usage.sh "after reference generation" --reference-source-identity "${{ matrix.reference_source_identity }}" --artifact-path "${{ matrix.artifact_path }}"
+        run: ./scripts/report-ci-disk-usage.sh "after reference generation"
       - name: Upload reference blueprint artifact
         uses: actions/upload-artifact@v7
         with:

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -390,8 +390,15 @@ policy metadata on each older release branch so the harness recognizes them as
 backport-only:
 
 ```bash
-python3 -m scripts.blueprint_harness set-default-dev-branch v4.32.0
+python3 -m scripts.blueprint_harness set-default-dev-branch <new-default-dev-toolchain>
 ```
+
+Use the exact command printed by `start-release-line`. For version 2 policies,
+`set-default-dev-branch` also adds the new branch's baseline release target when
+the older checkout does not have it yet and adds the corresponding target to
+in-repo project metadata. Passing the printed RC ref preserves its target-level
+RC pin. The command preserves the older checkout's own Lean toolchain, existing
+release targets, and required-backport list.
 
 Commit that metadata-only change separately on each older branch that still
 carries `branch-policy.json`, such as `v4.32.0`. Preserve their own Lean
@@ -463,6 +470,11 @@ packages back to make the cache usable again. Cache warm-up may refresh shared
 contents with `rsync`; this ownership rule does not yet provide transactional
 publication for simultaneous writers.
 
+Maintainer `sync`, `generate`, and `validate` operations involving external
+git-checkout projects require `rsync` on `PATH`. The harness checks this before
+starting external checkout or cache work and reports a focused diagnostic when
+it is unavailable.
+
 After warm-up, the disposable source checkout's duplicate `.lake/packages/`
 tree is removed once it has been copied into the dependency cache. This deletes
 only the source checkout's copy, not the shared dependency cache. CI likewise
@@ -482,7 +494,7 @@ python3 -m scripts.blueprint_harness create-worktree <name>
 After `git worktree add`, that command syncs the root checkout's `.lake/` and
 prepares the shared and per-worktree reference blueprint clones without running
 external reference project builds. New worktrees now base off the branch policy's
-preferred default-development ref, typically something like `origin/v4.32.0`.
+preferred default-development ref, `origin/<default-dev-branch>`.
 Pass `--base <release-ref>` explicitly for backport-only work.
 
 If you want to verify that the root checkout has not drifted before branching

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,7 +51,9 @@ Common starting points:
 python3 -m scripts.blueprint_harness create-worktree <name> --owner codex --lock --priority P1 --summary "short description"
 python3 -m scripts.blueprint_harness create-worktree <name> --lightweight  # docs/Python-only work
 python3 -m scripts.blueprint_harness release-status --require-sync
+# On the new default-development release branch:
 python3 -m scripts.blueprint_harness start-release-line 4.33-rc2
+# On each older maintained checkout, using the exact ref printed above:
 python3 -m scripts.blueprint_harness set-default-dev-branch v4.33.0-rc2
 python3 -m scripts.blueprint_harness paths
 python3 -m scripts.blueprint_reference_harness compose /path/to/source --project-root blueprint

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -52,7 +52,7 @@ python3 -m scripts.blueprint_harness create-worktree <name> --owner codex --lock
 python3 -m scripts.blueprint_harness create-worktree <name> --lightweight  # docs/Python-only work
 python3 -m scripts.blueprint_harness release-status --require-sync
 python3 -m scripts.blueprint_harness start-release-line 4.33-rc2
-python3 -m scripts.blueprint_harness set-default-dev-branch v4.33.0
+python3 -m scripts.blueprint_harness set-default-dev-branch v4.33.0-rc2
 python3 -m scripts.blueprint_harness paths
 python3 -m scripts.blueprint_reference_harness compose /path/to/source --project-root blueprint
 python3 -m scripts.blueprint_reference_harness projects

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -622,23 +622,52 @@ def command_start_release_line(args: argparse.Namespace) -> int:
     print(f"project_manifest={manifest_path}")
     print(f"deploy_pages={str(args.deploy_pages).lower()}")
     print("[blueprint-harness] next: commit this branch-start change, then update older branches with:")
-    print(f"python3 -m scripts.blueprint_harness set-default-dev-branch {release_id}")
+    print(f"python3 -m scripts.blueprint_harness set-default-dev-branch {result.lean_ref}")
     return 0
 
 
 def command_set_default_dev_branch(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
     old_policy = load_branch_policy(layout.package_root)
+    requested_lean_ref = normalize_lean_release_ref(args.branch)
+    new_default_branch = release_branch_from_lean_ref(requested_lean_ref)
+    rc = release_candidate_name_or_none(requested_lean_ref)
+    release_targets = old_policy.release_targets
+    release_target_added = False
+    if old_policy.version >= 2 and all(
+        target.release_id != new_default_branch for target in release_targets
+    ):
+        release_targets = upsert_release_target(
+            release_targets,
+            BranchPolicyReleaseTarget(
+                release_id=new_default_branch,
+                release_toolchain=new_default_branch,
+                release_verso_ref=new_default_branch,
+                branch=new_default_branch,
+                deploy_pages=False,
+            ),
+        )
+        release_target_added = True
     new_policy = write_branch_policy(
         layout.package_root,
-        default_dev_branch=args.branch,
+        default_dev_branch=new_default_branch,
         required_backport_branches=old_policy.required_backport_branches,
-        release_targets=old_policy.release_targets,
+        release_targets=release_targets,
         version=old_policy.version,
     )
+    manifest_path = resolve_manifest_path(None, layout.package_root)
+    if manifest_path.exists():
+        update_release_line_project_manifest(
+            manifest_path,
+            release_id=new_default_branch,
+            rc=rc,
+        )
     print(f"branch_policy={new_policy.source_path}")
     print(f"default_dev_branch={new_policy.default_dev_branch}")
+    print(f"rc={rc or ''}")
+    print(f"release_target_added={str(release_target_added).lower()}")
     print(f"required_backports={','.join(new_policy.required_backport_branches)}")
+    print(f"project_manifest={manifest_path}")
     print(f"active_release_branch={active_release_branch(layout.package_root)}")
     print(f"checkout_role={checkout_branch_role(layout.package_root)}")
     return 0
@@ -1393,11 +1422,11 @@ def add_release_management_commands(subparsers) -> None:
 
     set_default_dev_branch = subparsers.add_parser(
         "set-default-dev-branch",
-        help="Update only `branch-policy.json.default_dev_branch` in the current checkout.",
+        help="Update `branch-policy.json` for a new default-development release branch.",
     )
     set_default_dev_branch.add_argument(
         "branch",
-        help="New default development branch, such as `v4.32.0`.",
+        help="New default development Lean ref, including an RC ref when applicable.",
     )
     set_default_dev_branch.set_defaults(func=command_set_default_dev_branch)
 

--- a/scripts/blueprint_harness.py
+++ b/scripts/blueprint_harness.py
@@ -629,7 +629,7 @@ def command_start_release_line(args: argparse.Namespace) -> int:
 def command_set_default_dev_branch(args: argparse.Namespace) -> int:
     layout = detect_harness_layout(Path(__file__))
     old_policy = load_branch_policy(layout.package_root)
-    requested_lean_ref = normalize_lean_release_ref(args.branch)
+    requested_lean_ref = normalize_lean_release_ref(args.lean_ref)
     new_default_branch = release_branch_from_lean_ref(requested_lean_ref)
     rc = release_candidate_name_or_none(requested_lean_ref)
     release_targets = old_policy.release_targets
@@ -1425,7 +1425,8 @@ def add_release_management_commands(subparsers) -> None:
         help="Update `branch-policy.json` for a new default-development release branch.",
     )
     set_default_dev_branch.add_argument(
-        "branch",
+        "lean_ref",
+        metavar="LEAN_REF",
         help="New default development Lean ref, including an RC ref when applicable.",
     )
     set_default_dev_branch.set_defaults(func=command_set_default_dev_branch)

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -198,6 +198,11 @@ def validate_external_reference_toolchain(
     return project_toolchain.lean_ref
 
 
+def require_reference_rsync() -> None:
+    if shutil.which("rsync") is None:
+        raise SystemExit("[blueprint-harness] `rsync` is required for external reference cache copies.")
+
+
 def seed_lake_packages_from_dependency_cache(
     layout,
     project: HarnessProject,
@@ -827,20 +832,9 @@ def sync_reference_local_checkout(
         update_git_checkout(project, local_dir)
     bootstrap_reference_checkout(project_dir=local_dir / project.project_root)
 
-    dependency_packages = paths.dependency_packages
-    if dependency_packages.exists():
-        local_packages = local_dir / project.project_root / ".lake" / "packages"
-        local_packages.mkdir(parents=True, exist_ok=True)
-        run(
-            [
-                "rsync",
-                "-a",
-                f"{dependency_packages}/",
-                f"{local_packages}/",
-            ],
-            cwd=layout.package_root,
-        )
-    seed_lake_path_builds_from_dependency_cache(layout, project, local_dir / project.project_root)
+    project_dir = local_dir / project.project_root
+    seed_lake_packages_from_dependency_cache(layout, project, project_dir)
+    seed_lake_path_builds_from_dependency_cache(layout, project, project_dir)
     return local_dir
 
 
@@ -951,8 +945,7 @@ def sync_reference_blueprints(
     git_projects = [project for project in projects if project.git_checkout]
     if not git_projects:
         return
-    if shutil.which("rsync") is None:
-        raise SystemExit("[blueprint-harness] `rsync` is required for reference dependency cache sync.")
+    require_reference_rsync()
     for project in git_projects:
         cache_dir = sync_reference_cache_checkout(layout, project, warm_build=warm_build)
         if prepare_local_checkout:

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -901,7 +901,6 @@ def generate_git_project(
     discard_untracked_project_manifest(project_dir)
     output_dir = output_dir_for(project, output_root)
     output_dir.mkdir(parents=True, exist_ok=True)
-    bootstrap_reference_checkout(project_dir=project_dir)
 
     def update_reference_project() -> None:
         run_external_reference_lake_update(

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -57,6 +57,7 @@ from scripts.blueprint_harness_references import (
     reference_prune_plan,
     reference_source_identities,
     reference_source_paths,
+    require_reference_rsync,
     site_dir_for,
     sync_reference_blueprints,
 )
@@ -691,6 +692,9 @@ def generate_projects(
     in_repo_target_projects = [project for project in in_repo_projects if project.in_repo_target_project]
     in_repo_command_projects = [project for project in in_repo_projects if project.in_repo_command_project]
     git_projects = [project for project in projects if project.git_checkout]
+
+    if git_projects:
+        require_reference_rsync()
 
     if in_repo_target_projects:
         print(f"[blueprint-reference-harness] package root: {layout.package_root}")

--- a/scripts/report-ci-disk-usage.sh
+++ b/scripts/report-ci-disk-usage.sh
@@ -4,63 +4,30 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: scripts/report-ci-disk-usage.sh LABEL [options]
+Usage: scripts/report-ci-disk-usage.sh LABEL
 
 Print a compact disk-usage report for CI reference blueprint jobs.
 
-Options:
-  --reference-source-identity ID
-                              Include per-reference paths for the source ID.
-  --artifact-path PATH        Include the generated artifact path.
-  -h, --help                  Show this help.
+The BP_REFERENCE_SOURCE_IDENTITY, BP_REFERENCE_DEPENDENCY_PACKAGES_PATH,
+BP_REFERENCE_DEPENDENCY_PATH_BUILDS_PATH, and BP_REFERENCE_ARTIFACT_PATH
+environment variables select the per-reference paths to include.
 EOF
 }
 
-label=""
-reference_source_identity=""
-artifact_path=""
+reference_source_identity="${BP_REFERENCE_SOURCE_IDENTITY:-}"
+reference_dependency_packages_path="${BP_REFERENCE_DEPENDENCY_PACKAGES_PATH:-}"
+reference_dependency_path_builds_path="${BP_REFERENCE_DEPENDENCY_PATH_BUILDS_PATH:-}"
+artifact_path="${BP_REFERENCE_ARTIFACT_PATH:-}"
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    --reference-source-identity)
-      if [[ $# -lt 2 ]]; then
-        echo "missing value for --reference-source-identity" >&2
-        exit 2
-      fi
-      reference_source_identity="$2"
-      shift 2
-      ;;
-    --artifact-path)
-      if [[ $# -lt 2 ]]; then
-        echo "missing value for --artifact-path" >&2
-        exit 2
-      fi
-      artifact_path="$2"
-      shift 2
-      ;;
-    -*)
-      echo "unknown option: $1" >&2
-      exit 2
-      ;;
-    *)
-      if [[ -n "$label" ]]; then
-        echo "unexpected argument: $1" >&2
-        exit 2
-      fi
-      label="$1"
-      shift
-      ;;
-  esac
-done
-
-if [[ -z "$label" ]]; then
+if [[ $# -eq 1 && ( "$1" == "-h" || "$1" == "--help" ) ]]; then
+  usage
+  exit 0
+fi
+if [[ $# -ne 1 ]]; then
   usage >&2
   exit 2
 fi
+label="$1"
 
 begin_group() {
   if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
@@ -111,15 +78,19 @@ report_du() {
   if [[ -n "$reference_source_identity" ]]; then
     paths+=(
       ".worktrees/_reference-blueprints/cache/$reference_source_identity"
-      ".worktrees/_reference-blueprints/deps/$reference_source_identity"
-      ".worktrees/_reference-blueprints/deps/$reference_source_identity/packages"
-      ".worktrees/_reference-blueprints/deps/$reference_source_identity/path-builds"
     )
 
     shopt -s nullglob
     local local_checkouts=(.worktrees/_reference-blueprints/by-worktree/*/"$reference_source_identity")
     shopt -u nullglob
     paths+=("${local_checkouts[@]}")
+  fi
+
+  if [[ -n "$reference_dependency_packages_path" ]]; then
+    paths+=("$reference_dependency_packages_path")
+  fi
+  if [[ -n "$reference_dependency_path_builds_path" ]]; then
+    paths+=("$reference_dependency_path_builds_path")
   fi
 
   if [[ -n "$artifact_path" ]]; then
@@ -143,16 +114,16 @@ report_reference_children() {
     du -sh "$root"/* 2>/dev/null | sort -h || true
   fi
 
-  if [[ -n "$reference_source_identity" ]]; then
-    local packages=".worktrees/_reference-blueprints/deps/$reference_source_identity/packages"
-    if [[ -d "$packages" ]]; then
+  if [[ -n "$reference_dependency_packages_path" ]]; then
+    if [[ -d "$reference_dependency_packages_path" ]]; then
       printf '[ci-disk] packages for %s\n' "$reference_source_identity"
-      du -sh "$packages"/* 2>/dev/null | sort -h || true
+      du -sh "$reference_dependency_packages_path"/* 2>/dev/null | sort -h || true
     fi
-    local path_builds=".worktrees/_reference-blueprints/deps/$reference_source_identity/path-builds"
-    if [[ -d "$path_builds" ]]; then
+  fi
+  if [[ -n "$reference_dependency_path_builds_path" ]]; then
+    if [[ -d "$reference_dependency_path_builds_path" ]]; then
       printf '[ci-disk] path builds for %s\n' "$reference_source_identity"
-      du -sh "$path_builds"/* 2>/dev/null | sort -h || true
+      du -sh "$reference_dependency_path_builds_path"/* 2>/dev/null | sort -h || true
     fi
   fi
 }
@@ -161,6 +132,12 @@ begin_group "Disk usage: $label"
 printf '[ci-disk] label=%s\n' "$label"
 if [[ -n "$reference_source_identity" ]]; then
   printf '[ci-disk] reference_source_identity=%s\n' "$reference_source_identity"
+fi
+if [[ -n "$reference_dependency_packages_path" ]]; then
+  printf '[ci-disk] reference_dependency_packages_path=%s\n' "$reference_dependency_packages_path"
+fi
+if [[ -n "$reference_dependency_path_builds_path" ]]; then
+  printf '[ci-disk] reference_dependency_path_builds_path=%s\n' "$reference_dependency_path_builds_path"
 fi
 if [[ -n "$artifact_path" ]]; then
   printf '[ci-disk] artifact_path=%s\n' "$artifact_path"

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -1486,7 +1486,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 [target["release"] for target in manifest["projects"][1]["targets"]],
                 ["v4.29.0"],
             )
-            self.assertIn("set-default-dev-branch v4.30.0", out.getvalue())
+            self.assertIn("set-default-dev-branch v4.30.0-rc2", out.getvalue())
 
     def test_start_release_line_rejects_mismatched_rc_verso_line_before_mutation(self) -> None:
         args = argparse.Namespace(
@@ -1535,6 +1535,96 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 (root / "branch-policy.json").read_text(encoding="utf-8"),
                 '{\n  "version": 1,\n  "default_dev_branch": "v4.30.0",\n  "required_backport_branches": [\n    "v4.28.0"\n  ]\n}\n',
             )
+            self.assertIn("checkout_role=backport", out.getvalue())
+
+    def test_set_default_dev_branch_adds_missing_version_two_release_target(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "lean-toolchain").write_text("leanprover/lean4:v4.32.0\n", encoding="utf-8")
+            (root / "branch-policy.json").write_text(
+                json.dumps(
+                    {
+                        "version": 2,
+                        "default_dev_branch": "v4.32.0",
+                        "required_backport_branches": [],
+                        "release_targets": [
+                            {
+                                "id": "v4.32.0",
+                                "toolchain": "v4.32.0",
+                                "verso_ref": "v4.32.0",
+                                "branch": "v4.32.0",
+                                "deploy_pages": True,
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            manifest_path = root / "tests" / "harness" / "projects.json"
+            manifest_path.parent.mkdir(parents=True)
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "version": 2,
+                        "projects": [
+                            {
+                                "id": "project-template",
+                                "source": {"kind": "in_repo_project"},
+                                "targets": [{"release": "v4.32.0"}],
+                            },
+                            {
+                                "id": "external",
+                                "source": {"kind": "git_checkout"},
+                                "targets": [{"release": "v4.32.0", "ref": "abc"}],
+                            },
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            args = argparse.Namespace(branch="4.33-rc2")
+            layout = SimpleNamespace(package_root=root)
+            out = io.StringIO()
+            with patched_attrs(harness_mod, detect_harness_layout=lambda _start=None: layout):
+                with redirect_stdout(out):
+                    self.assertEqual(harness_mod.command_set_default_dev_branch(args), 0)
+
+            policy = json.loads((root / "branch-policy.json").read_text(encoding="utf-8"))
+            self.assertEqual(policy["default_dev_branch"], "v4.33.0")
+            self.assertEqual(policy["required_backport_branches"], [])
+            self.assertEqual(
+                policy["release_targets"],
+                [
+                    {
+                        "id": "v4.32.0",
+                        "toolchain": "v4.32.0",
+                        "verso_ref": "v4.32.0",
+                        "branch": "v4.32.0",
+                        "deploy_pages": True,
+                    },
+                    {
+                        "id": "v4.33.0",
+                        "toolchain": "v4.33.0",
+                        "verso_ref": "v4.33.0",
+                        "branch": "v4.33.0",
+                        "deploy_pages": False,
+                    },
+                ],
+            )
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                manifest["projects"][0]["targets"],
+                [
+                    {"release": "v4.32.0"},
+                    {"release": "v4.33.0", "rc": "4.33-rc2"},
+                ],
+            )
+            self.assertEqual(
+                manifest["projects"][1]["targets"],
+                [{"release": "v4.32.0", "ref": "abc"}],
+            )
+            self.assertIn("rc=4.33-rc2", out.getvalue())
+            self.assertIn("release_target_added=true", out.getvalue())
             self.assertIn("checkout_role=backport", out.getvalue())
 
     def test_paths_prints_current_release_project_sites_by_default(self) -> None:
@@ -2342,6 +2432,24 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 serial=False,
                 allow_local_build=False,
             )
+
+    def test_generate_projects_preflights_rsync_for_external_projects(self) -> None:
+        layout = SimpleNamespace(package_root=Path("/tmp/package"), in_linked_worktree=True)
+
+        with patch.object(
+            reference_harness_mod,
+            "require_reference_rsync",
+            side_effect=SystemExit("rsync required"),
+        ):
+            with self.assertRaisesRegex(SystemExit, "rsync required"):
+                generate_projects(
+                    layout,
+                    Path("/tmp/out"),
+                    [self.published_git_project()],
+                    skip_build=False,
+                    serial=False,
+                    allow_local_build=False,
+                )
 
     def test_validate_run_lean_tests_does_not_auto_sync_root_lake(self) -> None:
         args = argparse.Namespace(

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -272,10 +272,10 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertTrue(args.deploy_pages)
         self.assertTrue(args.skip_validation)
 
-    def test_set_default_dev_branch_parses_branch(self) -> None:
+    def test_set_default_dev_branch_parses_lean_ref(self) -> None:
         parser = build_parser()
         args = parser.parse_args(["set-default-dev-branch", "v4.30.0"])
-        self.assertEqual(args.branch, "v4.30.0")
+        self.assertEqual(args.lean_ref, "v4.30.0")
 
     def test_create_worktree_parses_lock_flag(self) -> None:
         parser = build_parser()
@@ -1521,7 +1521,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 '{\n  "version": 1,\n  "default_dev_branch": "v4.29.0",\n  "required_backport_branches": ["v4.28.0"]\n}\n',
                 encoding="utf-8",
             )
-            args = argparse.Namespace(branch="v4.30.0")
+            args = argparse.Namespace(lean_ref="v4.30.0")
             layout = SimpleNamespace(package_root=root)
             out = io.StringIO()
             with patched_attrs(
@@ -1582,7 +1582,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
-            args = argparse.Namespace(branch="4.33-rc2")
+            args = argparse.Namespace(lean_ref="4.33-rc2")
             layout = SimpleNamespace(package_root=root)
             out = io.StringIO()
             with patched_attrs(harness_mod, detect_harness_layout=lambda _start=None: layout):
@@ -1682,7 +1682,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
-            args = argparse.Namespace(branch="v4.33.0-rc2")
+            args = argparse.Namespace(lean_ref="v4.33.0-rc2")
             layout = SimpleNamespace(package_root=root)
             outputs: list[str] = []
             with patched_attrs(harness_mod, detect_harness_layout=lambda _start=None: layout):

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -1627,6 +1627,102 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             self.assertIn("release_target_added=true", out.getvalue())
             self.assertIn("checkout_role=backport", out.getvalue())
 
+    def test_set_default_dev_branch_is_idempotent_for_existing_rc_release_target(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "lean-toolchain").write_text("leanprover/lean4:v4.32.0\n", encoding="utf-8")
+            (root / "branch-policy.json").write_text(
+                json.dumps(
+                    {
+                        "version": 2,
+                        "default_dev_branch": "v4.33.0",
+                        "required_backport_branches": ["v4.32.0"],
+                        "release_targets": [
+                            {
+                                "id": "v4.32.0",
+                                "toolchain": "v4.32.0",
+                                "verso_ref": "v4.32.0",
+                                "branch": "v4.32.0",
+                                "deploy_pages": False,
+                            },
+                            {
+                                "id": "v4.33.0",
+                                "toolchain": "v4.33.0",
+                                "verso_ref": "v4.33.0",
+                                "branch": "v4.33.0",
+                                "deploy_pages": True,
+                            },
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            manifest_path = root / "tests" / "harness" / "projects.json"
+            manifest_path.parent.mkdir(parents=True)
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "version": 2,
+                        "projects": [
+                            {
+                                "id": "project-template",
+                                "source": {"kind": "in_repo_project"},
+                                "targets": [
+                                    {"release": "v4.32.0"},
+                                    {"release": "v4.33.0", "rc": "4.33-rc2"},
+                                ],
+                            },
+                            {
+                                "id": "external",
+                                "source": {"kind": "git_checkout"},
+                                "targets": [{"release": "v4.32.0", "ref": "abc"}],
+                            },
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            args = argparse.Namespace(branch="v4.33.0-rc2")
+            layout = SimpleNamespace(package_root=root)
+            outputs: list[str] = []
+            with patched_attrs(harness_mod, detect_harness_layout=lambda _start=None: layout):
+                for _ in range(2):
+                    out = io.StringIO()
+                    with redirect_stdout(out):
+                        self.assertEqual(harness_mod.command_set_default_dev_branch(args), 0)
+                    outputs.append(out.getvalue())
+
+            policy = json.loads((root / "branch-policy.json").read_text(encoding="utf-8"))
+            self.assertEqual(policy["default_dev_branch"], "v4.33.0")
+            self.assertEqual(policy["required_backport_branches"], ["v4.32.0"])
+            self.assertEqual(
+                [target for target in policy["release_targets"] if target["id"] == "v4.33.0"],
+                [
+                    {
+                        "id": "v4.33.0",
+                        "toolchain": "v4.33.0",
+                        "verso_ref": "v4.33.0",
+                        "branch": "v4.33.0",
+                        "deploy_pages": True,
+                    }
+                ],
+            )
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                manifest["projects"][0]["targets"],
+                [
+                    {"release": "v4.32.0"},
+                    {"release": "v4.33.0", "rc": "4.33-rc2"},
+                ],
+            )
+            self.assertEqual(
+                manifest["projects"][1]["targets"],
+                [{"release": "v4.32.0", "ref": "abc"}],
+            )
+            for output in outputs:
+                self.assertIn("rc=4.33-rc2", output)
+                self.assertIn("release_target_added=false", output)
+
     def test_paths_prints_current_release_project_sites_by_default(self) -> None:
         args = argparse.Namespace(all_projects=False)
         layout = SimpleNamespace(

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -562,25 +562,18 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertIn("matrix.reference_dependency_packages_path", workflow_text)
         self.assertIn("matrix.reference_dependency_path_builds_path", workflow_text)
         self.assertIn("reference-deps-v2-${{ matrix.reference_source_identity }}", workflow_text)
-        self.assertIn(
-            "BP_REFERENCE_DEPENDENCY_PACKAGES_PATH: ${{ matrix.reference_dependency_packages_path }}",
-            workflow_text,
-        )
-        self.assertIn(
-            "BP_REFERENCE_DEPENDENCY_PATH_BUILDS_PATH: ${{ matrix.reference_dependency_path_builds_path }}",
-            workflow_text,
-        )
         self.assertIn("matrix.reference_dependency_packages_path", deploy_workflow_text)
         self.assertIn("matrix.reference_dependency_path_builds_path", deploy_workflow_text)
         self.assertIn("reference-deploy-deps-v2-${{ matrix.reference_source_identity }}", deploy_workflow_text)
-        self.assertIn(
+        reference_environment = (
+            "BP_REFERENCE_SOURCE_IDENTITY: ${{ matrix.reference_source_identity }}",
             "BP_REFERENCE_DEPENDENCY_PACKAGES_PATH: ${{ matrix.reference_dependency_packages_path }}",
-            deploy_workflow_text,
-        )
-        self.assertIn(
             "BP_REFERENCE_DEPENDENCY_PATH_BUILDS_PATH: ${{ matrix.reference_dependency_path_builds_path }}",
-            deploy_workflow_text,
+            "BP_REFERENCE_ARTIFACT_PATH: ${{ matrix.artifact_path }}",
         )
+        for mapping in reference_environment:
+            self.assertIn(mapping, workflow_text)
+            self.assertIn(mapping, deploy_workflow_text)
         self.assertIn(
             "group: ${{ github.repository }}-reference-blueprints-pages",
             deploy_workflow_text,

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -1696,20 +1696,6 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             cache_dir.mkdir()
             local_dir.mkdir()
             (local_dir / "lakefile.lean").write_text('require VersoBlueprint from "../pkg"\n', encoding="utf-8")
-            (local_dir / ".gitmodules").write_text(
-                '[submodule "tools/verso-harness"]\n\tpath = tools/verso-harness\n\turl = git@github.com:ejgallego/leanblueprint-to-verso.git\n',
-                encoding="utf-8",
-            )
-            (local_dir / "verso-harness.toml").write_text(
-                'package_name = "Demo"\nblueprint_main = "Main"\nformalization_path = "DemoFormalization"\nchapter_root = "Chapters"\ntex_source_glob = "./blueprint/*.tex"\n[lt]\ndefault_chapters = []\n',
-                encoding="utf-8",
-            )
-            (local_dir / "tools" / "verso-harness" / "scripts").mkdir(parents=True)
-            (local_dir / "tools" / "verso-harness" / "scripts" / "check_harness.py").write_text(
-                "#!/usr/bin/env python3\n",
-                encoding="utf-8",
-            )
-            (local_dir / "DemoFormalization").mkdir()
 
             layout = SimpleNamespace(
                 package_root=root / "pkg",
@@ -1721,16 +1707,6 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             layout.package_root.mkdir()
             layout.repo_root.mkdir()
 
-            originals = {
-                "command_rewrite_local_blueprint_dependency": commands_mod.rewrite_local_blueprint_dependency,
-                "command_run": commands_mod.run,
-                "command_run_with_heartbeat": commands_mod.run_with_heartbeat,
-                "sync_reference_cache_checkout": refs_mod.sync_reference_cache_checkout,
-                "sync_reference_local_checkout": refs_mod.sync_reference_local_checkout,
-                "project_lake_update_command": refs_mod.project_lake_update_command,
-                "validate_external_reference_toolchain": refs_mod.validate_external_reference_toolchain,
-                "run": refs_mod.run,
-            }
             commands: list[list[str]] = []
             warm_build_values: list[bool] = []
 
@@ -1741,32 +1717,44 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             def fake_sync_reference_local_checkout(_layout, _project, _cache_dir):
                 return local_dir
 
-            try:
-                refs_mod.sync_reference_cache_checkout = fake_sync_reference_cache_checkout
-                refs_mod.sync_reference_local_checkout = fake_sync_reference_local_checkout
-                commands_mod.rewrite_local_blueprint_dependency = (
-                    lambda _project_dir, _package_root: local_dir / "lakefile.lean"
-                )
-                refs_mod.project_lake_update_command = lambda _package_root, _project_dir: ["lake", "update", "VersoBlueprint"]
-                refs_mod.validate_external_reference_toolchain = lambda *_args, **_kwargs: "v4.30.0"
-                refs_mod.run = lambda command, *, cwd: commands.append(command)
-                commands_mod.run = lambda command, *, cwd: commands.append(command)
-                commands_mod.run_with_heartbeat = lambda command, *, cwd, label: commands.append(command)
-
+            with (
+                patch.object(
+                    refs_mod,
+                    "sync_reference_cache_checkout",
+                    side_effect=fake_sync_reference_cache_checkout,
+                ),
+                patch.object(
+                    refs_mod,
+                    "sync_reference_local_checkout",
+                    side_effect=fake_sync_reference_local_checkout,
+                ),
+                patch.object(
+                    commands_mod,
+                    "rewrite_local_blueprint_dependency",
+                    return_value=local_dir / "lakefile.lean",
+                ),
+                patch.object(
+                    refs_mod,
+                    "project_lake_update_command",
+                    return_value=["lake", "update", "VersoBlueprint"],
+                ),
+                patch.object(
+                    refs_mod,
+                    "validate_external_reference_toolchain",
+                    return_value="v4.30.0",
+                ),
+                patch.object(refs_mod, "run", side_effect=lambda command, *, cwd: commands.append(command)),
+                patch.object(commands_mod, "run", side_effect=lambda command, *, cwd: commands.append(command)),
+                patch.object(
+                    commands_mod,
+                    "run_with_heartbeat",
+                    side_effect=lambda command, *, cwd, label: commands.append(command),
+                ),
+            ):
                 generate_git_project(layout, output_root, project, skip_build=False, pdf=True, verbose=True)
-            finally:
-                for name, value in originals.items():
-                    if name == "command_rewrite_local_blueprint_dependency":
-                        commands_mod.rewrite_local_blueprint_dependency = value
-                    elif name == "command_run":
-                        commands_mod.run = value
-                    elif name == "command_run_with_heartbeat":
-                        commands_mod.run_with_heartbeat = value
-                    else:
-                        setattr(refs_mod, name, value)
 
         self.assertEqual(warm_build_values, [False])
-        self.assertEqual(commands[0], reference_submodule_update_command())
+        self.assertNotIn(reference_submodule_update_command(), commands)
         self.assertIn(["lake", "update", "VersoBlueprint"], commands)
         self.assertTrue(any(command[1:] == ["lake", "build"] for command in commands))
         self.assertTrue(

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from dataclasses import replace
 import json
 from pathlib import Path
+import shutil
 import subprocess
 import tempfile
 from types import SimpleNamespace
 import unittest
+from unittest.mock import patch
 
 from scripts.blueprint_harness_projects import (
     HarnessProject,
@@ -43,6 +45,7 @@ from scripts.blueprint_harness_references import (
     seed_lake_packages_from_dependency_cache,
     store_lake_path_builds_in_dependency_cache,
     store_lake_packages_in_dependency_cache,
+    sync_reference_local_checkout,
     update_git_checkout,
     validate_external_reference_toolchain,
 )
@@ -346,6 +349,83 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             self.assertEqual(shared_marker.read_text(encoding="utf-8"), "warm")
             self.assertEqual(local_marker.read_text(encoding="utf-8"), "warm")
 
+    @unittest.skipUnless(shutil.which("rsync"), "rsync is required for the reference cache integration test")
+    def test_reference_local_checkout_seeds_without_consuming_shared_cache(self) -> None:
+        import scripts.blueprint_harness_references as refs_mod
+
+        project = external_project()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source_identity = reference_source_identity(project)
+            cache_dir = root / "cache" / source_identity
+            dependency_packages = root / "deps" / source_identity / "packages"
+            shared_marker = dependency_packages / "mathlib" / ".lake" / "build" / "Mathlib.olean"
+            shared_marker.parent.mkdir(parents=True)
+            shared_marker.write_text("shared", encoding="utf-8")
+            dependency_path_builds = root / "deps" / source_identity / "path-builds"
+            shared_path_marker = (
+                dependency_path_builds / "Formalization" / ".lake" / "build" / "Formalization.olean"
+            )
+            shared_path_marker.parent.mkdir(parents=True)
+            shared_path_marker.write_text("shared path build", encoding="utf-8")
+            layout = SimpleNamespace(
+                package_root=root / "pkg",
+                reference_source_cache_root=root / "cache",
+                reference_dependency_cache_root=root / "deps",
+                reference_project_checkout_root=root / "checkouts",
+            )
+            layout.package_root.mkdir()
+            clone_sources: list[str | None] = []
+
+            def fake_clone(_project, destination, *, cwd, source=None, shallow=True):
+                clone_sources.append(source)
+                project_dir = destination / project.project_root
+                project_dir.mkdir(parents=True)
+                (project_dir / "lake-manifest.json").write_text(
+                    json.dumps({"packages": [{"type": "path", "dir": "Formalization"}]}),
+                    encoding="utf-8",
+                )
+                return destination
+
+            with (
+                patch.object(refs_mod, "clone_git_project", side_effect=fake_clone),
+                patch.object(refs_mod, "bootstrap_reference_checkout"),
+            ):
+                local_dir = sync_reference_local_checkout(layout, project, cache_dir)
+
+            local_marker = (
+                local_dir
+                / project.project_root
+                / ".lake"
+                / "packages"
+                / "mathlib"
+                / ".lake"
+                / "build"
+                / "Mathlib.olean"
+            )
+            local_path_marker = (
+                local_dir
+                / project.project_root
+                / "Formalization"
+                / ".lake"
+                / "build"
+                / "Formalization.olean"
+            )
+            self.assertEqual(clone_sources, [str(cache_dir)])
+            self.assertEqual(local_marker.read_text(encoding="utf-8"), "shared")
+            self.assertEqual(local_path_marker.read_text(encoding="utf-8"), "shared path build")
+            local_marker.write_text("consumer", encoding="utf-8")
+            local_path_marker.write_text("consumer path build", encoding="utf-8")
+            self.assertEqual(shared_marker.read_text(encoding="utf-8"), "shared")
+            self.assertEqual(shared_path_marker.read_text(encoding="utf-8"), "shared path build")
+
+    def test_reference_rsync_requirement_has_a_maintainer_facing_error(self) -> None:
+        import scripts.blueprint_harness_references as refs_mod
+
+        with patch.object(refs_mod.shutil, "which", return_value=None):
+            with self.assertRaisesRegex(SystemExit, "`rsync` is required for external reference cache copies"):
+                refs_mod.require_reference_rsync()
+
     def test_reference_source_paths_share_one_identity_and_exclude_generated_output(self) -> None:
         project = external_project()
         layout = SimpleNamespace(
@@ -482,9 +562,25 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertIn("matrix.reference_dependency_packages_path", workflow_text)
         self.assertIn("matrix.reference_dependency_path_builds_path", workflow_text)
         self.assertIn("reference-deps-v2-${{ matrix.reference_source_identity }}", workflow_text)
+        self.assertIn(
+            "BP_REFERENCE_DEPENDENCY_PACKAGES_PATH: ${{ matrix.reference_dependency_packages_path }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "BP_REFERENCE_DEPENDENCY_PATH_BUILDS_PATH: ${{ matrix.reference_dependency_path_builds_path }}",
+            workflow_text,
+        )
         self.assertIn("matrix.reference_dependency_packages_path", deploy_workflow_text)
         self.assertIn("matrix.reference_dependency_path_builds_path", deploy_workflow_text)
         self.assertIn("reference-deploy-deps-v2-${{ matrix.reference_source_identity }}", deploy_workflow_text)
+        self.assertIn(
+            "BP_REFERENCE_DEPENDENCY_PACKAGES_PATH: ${{ matrix.reference_dependency_packages_path }}",
+            deploy_workflow_text,
+        )
+        self.assertIn(
+            "BP_REFERENCE_DEPENDENCY_PATH_BUILDS_PATH: ${{ matrix.reference_dependency_path_builds_path }}",
+            deploy_workflow_text,
+        )
         self.assertIn(
             "group: ${{ github.repository }}-reference-blueprints-pages",
             deploy_workflow_text,

--- a/tests/harness/test_harness_entrypoints.py
+++ b/tests/harness/test_harness_entrypoints.py
@@ -83,20 +83,22 @@ class HarnessEntrypointSmokeTests(unittest.TestCase):
         self.assertIn("BP_REFERENCE_ARTIFACT_PATH", result.stdout)
         self.assertNotIn("--reference-source-identity", result.stdout)
 
-    def test_report_ci_disk_usage_includes_dependency_path_builds(self) -> None:
+    def test_report_ci_disk_usage_includes_reference_paths_from_environment(self) -> None:
         identity = "external-main-123456789abc"
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            path_build = (
-                root
-                / ".worktrees"
-                / "_reference-blueprints"
-                / "deps"
-                / identity
-                / "path-builds"
-                / "Formalization"
-            )
+            reference_root = root / ".worktrees" / "_reference-blueprints"
+            source_cache = reference_root / "cache" / identity
+            local_checkout = reference_root / "by-worktree" / "demo" / identity
+            dependency_root = reference_root / "deps" / identity
+            packages = dependency_root / "packages" / "mathlib"
+            path_build = dependency_root / "path-builds" / "Formalization"
+            artifact = root / "_out" / "reference-blueprints" / "external-blueprint"
+            source_cache.mkdir(parents=True)
+            local_checkout.mkdir(parents=True)
+            packages.mkdir(parents=True)
             path_build.mkdir(parents=True)
+            artifact.mkdir(parents=True)
             result = subprocess.run(
                 [
                     "bash",
@@ -110,18 +112,20 @@ class HarnessEntrypointSmokeTests(unittest.TestCase):
                 env={
                     **os.environ,
                     "BP_REFERENCE_SOURCE_IDENTITY": identity,
-                    "BP_REFERENCE_DEPENDENCY_PACKAGES_PATH": (
-                        f".worktrees/_reference-blueprints/deps/{identity}/packages"
-                    ),
-                    "BP_REFERENCE_DEPENDENCY_PATH_BUILDS_PATH": (
-                        f".worktrees/_reference-blueprints/deps/{identity}/path-builds"
-                    ),
+                    "BP_REFERENCE_DEPENDENCY_PACKAGES_PATH": str(packages.parent.relative_to(root)),
+                    "BP_REFERENCE_DEPENDENCY_PATH_BUILDS_PATH": str(path_build.parent.relative_to(root)),
+                    "BP_REFERENCE_ARTIFACT_PATH": str(artifact.relative_to(root)),
                 },
             )
 
         self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn(f"cache/{identity}", result.stdout)
+        self.assertIn(f"by-worktree/demo/{identity}", result.stdout)
+        self.assertIn(f"[ci-disk] packages for {identity}", result.stdout)
+        self.assertIn("packages/mathlib", result.stdout)
         self.assertIn(f"[ci-disk] path builds for {identity}", result.stdout)
         self.assertIn("path-builds/Formalization", result.stdout)
+        self.assertIn("artifact_path=_out/reference-blueprints/external-blueprint", result.stdout)
 
     def test_validate_reference_wrapper_help(self) -> None:
         result = self.run_command(["bash", "scripts/validate-reference-blueprints.sh", "--help"])

--- a/tests/harness/test_harness_entrypoints.py
+++ b/tests/harness/test_harness_entrypoints.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 import subprocess
 import sys
@@ -76,7 +77,11 @@ class HarnessEntrypointSmokeTests(unittest.TestCase):
         result = self.run_command(["bash", "scripts/report-ci-disk-usage.sh", "--help"])
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("Print a compact disk-usage report", result.stdout)
-        self.assertIn("--reference-source-identity", result.stdout)
+        self.assertIn("BP_REFERENCE_SOURCE_IDENTITY", result.stdout)
+        self.assertIn("BP_REFERENCE_DEPENDENCY_PACKAGES_PATH", result.stdout)
+        self.assertIn("BP_REFERENCE_DEPENDENCY_PATH_BUILDS_PATH", result.stdout)
+        self.assertIn("BP_REFERENCE_ARTIFACT_PATH", result.stdout)
+        self.assertNotIn("--reference-source-identity", result.stdout)
 
     def test_report_ci_disk_usage_includes_dependency_path_builds(self) -> None:
         identity = "external-main-123456789abc"
@@ -97,13 +102,21 @@ class HarnessEntrypointSmokeTests(unittest.TestCase):
                     "bash",
                     str(PACKAGE_ROOT / "scripts" / "report-ci-disk-usage.sh"),
                     "test",
-                    "--reference-source-identity",
-                    identity,
                 ],
                 cwd=root,
                 check=False,
                 text=True,
                 capture_output=True,
+                env={
+                    **os.environ,
+                    "BP_REFERENCE_SOURCE_IDENTITY": identity,
+                    "BP_REFERENCE_DEPENDENCY_PACKAGES_PATH": (
+                        f".worktrees/_reference-blueprints/deps/{identity}/packages"
+                    ),
+                    "BP_REFERENCE_DEPENDENCY_PATH_BUILDS_PATH": (
+                        f".worktrees/_reference-blueprints/deps/{identity}/path-builds"
+                    ),
+                },
             )
 
         self.assertEqual(result.returncode, 0, msg=result.stderr)


### PR DESCRIPTION
## Summary
Backport #379 to `v4.32.0`.

## Primary Review
- Primary review: #379
- Keep review comments on #379 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.32.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.