### PR TITLE
perf: reuse the KaTeX linter process

### DIFF
--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -1278,6 +1278,9 @@ prefixes with document-order block counts.
 - `verso.blueprint.math.lint`
   - default: `true`
   - runs best-effort KaTeX validation during elaboration
+  - uses a local `node` executable from `PATH`; linting is silently skipped when
+    Node or the packaged lint assets are unavailable
+  - set this option to `false` to disable elaboration-time math linting
 - `verso.blueprint.externalCode.strictResolve`
   - default: `false`
   - upgrades unresolved or ambiguous external Lean names from warnings to errors

--- a/doc/performance/FLT_FUJISAKI_BUILD_PROFILE.md
+++ b/doc/performance/FLT_FUJISAKI_BUILD_PROFILE.md
@@ -1,0 +1,101 @@
+# FLT Fujisaki module build profile
+
+Status: exploratory workstation experiment, 2026-08-08. This records target
+selection and the persistent-worker result; it is not a regression threshold.
+
+## Scope
+
+The workload is the isolated `.olean` phase behind Lake's
+`FLTBlueprint.Chapters.FujisakiProject` job. It excludes compilation of imports,
+generated C, native objects, and executables. The measurements use FLT revision
+`e4f1595` with `leanprover/lean4:v4.33.0-rc1`.
+
+Local raw evidence is under the root checkout at
+`_out/persistent-katex-worker/profiles/fujisaki/`. The earlier baseline evidence
+is under `_out/profile-flt-traversal/profiles/flt-html-escape-016/`.
+
+## Result
+
+The persistent worker removes the repeated Node and KaTeX startup cost while
+keeping math lint enabled. In comparable structured-profile runs, it reduced
+wall time from 24.21s to 12.44s (-48.6%), runtime interpretation from 19.2s to
+5.96s (-69.0%), and system CPU from 11.09s to 2.01s (-81.9%). Its wall time is
+within run-to-run noise of the 13.00s lint-disabled control.
+
+| Measurement | Original linter | Lint disabled | Persistent worker |
+| --- | ---: | ---: | ---: |
+| Wall time | 24.21s | 13.00s | 12.44s |
+| User CPU | 14.94s | 11.38s | 11.14s |
+| System CPU | 11.09s | 2.72s | 2.01s |
+| Runtime interpretation | 19.2s | 4.97s | 5.96s |
+| Imports | 2.75s | 4.15s | 2.93s |
+| Peak RSS | 4,567,868 KiB | 4,565,448 KiB | 4,734,280 KiB |
+
+The persistent-worker profile's first `Informal.Math.inlineMathExpand` call took
+137ms, including lazy worker startup and the first KaTeX module load. Each of
+the other 134 calls was below the profile's 10ms reporting threshold. With the
+original linter, the 135 calls took 15.20s in aggregate.
+
+Peak RSS was about 163 MiB higher in this candidate run. Workstation RSS and
+wall measurements vary, so this observation should be checked by a dedicated
+benchmark before treating it as a regression.
+
+## Uninstrumented paired runs
+
+Two interleaved, uninstrumented control/candidate pairs were collected while
+the workstation load was falling. The absolute wall times are noisy, but the
+system-CPU and page-fault reductions consistently show the removed process
+startup work.
+
+| Run | Wall | User CPU | System CPU | Minor faults | Peak RSS |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Original 1 | 37.37s | 23.91s | 16.34s | 985,060 | 4,523,220 KiB |
+| Worker 1 | 17.67s | 16.45s | 3.48s | 137,400 | 4,699,636 KiB |
+| Original 2 | 33.76s | 20.89s | 15.25s | 986,740 | 4,530,056 KiB |
+| Worker 2 | 9.88s | 8.68s | 1.89s | 134,487 | 4,703,100 KiB |
+
+The worker reduced wall time by 52.7% and 70.7% in the two pairs, system CPU by
+78.7% and 87.6%, and minor faults by about 86%.
+
+## Cause and implementation
+
+The original exact-payload cache did not help Fujisaki's 135 mostly unique
+formulas. Each miss started a fresh Node process, imported the vendored KaTeX
+module, validated the shared prelude and one formula, wrote one JSON response,
+and exited.
+
+The replacement keeps one best-effort worker per Lean process:
+
+- Node imports KaTeX once and serves sequential newline-delimited JSON requests
+  over piped stdin/stdout.
+- The worker caches prelude validation by trimmed prelude string.
+- Lean retains the exact-payload result cache and serializes concurrent requests
+  with a lazily initialized mutex.
+- A spawn, transport, or protocol failure marks linting unavailable for the rest
+  of the Lean process, preserving the existing non-fatal behavior without
+  repeatedly trying to restart a broken worker.
+- One-shot script invocation remains supported for compatibility and diagnosis.
+
+Live process inspection during the FLT run showed one worker child of Lean. The
+worker exited when Lean closed its stdin, and no Node process remained after the
+compile.
+
+## Validation
+
+- The focused Lean math-lint test covers valid and invalid source spans, invalid
+  preludes, concurrent calls, and repeated use of one invalid prelude.
+- The focused test also passes with a deliberately unavailable `node` command.
+- The JavaScript entrypoint passes `node --check` and direct one-shot/worker
+  protocol probes.
+- `VersoBlueprint` builds successfully with the FLT RC1 toolchain, and the
+  isolated Fujisaki compile completes with math lint enabled.
+
+## Remaining targets
+
+With math lint no longer dominant, the earlier lint-disabled drill-down selects
+external-declaration snapshot construction as the next Blueprint-specific
+target. Configuration resolution spent 1.217s in the nested run; a diagnostic
+control retaining name resolution while bypassing the full snapshot reduced it
+to 0.010s. The next step is to separate name/status lookup, source and Git
+provenance, and declaration-HTML rendering before choosing what to defer or
+cache. Preview-value evaluation, measured at 0.647s, follows it.

--- a/doc/performance/FLT_FUJISAKI_BUILD_PROFILE.md
+++ b/doc/performance/FLT_FUJISAKI_BUILD_PROFILE.md
@@ -72,6 +72,21 @@ startup work.
 The worker reduced wall time by 52.7% and 70.7% in the two pairs, system CPU by
 78.7% and 87.6%, and minor faults by about 86%.
 
+## CI corroboration
+
+The v4.32 reference-Blueprint workflow independently exercised the same FLT
+source revision, `bc09f1e5ce35d6418173386b5f134b51a81e6c17`. Lake reported
+`FLTBlueprint.Chapters.FujisakiProject` at 30s in the
+[base job](https://github.com/leanprover/verso-blueprint/actions/runs/31261292723/job/93112402344)
+and 14s in the
+[candidate job](https://github.com/leanprover/verso-blueprint/actions/runs/31262165786/job/93116039081),
+a 53.3% reduction that agrees with the isolated workstation result.
+
+This is corroboration of the module-level effect, not a controlled whole-build
+measurement. The candidate's complete reference-generation step was also
+shorter (12m43s versus 19m39s), but the base job rebuilt substantially more FLT
+dependencies, so cache state explains an unknown portion of that difference.
+
 ## Cause and implementation
 
 The original exact-payload cache did not help Fujisaki's 135 mostly unique

--- a/doc/performance/FLT_FUJISAKI_BUILD_PROFILE.md
+++ b/doc/performance/FLT_FUJISAKI_BUILD_PROFILE.md
@@ -8,11 +8,26 @@ selection and the persistent-worker result; it is not a regression threshold.
 The workload is the isolated `.olean` phase behind Lake's
 `FLTBlueprint.Chapters.FujisakiProject` job. It excludes compilation of imports,
 generated C, native objects, and executables. The measurements use FLT revision
-`e4f1595` with `leanprover/lean4:v4.33.0-rc1`.
+`e4f1595` with `leanprover/lean4:v4.33.0-rc1`. Both worktrees started from
+Verso Blueprint revision `2c18ef309c3810bc0e53a7e9214a8ea59c2f86d9`;
+the candidate implementation was subsequently published as
+`708978dfaa6a85ed3f1eac30df1bf83aa6b5be2b` after rebasing.
 
 Local raw evidence is under the root checkout at
 `_out/persistent-katex-worker/profiles/fujisaki/`. The earlier baseline evidence
 is under `_out/profile-flt-traversal/profiles/flt-html-escape-016/`.
+
+From the FLT checkout, the candidate profile used this command shape, with
+`<verso-blueprint>` replaced by the candidate worktree path:
+
+```sh
+<verso-blueprint>/scripts/lean-low-priority lake env lean \
+  FLTBlueprint/Chapters/FujisakiProject.lean \
+  -o /tmp/fujisaki-profile.olean -i /tmp/fujisaki-profile.ilean \
+  --profile -Dprofiler.threshold=10 \
+  -Dtrace.profiler=true -Dtrace.profiler.threshold=1 \
+  -Dtrace.profiler.output=/tmp/fujisaki-profile-firefox.json
+```
 
 ## Result
 
@@ -74,7 +89,6 @@ The replacement keeps one best-effort worker per Lean process:
 - A spawn, transport, or protocol failure marks linting unavailable for the rest
   of the Lean process, preserving the existing non-fatal behavior without
   repeatedly trying to restart a broken worker.
-- One-shot script invocation remains supported for compatibility and diagnosis.
 
 Live process inspection during the FLT run showed one worker child of Lean. The
 worker exited when Lean closed its stdin, and no Node process remained after the
@@ -85,8 +99,8 @@ compile.
 - The focused Lean math-lint test covers valid and invalid source spans, invalid
   preludes, concurrent calls, and repeated use of one invalid prelude.
 - The focused test also passes with a deliberately unavailable `node` command.
-- The JavaScript entrypoint passes `node --check` and direct one-shot/worker
-  protocol probes.
+- The JavaScript entrypoint passes `node --check` and a direct worker protocol
+  probe.
 - `VersoBlueprint` builds successfully with the FLT RC1 toolchain, and the
   isolated Fujisaki compile completes with math lint enabled.
 

--- a/src/VersoBlueprint/MathLint.lean
+++ b/src/VersoBlueprint/MathLint.lean
@@ -98,9 +98,47 @@ private structure RuntimePaths where
   script : System.FilePath
   katexModule : System.FilePath
 
-initialize nodeAvailableRef : IO.Ref (Option Bool) ← IO.mkRef none
 initialize runtimePathsRef : IO.Ref (Option (Option RuntimePaths)) ← IO.mkRef none
+
+private abbrev WorkerChild := IO.Process.Child {
+  stdin := .piped
+  stdout := .piped
+  stderr := .null
+}
+
+private structure Worker where
+  child : WorkerChild
+
+private inductive WorkerStatus where
+  | notStarted
+  | running (worker : Worker)
+  | unavailable
+deriving Inhabited
+
+initialize workerStatusRef : IO.Ref WorkerStatus ← IO.mkRef .notStarted
 initialize lintCacheRef : IO.Ref (Std.HashMap String (Option Failure)) ← IO.mkRef {}
+initialize lintRequestMutexRef : IO.Ref (Option Std.BaseMutex) ← IO.mkRef none
+
+/--
+Create the request mutex lazily: this module runs in Lean's interpreter during elaboration, where
+a platform mutex cannot safely be allocated by the module initializer. `modifyGet` also ensures
+that concurrent first requests converge on one mutex.
+-/
+private def lintRequestMutex : IO Std.BaseMutex := do
+  if let some mutex ← lintRequestMutexRef.get then
+    return mutex
+  let fresh ← Std.BaseMutex.new
+  lintRequestMutexRef.modifyGet fun
+    | some mutex => (mutex, some mutex)
+    | none => (fresh, some fresh)
+
+private def withLintRequestMutex (action : IO α) : IO α := do
+  let mutex ← lintRequestMutex
+  mutex.lock
+  try
+    action
+  finally
+    mutex.unlock
 
 private partial def findPackageAssetFrom
     (dir : System.FilePath) (assetPath : System.FilePath) : IO (Option System.FilePath) := do
@@ -157,20 +195,6 @@ private def runtimePaths : IO (Option RuntimePaths) := do
       pure (some { script, katexModule })
     runtimePathsRef.set (some resolved)
     pure resolved
-
-/-- Probe `node` once per Lean process so missing Node just disables linting quietly. -/
-private def nodeAvailable : IO Bool := do
-  match ← nodeAvailableRef.get with
-  | some available => pure available
-  | none =>
-    let available ←
-      try
-        let out ← IO.Process.output { cmd := "node", args := #["--version"] }
-        pure (out.exitCode == 0)
-      catch _ =>
-        pure false
-    nodeAvailableRef.set (some available)
-    pure available
 
 def enabled (opts : Options) : Bool :=
   opts.get verso.blueprint.math.lint.name verso.blueprint.math.lint.defValue
@@ -251,42 +275,87 @@ private def RawResult.toFailure : RawResult → Failure
         | none, none => .unknown
     }
 
+private def startWorker (paths : RuntimePaths) : IO (Option Worker) := do
+  try
+    let child ← IO.Process.spawn {
+      cmd := "node"
+      args := #[paths.script.toString, "--worker", paths.katexModule.toString]
+      stdin := .piped
+      stdout := .piped
+      stderr := .null
+    }
+    pure <| some { child }
+  catch _ =>
+    pure none
+
+private def stopWorker (worker : Worker) : IO Unit := do
+  try
+    worker.child.kill
+  catch _ =>
+    pure ()
+  try
+    discard worker.child.wait
+  catch _ =>
+    pure ()
+
+private def requestWorker (worker : Worker) (payloadJson : String) : IO (Option RawResult) := do
+  if (← worker.child.tryWait).isSome then
+    return none
+  worker.child.stdin.putStr payloadJson
+  worker.child.stdin.putStr "\n"
+  worker.child.stdin.flush
+  let line ← worker.child.stdout.getLine
+  if line.isEmpty then
+    return none
+  let json ←
+    match Json.parse line with
+    | .ok json => pure json
+    | .error _ => return none
+  match fromJson? (α := RawResult) json with
+  | .ok report => pure (some report)
+  | .error _ => pure none
+
+private def requestWithState
+    (status : WorkerStatus) (payloadJson : String) : IO (WorkerStatus × Option RawResult) := do
+  if let .unavailable := status then
+    return (.unavailable, none)
+  let some paths ← runtimePaths
+    | return (.unavailable, none)
+  let worker? ←
+    match status with
+    | .notStarted => startWorker paths
+    | .running worker => pure (some worker)
+    | .unavailable => pure none
+  let some worker := worker?
+    | return (status, none)
+  let report? ←
+    try
+      requestWorker worker payloadJson
+    catch _ =>
+      pure none
+  match report? with
+  | some report =>
+    pure (.running worker, some report)
+  | none =>
+    stopWorker worker
+    pure (.unavailable, none)
+
 /--
-Runs the vendored Node+KaTeX checker synchronously and memoizes by payload.
+Runs the persistent Node+KaTeX checker synchronously and memoizes by payload.
 Returning `none` means either "no error" or "linting unavailable"; callers treat both as non-fatal.
 -/
 def lint? (payload : Payload) : IO (Option Failure) := do
-  if !(← nodeAvailable) then
-    return none
-
-  -- maybe a hash function would be faster? Anyways we are sending the TeX like this to node
   let key := Json.compress (toJson payload)
-  if let some cached := (← lintCacheRef.get)[key]? then
-    return cached
-
-  let result ← do
-    let some { script, katexModule } ← runtimePaths
+  withLintRequestMutex do
+    if let some cached := (← lintCacheRef.get)[key]? then
+      return cached
+    let (status, report?) ← requestWithState (← workerStatusRef.get) key
+    workerStatusRef.set status
+    let some report := report?
       | return none
-    let out ←
-      try
-        IO.Process.output {
-          cmd := "node"
-          args := #[script.toString, key, katexModule.toString]
-        }
-      catch _ =>
-        return none
-    if out.exitCode != 0 then
-      return none
-    let json ←
-      match Json.parse out.stdout with
-      | .ok json => pure json
-      | .error _ => return none
-    match fromJson? (α := RawResult) json with
-    | .ok report => pure <| if report.ok then none else some report.toFailure
-    | .error _ => pure none
-
-  lintCacheRef.modify fun cache => cache.insert key result
-  pure result
+    let result := if report.ok then none else some report.toFailure
+    lintCacheRef.modify fun cache => cache.insert key result
+    pure result
 
 /-- Render the most precise span wording we have, preferring source-relative spans over KaTeX-input ones. -/
 private def spanText? (label : String) (span? : Option Span) : Option MessageData :=

--- a/src/VersoBlueprint/MathLint.lean
+++ b/src/VersoBlueprint/MathLint.lean
@@ -79,7 +79,7 @@ private structure RawResult where
   sourcePosition : Option Nat := none
   sourceLength : Option Nat := none
   inPrelude : Bool := false
-deriving FromJson, ToJson, Repr
+deriving FromJson
 
 /--
 Package-relative location of the vendored KaTeX lint entrypoint.
@@ -204,11 +204,6 @@ private def mkSpan? (start? length? : Option Nat) : Option Span := do
   let length ← length?
   pure { start, length }
 
-private def Site.sourceSpan? (site : Site) : Option Span :=
-  match site with
-  | .source src _katexInput => some src
-  | _ => none
-
 /--
 Map a decoded span back onto the raw inline-code contents parsed by Verso.
 
@@ -319,7 +314,12 @@ private def requestWithState
     (status : WorkerStatus) (payloadJson : String) : IO (WorkerStatus × Option RawResult) := do
   if let .unavailable := status then
     return (.unavailable, none)
-  let some paths ← runtimePaths
+  let paths? ←
+    try
+      runtimePaths
+    catch _ =>
+      pure none
+  let some paths := paths?
     | return (.unavailable, none)
   let worker? ←
     match status with
@@ -327,7 +327,7 @@ private def requestWithState
     | .running worker => pure (some worker)
     | .unavailable => pure none
   let some worker := worker?
-    | return (status, none)
+    | return (.unavailable, none)
   let report? ←
     try
       requestWorker worker payloadJson

--- a/static-web/katex-lint.mjs
+++ b/static-web/katex-lint.mjs
@@ -1,4 +1,5 @@
 import { pathToFileURL } from "node:url";
+import { createInterface } from "node:readline";
 
 function sanitizeMessage(message) {
   return String(message ?? "")
@@ -7,8 +8,7 @@ function sanitizeMessage(message) {
     .trim();
 }
 
-function readPayload() {
-  const raw = process.argv[2] ?? "";
+function readPayload(raw) {
   if (!raw) return null;
   try {
     return JSON.parse(raw);
@@ -17,8 +17,7 @@ function readPayload() {
   }
 }
 
-async function loadKatex() {
-  const katexPath = process.argv[3] ?? "";
+async function loadKatex(katexPath) {
   if (!katexPath) return null;
   try {
     const katexModule = await import(pathToFileURL(katexPath).href);
@@ -27,24 +26,6 @@ async function loadKatex() {
     return null;
   }
 }
-
-const payload = readPayload();
-const katex = await loadKatex();
-if (
-  !payload ||
-  typeof payload.source !== "string" ||
-  !katex ||
-  typeof katex.renderToString !== "function"
-) {
-  process.exit(1);
-}
-
-const texPrelude =
-  typeof payload.texPrelude === "string" ? payload.texPrelude.trim() : "";
-const source = payload.source;
-const displayMode = payload.mode === "display";
-const combinedInput = texPrelude ? `${texPrelude}\n${source}` : source;
-const sourceOffset = texPrelude ? texPrelude.length + 1 : 0;
 
 function toCodepointIndex(input, utf16Index) {
   return Array.from(input.slice(0, utf16Index)).length;
@@ -120,27 +101,85 @@ function renderError(
   };
 }
 
-if (texPrelude) {
+function renderSuccess() {
+  return {
+    ok: true,
+    message: "",
+    position: null,
+    length: null,
+    sourcePosition: null,
+    sourceLength: null,
+    inPrelude: false,
+  };
+}
+
+function lintPayload(payload, katex, preludeCache = null) {
+  if (!payload || typeof payload.source !== "string") return null;
+
+  const texPrelude =
+    typeof payload.texPrelude === "string" ? payload.texPrelude.trim() : "";
+  const source = payload.source;
+  const displayMode = payload.mode === "display";
+  const combinedInput = texPrelude ? `${texPrelude}\n${source}` : source;
+  const sourceOffset = texPrelude ? texPrelude.length + 1 : 0;
+
+  let preludeError = null;
+  if (texPrelude && preludeCache?.has(texPrelude)) {
+    preludeError = preludeCache.get(texPrelude);
+  } else if (texPrelude) {
+    try {
+      katex.renderToString(texPrelude, {
+        throwOnError: true,
+        displayMode: false,
+      });
+    } catch (error) {
+      preludeError = renderError(error, texPrelude, { inPrelude: true });
+    }
+    preludeCache?.set(texPrelude, preludeError);
+  }
+
+  if (preludeError) return preludeError;
+
   try {
-    katex.renderToString(texPrelude, { throwOnError: true, displayMode: false });
+    katex.renderToString(combinedInput, { throwOnError: true, displayMode });
+    return renderSuccess();
   } catch (error) {
-    process.stdout.write(
-      JSON.stringify(renderError(error, texPrelude, { inPrelude: true }))
-    );
-    process.exit(0);
+    return renderError(error, combinedInput, {
+      sourceText: source,
+      sourceOffsetUtf16: sourceOffset,
+    });
   }
 }
 
-try {
-  katex.renderToString(combinedInput, { throwOnError: true, displayMode });
-  process.stdout.write(JSON.stringify({ ok: true }));
-} catch (error) {
-  process.stdout.write(
-    JSON.stringify(
-      renderError(error, combinedInput, {
-        sourceText: source,
-        sourceOffsetUtf16: sourceOffset,
-      })
-    )
-  );
+async function runOneShot() {
+  const payload = readPayload(process.argv[2] ?? "");
+  const katex = await loadKatex(process.argv[3] ?? "");
+  if (!katex || typeof katex.renderToString !== "function") return false;
+  const result = lintPayload(payload, katex);
+  if (!result) return false;
+  process.stdout.write(JSON.stringify(result));
+  return true;
+}
+
+async function runWorker() {
+  const katex = await loadKatex(process.argv[3] ?? "");
+  if (!katex || typeof katex.renderToString !== "function") return false;
+
+  const preludeCache = new Map();
+  const lines = createInterface({ input: process.stdin, crlfDelay: Infinity });
+  for await (const raw of lines) {
+    const result = lintPayload(readPayload(raw), katex, preludeCache);
+    if (!result) {
+      lines.close();
+      return false;
+    }
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  }
+  return true;
+}
+
+const ok =
+  process.argv[2] === "--worker" ? await runWorker() : await runOneShot();
+if (!ok) {
+  process.exitCode = 1;
 }

--- a/static-web/katex-lint.mjs
+++ b/static-web/katex-lint.mjs
@@ -21,7 +21,8 @@ async function loadKatex(katexPath) {
   if (!katexPath) return null;
   try {
     const katexModule = await import(pathToFileURL(katexPath).href);
-    return katexModule.default ?? katexModule;
+    const loaded = katexModule.default ?? katexModule;
+    return typeof loaded.renderToString === "function" ? loaded : null;
   } catch {
     return null;
   }
@@ -151,19 +152,9 @@ function lintPayload(payload, katex, preludeCache = null) {
   }
 }
 
-async function runOneShot() {
-  const payload = readPayload(process.argv[2] ?? "");
-  const katex = await loadKatex(process.argv[3] ?? "");
-  if (!katex || typeof katex.renderToString !== "function") return false;
-  const result = lintPayload(payload, katex);
-  if (!result) return false;
-  process.stdout.write(JSON.stringify(result));
-  return true;
-}
-
 async function runWorker() {
   const katex = await loadKatex(process.argv[3] ?? "");
-  if (!katex || typeof katex.renderToString !== "function") return false;
+  if (!katex) return false;
 
   const preludeCache = new Map();
   const lines = createInterface({ input: process.stdin, crlfDelay: Infinity });
@@ -178,8 +169,7 @@ async function runWorker() {
   return true;
 }
 
-const ok =
-  process.argv[2] === "--worker" ? await runWorker() : await runOneShot();
+const ok = process.argv[2] === "--worker" && (await runWorker());
 if (!ok) {
   process.exitCode = 1;
 }

--- a/tests/VersoBlueprintTests/BlueprintMathLint.lean
+++ b/tests/VersoBlueprintTests/BlueprintMathLint.lean
@@ -55,6 +55,18 @@ private def localNodeAvailable : IO Bool := do
 /-- info: true -/
 #guard_msgs in
 #eval
+  show IO Bool from do
+    let tasks ← (List.range 8).mapM fun i =>
+      IO.asTask <| Informal.MathLint.lint? {
+        mode := .inline
+        source := "x_" ++ toString i
+      }
+    let reports ← tasks.mapM fun task => IO.ofExcept task.get
+    pure <| reports.all (·.isNone)
+
+/-- info: true -/
+#guard_msgs in
+#eval
   show Bool from
     extractedRaw? r#"\`x"# { start := 0, length := 1 } == some r#"\`"#
 
@@ -96,5 +108,23 @@ private def localNodeAvailable : IO Bool := do
       match failure.site with
       | .prelude { start, length } => start > 0 && length == 0
       | _ => false
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show IO Bool from do
+    let invalidPrelude := r#"\newcommand{\foo}{\mathsf{Foo}"#
+    let nodeAvailable ← localNodeAvailable
+    let first ← Informal.MathLint.lint? {
+      mode := .inline
+      source := r#"\foo + 1"#
+      texPrelude := invalidPrelude
+    }
+    let second ← Informal.MathLint.lint? {
+      mode := .inline
+      source := r#"\foo + 2"#
+      texPrelude := invalidPrelude
+    }
+    pure <| !nodeAvailable || (first.isSome && first == second)
 
 end Verso.VersoBlueprintTests.BlueprintMathLint

--- a/tests/VersoBlueprintTests/BlueprintMathLint.lean
+++ b/tests/VersoBlueprintTests/BlueprintMathLint.lean
@@ -56,13 +56,14 @@ private def localNodeAvailable : IO Bool := do
 #guard_msgs in
 #eval
   show IO Bool from do
+    let nodeAvailable ← localNodeAvailable
     let tasks ← (List.range 8).mapM fun i =>
       IO.asTask <| Informal.MathLint.lint? {
         mode := .inline
-        source := "x_" ++ toString i
+        source := r#"\undefinedmacro"# ++ toString i
       }
     let reports ← tasks.mapM fun task => IO.ofExcept task.get
-    pure <| reports.all (·.isNone)
+    pure <| !nodeAvailable || reports.all (·.isSome)
 
 /-- info: true -/
 #guard_msgs in
@@ -86,28 +87,35 @@ private def localNodeAvailable : IO Bool := do
 #guard_msgs in
 #eval
   show IO Bool from do
-    let some failure ← Informal.MathLint.lint? {
+    let nodeAvailable ← localNodeAvailable
+    let failure? ← Informal.MathLint.lint? {
       mode := .inline
       source := r#"\frac{a}{"#
     }
-      | pure true
-    pure <| failure.site == .source { start := 9, length := 0 } { start := 9, length := 0 }
+    pure <| if !nodeAvailable then true else
+      match failure? with
+      | some failure =>
+        failure.site == .source { start := 9, length := 0 } { start := 9, length := 0 }
+      | none => false
 
 /-- info: true -/
 #guard_msgs in
 #eval
   show IO Bool from do
-    let some failure ← Informal.MathLint.lint? {
+    let nodeAvailable ← localNodeAvailable
+    let failure? ← Informal.MathLint.lint? {
       mode := .display
       source := r#"\foo + 1"#
       texPrelude := r#"\newcommand{\foo}{\mathsf{Foo}"#
     }
-      | pure true
-    pure <|
-      failure.reason.contains "expected '}'" &&
-      match failure.site with
-      | .prelude { start, length } => start > 0 && length == 0
-      | _ => false
+    pure <| if !nodeAvailable then true else
+      match failure? with
+      | some failure =>
+        failure.reason.contains "expected '}'" &&
+        match failure.site with
+        | .prelude { start, length } => start > 0 && length == 0
+        | _ => false
+      | none => false
 
 /-- info: true -/
 #guard_msgs in


### PR DESCRIPTION
This PR keeps one KaTeX lint worker alive per Lean process, eliminating repeated Node and KaTeX startup during Blueprint elaboration.

- Serve math-lint requests through one persistent newline-delimited JSON worker and retain best-effort failure behavior.
- Cache shared TeX prelude validation while preserving exact-payload result caching.
- Stop retrying after asset, spawn, transport, or protocol failures.
- Cover concurrent callers, repeated invalid preludes, and unavailable Node environments.

Backport v4.32.0: #388