### PR TITLE
[backport v4.32.0] fix: enforce reference Blueprint version ordering

### DIFF
--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -82,12 +82,14 @@ Reference release metadata has two tracked sources of truth. `branch-policy.json
 owns release ids, branch names, baseline Lean toolchain refs, baseline `verso`
 refs, default-development/backport policy, and the release-level Pages deploy
 flag. `tests/harness/projects.json` owns project ids, external repository refs,
-the `publish_reference` flag, and any per-project compiler or RC override.
+the `publish_reference` flag, and the exact `reference_toolchain` when an
+external project is behind VBP within the same release family.
 Matrix emitter scripts derive effective per-project `toolchain` and `verso_ref`
-values from those two files; release targets themselves do not carry `rc`
-metadata. A project-target `rc` changes both values for legacy RC lockstep,
-while a project-target `toolchain` changes only the compiler and leaves the
-release target's VBP/Verso ref intact.
+values from those two files. A project-target `rc` is reserved for VBP's own
+in-repository fixtures, which move in lockstep with VBP. External reference
+projects never select the VBP/Verso ref: their `reference_toolchain` controls
+only the effective compiler, while the release target continues to control
+VBP/Verso.
 
 ## Everyday Workflows
 
@@ -386,9 +388,10 @@ the command pins the managed root-package files to `v4.33.0-rc2`.
 
 External reference projects are not auto-pinned for a new release line. Add
 their release-target refs only after those repositories have been updated and
-validated on the new Lean release. If one project target still needs a release
-candidate, put the short RC name, for example `"rc": "4.33-rc2"`, on that
-specific project target in `tests/harness/projects.json`.
+validated on the new Lean release. If an external project still uses a release
+candidate while VBP has moved further within that release family, record its
+exact compiler, for example `"reference_toolchain": "v4.33.0-rc1"`, on that
+project target in `tests/harness/projects.json`.
 
 Do not backport the branch-start commit to older release lines: that commit
 changes the actual Lean toolchain. Instead, update only the tracked branch
@@ -776,10 +779,10 @@ the project id, release, pinned ref, and publication flag. For each deploy
 matrix entry, the workflow writes a small one-project manifest from that
 default-development catalog and passes it to the release-branch harness with
 `--manifest`; the deploy job therefore does not rely on stale branch-local
-`projects.json` refs. The per-project target entry also owns any RC or
-compiler-only override, so two projects in the same release line can use
-different compilers when needed without necessarily selecting different
-VBP/Verso refs. Deploy one-project manifests append `--pdf` to the
+`projects.json` refs. The per-project target entry also owns the exact external
+reference toolchain, so two projects in the same release family can use
+different compilers while sharing the release target's VBP/Verso ref. Deploy
+one-project manifests append `--pdf` to the
 selected generator command only for the default-development release target, so
 the current published catalog includes PDFs while archived release targets stay
 HTML-only unless their deploy policy is deliberately expanded.
@@ -880,24 +883,25 @@ The harness is now project-driven rather than hardcoded to one project.
   external test projects exercise the local `VersoBlueprint` checkout instead
   of the committed upstream dependency
 - the external project's top-level `lean-toolchain` selects its compiler; the
-  harness validates that it exactly matches the project target's final/RC
-  metadata and belongs to the same Lean release family as the VBP checkout, but
-  never promotes an RC project or rewrites dependency toolchains
+  harness validates that it exactly matches the project target's
+  `reference_toolchain` (or the release baseline when that field is omitted),
+  belongs to the same Lean release family as VBP, and is not newer than VBP;
+  the harness never promotes an RC project or rewrites dependency toolchains
 - the current local override injection expects a `lakefile.lean` project that
   declares `VersoBlueprint` from the official `leanprover/verso-blueprint` Git
   repository, and it tolerates different Git refs and URL spellings for that
   source
 - local worktree bookkeeping is intentionally not tracked in the repository
 
-For example, the release id may remain `v4.32.0` while a specific published
-project target records `"rc": "4.32-rc1"`. That row then builds with
-`leanprover/lean4:v4.32.0-rc1` and pins `verso` to `v4.32.0-rc1`, while another
-project target on the same release id can use a different RC or the final
-release tag.
-
-Use `"toolchain": "v4.32.0-rc1"` instead when only the external project's
-compiler must remain on that RC while VBP/Verso use the release target's normal
-ref. Do not combine `rc` and `toolchain` on one project target.
+The compatibility rule is monotonic within one Lean release family. If VBP's
+subversion is older than the reference project's subversion, validation fails
+and the VBP maintainers must bump VBP. If VBP is equal or newer, the reference
+project's exact toolchain remains the effective compiler. For example, a
+`v4.33.0` VBP release may build an external project with
+`"reference_toolchain": "v4.33.0-rc1"`; VBP/Verso stay on `v4.33.0`, while the
+wrapper, formalization, Mathlib artifacts, and build all stay on `v4.33.0-rc1`.
+Cross-family combinations such as VBP `v4.34.0` with a `v4.33.0` reference are
+always rejected.
 
 Minimal external catalog entry shape:
 

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -13,6 +13,8 @@ from scripts.blueprint_harness_branches import (
     load_branch_policy,
 )
 from scripts.blueprint_harness_releases import (
+    lean_release_family,
+    lean_release_subversion,
     normalize_lean_release_ref,
     normalize_release_candidate_name,
     release_candidate_ref,
@@ -40,7 +42,7 @@ class HarnessProjectTarget:
     ref: str | None
     publish_reference: bool = False
     rc: str | None = None
-    toolchain: str | None = None
+    reference_toolchain: str | None = None
 
 
 @dataclass(frozen=True)
@@ -74,7 +76,7 @@ class HarnessProject:
     targets: tuple[HarnessProjectTarget, ...] = ()
     selected_release: str | None = None
     selected_rc: str | None = None
-    selected_toolchain: str | None = None
+    selected_reference_toolchain: str | None = None
 
     @property
     def in_repo_project(self) -> bool:
@@ -111,8 +113,8 @@ def short_git_ref(ref: str) -> str:
 
 
 def selected_project_toolchain(project: HarnessProject) -> str:
-    if project.selected_toolchain is not None:
-        return project.selected_toolchain
+    if project.selected_reference_toolchain is not None:
+        return project.selected_reference_toolchain
     if project.selected_rc is not None:
         return release_candidate_ref(project.selected_rc)
     if project.selected_release is not None:
@@ -222,7 +224,7 @@ def _load_project_targets(
     entry: dict,
     *,
     context: str,
-    release_ids: set[str],
+    release_targets: dict[str, HarnessReleaseTarget],
     source_kind: str,
 ) -> tuple[HarnessProjectTarget, ...]:
     raw_targets = entry.get("targets")
@@ -236,7 +238,7 @@ def _load_project_targets(
             raise ValueError(f"{context}: target #{index} must be an object")
         target_context = f"{context}: target #{index}"
         release = release_branch_from_lean_ref(_require_string(raw_target, "release", context=target_context))
-        if release not in release_ids:
+        if release not in release_targets:
             raise ValueError(f"{target_context}: unknown release target `{release}`")
         if release in seen_releases:
             raise ValueError(f"{target_context}: duplicate release target `{release}`")
@@ -255,18 +257,32 @@ def _load_project_targets(
             rc = normalize_release_candidate_name(rc)
             if release_branch_from_lean_ref(rc) != release:
                 raise ValueError(f"{target_context}: `rc` `{rc}` does not belong to release `{release}`")
-        toolchain = _optional_string(raw_target, "toolchain", context=target_context)
-        if toolchain is not None:
-            toolchain = normalize_lean_release_ref(toolchain)
-            if release_branch_from_lean_ref(toolchain) != release:
+            if source_kind == GIT_CHECKOUT_SOURCE_KIND:
                 raise ValueError(
-                    f"{target_context}: `toolchain` `{toolchain}` does not belong to release `{release}`"
+                    f"{target_context}: external reference projects must use `reference_toolchain`, "
+                    "not the coupled `rc` field"
                 )
-            if rc is not None:
+        if "toolchain" in raw_target:
+            raise ValueError(
+                f"{target_context}: project-target `toolchain` was renamed to `reference_toolchain`"
+            )
+        reference_toolchain = _optional_string(raw_target, "reference_toolchain", context=target_context)
+        if reference_toolchain is not None:
+            if source_kind != GIT_CHECKOUT_SOURCE_KIND:
                 raise ValueError(
-                    f"{target_context}: `rc` and `toolchain` are mutually exclusive; "
-                    "use `rc` to override both compiler and Verso ref, or `toolchain` "
-                    "to override only the compiler"
+                    f"{target_context}: `reference_toolchain` belongs only on external reference projects"
+                )
+            reference_toolchain = normalize_lean_release_ref(reference_toolchain)
+            if lean_release_family(reference_toolchain) != lean_release_family(release):
+                raise ValueError(
+                    f"{target_context}: reference toolchain `{reference_toolchain}` does not belong "
+                    f"to release family `{release}`"
+                )
+            vbp_toolchain = release_targets[release].toolchain
+            if lean_release_subversion(vbp_toolchain) < lean_release_subversion(reference_toolchain):
+                raise ValueError(
+                    f"{target_context}: VBP toolchain `{vbp_toolchain}` is older than reference "
+                    f"toolchain `{reference_toolchain}`; ask the VBP maintainers to bump this release target"
                 )
         targets.append(
             HarnessProjectTarget(
@@ -274,7 +290,7 @@ def _load_project_targets(
                 ref=ref,
                 publish_reference=_optional_bool(raw_target, "publish_reference", default=False, context=target_context),
                 rc=rc,
-                toolchain=toolchain,
+                reference_toolchain=reference_toolchain,
             )
         )
     return tuple(targets)
@@ -289,7 +305,7 @@ def load_project_catalog_data(raw: dict, manifest_path: Path | str) -> HarnessPr
             "mark published project targets with `publish_reference`"
         )
     release_targets = _load_release_targets(raw, manifest_path)
-    release_ids = {target.release_id for target in release_targets}
+    release_targets_by_id = {target.release_id: target for target in release_targets}
 
     entries = raw.get("projects")
     if not isinstance(entries, list):
@@ -327,7 +343,12 @@ def load_project_catalog_data(raw: dict, manifest_path: Path | str) -> HarnessPr
         browser_tests_path = _optional_string(validation, "browser_tests_path", context=context)
         description = _optional_string(entry, "description", context=context)
         site_subdir = _optional_string(entry, "site_subdir", context=context) or "html-multi"
-        targets = _load_project_targets(entry, context=context, release_ids=release_ids, source_kind=source_kind)
+        targets = _load_project_targets(
+            entry,
+            context=context,
+            release_targets=release_targets_by_id,
+            source_kind=source_kind,
+        )
 
         if source_kind == IN_REPO_PROJECT_SOURCE_KIND:
             target_mode = build_target is not None or generator is not None
@@ -426,6 +447,9 @@ def resolve_projects_for_release(
     require_selected_targets: bool = True,
 ) -> list[HarnessProject]:
     by_id = {project.project_id: project for project in catalog.projects}
+    release_target = catalog.release_target(release)
+    if release_target is None:
+        raise ValueError(f"unknown release target `{release}`")
 
     if selected_ids is None:
         candidates = [
@@ -457,7 +481,11 @@ def resolve_projects_for_release(
                 ref=target.ref,
                 selected_release=release,
                 selected_rc=target.rc,
-                selected_toolchain=target.toolchain,
+                selected_reference_toolchain=(
+                    target.reference_toolchain or release_target.toolchain
+                    if project.git_checkout
+                    else None
+                ),
             )
         )
     return resolved
@@ -494,8 +522,8 @@ def project_target_rc(project: HarnessProject) -> str:
 
 
 def project_target_toolchain(release_target: HarnessReleaseTarget, project: HarnessProject) -> str:
-    if project.selected_toolchain is not None:
-        return project.selected_toolchain
+    if project.selected_reference_toolchain is not None:
+        return project.selected_reference_toolchain
     return release_candidate_ref(project.selected_rc) if project.selected_rc is not None else release_target.toolchain
 
 
@@ -612,8 +640,12 @@ def project_manifest_entry(project: HarnessProject, *, include_pdf: bool = False
         target["ref"] = project.ref
     if project.selected_rc is not None:
         target["rc"] = project.selected_rc
-    if project.selected_toolchain is not None:
-        target["toolchain"] = project.selected_toolchain
+    if (
+        project.selected_reference_toolchain is not None
+        and project.selected_reference_toolchain
+        != normalize_lean_release_ref(project.selected_release)
+    ):
+        target["reference_toolchain"] = project.selected_reference_toolchain
 
     entry: dict[str, object] = {
         "id": project.project_id,

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -9,8 +9,9 @@ from pathlib import Path
 import tomllib
 
 from scripts.blueprint_harness_releases import (
+    lean_release_family,
+    lean_release_subversion,
     normalize_lean_release_ref,
-    release_branch_from_lean_ref,
 )
 from scripts.blueprint_harness_projects import (
     HarnessProject,
@@ -78,7 +79,8 @@ class ReferenceProjectBumpResult:
 @dataclass(frozen=True)
 class ReferenceToolchain:
     lean_ref: str
-    release_branch: str
+    release_family: tuple[int, int]
+    subversion: tuple[int, int, int]
 
 
 @dataclass(frozen=True)
@@ -150,7 +152,8 @@ def read_reference_toolchain(path: Path) -> ReferenceToolchain | None:
 
     return ReferenceToolchain(
         lean_ref=lean_ref,
-        release_branch=release_branch_from_lean_ref(lean_ref),
+        release_family=lean_release_family(lean_ref),
+        subversion=lean_release_subversion(lean_ref),
     )
 
 
@@ -179,13 +182,20 @@ def validate_external_reference_toolchain(
             "[blueprint-harness] external reference project has no valid `lean-toolchain`: "
             f"{project_dir / 'lean-toolchain'}"
         )
-    if package_toolchain.release_branch != project_toolchain.release_branch:
+    if package_toolchain.release_family != project_toolchain.release_family:
         raise SystemExit(
             "[blueprint-harness] reference Blueprint release mismatch: "
             f"project `{project_dir}` uses Lean `{project_toolchain.lean_ref}` "
-            f"({project_toolchain.release_branch}), but the selected Verso Blueprint checkout "
-            f"uses Lean `{package_toolchain.lean_ref}` ({package_toolchain.release_branch}). "
+            f"(family {project_toolchain.release_family}), but the selected Verso Blueprint checkout "
+            f"uses Lean `{package_toolchain.lean_ref}` (family {package_toolchain.release_family}). "
             "Catalog each external Blueprint only under its current matching release."
+        )
+    if package_toolchain.subversion < project_toolchain.subversion:
+        raise SystemExit(
+            "[blueprint-harness] Verso Blueprint is older than the reference Blueprint: "
+            f"VBP uses Lean `{package_toolchain.lean_ref}`, while project `{project_dir}` uses "
+            f"Lean `{project_toolchain.lean_ref}`. Ask the VBP maintainers to bump VBP before "
+            "building this reference."
         )
     expected_ref = normalize_lean_release_ref(expected_project_toolchain)
     if project_toolchain.lean_ref != expected_ref:
@@ -193,7 +203,7 @@ def validate_external_reference_toolchain(
             "[blueprint-harness] reference Blueprint toolchain mismatch: "
             f"catalog target expects Lean `{expected_ref}`, but project `{project_dir}` "
             f"uses Lean `{project_toolchain.lean_ref}`. Update the external project ref "
-            "or keep its explicit project-target RC metadata."
+            "or its `reference_toolchain` metadata."
         )
     return project_toolchain.lean_ref
 

--- a/scripts/blueprint_harness_releases.py
+++ b/scripts/blueprint_harness_releases.py
@@ -79,6 +79,30 @@ def release_branch_version(raw_ref: str) -> tuple[int, int, int]:
     return int(major), int(minor), int(patch)
 
 
+def lean_release_family(raw_ref: str) -> tuple[int, int]:
+    """Return the Lean major/minor release family for a stable or RC ref."""
+    major, minor, _patch = release_branch_version(raw_ref)
+    return major, minor
+
+
+def lean_release_subversion(raw_ref: str) -> tuple[int, int, int]:
+    """Order versions within one Lean release family.
+
+    The first component is the patch version. Within one patch, release
+    candidates precede the final release and are ordered by RC number.
+    """
+    ref = normalize_lean_release_ref(raw_ref)
+    rc_match = LEAN_RELEASE_CANDIDATE_PATTERN.fullmatch(ref)
+    if rc_match is not None:
+        return int(rc_match.group("patch") or "0"), 0, int(rc_match.group("rc"))
+    if NUMERIC_LEAN_RELEASE_PATTERN.fullmatch(ref) is not None:
+        _major, _minor, patch = ref.removeprefix("v").split(".")
+        return int(patch), 1, 0
+    raise SystemExit(
+        f"[blueprint-harness] expected an official numeric Lean release or release candidate, got `{ref}`"
+    )
+
+
 def lean_toolchain_spec(lean_ref: str) -> str:
     return f"{LEAN_TOOLCHAIN_PREFIX}{lean_ref}"
 

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -1314,7 +1314,13 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                             {
                                 "id": "external",
                                 "source": {"kind": "git_checkout"},
-                                "targets": [{"release": "v4.30.0", "ref": "abc", "rc": "4.30-rc1"}],
+                                "targets": [
+                                    {
+                                        "release": "v4.30.0",
+                                        "ref": "abc",
+                                        "reference_toolchain": "v4.30.0-rc1",
+                                    }
+                                ],
                             },
                         ],
                     }
@@ -1343,7 +1349,10 @@ class BlueprintHarnessCliTests(unittest.TestCase):
                     {"release": "v4.30.0", "rc": "4.30-rc2"},
                 ],
             )
-            self.assertEqual(manifest["projects"][1]["targets"][0]["rc"], "4.30-rc1")
+            self.assertEqual(
+                manifest["projects"][1]["targets"][0]["reference_toolchain"],
+                "v4.30.0-rc1",
+            )
 
             harness_mod.update_release_line_project_manifest(
                 manifest_path,
@@ -1352,7 +1361,10 @@ class BlueprintHarnessCliTests(unittest.TestCase):
             )
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
             self.assertNotIn("rc", manifest["projects"][0]["targets"][1])
-            self.assertEqual(manifest["projects"][1]["targets"][0]["rc"], "4.30-rc1")
+            self.assertEqual(
+                manifest["projects"][1]["targets"][0]["reference_toolchain"],
+                "v4.30.0-rc1",
+            )
 
     def test_start_release_line_updates_policy_and_in_repo_targets(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -18,6 +18,8 @@ from scripts.blueprint_harness_projects import (
     deploy_matrix_from_controller_catalog,
     load_project_catalog,
     load_project_catalog_data,
+    project_target_toolchain,
+    project_target_verso_ref,
     reference_build_matrix,
     reference_source_identity,
     reference_release_payload,
@@ -85,6 +87,40 @@ def load_project_catalog_text(text: str, manifest_path: Path | str):
     return load_project_catalog_data(raw, manifest_path)
 
 
+def external_catalog_data(
+    *,
+    vbp_toolchain: str,
+    reference_toolchain: str | None,
+    release: str = "v4.33.0",
+) -> dict[str, object]:
+    target: dict[str, object] = {"release": release, "ref": "reference-ref"}
+    if reference_toolchain is not None:
+        target["reference_toolchain"] = reference_toolchain
+    return {
+        "version": 2,
+        "release_targets": [
+            {
+                "id": release,
+                "toolchain": vbp_toolchain,
+                "verso_ref": release,
+                "branch": release,
+                "deploy_pages": True,
+            }
+        ],
+        "projects": [
+            {
+                "id": "external-blueprint",
+                "source": {
+                    "kind": "git_checkout",
+                    "repository": "https://example.com/external-blueprint.git",
+                },
+                "targets": [target],
+                "generate_command": list(VBP_BUILD_COMMAND),
+            }
+        ],
+    }
+
+
 class BlueprintHarnessProjectsTests(unittest.TestCase):
     def test_command_with_pdf_appends_pdf_once(self) -> None:
         self.assertEqual(
@@ -133,13 +169,16 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             expected_projects.append(project.project_id)
             expected_refs[project.project_id] = target.ref
             expected_rcs[project.project_id] = target.rc
-            expected_toolchains[project.project_id] = target.toolchain
+            expected_toolchains[project.project_id] = target.reference_toolchain or release.toolchain
 
         self.assertEqual([project.project_id for project in projects], expected_projects)
         for project in projects:
             self.assertEqual(project.selected_release, release.release_id)
             self.assertEqual(project.selected_rc, expected_rcs[project.project_id])
-            self.assertEqual(project.selected_toolchain, expected_toolchains[project.project_id])
+            self.assertEqual(
+                project.selected_reference_toolchain,
+                expected_toolchains[project.project_id],
+            )
             expected_ref = expected_refs[project.project_id]
             if expected_ref is not None:
                 self.assertEqual(project.ref, expected_ref)
@@ -215,14 +254,87 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "has no selected release target"):
             selected_project_toolchain(external_project())
 
-    def test_selected_project_toolchain_prefers_compiler_only_override(self) -> None:
+    def test_selected_project_toolchain_uses_reference_toolchain(self) -> None:
         project = external_project(
             selected_release="v4.33.0",
             selected_rc=None,
-            selected_toolchain="v4.33.0-rc1",
+            selected_reference_toolchain="v4.33.0-rc1",
         )
 
         self.assertEqual(selected_project_toolchain(project), "v4.33.0-rc1")
+
+    def test_reference_toolchain_accepts_equal_vbp_subversion(self) -> None:
+        catalog = load_project_catalog_data(
+            external_catalog_data(
+                vbp_toolchain="v4.33.0-rc2",
+                reference_toolchain="v4.33.0-rc2",
+            ),
+            "projects.json",
+        )
+        release = catalog.release_target("v4.33.0")
+        self.assertIsNotNone(release)
+        project = resolve_projects_for_release(catalog, "v4.33.0", ["external-blueprint"])[0]
+
+        self.assertEqual(selected_project_toolchain(project), "v4.33.0-rc2")
+        self.assertEqual(project_target_toolchain(release, project), "v4.33.0-rc2")
+
+    def test_reference_toolchain_accepts_vbp_ahead_and_keeps_reference_effective(self) -> None:
+        catalog = load_project_catalog_data(
+            external_catalog_data(
+                vbp_toolchain="v4.33.0",
+                reference_toolchain="v4.33.0-rc1",
+            ),
+            "projects.json",
+        )
+        release = catalog.release_target("v4.33.0")
+        self.assertIsNotNone(release)
+        project = resolve_projects_for_release(catalog, "v4.33.0", ["external-blueprint"])[0]
+
+        self.assertEqual(project_target_toolchain(release, project), "v4.33.0-rc1")
+        self.assertEqual(project_target_verso_ref(release, project), "v4.33.0")
+
+    def test_reference_toolchain_rejects_vbp_behind(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "VBP toolchain `v4.33.0-rc1` is older than reference toolchain `v4.33.0-rc2`.*ask the VBP maintainers to bump",
+        ):
+            load_project_catalog_data(
+                external_catalog_data(
+                    vbp_toolchain="v4.33.0-rc1",
+                    reference_toolchain="v4.33.0-rc2",
+                ),
+                "projects.json",
+            )
+
+    def test_reference_toolchain_rejects_different_release_family(self) -> None:
+        with self.assertRaisesRegex(ValueError, "does not belong to release family `v4.33.0`"):
+            load_project_catalog_data(
+                external_catalog_data(
+                    vbp_toolchain="v4.33.0",
+                    reference_toolchain="v4.34.0-rc1",
+                ),
+                "projects.json",
+            )
+
+    def test_external_reference_rejects_coupled_rc_field(self) -> None:
+        manifest = external_catalog_data(
+            vbp_toolchain="v4.33.0",
+            reference_toolchain=None,
+        )
+        manifest["projects"][0]["targets"][0]["rc"] = "4.33-rc1"
+
+        with self.assertRaisesRegex(ValueError, "must use `reference_toolchain`, not the coupled `rc` field"):
+            load_project_catalog_data(manifest, "projects.json")
+
+    def test_external_reference_rejects_renamed_toolchain_field(self) -> None:
+        manifest = external_catalog_data(
+            vbp_toolchain="v4.33.0",
+            reference_toolchain=None,
+        )
+        manifest["projects"][0]["targets"][0]["toolchain"] = "v4.33.0-rc1"
+
+        with self.assertRaisesRegex(ValueError, "`toolchain` was renamed to `reference_toolchain`"):
+            load_project_catalog_data(manifest, "projects.json")
 
     def test_project_catalog_requires_json_object(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -615,8 +727,8 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         for project, target in expected_targets:
             row = rows[project.project_id]
             expected_toolchain = (
-                target.toolchain
-                if target.toolchain is not None
+                target.reference_toolchain
+                if target.reference_toolchain is not None
                 else release_candidate_ref(target.rc)
                 if target.rc is not None
                 else release.toolchain
@@ -688,7 +800,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                                 {
                                     "release": "v4.29.0",
                                     "ref": "new-controller-ref",
-                                    "rc": "4.29-rc1",
+                                    "reference_toolchain": "v4.29.0-rc1",
                                     "publish_reference": True,
                                 }
                             ],
@@ -706,7 +818,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                                 {
                                     "release": "v4.29.0",
                                     "ref": "new-second-controller-ref",
-                                    "toolchain": "v4.29.0-rc2",
+                                    "reference_toolchain": "v4.29.0-rc2",
                                     "publish_reference": True,
                                 }
                             ],
@@ -761,7 +873,13 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         )
         self.assertEqual(
             manifest_by_project["new-release-project"]["projects"][0]["targets"],
-            [{"release": "v4.29.0", "ref": "new-controller-ref", "rc": "4.29-rc1"}],
+            [
+                {
+                    "release": "v4.29.0",
+                    "ref": "new-controller-ref",
+                    "reference_toolchain": "v4.29.0-rc1",
+                }
+            ],
         )
         self.assertEqual(
             manifest_by_project["new-release-project"]["projects"][0]["generate_command"],
@@ -769,12 +887,18 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         )
         self.assertTrue(matrix_by_project["new-release-project"]["publish_pdf"])
         self.assertNotIn("rc", manifest_by_project["new-release-project"]["release_targets"][0])
-        self.assertEqual(matrix_by_project["new-release-project"]["rc"], "4.29-rc1")
+        self.assertEqual(matrix_by_project["new-release-project"]["rc"], "")
         self.assertEqual(matrix_by_project["new-release-project"]["toolchain"], "v4.29.0-rc1")
-        self.assertEqual(matrix_by_project["new-release-project"]["verso_ref"], "v4.29.0-rc1")
+        self.assertEqual(matrix_by_project["new-release-project"]["verso_ref"], "v4.29.0")
         self.assertEqual(
             manifest_by_project["new-release-second-project"]["projects"][0]["targets"],
-            [{"release": "v4.29.0", "ref": "new-second-controller-ref", "toolchain": "v4.29.0-rc2"}],
+            [
+                {
+                    "release": "v4.29.0",
+                    "ref": "new-second-controller-ref",
+                    "reference_toolchain": "v4.29.0-rc2",
+                }
+            ],
         )
         self.assertEqual(
             manifest_by_project["new-release-second-project"]["projects"][0]["generate_command"],
@@ -848,7 +972,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                         {
                             "release": "v4.29.0",
                             "ref": "main",
-                            "toolchain": "v4.29.0-rc1",
+                            "reference_toolchain": "v4.29.0-rc1",
                         }
                     ],
                     "build_command": ["lake", "build"],
@@ -866,7 +990,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertEqual(len(projects), 1)
         self.assertTrue(projects[0].git_checkout)
         self.assertEqual(projects[0].generate_command, VBP_BUILD_OUTPUT_COMMAND)
-        self.assertEqual(projects[0].targets[0].toolchain, "v4.29.0-rc1")
+        self.assertEqual(projects[0].targets[0].reference_toolchain, "v4.29.0-rc1")
 
     def test_in_repo_command_project_is_supported(self) -> None:
         manifest_data = {
@@ -1173,6 +1297,32 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 "leanprover/lean4:v4.29.0\n",
             )
 
+    def test_validate_reference_toolchains_rejects_vbp_behind_project(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_root = root / "pkg"
+            project_dir = root / "external"
+            package_root.mkdir()
+            project_dir.mkdir()
+            (package_root / "lean-toolchain").write_text(
+                "leanprover/lean4:v4.33.0-rc1\n",
+                encoding="utf-8",
+            )
+            (project_dir / "lean-toolchain").write_text(
+                "leanprover/lean4:v4.33.0-rc2\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                SystemExit,
+                "Verso Blueprint is older than the reference Blueprint.*Ask the VBP maintainers to bump VBP",
+            ):
+                validate_external_reference_toolchain(
+                    package_root,
+                    project_dir,
+                    expected_project_toolchain="v4.33.0-rc2",
+                )
+
     def test_validate_reference_toolchains_rejects_different_release_branches(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -1256,7 +1406,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 refs_mod.run = unexpected_run
                 with self.assertRaisesRegex(
                     SystemExit,
-                    "catalog target expects Lean `v4.30.0`.*keep its explicit project-target RC metadata",
+                    "catalog target expects Lean `v4.30.0`.*its `reference_toolchain` metadata",
                 ):
                     run_external_reference_lake_update(
                         package_root,

--- a/tests/harness/test_blueprint_harness_releases.py
+++ b/tests/harness/test_blueprint_harness_releases.py
@@ -40,6 +40,18 @@ class BlueprintHarnessReleaseHelperTests(unittest.TestCase):
         with self.assertRaisesRegex(SystemExit, "expected a numeric Lean release branch"):
             releases_mod.release_branch_version("main")
 
+    def test_release_family_and_subversion_order_rc_final_and_patch(self) -> None:
+        versions = ["v4.33.0-rc1", "v4.33.0-rc2", "v4.33.0", "v4.33.1-rc1", "v4.33.1"]
+
+        self.assertEqual(
+            {releases_mod.lean_release_family(version) for version in versions},
+            {(4, 33)},
+        )
+        self.assertEqual(
+            sorted(versions, key=releases_mod.lean_release_subversion),
+            versions,
+        )
+
     def test_rewrite_lean_toolchain_preserves_existing_final_newline_style(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
Backport #381 to `v4.32.0`.

## Primary Review
- Primary review: #381
- Keep review comments on #381 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.32.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.
