### PR TITLE
perf: record reference Blueprint build timings

### DIFF
--- a/.github/workflows/reference-blueprints-deploy.yml
+++ b/.github/workflows/reference-blueprints-deploy.yml
@@ -178,6 +178,7 @@ jobs:
             --allow-unsafe-root-release \
             --allow-local-build \
             --serial \
+            --record-build-metrics \
             _out/reference-blueprints/${{ matrix.release_id }}
       - name: Report disk usage after reference generation
         if: ${{ always() }}
@@ -302,6 +303,12 @@ jobs:
           path: _out/test-blueprints
       - name: Prepare combined Pages artifact
         run: python3 ./scripts/prepare_reference_blueprints_pages.py --js-api-docs-root _out/jsdoc-api
+      - name: Report reference build metrics
+        run: |
+          python3 ./scripts/reference_build_metrics.py report \
+            --input-root _out/reference-blueprints \
+            --output _site/build-data/reference-blueprints.json \
+            --summary-output "$GITHUB_STEP_SUMMARY"
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
         with:

--- a/.github/workflows/reference-blueprints.yml
+++ b/.github/workflows/reference-blueprints.yml
@@ -113,7 +113,12 @@ jobs:
           lualatex --version | head -n 1
           python3 --version
       - name: Generate reference blueprint with PDF
-        run: ./scripts/generate-reference-blueprints.sh --allow-unsafe-root-release --pdf --project ${{ matrix.project_id }}
+        run: |
+          ./scripts/generate-reference-blueprints.sh \
+            --allow-unsafe-root-release \
+            --pdf \
+            --record-build-metrics \
+            --project ${{ matrix.project_id }}
       - name: Report disk usage after reference generation
         if: ${{ always() }}
         run: ./scripts/report-ci-disk-usage.sh "after reference generation"
@@ -189,6 +194,12 @@ jobs:
           path: _out/test-blueprints
       - name: Prepare site artifact
         run: python3 ./scripts/prepare_reference_blueprints_pages.py --reference-root _out/reference-blueprints-artifacts
+      - name: Report reference build metrics
+        run: |
+          python3 ./scripts/reference_build_metrics.py report \
+            --input-root _out/reference-blueprints-artifacts \
+            --output _site/build-data/reference-blueprints.json \
+            --summary-output "$GITHUB_STEP_SUMMARY"
       - name: Upload site artifact
         uses: actions/upload-artifact@v7
         with:

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -257,6 +257,27 @@ Pass `--verbose` to `compose`, `generate`, or `validate` when you want each
 Blueprint generator to print its own progress diagnostics during HTML
 emission.
 
+Pass `--record-build-metrics` to `generate` or `validate` when the phase
+timings need to be retained. This option also enables generator `--verbose`
+output, tees the normal build log unchanged, and writes `build-metrics.json`
+beside each generated project artifact. The record contains the total
+generator-command duration plus every canonical
+`Blueprint: finished <phase> in <milliseconds>ms` measurement emitted by the
+generator. In particular, single-page and multi-page HTML traversal remain
+separate measurements rather than being inferred from the surrounding Lake
+build time.
+
+Reference Blueprint CI enables this recording by default. It aggregates the
+per-project files into the Actions job summary and the published
+`/build-data/reference-blueprints.json` report. The report retains the latest
+50 snapshots and compares a run with the currently deployed baseline when the
+reference source revision and Lean toolchain match. A total-command or phase
+increase is marked as a regression warning only when it exceeds both 20
+percent and one second; warnings are initially advisory so ordinary
+hosted-runner variation cannot block a release. Full command and phase data
+remains available in JSON even when a value does not cross the warning
+threshold.
+
 When editing an external reference repository, use an editable clone rather
 than the disposable validation clones:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -104,6 +104,10 @@ script map, not a second command reference.
 - `blueprint_reference_harness.py`
   Editable external Blueprint composition plus reference-blueprint generation,
   validation, and reference-checkout CLI.
+- `reference_build_metrics.py`
+  Tee and persist verbose Blueprint phase timings, aggregate reference-project
+  measurements, compare them with the deployed baseline, and emit the Actions
+  summary/public build-data report used for regression visibility.
 - `blueprint_harness_composition.py`
   User-provided Blueprint composition, Lake-configuration preservation,
   toolchain validation, and mandatory Mathlib-cache retrieval.

--- a/scripts/blueprint_harness_references.py
+++ b/scripts/blueprint_harness_references.py
@@ -5,6 +5,7 @@ import json
 import re
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 import tomllib
 
@@ -43,6 +44,7 @@ GITHUB_SUBMODULE_URL_REWRITE_ARGS = (
     "url.https://github.com/.insteadOf=ssh://git@github.com/",
 )
 REFERENCE_HARNESS_CONFIG = "verso-harness.toml"
+REFERENCE_BUILD_METRICS_FILENAME = "build-metrics.json"
 
 
 def command_with_verbose(command: tuple[str, ...]) -> tuple[str, ...]:
@@ -62,6 +64,33 @@ def reference_generation_command(
     if verbose:
         command = command_with_verbose(command)
     return command
+
+
+def reference_build_metrics_command(
+    package_root: Path,
+    project: HarnessProject,
+    output_dir: Path,
+    command: tuple[str, ...],
+) -> tuple[str, ...]:
+    if project.selected_release is None:
+        raise ValueError(f"project `{project.project_id}` is missing selected release metadata")
+    return (
+        sys.executable,
+        str(package_root / "scripts" / "reference_build_metrics.py"),
+        "record",
+        "--output",
+        str(output_dir / REFERENCE_BUILD_METRICS_FILENAME),
+        "--project-id",
+        project.project_id,
+        "--release-id",
+        project.selected_release,
+        "--source-ref",
+        project.ref or "",
+        "--toolchain",
+        selected_project_toolchain(project),
+        "--",
+        *command,
+    )
 
 
 @dataclass(frozen=True)
@@ -856,6 +885,7 @@ def generate_in_repo_command_project(
     skip_build: bool,
     pdf: bool = False,
     verbose: bool = False,
+    record_build_metrics: bool = False,
 ) -> None:
     project_dir = layout.package_root / project.project_root
     if not project_dir.exists():
@@ -868,7 +898,18 @@ def generate_in_repo_command_project(
     original_manifest = snapshot_tracked_project_manifest(project_dir)
     try:
         with maybe_in_repo_blueprint_dependency_override(project_dir, layout.package_root, log=True):
-            generate_command = reference_generation_command(project.generate_command or (), pdf=pdf, verbose=verbose)
+            generate_command = reference_generation_command(
+                project.generate_command or (),
+                pdf=pdf,
+                verbose=verbose or record_build_metrics,
+            )
+            if record_build_metrics:
+                generate_command = reference_build_metrics_command(
+                    layout.package_root,
+                    project,
+                    output_dir,
+                    generate_command,
+                )
             run_project_update_build_generate(
                 layout.package_root,
                 project_dir,
@@ -903,6 +944,7 @@ def generate_git_project(
     skip_build: bool,
     pdf: bool = False,
     verbose: bool = False,
+    record_build_metrics: bool = False,
 ) -> None:
     rebuild_and_log_embedded_asset_owners(layout.package_root)
     cache_dir = sync_reference_cache_checkout(layout, project, warm_build=False)
@@ -921,7 +963,18 @@ def generate_git_project(
         seed_lake_path_builds_from_dependency_cache(layout, project, project_dir)
 
     with local_blueprint_dependency_override(layout.package_root, project_dir, restore_lakefile=False, log=True):
-        generate_command = reference_generation_command(project.generate_command or (), pdf=pdf, verbose=verbose)
+        generate_command = reference_generation_command(
+            project.generate_command or (),
+            pdf=pdf,
+            verbose=verbose or record_build_metrics,
+        )
+        if record_build_metrics:
+            generate_command = reference_build_metrics_command(
+                layout.package_root,
+                project,
+                output_dir,
+                generate_command,
+            )
         run_project_update_build_generate(
             layout.package_root,
             project_dir,

--- a/scripts/blueprint_reference_harness.py
+++ b/scripts/blueprint_reference_harness.py
@@ -52,6 +52,7 @@ from scripts.blueprint_harness_references import (
     generate_git_project,
     output_dir_for,
     prepare_reference_edit_checkout,
+    reference_build_metrics_command,
     reference_generation_command,
     ref_is_commit_hash,
     reference_prune_plan,
@@ -120,6 +121,17 @@ def add_generation_verbose_argument(parser: argparse.ArgumentParser) -> None:
         "--verbose",
         action="store_true",
         help="Pass `--verbose` to Blueprint generator commands.",
+    )
+
+
+def add_generation_metrics_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--record-build-metrics",
+        action="store_true",
+        help=(
+            "Record structured generator phase timings beside each project artifact. "
+            "This also enables generator `--verbose` output."
+        ),
     )
 
 
@@ -621,13 +633,21 @@ def reference_executable_args(
     *,
     pdf: bool,
     verbose: bool,
+    record_build_metrics: bool,
 ) -> list[str]:
     args = [
         str(ensure_prebuilt_executable(package_root, project.generator or project.project_id)),
         "--output",
         str(output_dir),
     ]
-    return list(reference_generation_command(tuple(args), pdf=pdf, verbose=verbose))
+    command = reference_generation_command(
+        tuple(args),
+        pdf=pdf,
+        verbose=verbose or record_build_metrics,
+    )
+    if record_build_metrics:
+        command = reference_build_metrics_command(package_root, project, output_dir, command)
+    return list(command)
 
 
 def render_in_repo_projects(
@@ -638,6 +658,7 @@ def render_in_repo_projects(
     *,
     pdf: bool = False,
     verbose: bool = False,
+    record_build_metrics: bool = False,
 ) -> None:
     output_root.mkdir(parents=True, exist_ok=True)
     if serial:
@@ -646,7 +667,14 @@ def render_in_repo_projects(
             run(
                 lean_low_priority_command(
                     package_root,
-                    *reference_executable_args(package_root, project, output_dir, pdf=pdf, verbose=verbose),
+                    *reference_executable_args(
+                        package_root,
+                        project,
+                        output_dir,
+                        pdf=pdf,
+                        verbose=verbose,
+                        record_build_metrics=record_build_metrics,
+                    ),
                 ),
                 cwd=package_root,
             )
@@ -659,7 +687,14 @@ def render_in_repo_projects(
             output_dir.mkdir(parents=True, exist_ok=True)
             command = lean_low_priority_command(
                 package_root,
-                *reference_executable_args(package_root, project, output_dir, pdf=pdf, verbose=verbose),
+                *reference_executable_args(
+                    package_root,
+                    project,
+                    output_dir,
+                    pdf=pdf,
+                    verbose=verbose,
+                    record_build_metrics=record_build_metrics,
+                ),
             )
             print(f"[blueprint-reference-harness] launching {project.project_id} -> {output_dir}", flush=True)
             procs.append((project.project_id, spawn_managed_process(command, cwd=package_root)))
@@ -687,6 +722,7 @@ def generate_projects(
     allow_local_build: bool,
     pdf: bool = False,
     verbose: bool = False,
+    record_build_metrics: bool = False,
 ) -> None:
     in_repo_projects = [project for project in projects if project.in_repo_project]
     in_repo_target_projects = [project for project in in_repo_projects if project.in_repo_target_project]
@@ -714,7 +750,15 @@ def generate_projects(
         elif not skip_build and not use_local_build:
             for project in in_repo_target_projects:
                 ensure_prebuilt_executable(layout.package_root, project.generator or project.project_id)
-        render_in_repo_projects(layout.package_root, output_root, in_repo_target_projects, serial, pdf=pdf, verbose=verbose)
+        render_in_repo_projects(
+            layout.package_root,
+            output_root,
+            in_repo_target_projects,
+            serial,
+            pdf=pdf,
+            verbose=verbose,
+            record_build_metrics=record_build_metrics,
+        )
 
     if in_repo_command_projects:
         print(f"[blueprint-reference-harness] package root: {layout.package_root}")
@@ -731,6 +775,7 @@ def generate_projects(
                 skip_build=skip_build,
                 pdf=pdf,
                 verbose=verbose,
+                record_build_metrics=record_build_metrics,
             )
 
     for project in git_projects:
@@ -742,6 +787,7 @@ def generate_projects(
             skip_build=skip_build,
             pdf=pdf,
             verbose=verbose,
+            record_build_metrics=record_build_metrics,
         )
 
 
@@ -761,6 +807,7 @@ def command_generate(args: argparse.Namespace) -> int:
         allow_local_build=args.allow_local_build,
         pdf=args.pdf,
         verbose=getattr(args, "verbose", False),
+        record_build_metrics=getattr(args, "record_build_metrics", False),
     )
 
     print(f"[blueprint-reference-harness] project manifest: {manifest_path}")
@@ -848,6 +895,7 @@ def command_validate(args: argparse.Namespace) -> int:
             serial=args.serial,
             allow_local_build=args.allow_local_build,
             verbose=getattr(args, "verbose", False),
+            record_build_metrics=getattr(args, "record_build_metrics", False),
         )
     except SystemExit as err:
         failures.append(StepFailure("generate projects", str(err)))
@@ -1164,6 +1212,7 @@ def add_generation_commands(subparsers) -> None:
         help="Also build pdf/main.pdf for each generated reference blueprint.",
     )
     add_generation_verbose_argument(generate)
+    add_generation_metrics_argument(generate)
     add_allow_unsafe_root_release_argument(generate)
     add_serial_argument(generate)
     add_allow_local_build_argument(
@@ -1197,6 +1246,7 @@ def add_generation_commands(subparsers) -> None:
     )
     add_allow_unsafe_root_release_argument(validate)
     add_generation_verbose_argument(validate)
+    add_generation_metrics_argument(validate)
     add_serial_argument(validate)
     validate.add_argument(
         "--pytest-arg",

--- a/scripts/reference_build_metrics.py
+++ b/scripts/reference_build_metrics.py
@@ -1,0 +1,498 @@
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import time
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+SCHEMA_VERSION = 1
+METRICS_FILENAME = "build-metrics.json"
+DEFAULT_BASELINE_URL = (
+    "https://leanprover.github.io/verso-blueprint/"
+    "build-data/reference-blueprints.json"
+)
+DEFAULT_REGRESSION_PERCENT = 20.0
+DEFAULT_REGRESSION_MIN_MS = 1_000
+DEFAULT_HISTORY_LIMIT = 50
+
+ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+FINISHED_PHASE_PATTERN = re.compile(
+    r"^Blueprint: finished (?P<name>.+) in (?P<duration_ms>[0-9]+)ms$"
+)
+TRAVERSAL_PHASES = (
+    "single-page HTML traversal",
+    "multi-page HTML traversal",
+)
+COMMAND_METRIC = "generator command"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def parse_finished_phase(line: str) -> dict[str, object] | None:
+    normalized = ANSI_ESCAPE_PATTERN.sub("", line).strip()
+    match = FINISHED_PHASE_PATTERN.fullmatch(normalized)
+    if match is None:
+        return None
+    return {
+        "name": match.group("name"),
+        "duration_ms": int(match.group("duration_ms")),
+    }
+
+
+def _optional_text(value: str | None) -> str | None:
+    if value is None or not value.strip():
+        return None
+    return value.strip()
+
+
+def record_build(args: argparse.Namespace) -> int:
+    command = list(args.command)
+    if command[:1] == ["--"]:
+        command = command[1:]
+    if not command:
+        raise SystemExit("reference build metrics recorder requires a command after `--`")
+
+    phases: list[dict[str, object]] = []
+    started = time.monotonic_ns()
+    process = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    assert process.stdout is not None
+    try:
+        for line in process.stdout:
+            print(line, end="", flush=True)
+            phase = parse_finished_phase(line)
+            if phase is not None:
+                phases.append(phase)
+    finally:
+        process.stdout.close()
+    returncode = process.wait()
+    duration_ms = (time.monotonic_ns() - started) // 1_000_000
+
+    measurement = {
+        "schema_version": SCHEMA_VERSION,
+        "project_id": args.project_id,
+        "release_id": args.release_id,
+        "source_ref": _optional_text(args.source_ref),
+        "toolchain": _optional_text(args.toolchain),
+        "recorded_at": utc_now(),
+        "generator_revision": _optional_text(os.environ.get("GITHUB_SHA")),
+        "github_run_id": _optional_text(os.environ.get("GITHUB_RUN_ID")),
+        "github_run_attempt": _optional_text(os.environ.get("GITHUB_RUN_ATTEMPT")),
+        "status": "success" if returncode == 0 else "failure",
+        "command_duration_ms": duration_ms,
+        "phases": phases,
+    }
+    output = Path(args.output)
+    write_json(output, measurement)
+    print(
+        f"[reference-build-metrics] recorded {len(phases)} phases for "
+        f"{args.release_id}/{args.project_id} in {output}",
+        flush=True,
+    )
+    return returncode
+
+
+def _require_string(value: object, field: str, *, context: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{context}: `{field}` must be a non-empty string")
+    return value
+
+
+def validate_measurement(value: object, *, context: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{context}: expected a JSON object")
+    if value.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"{context}: unsupported build metrics schema")
+    _require_string(value.get("project_id"), "project_id", context=context)
+    _require_string(value.get("release_id"), "release_id", context=context)
+    command_duration_ms = value.get("command_duration_ms")
+    if not isinstance(command_duration_ms, int) or command_duration_ms < 0:
+        raise ValueError(f"{context}: `command_duration_ms` must be a non-negative integer")
+    phases = value.get("phases")
+    if not isinstance(phases, list):
+        raise ValueError(f"{context}: `phases` must be a list")
+    for index, phase in enumerate(phases):
+        phase_context = f"{context}: phase {index}"
+        if not isinstance(phase, dict):
+            raise ValueError(f"{phase_context} must be an object")
+        _require_string(phase.get("name"), "name", context=phase_context)
+        duration_ms = phase.get("duration_ms")
+        if not isinstance(duration_ms, int) or duration_ms < 0:
+            raise ValueError(f"{phase_context}: `duration_ms` must be a non-negative integer")
+    return value
+
+
+def load_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def discover_measurements(input_root: Path) -> list[dict[str, object]]:
+    measurements = [
+        validate_measurement(load_json(path), context=str(path))
+        for path in sorted(input_root.rglob(METRICS_FILENAME))
+    ]
+    if not measurements:
+        raise ValueError(f"no `{METRICS_FILENAME}` files found under {input_root}")
+    keys: set[tuple[str, str]] = set()
+    for measurement in measurements:
+        key = (str(measurement["release_id"]), str(measurement["project_id"]))
+        if key in keys:
+            raise ValueError(f"duplicate build metrics for {key[0]}/{key[1]}")
+        keys.add(key)
+    return sorted(measurements, key=lambda item: (str(item["release_id"]), str(item["project_id"])))
+
+
+def load_baseline_file(path: Path) -> dict[str, object]:
+    value = load_json(path)
+    if not isinstance(value, dict) or value.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"{path}: unsupported reference build report schema")
+    return value
+
+
+def load_baseline_url(url: str) -> tuple[dict[str, object] | None, str | None]:
+    request = Request(url, headers={"User-Agent": "verso-blueprint-build-metrics"})
+    try:
+        with urlopen(request, timeout=15) as response:
+            value = json.loads(response.read().decode("utf-8"))
+    except (HTTPError, URLError, TimeoutError, json.JSONDecodeError) as error:
+        return None, str(error)
+    if not isinstance(value, dict) or value.get("schema_version") != SCHEMA_VERSION:
+        return None, "unsupported reference build report schema"
+    return value, None
+
+
+def measurement_key(measurement: dict[str, object]) -> tuple[str, str]:
+    return str(measurement["release_id"]), str(measurement["project_id"])
+
+
+def phase_durations(measurement: dict[str, object]) -> dict[str, int]:
+    phases = measurement.get("phases")
+    if not isinstance(phases, list):
+        return {}
+    return {
+        str(phase["name"]): int(phase["duration_ms"])
+        for phase in phases
+        if isinstance(phase, dict)
+        and isinstance(phase.get("name"), str)
+        and isinstance(phase.get("duration_ms"), int)
+    }
+
+
+def metric_durations(measurement: dict[str, object]) -> dict[str, int]:
+    metrics = phase_durations(measurement)
+    command_duration_ms = measurement.get("command_duration_ms")
+    if isinstance(command_duration_ms, int):
+        return {COMMAND_METRIC: command_duration_ms, **metrics}
+    return metrics
+
+
+def measurements_comparable(current: dict[str, object], baseline: dict[str, object]) -> bool:
+    return (
+        current.get("source_ref") == baseline.get("source_ref")
+        and current.get("toolchain") == baseline.get("toolchain")
+    )
+
+
+def compare_measurements(
+    current: list[dict[str, object]],
+    baseline_report: dict[str, object] | None,
+    *,
+    regression_percent: float,
+    regression_min_ms: int,
+) -> list[dict[str, object]]:
+    if baseline_report is None:
+        return []
+    baseline_values = baseline_report.get("measurements")
+    if not isinstance(baseline_values, list):
+        return []
+    baseline_by_key: dict[tuple[str, str], dict[str, object]] = {}
+    for index, value in enumerate(baseline_values):
+        try:
+            baseline_measurement = validate_measurement(
+                value,
+                context=f"baseline measurement {index}",
+            )
+        except ValueError:
+            continue
+        baseline_by_key[measurement_key(baseline_measurement)] = baseline_measurement
+
+    comparisons: list[dict[str, object]] = []
+    for measurement in current:
+        key = measurement_key(measurement)
+        baseline = baseline_by_key.get(key)
+        if baseline is None:
+            continue
+        comparable = measurements_comparable(measurement, baseline)
+        baseline_metrics = metric_durations(baseline)
+        for metric_name, current_ms in metric_durations(measurement).items():
+            baseline_ms = baseline_metrics.get(metric_name)
+            if baseline_ms is None:
+                continue
+            delta_ms = current_ms - baseline_ms
+            delta_percent = None if baseline_ms == 0 else (delta_ms * 100.0 / baseline_ms)
+            regression = bool(
+                comparable
+                and delta_ms >= regression_min_ms
+                and delta_percent is not None
+                and delta_percent >= regression_percent
+            )
+            comparisons.append(
+                {
+                    "release_id": key[0],
+                    "project_id": key[1],
+                    "phase": metric_name,
+                    "current_ms": current_ms,
+                    "baseline_ms": baseline_ms,
+                    "delta_ms": delta_ms,
+                    "delta_percent": delta_percent,
+                    "comparable": comparable,
+                    "regression": regression,
+                }
+            )
+    return comparisons
+
+
+def format_duration(duration_ms: int | None) -> str:
+    if duration_ms is None:
+        return "—"
+    if duration_ms < 1_000:
+        return f"{duration_ms}ms"
+    seconds = duration_ms / 1_000.0
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes = int(seconds // 60)
+    return f"{minutes}m{seconds - minutes * 60:04.1f}s"
+
+
+def comparison_by_phase(comparisons: list[dict[str, object]]) -> dict[tuple[str, str, str], dict[str, object]]:
+    return {
+        (str(item["release_id"]), str(item["project_id"]), str(item["phase"])): item
+        for item in comparisons
+    }
+
+
+def format_phase_cell(
+    measurement: dict[str, object],
+    phase_name: str,
+    comparisons: dict[tuple[str, str, str], dict[str, object]],
+) -> str:
+    duration = metric_durations(measurement).get(phase_name)
+    text = format_duration(duration)
+    comparison = comparisons.get((*measurement_key(measurement), phase_name))
+    if comparison is None:
+        return text
+    if not comparison["comparable"]:
+        return f"{text} (source/toolchain changed)"
+    delta_percent = comparison["delta_percent"]
+    if delta_percent is None:
+        return text
+    marker = " ⚠" if comparison["regression"] else ""
+    return f"{text} ({float(delta_percent):+.1f}%){marker}"
+
+
+def markdown_report(
+    measurements: list[dict[str, object]],
+    comparisons: list[dict[str, object]],
+    *,
+    baseline_description: str,
+    regression_percent: float,
+    regression_min_ms: int,
+) -> str:
+    by_phase = comparison_by_phase(comparisons)
+    lines = [
+        "## Reference Blueprint build timings",
+        "",
+        f"Baseline: {baseline_description}",
+        "",
+        "| Release | Blueprint | `vbp build` | Single-page traversal | Multi-page traversal |",
+        "|---|---|---:|---:|---:|",
+    ]
+    for measurement in measurements:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(measurement["release_id"]),
+                    str(measurement["project_id"]),
+                    format_phase_cell(measurement, COMMAND_METRIC, by_phase),
+                    format_phase_cell(measurement, TRAVERSAL_PHASES[0], by_phase),
+                    format_phase_cell(measurement, TRAVERSAL_PHASES[1], by_phase),
+                ]
+            )
+            + " |"
+        )
+
+    regressions = [item for item in comparisons if item["regression"]]
+    lines.extend(
+        [
+            "",
+            (
+                "Regression warnings require both "
+                f"+{regression_percent:g}% and +{format_duration(regression_min_ms)} "
+                "against the same reference source and toolchain. Full command and phase data is retained in JSON."
+            ),
+        ]
+    )
+    if regressions:
+        lines.extend(["", "Warnings:"])
+        for item in regressions:
+            lines.append(
+                f"- {item['release_id']}/{item['project_id']} — {item['phase']}: "
+                f"{format_duration(int(item['baseline_ms']))} → {format_duration(int(item['current_ms']))} "
+                f"({float(item['delta_percent']):+.1f}%)"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def history_from_baseline(baseline: dict[str, object] | None) -> list[object]:
+    if baseline is None:
+        return []
+    history = baseline.get("history")
+    return list(history) if isinstance(history, list) else []
+
+
+def report_builds(args: argparse.Namespace) -> int:
+    input_root = Path(args.input_root)
+    try:
+        measurements = discover_measurements(input_root)
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        raise SystemExit(str(error)) from error
+
+    baseline: dict[str, object] | None = None
+    baseline_description = "unavailable (first measurement or baseline fetch failed)"
+    baseline_error: str | None = None
+    if args.baseline is not None:
+        try:
+            baseline = load_baseline_file(Path(args.baseline))
+            baseline_description = str(args.baseline)
+        except (OSError, ValueError, json.JSONDecodeError) as error:
+            baseline_error = str(error)
+    elif args.baseline_url:
+        baseline, baseline_error = load_baseline_url(args.baseline_url)
+        if baseline is not None:
+            baseline_description = args.baseline_url
+
+    if baseline_error is not None:
+        print(f"[reference-build-metrics] baseline unavailable: {baseline_error}", file=sys.stderr)
+
+    comparisons = compare_measurements(
+        measurements,
+        baseline,
+        regression_percent=args.regression_percent,
+        regression_min_ms=args.regression_min_ms,
+    )
+    regressions = [item for item in comparisons if item["regression"]]
+    generated_at = utc_now()
+    snapshot = {
+        "generated_at": generated_at,
+        "generator_revision": _optional_text(os.environ.get("GITHUB_SHA")),
+        "github_run_id": _optional_text(os.environ.get("GITHUB_RUN_ID")),
+        "measurements": measurements,
+    }
+    history = history_from_baseline(baseline)
+    history.append(snapshot)
+    if args.history_limit >= 0:
+        history = history[-args.history_limit :] if args.history_limit else []
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": generated_at,
+        "generator_revision": snapshot["generator_revision"],
+        "github_run_id": snapshot["github_run_id"],
+        "measurements": measurements,
+        "comparison": {
+            "baseline": baseline_description,
+            "baseline_error": baseline_error,
+            "regression_percent": args.regression_percent,
+            "regression_min_ms": args.regression_min_ms,
+            "phases": comparisons,
+            "regression_count": len(regressions),
+        },
+        "history": history,
+    }
+    output = Path(args.output)
+    write_json(output, report)
+
+    markdown = markdown_report(
+        measurements,
+        comparisons,
+        baseline_description=baseline_description,
+        regression_percent=args.regression_percent,
+        regression_min_ms=args.regression_min_ms,
+    )
+    if args.summary_output is not None:
+        summary_path = Path(args.summary_output)
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        with summary_path.open("a", encoding="utf-8") as stream:
+            stream.write(markdown)
+    print(markdown, end="")
+    print(f"[reference-build-metrics] wrote {output}")
+
+    for item in regressions:
+        message = (
+            f"{item['release_id']}/{item['project_id']} {item['phase']} increased "
+            f"from {format_duration(int(item['baseline_ms']))} to "
+            f"{format_duration(int(item['current_ms']))} "
+            f"({float(item['delta_percent']):+.1f}%)"
+        )
+        print(f"::warning title=Reference Blueprint timing regression::{message}")
+    return 1 if args.fail_on_regression and regressions else 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Record and report reference Blueprint build metrics.")
+    subparsers = parser.add_subparsers(dest="command_name", required=True)
+
+    record = subparsers.add_parser("record", help="Run one Blueprint generator and record verbose phase timings.")
+    record.add_argument("--output", required=True)
+    record.add_argument("--project-id", required=True)
+    record.add_argument("--release-id", required=True)
+    record.add_argument("--source-ref", default="")
+    record.add_argument("--toolchain", default="")
+    record.add_argument("command", nargs=argparse.REMAINDER)
+    record.set_defaults(func=record_build)
+
+    report = subparsers.add_parser("report", help="Aggregate metrics and compare them with a deployed baseline.")
+    report.add_argument("--input-root", required=True)
+    report.add_argument("--output", required=True)
+    baseline = report.add_mutually_exclusive_group()
+    baseline.add_argument("--baseline")
+    baseline.add_argument("--baseline-url", default=DEFAULT_BASELINE_URL)
+    report.add_argument("--summary-output")
+    report.add_argument("--regression-percent", type=float, default=DEFAULT_REGRESSION_PERCENT)
+    report.add_argument("--regression-min-ms", type=int, default=DEFAULT_REGRESSION_MIN_MS)
+    report.add_argument("--history-limit", type=int, default=DEFAULT_HISTORY_LIMIT)
+    report.add_argument("--fail-on-regression", action="store_true")
+    report.set_defaults(func=report_builds)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/harness/test_blueprint_harness_cli.py
+++ b/tests/harness/test_blueprint_harness_cli.py
@@ -185,6 +185,32 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         self.assertFalse(parser.parse_args(["validate"]).verbose)
         self.assertTrue(parser.parse_args(["validate", "--verbose"]).verbose)
 
+    def test_reference_generation_commands_parse_build_metrics(self) -> None:
+        parser = reference_harness_mod.build_parser()
+        self.assertFalse(parser.parse_args(["generate"]).record_build_metrics)
+        self.assertTrue(parser.parse_args(["generate", "--record-build-metrics"]).record_build_metrics)
+        self.assertFalse(parser.parse_args(["validate"]).record_build_metrics)
+        self.assertTrue(parser.parse_args(["validate", "--record-build-metrics"]).record_build_metrics)
+
+    def test_record_build_metrics_enables_verbose_generator(self) -> None:
+        project = self.published_git_project()
+        with patch.object(
+            reference_harness_mod,
+            "ensure_prebuilt_executable",
+            return_value=Path("/tmp/published"),
+        ):
+            command = reference_harness_mod.reference_executable_args(
+                Path("/tmp/package"),
+                project,
+                Path("/tmp/out/published"),
+                pdf=False,
+                verbose=False,
+                record_build_metrics=True,
+            )
+
+        self.assertIn("/tmp/package/scripts/reference_build_metrics.py", command)
+        self.assertEqual(command[-1], "--verbose")
+
     def test_reference_projects_parses_release_filter(self) -> None:
         parser = reference_harness_mod.build_parser()
         args = parser.parse_args(["projects", "--release", "v4.29.0"])
@@ -2603,7 +2629,7 @@ class BlueprintHarnessCliTests(unittest.TestCase):
         with patched_attrs(
             reference_harness_mod,
             ensure_prebuilt_executable=lambda _package_root, _exe_name: Path("/tmp/demo"),
-            render_in_repo_projects=lambda _package_root, _output_root, _projects, _serial, *, pdf=False, verbose=False: None,
+            render_in_repo_projects=lambda _package_root, _output_root, _projects, _serial, **_kwargs: None,
         ):
             generate_projects(
                 layout,

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -38,6 +38,7 @@ from scripts.blueprint_harness_references import (
     default_reference_edit_base,
     generate_git_project,
     output_dir_for,
+    reference_build_metrics_command,
     reference_source_paths,
     reference_submodule_update_command,
     require_reference_harness_layout,
@@ -131,6 +132,28 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             command_with_pdf(VBP_BUILD_PDF_COMMAND),
             VBP_BUILD_PDF_COMMAND,
         )
+
+    def test_reference_build_metrics_command_wraps_generator_with_identity(self) -> None:
+        project = external_project(
+            selected_release="v4.33.0",
+            selected_reference_toolchain="v4.33.0-rc1",
+            ref="abc123",
+        )
+        output_dir = Path("/tmp/out/external-blueprint")
+
+        command = reference_build_metrics_command(
+            PACKAGE_ROOT,
+            project,
+            output_dir,
+            (*VBP_BUILD_OUTPUT_COMMAND, "--verbose"),
+        )
+
+        self.assertEqual(command[1], str(PACKAGE_ROOT / "scripts" / "reference_build_metrics.py"))
+        self.assertEqual(command[2:4], ("record", "--output"))
+        self.assertIn(str(output_dir / "build-metrics.json"), command)
+        self.assertIn("v4.33.0", command)
+        self.assertIn("v4.33.0-rc1", command)
+        self.assertEqual(command[-len(VBP_BUILD_OUTPUT_COMMAND) - 1 :], (*VBP_BUILD_OUTPUT_COMMAND, "--verbose"))
 
     def init_git_repo(self, root: Path) -> None:
         subprocess.run(["git", "init"], cwd=root, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -644,9 +667,11 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertIn("--reference-root _out/reference-blueprints-artifacts", workflow_text)
         self.assertNotIn("merge-multiple: true", workflow_text)
         self.assertIn("--project ${{ matrix.project_id }}", workflow_text)
-        self.assertIn("--pdf --project ${{ matrix.project_id }}", workflow_text)
         self.assertIn("Install PDF toolchain", workflow_text)
         self.assertIn("Generate reference blueprint with PDF", workflow_text)
+        self.assertIn("--record-build-metrics", workflow_text)
+        self.assertIn("reference_build_metrics.py report", workflow_text)
+        self.assertIn("_site/build-data/reference-blueprints.json", workflow_text)
         self.assertIn("lualatex --version", workflow_text)
         self.assertIn("texlive-fonts-extra", workflow_text)
         self.assertIn("texlive-plain-generic", workflow_text)
@@ -679,6 +704,9 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         )
         self.assertIn("publish_pdf=${{ matrix.publish_pdf }}", deploy_workflow_text)
         self.assertIn("Generate release reference blueprints", deploy_workflow_text)
+        self.assertIn("--record-build-metrics", deploy_workflow_text)
+        self.assertIn("reference_build_metrics.py report", deploy_workflow_text)
+        self.assertIn("_site/build-data/reference-blueprints.json", deploy_workflow_text)
         self.assertIn("lualatex --version", deploy_workflow_text)
         self.assertIn("texlive-fonts-extra", deploy_workflow_text)
         self.assertIn("texlive-plain-generic", deploy_workflow_text)

--- a/tests/harness/test_reference_build_metrics.py
+++ b/tests/harness/test_reference_build_metrics.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+from scripts.reference_build_metrics import (
+    DEFAULT_BASELINE_URL,
+    compare_measurements,
+    discover_measurements,
+    load_json,
+    parse_finished_phase,
+    record_build,
+    report_builds,
+)
+
+
+def measurement(
+    project_id: str,
+    *,
+    source_ref: str = "abc",
+    toolchain: str = "v4.33.0-rc1",
+    traversal_ms: int = 1_000,
+    command_ms: int = 10_000,
+) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "project_id": project_id,
+        "release_id": "v4.33.0",
+        "source_ref": source_ref,
+        "toolchain": toolchain,
+        "recorded_at": "2026-08-06T00:00:00Z",
+        "generator_revision": "def",
+        "github_run_id": "1",
+        "github_run_attempt": "1",
+        "status": "success",
+        "command_duration_ms": command_ms,
+        "phases": [
+            {"name": "multi-page HTML traversal", "duration_ms": traversal_ms},
+            {"name": "emitting multi-page HTML", "duration_ms": 250},
+        ],
+    }
+
+
+class TestReferenceBuildMetrics(unittest.TestCase):
+    def test_parse_finished_phase_accepts_ansi_and_rejects_progress(self) -> None:
+        self.assertEqual(
+            parse_finished_phase("\x1b[32mBlueprint: finished multi-page HTML traversal in 1234ms\x1b[0m\n"),
+            {"name": "multi-page HTML traversal", "duration_ms": 1234},
+        )
+        self.assertIsNone(parse_finished_phase("Blueprint: starting multi-page HTML traversal"))
+
+    def test_record_build_tees_output_and_writes_structured_metrics(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "metrics.json"
+            args = argparse.Namespace(
+                output=str(output),
+                project_id="verso-flt",
+                release_id="v4.33.0",
+                source_ref="abc",
+                toolchain="v4.33.0-rc1",
+                command=[
+                    "--",
+                    sys.executable,
+                    "-c",
+                    (
+                        "print('ordinary output'); "
+                        "print('Blueprint: finished multi-page HTML traversal in 4321ms')"
+                    ),
+                ],
+            )
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                returncode = record_build(args)
+
+            self.assertEqual(returncode, 0)
+            self.assertIn("ordinary output", stdout.getvalue())
+            data = load_json(output)
+            self.assertEqual(data["project_id"], "verso-flt")
+            self.assertEqual(data["status"], "success")
+            self.assertEqual(
+                data["phases"],
+                [{"name": "multi-page HTML traversal", "duration_ms": 4321}],
+            )
+            self.assertGreaterEqual(data["command_duration_ms"], 0)
+
+    def test_discover_measurements_rejects_duplicate_release_project(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for directory in (root / "one", root / "two"):
+                directory.mkdir()
+                (directory / "build-metrics.json").write_text(
+                    json.dumps(measurement("verso-flt")),
+                    encoding="utf-8",
+                )
+            with self.assertRaisesRegex(ValueError, "duplicate build metrics"):
+                discover_measurements(root)
+
+    def test_comparison_warns_only_for_same_source_and_toolchain(self) -> None:
+        baseline = {
+            "schema_version": 1,
+            "measurements": [measurement("same"), measurement("changed")],
+        }
+        comparisons = compare_measurements(
+            [
+                measurement("same", traversal_ms=1_500),
+                measurement("changed", source_ref="new", traversal_ms=1_500),
+            ],
+            baseline,
+            regression_percent=20,
+            regression_min_ms=250,
+        )
+        traversal = {
+            (item["project_id"], item["phase"]): item
+            for item in comparisons
+            if item["phase"] == "multi-page HTML traversal"
+        }
+        self.assertTrue(traversal[("same", "multi-page HTML traversal")]["regression"])
+        self.assertFalse(traversal[("changed", "multi-page HTML traversal")]["comparable"])
+        self.assertFalse(traversal[("changed", "multi-page HTML traversal")]["regression"])
+
+    def test_comparison_includes_total_generator_command(self) -> None:
+        baseline = {
+            "schema_version": 1,
+            "measurements": [measurement("verso-flt", command_ms=10_000)],
+        }
+        comparisons = compare_measurements(
+            [measurement("verso-flt", command_ms=13_000)],
+            baseline,
+            regression_percent=20,
+            regression_min_ms=1_000,
+        )
+
+        command = next(item for item in comparisons if item["phase"] == "generator command")
+        self.assertTrue(command["regression"])
+        self.assertEqual(command["delta_ms"], 3_000)
+
+    def test_report_writes_summary_comparison_and_history(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            artifact = root / "artifact"
+            artifact.mkdir()
+            (artifact / "build-metrics.json").write_text(
+                json.dumps(measurement("verso-flt", traversal_ms=1_500)),
+                encoding="utf-8",
+            )
+            baseline_path = root / "baseline.json"
+            baseline_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "measurements": [measurement("verso-flt")],
+                        "history": [{"generated_at": "earlier", "measurements": []}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            output = root / "site" / "build-data.json"
+            summary = root / "summary.md"
+            args = argparse.Namespace(
+                input_root=str(root),
+                output=str(output),
+                baseline=str(baseline_path),
+                baseline_url=DEFAULT_BASELINE_URL,
+                summary_output=str(summary),
+                regression_percent=20.0,
+                regression_min_ms=250,
+                history_limit=50,
+                fail_on_regression=False,
+            )
+
+            with contextlib.redirect_stdout(io.StringIO()):
+                returncode = report_builds(args)
+
+            self.assertEqual(returncode, 0)
+            report = load_json(output)
+            self.assertEqual(report["comparison"]["regression_count"], 1)
+            self.assertEqual(len(report["history"]), 2)
+            summary_text = summary.read_text(encoding="utf-8")
+            self.assertIn("Reference Blueprint build timings", summary_text)
+            self.assertIn("1.5s (+50.0%) ⚠", summary_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR records structured timing data for reference Blueprint generation so traversal and whole-command regressions remain visible across CI and deployments.

- Add an opt-in harness recorder that preserves normal verbose output and writes per-project build metrics.
- Publish aggregate metrics, 50-run history, and advisory same-source/toolchain regression comparisons in Actions summaries and Pages build data.
- Enable metrics for reference validation and deployment workflows, with focused unit and workflow coverage.

Backport v4.32.0: #384