### PR TITLE
[backport v4.32.0] fix: select reference projects from controller catalog

### DIFF
--- a/.github/workflows/reference-blueprints.yml
+++ b/.github/workflows/reference-blueprints.yml
@@ -26,9 +26,30 @@ jobs:
       reference_matrix: ${{ steps.resolve.outputs.reference_matrix }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Select controller catalog
+        id: controller
+        env:
+          BP_DEFAULT_DEV_BRANCH: ${{ github.event.repository.default_branch }}
+          BP_RELEASE_ID: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
+        run: |
+          manifest_path=tests/harness/projects.json
+          if [ "$BP_RELEASE_ID" != "$BP_DEFAULT_DEV_BRANCH" ]; then
+            git fetch --no-tags origin "$BP_DEFAULT_DEV_BRANCH"
+            manifest_path=_out/controller-projects.json
+            mkdir -p "$(dirname "$manifest_path")"
+            git show "origin/$BP_DEFAULT_DEV_BRANCH:tests/harness/projects.json" > "$manifest_path"
+          fi
+          echo "manifest_path=$manifest_path" >> "$GITHUB_OUTPUT"
+          echo "release_id=$BP_RELEASE_ID" >> "$GITHUB_OUTPUT"
       - name: Resolve release metadata
         id: resolve
-        run: python3 ./scripts/emit_reference_release_matrix.py --github-output >> "$GITHUB_OUTPUT"
+        run: |
+          python3 ./scripts/emit_reference_release_matrix.py \
+            --manifest "${{ steps.controller.outputs.manifest_path }}" \
+            --release "${{ steps.controller.outputs.release_id }}" \
+            --github-output >> "$GITHUB_OUTPUT"
 
   build-reference-blueprints:
     name: Build Reference ${{ matrix.project_id }}
@@ -54,6 +75,21 @@ jobs:
           echo "blueprint=${{ matrix.project_id }}"
           echo "hash=${{ matrix.hash }}"
           echo "reference_source_identity=${{ matrix.reference_source_identity }}"
+      - name: Write reference project manifest
+        env:
+          BP_PROJECT_ID: ${{ matrix.project_id }}
+          BP_REFERENCE_PROJECT_MANIFEST: ${{ toJSON(matrix.project_manifest) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path("_out/reference-projects") / (os.environ["BP_PROJECT_ID"] + ".json")
+          path.parent.mkdir(parents=True, exist_ok=True)
+          manifest = json.loads(os.environ["BP_REFERENCE_PROJECT_MANIFEST"])
+          path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+          PY
       - name: Match reference target toolchain
         run: printf 'leanprover/lean4:${{ matrix.toolchain }}\n' > lean-toolchain
       - name: Report disk usage before cache restore
@@ -116,6 +152,8 @@ jobs:
         run: |
           ./scripts/generate-reference-blueprints.sh \
             --allow-unsafe-root-release \
+            --manifest _out/reference-projects/${{ matrix.project_id }}.json \
+            --release ${{ needs.resolve-reference-release.outputs.release_id }} \
             --pdf \
             --record-build-metrics \
             --project ${{ matrix.project_id }}

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -775,9 +775,15 @@ template-owned CI path.
 `reference-blueprints.yml` is the shared build workflow. On pull requests,
 pushes to release branches named like `v4.32.0`, and manual dispatch, it:
 
-- resolves the current branch's release target from `branch-policy.json`
+- resolves the triggering branch's release target from `branch-policy.json`
+- uses the triggering checkout's catalog on the default-development line, but
+  reads the default-development branch's controller catalog for maintenance
+  lines so stale branch-local targets cannot recreate retired Blueprint builds
 - builds only project targets for that release that set
   `publish_reference: true`
+- passes each selected target to the release-branch harness through an exact
+  generated one-project manifest, preserving the controller ref and effective
+  reference toolchain
 - builds `pdf/main.pdf` for those reference targets, using the workflow's
   installed TeX toolchain
 - builds the local `test-blueprints/` artifact set, including

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -563,6 +563,7 @@ def reference_build_matrix(
             {
                 "artifact_name": reference_artifact_name(project),
                 "artifact_path": reference_artifact_path(project),
+                "project_manifest": release_project_manifest(release_target, project),
             }
         )
         include.append(entry)
@@ -678,11 +679,11 @@ def project_manifest_entry(project: HarnessProject, *, include_pdf: bool = False
     return entry
 
 
-def deploy_project_manifest(
+def release_project_manifest(
     target: HarnessReleaseTarget,
     project: HarnessProject,
     *,
-    include_pdf: bool = True,
+    include_pdf: bool = False,
 ) -> dict[str, object]:
     return {
         "version": 2,
@@ -724,7 +725,7 @@ def deploy_matrix_from_controller_catalog(
                     "artifact_name": deploy_project_artifact_name(project),
                     "artifact_path": deploy_project_artifact_path(project),
                     "publish_pdf": publish_pdf,
-                    "project_manifest": deploy_project_manifest(target, project, include_pdf=publish_pdf),
+                    "project_manifest": release_project_manifest(target, project, include_pdf=publish_pdf),
                 }
             )
     return {"include": include}

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -55,42 +55,6 @@
       ],
       "generate_command": ["lake", "exe", "vbp", "build", "--output", "{output_dir}"],
       "site_subdir": "html-multi"
-    },
-    {
-      "id": "verso-flt",
-      "description": "External FLT blueprint integration layer with an FLT submodule checkout.",
-      "source": {
-        "kind": "git_checkout",
-        "repository": "https://github.com/ejgallego/verso-flt.git",
-        "project_root": "."
-      },
-      "targets": [
-        {
-          "release": "v4.32.0",
-          "ref": "bc09f1e5ce35d6418173386b5f134b51a81e6c17",
-          "publish_reference": true
-        }
-      ],
-      "generate_command": ["lake", "exe", "vbp", "build", "--output", "{output_dir}"],
-      "site_subdir": "html-multi"
-    },
-    {
-      "id": "verso-carleson",
-      "description": "External Carleson blueprint integration layer with a Carleson submodule checkout.",
-      "source": {
-        "kind": "git_checkout",
-        "repository": "https://github.com/ejgallego/verso-carleson.git",
-        "project_root": "."
-      },
-      "targets": [
-        {
-          "release": "v4.32.0",
-          "ref": "e89a585c13d05c965d9d28d307517da0bfe13960",
-          "publish_reference": true
-        }
-      ],
-      "generate_command": ["lake", "exe", "vbp", "build", "--output", "{output_dir}"],
-      "site_subdir": "html-multi"
     }
   ]
 }

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -233,8 +233,6 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 "project-template",
                 "noperthedron",
                 "spherepackingblueprint",
-                "verso-flt",
-                "verso-carleson",
             ],
         )
         self.assertEqual(catalog.release_targets, branch_policy.release_targets)
@@ -260,8 +258,6 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         expected_external_repositories = {
             "noperthedron": "https://github.com/ejgallego/verso-noperthedron.git",
             "spherepackingblueprint": "https://github.com/ejgallego/verso-sphere-packing.git",
-            "verso-flt": "https://github.com/ejgallego/verso-flt.git",
-            "verso-carleson": "https://github.com/ejgallego/verso-carleson.git",
         }
         for project in projects[1:]:
             self.assertTrue(project.git_checkout)
@@ -653,6 +649,11 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertIn("--reference-root _out/reference-blueprints-artifacts", workflow_text)
         self.assertNotIn("merge-multiple: true", workflow_text)
         self.assertIn("--project ${{ matrix.project_id }}", workflow_text)
+        self.assertIn("Select controller catalog", workflow_text)
+        self.assertIn("origin/$BP_DEFAULT_DEV_BRANCH:tests/harness/projects.json", workflow_text)
+        self.assertIn("BP_REFERENCE_PROJECT_MANIFEST", workflow_text)
+        self.assertIn("--manifest _out/reference-projects/${{ matrix.project_id }}.json", workflow_text)
+        self.assertIn("--release ${{ needs.resolve-reference-release.outputs.release_id }}", workflow_text)
         self.assertIn("Install PDF toolchain", workflow_text)
         self.assertIn("Generate reference blueprint with PDF", workflow_text)
         self.assertIn("--record-build-metrics", workflow_text)
@@ -728,6 +729,14 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                 self.assertEqual(entry["reference_source_identity"], "")
                 self.assertEqual(entry["reference_dependency_packages_path"], "")
                 self.assertEqual(entry["reference_dependency_path_builds_path"], "")
+            project_manifest = entry["project_manifest"]
+            self.assertEqual(len(project_manifest["projects"]), 1)
+            self.assertEqual(project_manifest["projects"][0]["id"], entry["project_id"])
+            self.assertEqual(
+                project_manifest["projects"][0]["targets"][0]["release"],
+                release.release_id,
+            )
+            self.assertNotIn("--pdf", project_manifest["projects"][0]["generate_command"])
 
     def test_reference_release_payload_uses_project_target_rcs(self) -> None:
         manifest = default_project_manifest(PACKAGE_ROOT)
@@ -766,6 +775,10 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             self.assertEqual(row["toolchain"], expected_toolchain)
             self.assertEqual(row["verso_ref"], expected_verso_ref)
             self.assertEqual(row["hash"], target.ref)
+            self.assertEqual(
+                row["project_manifest"]["projects"][0]["targets"][0].get("ref"),
+                target.ref,
+            )
 
     def test_deploy_matrix_uses_controller_publish_targets_for_generated_manifests(self) -> None:
         controller_catalog = load_project_catalog_text(


### PR DESCRIPTION
## Summary
Backport #385 to `v4.32.0`.

## Primary Review
- Primary review: #385
- Keep review comments on #385 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.32.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- Remove the retired FLT and Carleson v4.32 catalog entries so the maintenance-line catalog agrees with the controller policy.
