### PR TITLE
fix: select reference projects from controller catalog

### DIFF
--- a/.github/workflows/reference-blueprints.yml
+++ b/.github/workflows/reference-blueprints.yml
@@ -26,9 +26,30 @@ jobs:
       reference_matrix: ${{ steps.resolve.outputs.reference_matrix }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Select controller catalog
+        id: controller
+        env:
+          BP_DEFAULT_DEV_BRANCH: ${{ github.event.repository.default_branch }}
+          BP_RELEASE_ID: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
+        run: |
+          manifest_path=tests/harness/projects.json
+          if [ "$BP_RELEASE_ID" != "$BP_DEFAULT_DEV_BRANCH" ]; then
+            git fetch --no-tags origin "$BP_DEFAULT_DEV_BRANCH"
+            manifest_path=_out/controller-projects.json
+            mkdir -p "$(dirname "$manifest_path")"
+            git show "origin/$BP_DEFAULT_DEV_BRANCH:tests/harness/projects.json" > "$manifest_path"
+          fi
+          echo "manifest_path=$manifest_path" >> "$GITHUB_OUTPUT"
+          echo "release_id=$BP_RELEASE_ID" >> "$GITHUB_OUTPUT"
       - name: Resolve release metadata
         id: resolve
-        run: python3 ./scripts/emit_reference_release_matrix.py --github-output >> "$GITHUB_OUTPUT"
+        run: |
+          python3 ./scripts/emit_reference_release_matrix.py \
+            --manifest "${{ steps.controller.outputs.manifest_path }}" \
+            --release "${{ steps.controller.outputs.release_id }}" \
+            --github-output >> "$GITHUB_OUTPUT"
 
   build-reference-blueprints:
     name: Build Reference ${{ matrix.project_id }}
@@ -54,6 +75,21 @@ jobs:
           echo "blueprint=${{ matrix.project_id }}"
           echo "hash=${{ matrix.hash }}"
           echo "reference_source_identity=${{ matrix.reference_source_identity }}"
+      - name: Write reference project manifest
+        env:
+          BP_PROJECT_ID: ${{ matrix.project_id }}
+          BP_REFERENCE_PROJECT_MANIFEST: ${{ toJSON(matrix.project_manifest) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path("_out/reference-projects") / (os.environ["BP_PROJECT_ID"] + ".json")
+          path.parent.mkdir(parents=True, exist_ok=True)
+          manifest = json.loads(os.environ["BP_REFERENCE_PROJECT_MANIFEST"])
+          path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+          PY
       - name: Match reference target toolchain
         run: printf 'leanprover/lean4:${{ matrix.toolchain }}\n' > lean-toolchain
       - name: Report disk usage before cache restore
@@ -116,6 +152,8 @@ jobs:
         run: |
           ./scripts/generate-reference-blueprints.sh \
             --allow-unsafe-root-release \
+            --manifest _out/reference-projects/${{ matrix.project_id }}.json \
+            --release ${{ needs.resolve-reference-release.outputs.release_id }} \
             --pdf \
             --record-build-metrics \
             --project ${{ matrix.project_id }}

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -789,9 +789,15 @@ template-owned CI path.
 `reference-blueprints.yml` is the shared build workflow. On pull requests,
 pushes to release branches named like `v4.32.0`, and manual dispatch, it:
 
-- resolves the current branch's release target from `branch-policy.json`
+- resolves the triggering branch's release target from `branch-policy.json`
+- uses the triggering checkout's catalog on the default-development line, but
+  reads the default-development branch's controller catalog for maintenance
+  lines so stale branch-local targets cannot recreate retired Blueprint builds
 - builds only project targets for that release that set
   `publish_reference: true`
+- passes each selected target to the release-branch harness through an exact
+  generated one-project manifest, preserving the controller ref and effective
+  reference toolchain
 - builds `pdf/main.pdf` for those reference targets, using the workflow's
   installed TeX toolchain
 - builds the local `test-blueprints/` artifact set, including

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -563,6 +563,7 @@ def reference_build_matrix(
             {
                 "artifact_name": reference_artifact_name(project),
                 "artifact_path": reference_artifact_path(project),
+                "project_manifest": release_project_manifest(release_target, project),
             }
         )
         include.append(entry)
@@ -678,11 +679,11 @@ def project_manifest_entry(project: HarnessProject, *, include_pdf: bool = False
     return entry
 
 
-def deploy_project_manifest(
+def release_project_manifest(
     target: HarnessReleaseTarget,
     project: HarnessProject,
     *,
-    include_pdf: bool = True,
+    include_pdf: bool = False,
 ) -> dict[str, object]:
     return {
         "version": 2,
@@ -724,7 +725,7 @@ def deploy_matrix_from_controller_catalog(
                     "artifact_name": deploy_project_artifact_name(project),
                     "artifact_path": deploy_project_artifact_path(project),
                     "publish_pdf": publish_pdf,
-                    "project_manifest": deploy_project_manifest(target, project, include_pdf=publish_pdf),
+                    "project_manifest": release_project_manifest(target, project, include_pdf=publish_pdf),
                 }
             )
     return {"include": include}

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -667,6 +667,11 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertIn("--reference-root _out/reference-blueprints-artifacts", workflow_text)
         self.assertNotIn("merge-multiple: true", workflow_text)
         self.assertIn("--project ${{ matrix.project_id }}", workflow_text)
+        self.assertIn("Select controller catalog", workflow_text)
+        self.assertIn("origin/$BP_DEFAULT_DEV_BRANCH:tests/harness/projects.json", workflow_text)
+        self.assertIn("BP_REFERENCE_PROJECT_MANIFEST", workflow_text)
+        self.assertIn("--manifest _out/reference-projects/${{ matrix.project_id }}.json", workflow_text)
+        self.assertIn("--release ${{ needs.resolve-reference-release.outputs.release_id }}", workflow_text)
         self.assertIn("Install PDF toolchain", workflow_text)
         self.assertIn("Generate reference blueprint with PDF", workflow_text)
         self.assertIn("--record-build-metrics", workflow_text)
@@ -742,6 +747,14 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 self.assertEqual(entry["reference_source_identity"], "")
                 self.assertEqual(entry["reference_dependency_packages_path"], "")
                 self.assertEqual(entry["reference_dependency_path_builds_path"], "")
+            project_manifest = entry["project_manifest"]
+            self.assertEqual(len(project_manifest["projects"]), 1)
+            self.assertEqual(project_manifest["projects"][0]["id"], entry["project_id"])
+            self.assertEqual(
+                project_manifest["projects"][0]["targets"][0]["release"],
+                release.release_id,
+            )
+            self.assertNotIn("--pdf", project_manifest["projects"][0]["generate_command"])
 
     def test_reference_release_payload_uses_project_target_rcs(self) -> None:
         manifest = default_project_manifest(PACKAGE_ROOT)
@@ -780,6 +793,10 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             self.assertEqual(row["toolchain"], expected_toolchain)
             self.assertEqual(row["verso_ref"], expected_verso_ref)
             self.assertEqual(row["hash"], target.ref)
+            self.assertEqual(
+                row["project_manifest"]["projects"][0]["targets"][0].get("ref"),
+                target.ref,
+            )
 
     def test_deploy_matrix_uses_controller_publish_targets_for_generated_manifests(self) -> None:
         controller_catalog = load_project_catalog_text(


### PR DESCRIPTION
This PR makes maintenance-line reference validation select exact one-project manifests from the default-development controller catalog. Retired reference targets can no longer be rebuilt from stale release-branch catalogs, while the existing PDF validation remains enabled.

Backport v4.32.0: #386
