### PR TITLE
refactor: tighten generated data preparation

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -172,12 +172,16 @@ In practice:
 Generator-side data flow is source-to-traversal-to-public JSON. During Manual
 traversal, Blueprint records preview identities, rendered bodies, Lean-code
 associations, citations, graph data, and external-markup witnesses in traversal
-state and traversal domains. `Informal.PreviewManifest.buildPreviewDataFiles`
-then assembles a `PreviewDataModel` and crosses its `finish` boundary into the
-emission-ready semantic manifest/rendered-fragment-cache `Files` pair. The
-final type has a private constructor, so unresolved candidate references cannot
-enter the normal emission path. Generated ESM APIs load those two files; they
-do not rerun traversal and should not recover semantics by scraping cached HTML.
+state and traversal domains. Before assembly, the state crosses the explicit
+`PreparedPreviewState` boundary, which installs the relation indexes consumed by
+manifest construction. The standard HTML pipeline supplies an already-prepared
+state; direct callers use `PreparedPreviewState.prepare`.
+`Informal.PreviewManifest.buildPreviewDataFiles` then assembles a
+`PreviewDataModel` and crosses its `finish` boundary into the emission-ready
+semantic manifest/rendered-fragment-cache `Files` pair. The final type has a
+private constructor, so unresolved candidate references cannot enter the normal
+emission path. Generated ESM APIs load those two files; they do not rerun
+traversal and should not recover semantics by scraping cached HTML.
 
 Persisted or externally supplied manifest/cache pairs enter maintainer audits
 as `PreviewManifest.PersistedFiles`, not as emission-ready `Files`. Parsing each

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -336,9 +336,10 @@ repeatedly selecting artifacts, and finalized files cannot be finalized again.
 For `m` manifest preview/group records, `c` rendered-cache entries, `r`
 non-graph preview references, `n` graph nodes, and `v` graph-variant
 records/mappings, `finish` runs in expected `O(m + c + r + n + v)` time under
-hash-map operations. Its auxiliary indexes use `O(m + c)` space; the finalized
-arrays it returns are linear in the candidate output size. Graph topology and
-DOT are not rebuilt.
+hash-set operations. Its auxiliary indexes retain only the `O(m + c)` preview
+keys needed for membership checks, rather than duplicate full entry indexes;
+the finalized arrays it returns are linear in the candidate output size. Graph
+topology and DOT are not rebuilt.
 
 Generated-data readers preserve the same boundary without charging every
 semantic query for projections it cannot consume. The general manifest reader
@@ -347,9 +348,12 @@ rejects mismatches; `vbp check` and the graph-backed `work-queue` selector use
 that reader. Other `vbp query` selectors remove the top-level graph array before
 decoding because they do not consume graph projections. They still validate the
 manifest schema and decode all queryable semantic data, while avoiding graph and
-DOT rematerialization on graph-free planning-data paths. The manifest/cache pair
-read by `vbp check` is represented as `PreviewManifest.PersistedFiles`, because
-successful local decoding does not imply that cross-file references agree.
+DOT rematerialization on graph-free planning-data paths. Query arguments are
+validated before artifact I/O into a `QueryPlan`; each selector declaration owns
+its argument shape, graph-read requirement, help line, and execution function.
+The manifest/cache pair read by `vbp check` is represented as
+`PreviewManifest.PersistedFiles`, because successful local decoding does not
+imply that cross-file references agree.
 
 ### Render Path Inventory
 
@@ -722,13 +726,18 @@ Lean/Verso source modules
 
 Traversal domains are richer than rendered page HTML. They carry semantic
 payloads for the current generator process, including bodyless directives whose
-visible text comes from an external source. `buildPreviewDataFiles` is the
-normalization point where those traversal facts become documented generated
-data. It must therefore decide from traversal metadata, not from whether a
-rendered block body is empty, whether a preview entry is semantically real. If
-that boundary loses semantic data such as Lean preview keys, downstream
-fallbacks should report or copy the existing traversal metadata rather than
-reconstruct it from rendered markup.
+visible text comes from an external source. Relation indexes are installed once
+when traversal state becomes `PreparedPreviewState`; manifest assembly does not
+silently recover missing indexes by rescanning all stored blocks.
+For `b` stored blocks and `e` dependency uses, preparation is `O(b + e)` and
+relation assembly consumes the cached rows; direct construction therefore
+cannot regress to the former `O(b²)` full-store fallback path.
+`buildPreviewDataFiles` is the normalization point where those traversal facts
+become documented generated data. It must therefore decide from traversal
+metadata, not from whether a rendered block body is empty, whether a preview
+entry is semantically real. If that boundary loses semantic data such as Lean
+preview keys, downstream fallbacks should report or copy the existing traversal
+metadata rather than reconstruct it from rendered markup.
 
 Serialized preview references are finalized at this boundary. Relation entries,
 graph nodes, graph variants, and Lean-code associations may start from

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -65,7 +65,9 @@ finalizes their preview references before emission. Use `check` when validating
 persisted, copied, or externally supplied output; it deliberately performs
 stricter cross-artifact and graph-projection checks than ordinary semantic
 queries. The graph-backed `work-queue` selector also retains strict graph
-decoding; graph-free selectors avoid materializing graph projections.
+decoding; graph-free selectors avoid materializing graph projections. Query
+arguments are parsed into a validated plan before any generated file is read,
+so unknown or malformed selectors fail without paying manifest-decoding cost.
 
 Treat `vbp` JSON as fully unstable. It may change within this repository as
 agent workflows evolve, and is not part of the documented integration API.

--- a/skills/verso-blueprint/references/vbp.md
+++ b/skills/verso-blueprint/references/vbp.md
@@ -74,7 +74,7 @@ generated data also prints an error to stderr and exits nonzero.
 
 ## Query Output
 
-All query commands print compact JSON for agent consumption. The JSON shape is fully unstable today; do not treat it as a compatibility contract. Top-level query objects include `"apiStability":"unstable"`. Query reads the semantic manifest only; use `check` when you need to validate the rendered HTML cache as well.
+All query commands print compact JSON for agent consumption. The JSON shape is fully unstable today; do not treat it as a compatibility contract. Top-level query objects include `"apiStability":"unstable"`. Query arguments are validated before generated data is read, so unknown or malformed selectors do not require a built site. Query reads the semantic manifest only for valid selectors; use `check` when you need to validate the rendered HTML cache as well.
 
 - `selectors`: query selector forms supported by this `vbp` binary. This selector does not require generated Blueprint data.
 - `labels`: statement-level Blueprint block summaries.

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -1195,6 +1195,24 @@ def readFile (path : System.FilePath) : IO File := do
 end HtmlCache
 
 /--
+Traversal state whose relation indexes have been prepared for preview-data
+construction.
+
+The standard HTML pipeline installs these indexes before rendering. Direct
+callers cross this boundary explicitly through `prepare` so manifest assembly
+never falls back to repeatedly scanning the full stored-block collection.
+-/
+structure PreparedPreviewState where private mk ::
+  state : TraverseState
+
+/-- Install the relation indexes required by preview-data construction. -/
+def PreparedPreviewState.prepare (state : TraverseState) : PreparedPreviewState :=
+  PreparedPreviewState.mk (Informal.RelatedPanel.patchRelationCaches state)
+
+private def PreparedPreviewState.ofPatched (state : TraverseState) : PreparedPreviewState :=
+  PreparedPreviewState.mk state
+
+/--
 Assembled preview-data candidates before rendered-preview references are
 resolved against the paired manifest and HTML cache.
 -/
@@ -1273,13 +1291,15 @@ Indexes over the generated manifest/cache pair used to decide whether a
 serialized preview reference can render.
 -/
 structure PreviewArtifactIndex where
-  manifestIndex : Index := {}
-  htmlCacheIndex : HtmlCache.Index := {}
+  manifestKeys : Std.HashSet String := {}
+  htmlCacheKeys : Std.HashSet String := {}
 
 private def PreviewArtifactIndex.ofArtifacts
     (manifest : File) (htmlCache : HtmlCache.File) : PreviewArtifactIndex := {
-  manifestIndex := manifest.index
-  htmlCacheIndex := htmlCache.index
+  manifestKeys :=
+    manifest.previews.foldl (fun keys entry => keys.insert entry.key) {}
+  htmlCacheKeys :=
+    htmlCache.entries.foldl (fun keys entry => keys.insert entry.key) {}
 }
 
 def PreviewArtifactIndex.ofModel (model : PreviewDataModel) : PreviewArtifactIndex :=
@@ -1290,11 +1310,11 @@ def PreviewArtifactIndex.ofPersistedFiles (files : PersistedFiles) : PreviewArti
 
 def PreviewArtifactIndex.hasManifestKey
     (index : PreviewArtifactIndex) (key : String) : Bool :=
-  (index.manifestIndex.findEntry? key).isSome
+  index.manifestKeys.contains key
 
 def PreviewArtifactIndex.hasCacheKey
     (index : PreviewArtifactIndex) (key : String) : Bool :=
-  (index.htmlCacheIndex.findEntry? key).isSome
+  index.htmlCacheKeys.contains key
 
 def PreviewArtifactIndex.resolves (index : PreviewArtifactIndex) (key : String) :
     Bool :=
@@ -2047,32 +2067,18 @@ private def buildUsesRelations
   labels.map fun label =>
     relatedEntryForLabel state label (relatedAxes blockData label)
 
-/--
-Read the reverse-dependency index installed after normal HTML traversal.
-The fallback keeps direct `buildPreviewDataFiles` callers with an unpatched
-traversal state correct.
--/
+/-- Read the reverse-dependency index installed during preview-state preparation. -/
 private def buildUsedByRelations
     (state : TraverseState)
     (blockData : Informal.BlockData) : Array RelatedEntry :=
-  match Informal.TraversalIndex.RelatedPanelUsedByCache.data? state blockData.label with
-  | some cachedEntries =>
-      cachedEntries.filterMap fun cached => do
-        let source ← blockInfo? state cached.sourceLabel
-        let axes : Array RelationAxis :=
-          if cached.inStatement then #[.statement] else #[]
-        let axes := if cached.inProof then axes.push .proof else axes
-        some <| relatedEntryForBlock state source axes
-  | none =>
-      Informal.collectStoredBlocks state |>.filterMap fun source =>
-        if source.label == blockData.label then
-          none
-        else
-          let axes := relatedAxes source blockData.label
-          if axes.isEmpty then
-            none
-          else
-            some <| relatedEntryForBlock state source axes
+  let cachedEntries :=
+    Informal.TraversalIndex.RelatedPanelUsedByCache.data? state blockData.label |>.getD #[]
+  cachedEntries.filterMap fun cached => do
+    let source ← blockInfo? state cached.sourceLabel
+    let axes : Array RelationAxis :=
+      if cached.inStatement then #[.statement] else #[]
+    let axes := if cached.inProof then axes.push .proof else axes
+    some <| relatedEntryForBlock state source axes
 
 private def groupRelationHeader
     (state : TraverseState)
@@ -2108,26 +2114,17 @@ private def buildGroupRelations (state : TraverseState) : Array GroupRelation :=
   return groups
 
 /--
-Resolve traversal-backed group metadata for one entry without storing it per
-entry. Normal HTML generation uses the cached member index; direct callers with
-an unpatched traversal state retain the full-store fallback.
+Resolve traversal-backed group metadata from the member index installed by the
+standard Blueprint traversal pipeline.
 -/
 def groupRelationForEntry? (state : TraverseState) (entry : Entry) : Option GroupRelation := do
   let parent ← entry.parent
-  let entries :=
-    match Informal.TraversalIndex.RelatedPanelGroupMembersCache.data? state parent with
-    | some labels =>
-        labels.filterMap fun label =>
-          if label == entry.label then
-            none
-          else
-            (blockInfo? state label).map (relatedEntryForBlock state)
-    | none =>
-        Informal.collectStoredBlocks state |>.filterMap fun blockData =>
-          if statementGroupParent? blockData == some parent && blockData.label != entry.label then
-            some <| relatedEntryForBlock state blockData
-          else
-            none
+  let labels ← Informal.TraversalIndex.RelatedPanelGroupMembersCache.data? state parent
+  let entries := labels.filterMap fun label =>
+    if label == entry.label then
+      none
+    else
+      (blockInfo? state label).map (relatedEntryForBlock state)
   let (title, declared) := groupRelationHeader state parent
   pure { label := parent, title, declared, entries }
 
@@ -2495,9 +2492,10 @@ the manifest, and keep rendered fragments in the HTML cache.
 def buildPreviewDataFiles
     (impls : ExtensionImpls)
     (logError : String → IO Unit)
-    (state : TraverseState)
+    (preparedState : PreparedPreviewState)
     (externalMarkupConfig : Informal.ExternalMarkupRender.Config := {})
     (verbose : Bool := false) : IO Files := do
+  let state := preparedState.state
   let hoverState := HtmlCache.initialHoverState
   let (traversalPreviews, traversalHtml, hoverState) ←
     withTimedBuildProgress verbose "building traversal preview entries" <|
@@ -2565,8 +2563,9 @@ private def dumpManifest
   let (_text, traverseState) ←
     ReaderT.run (Verso.Genre.Manual.traverseHtmlMulti traverseCfg text) extensionImpls
       |>.run (callbackLogger logError)
-  let traverseState := Informal.RelatedPanel.patchRelationCaches traverseState
-  let files ← buildPreviewDataFiles extensionImpls logError traverseState externalMarkupConfig
+  let preparedState := PreparedPreviewState.prepare traverseState
+  let traverseState := preparedState.state
+  let files ← buildPreviewDataFiles extensionImpls logError preparedState externalMarkupConfig
     (verbose := cfg.verbose)
   let logger := callbackLogger logError
   reportPreviewMetadataLossWarnings logger traverseState files.manifest
@@ -2594,8 +2593,9 @@ private def dumpHtmlCache
   let (_text, traverseState) ←
     ReaderT.run (Verso.Genre.Manual.traverseHtmlMulti traverseCfg text) extensionImpls
       |>.run (callbackLogger logError)
-  let traverseState := Informal.RelatedPanel.patchRelationCaches traverseState
-  let files ← buildPreviewDataFiles extensionImpls logError traverseState externalMarkupConfig
+  let preparedState := PreparedPreviewState.prepare traverseState
+  let traverseState := preparedState.state
+  let files ← buildPreviewDataFiles extensionImpls logError preparedState externalMarkupConfig
     (verbose := cfg.verbose)
   let logger := callbackLogger logError
   reportPreviewMetadataLossWarnings logger traverseState files.manifest
@@ -2634,7 +2634,8 @@ def emitBlueprintPreviewData
   let logger : Verso.Logger IO ← read
   let logError := fun msg => logger.reportError msg
   let modeDescription := htmlModeDescription mode
-  let files ← buildPreviewDataFiles extensionImpls logError state externalMarkupConfig
+  let files ← buildPreviewDataFiles extensionImpls logError
+    (PreparedPreviewState.ofPatched state) externalMarkupConfig
     (verbose := cfg.verbose)
   reportPreviewMetadataLossWarnings logger state files.manifest
   let countSummary :=

--- a/src/VersoBlueprint/Vbp.lean
+++ b/src/VersoBlueprint/Vbp.lean
@@ -28,29 +28,8 @@ def defaultOutput : FilePath := defaultSite
 
 def apiStability : String := "unstable"
 
-def querySelectorLines : List String := [
-  "selectors",
-  "labels",
-  "node <label>",
-  "uses <label>",
-  "used-by <label>",
-  "group <label>",
-  "owners",
-  "tags",
-  "work-queue",
-  "metadata",
-  "search <text>",
-  "code <decl>",
-  "stats"
-]
-
 def responseJson (fields : List (String × Json)) : Json :=
   Json.mkObj (("apiStability", Json.str apiStability) :: fields)
-
-def querySelectorsJson : Json :=
-  responseJson [
-    ("selectors", Json.arr (querySelectorLines.toArray.map Json.str))
-  ]
 
 def htmlDirForSite (site : FilePath) : IO FilePath := do
   if ← (site / "-verso-data" / Informal.PreviewManifest.manifestFilename).pathExists then
@@ -213,67 +192,149 @@ private def missingLabelJson (label : String) : Json :=
   ]
 
 private def withPrimaryEntry
-    (manifest : ManifestFile) (label : String) (mkJson : Entry → Json) : Except String Json :=
+    (manifest : ManifestFile) (label : String) (mkJson : Entry → Json) : Json :=
   match manifest.findPrimaryQueryableEntry? label with
-  | some entry => .ok (mkJson entry)
-  | none => .ok (missingLabelJson label)
+  | some entry => mkJson entry
+  | none => missingLabelJson label
+
+/-- A validated query and the manifest projection needed to execute it. -/
+structure QueryPlan where
+  /-- Whether execution requires reconstructing strict graph projections. -/
+  needsGraphData : Bool
+  /-- Execute the validated query against the selected manifest projection. -/
+  run : ManifestFile → Json
+
+private structure QuerySelector where
+  name : String
+  argumentName : String
+  needsGraphData : Bool
+  run : Sum (ManifestFile → Json) (String → ManifestFile → Json)
+
+private def QuerySelector.noArg
+    (name : String) (needsGraphData : Bool) (run : ManifestFile → Json) : QuerySelector :=
+  { name, argumentName := "", needsGraphData, run := .inl run }
+
+private def QuerySelector.oneArg
+    (name argumentName : String) (needsGraphData : Bool)
+    (run : String → ManifestFile → Json) : QuerySelector :=
+  { name, argumentName, needsGraphData, run := .inr run }
+
+private def QuerySelector.line (selector : QuerySelector) : String :=
+  match selector.run with
+  | .inl _ => selector.name
+  | .inr _ => s!"{selector.name} <{selector.argumentName}>"
+
+private def QuerySelector.plan? (selector : QuerySelector) (args : List String) : Option QueryPlan :=
+  match selector.run, args with
+  | .inl run, [name] =>
+      if name == selector.name then
+        some { needsGraphData := selector.needsGraphData, run }
+      else
+        none
+  | .inr run, [name, argument] =>
+      if name == selector.name then
+        some {
+          needsGraphData := selector.needsGraphData
+          run := run argument
+        }
+      else
+        none
+  | _, _ => none
+
+private def querySelectors : List QuerySelector := [
+  QuerySelector.noArg "labels" false fun manifest =>
+    responseJson [
+      ("labels", Json.arr (manifest.queryableStatementEntries.map entrySummaryJson))
+    ],
+  QuerySelector.oneArg "node" "label" false fun label manifest =>
+    withPrimaryEntry manifest label (entryResponseJson manifest),
+  QuerySelector.oneArg "uses" "label" false fun label manifest =>
+    withPrimaryEntry manifest label fun entry =>
+      responseJson [
+        ("label", Json.str label),
+        ("statementUses", Json.arr (entry.statementUses.map useRefJson)),
+        ("proofUses", Json.arr (entry.proofUses.map useRefJson)),
+        ("uses", Json.arr (entry.uses.map relatedEntryJson))
+      ],
+  QuerySelector.oneArg "used-by" "label" false fun label manifest =>
+    withPrimaryEntry manifest label fun entry =>
+      responseJson [
+        ("label", Json.str label),
+        ("usedBy", Json.arr (entry.usedBy.map relatedEntryJson))
+      ],
+  QuerySelector.oneArg "group" "label" false fun label manifest =>
+    withPrimaryEntry manifest label fun entry =>
+      responseJson [
+        ("label", Json.str label),
+        ("group", entryGroupJson manifest entry)
+      ],
+  QuerySelector.noArg "owners" false fun manifest =>
+    responseJson [("owners", stringArrayJson manifest.ownerValues)],
+  QuerySelector.noArg "tags" false fun manifest =>
+    responseJson [("tags", stringArrayJson manifest.tagValues)],
+  QuerySelector.noArg "work-queue" true fun manifest =>
+    responseJson [
+      ("entries", Json.arr (manifest.workQueueItems.map workQueueItemJson))
+    ],
+  QuerySelector.noArg "metadata" false fun manifest =>
+    responseJson [
+      ("entries", Json.arr (manifest.metadataEntries.map entrySummaryJson))
+    ],
+  QuerySelector.oneArg "search" "text" false fun text manifest =>
+    responseJson [
+      ("query", Json.str text),
+      ("labels", Json.arr (manifest.queryableStatementEntries |>.filter
+        (fun entry => entry.matchesText text) |>.map entrySummaryJson))
+    ],
+  QuerySelector.oneArg "code" "decl" false fun decl manifest =>
+    responseJson [
+      ("query", Json.str decl),
+      ("labels", Json.arr (manifest.queryableStatementEntries |>.filter
+        (fun entry => entry.matchesCode decl) |>.map entrySummaryJson))
+    ],
+  QuerySelector.noArg "stats" false statsJson
+]
+
+def querySelectorLines : List String :=
+  "selectors" :: querySelectors.map QuerySelector.line
+
+def querySelectorsJson : Json :=
+  responseJson [
+    ("selectors", Json.arr (querySelectorLines.toArray.map Json.str))
+  ]
+
+private def findQueryPlan? (args : List String) : List QuerySelector → Option QueryPlan
+  | [] => none
+  | selector :: selectors =>
+      selector.plan? args |>.orElse (fun _ => findQueryPlan? args selectors)
+
+private def findQuerySelector? (name : String) : List QuerySelector → Option QuerySelector
+  | [] => none
+  | selector :: selectors =>
+      if selector.name == name then some selector else findQuerySelector? name selectors
+
+/-- Parse and validate a query before reading any generated data. -/
+def parseQueryPlan (args : List String) : Except String (Option QueryPlan) :=
+  match args with
+  | ["selectors"] => .ok none
+  | [] => .error "missing query selector"
+  | name :: _ =>
+      match findQueryPlan? args querySelectors with
+      | some plan => .ok (some plan)
+      | none =>
+          if name == "selectors" then
+            .error "invalid arguments for query selector 'selectors'; expected 'selectors'"
+          else
+            match findQuerySelector? name querySelectors with
+            | some selector =>
+                .error s!"invalid arguments for query selector '{name}'; expected '{selector.line}'"
+            | none => .error s!"unknown query selector '{name}'"
 
 def queryJson (manifest : ManifestFile) (args : List String) : Except String Json :=
-  match args with
-  | ["selectors"] =>
-      .ok querySelectorsJson
-  | ["labels"] =>
-      .ok <| responseJson [
-        ("labels", Json.arr (manifest.queryableStatementEntries.map entrySummaryJson))
-      ]
-  | ["node", label] =>
-      withPrimaryEntry manifest label (entryResponseJson manifest)
-  | ["uses", label] =>
-      withPrimaryEntry manifest label fun entry =>
-        responseJson [
-          ("label", Json.str label),
-          ("statementUses", Json.arr (entry.statementUses.map useRefJson)),
-          ("proofUses", Json.arr (entry.proofUses.map useRefJson)),
-          ("uses", Json.arr (entry.uses.map relatedEntryJson))
-        ]
-  | ["used-by", label] =>
-      withPrimaryEntry manifest label fun entry =>
-        responseJson [
-          ("label", Json.str label),
-          ("usedBy", Json.arr (entry.usedBy.map relatedEntryJson))
-        ]
-  | ["group", label] =>
-      withPrimaryEntry manifest label fun entry =>
-        responseJson [
-          ("label", Json.str label),
-          ("group", entryGroupJson manifest entry)
-        ]
-  | ["owners"] =>
-      .ok <| responseJson [("owners", stringArrayJson manifest.ownerValues)]
-  | ["tags"] =>
-      .ok <| responseJson [("tags", stringArrayJson manifest.tagValues)]
-  | ["work-queue"] =>
-      .ok <| responseJson [
-        ("entries", Json.arr (manifest.workQueueItems.map workQueueItemJson))
-      ]
-  | ["metadata"] =>
-      .ok <| responseJson [
-        ("entries", Json.arr (manifest.metadataEntries.map entrySummaryJson))
-      ]
-  | ["search", text] =>
-      .ok <| responseJson [
-        ("query", Json.str text),
-        ("labels", Json.arr (manifest.queryableStatementEntries |>.filter (fun entry => entry.matchesText text) |>.map entrySummaryJson))
-      ]
-  | ["code", decl] =>
-      .ok <| responseJson [
-        ("query", Json.str decl),
-        ("labels", Json.arr (manifest.queryableStatementEntries |>.filter (fun entry => entry.matchesCode decl) |>.map entrySummaryJson))
-      ]
-  | ["stats"] =>
-      .ok (statsJson manifest)
-  | [] => .error "missing query selector"
-  | selector :: _ => .error s!"unknown query selector '{selector}'"
+  match parseQueryPlan args with
+  | .ok none => .ok querySelectorsJson
+  | .ok (some plan) => .ok (plan.run manifest)
+  | .error err => .error err
 
 private def readManifestWith
     (read : FilePath → IO ManifestFile) (site : FilePath) : IO ManifestFile := do
@@ -285,30 +346,9 @@ private def readManifestWith
 def readManifestForSite (site : FilePath) : IO ManifestFile :=
   readManifestWith Informal.PreviewManifest.readFile site
 
-/--
-Whether a query must use the strict manifest reader that reconstructs graph data.
-
-Graph-free loading is an explicit allowlist. Unknown or newly added selector
-shapes default to strict loading so they cannot silently observe an empty graph
-projection when their read mode has not yet been classified.
--/
-def queryNeedsGraphData : List String → Bool
-  | ["selectors"]
-  | ["labels"]
-  | ["node", _]
-  | ["uses", _]
-  | ["used-by", _]
-  | ["group", _]
-  | ["owners"]
-  | ["tags"]
-  | ["metadata"]
-  | ["search", _]
-  | ["code", _]
-  | ["stats"] => false
-  | _ => true
-
-def readManifestForQuery (site : FilePath) (selector : List String) : IO ManifestFile := do
-  if queryNeedsGraphData selector then
+/-- Read exactly the manifest projection required by a validated query. -/
+def readManifestForQuery (site : FilePath) (plan : QueryPlan) : IO ManifestFile := do
+  if plan.needsGraphData then
     readManifestForSite site
   else
     readManifestWith Informal.PreviewManifest.readFileWithoutGraphs site

--- a/src/VersoBlueprint/VbpMain.lean
+++ b/src/VersoBlueprint/VbpMain.lean
@@ -457,20 +457,18 @@ def query (args : List String) : IO UInt32 := do
       IO.eprintln err
       pure 2
   | .ok opts =>
-      match opts.rest with
-      | ["selectors"] =>
+      match VersoBlueprint.Vbp.parseQueryPlan opts.rest with
+      | .error err =>
+          IO.eprintln err
+          pure 2
+      | .ok none =>
           printJson VersoBlueprint.Vbp.querySelectorsJson
           pure 0
-      | _ =>
+      | .ok (some plan) =>
           try
-            let manifest ← VersoBlueprint.Vbp.readManifestForQuery opts.site opts.rest
-            match VersoBlueprint.Vbp.queryJson manifest opts.rest with
-            | .ok json =>
-                printJson json
-                pure 0
-            | .error err =>
-                IO.eprintln err
-                pure 2
+            let manifest ← VersoBlueprint.Vbp.readManifestForQuery opts.site plan
+            printJson (plan.run manifest)
+            pure 0
           catch err =>
             IO.eprintln err.toString
             pure 1

--- a/tests/VersoBlueprintTests/Blueprint/Support.lean
+++ b/tests/VersoBlueprintTests/Blueprint/Support.lean
@@ -91,7 +91,8 @@ def buildManualPreviewDataFiles
     (logError : String → IO Unit := fun _ => pure ()) :
     IO Informal.PreviewManifest.Files := do
   let (_html, st) ← renderManualDocHtmlStringAndState impls doc
-  Informal.PreviewManifest.buildPreviewDataFiles impls logError st
+  Informal.PreviewManifest.buildPreviewDataFiles impls logError
+    (Informal.PreviewManifest.PreparedPreviewState.prepare st)
 
 def findExtraJsContaining? (st : TraverseState) (needle : String) : Option String :=
   st.toHtmlAssets.extraJs.toArray.findSome? fun js =>

--- a/tests/VersoBlueprintTests/BlueprintExternalMarkup.lean
+++ b/tests/VersoBlueprintTests/BlueprintExternalMarkup.lean
@@ -15,6 +15,10 @@ open Verso.VersoBlueprintTests.Blueprint.Support
 
 namespace Verso.VersoBlueprintTests.BlueprintExternalMarkup
 
+private def preparePreviewState (state : TraverseState) :
+    Informal.PreviewManifest.PreparedPreviewState :=
+  Informal.PreviewManifest.PreparedPreviewState.prepare state
+
 private def externalMarkupRaw?
     (sources : Informal.Data.ExternalMarkupSet)
     (language : Informal.Data.ExternalMarkupLanguage)
@@ -549,7 +553,8 @@ external markup.
     let (showcaseHtml, showcaseState) ←
       renderManualDocHtmlStringAndState extension_impls% externalMarkupShowcaseDoc
     let showcaseFiles ←
-      Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ()) showcaseState
+      Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ())
+        (preparePreviewState showcaseState)
     let manifest := showcaseFiles.manifest
     let nativeKey := Informal.PreviewCache.statementKey (Name.mkSimple "showcase.visible.attachments")
     let theorem21Key :=
@@ -722,7 +727,8 @@ external markup.
     let (_showcaseHtml, showcaseState) ←
       renderManualDocHtmlStringAndState extension_impls% externalMarkupShowcaseDoc
     let showcaseFiles ←
-      Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ()) showcaseState
+      Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ())
+        (preparePreviewState showcaseState)
         ({ mode := .none } : Informal.ExternalMarkupRender.Config)
     let theorem21Label := Name.mkSimple "ImportedPaper:Theorem2.1"
     let proposition24Label := Name.mkSimple "ImportedPaper:Proposition2.4"
@@ -813,16 +819,18 @@ external markup.
     let traversed := (Informal.TraversalIndex.ExternalMarkup.data? externalState (Name.mkSimple "external.markup")).map (·.markup) |>.getD {}
     let traversedTex := externalMarkupRaw? traversed .tex "statement" |>.getD ""
     let traversedMd := externalMarkupRaw? traversed .markdown "proof" |>.getD ""
-    let externalFiles ← Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ()) externalState
+    let externalFiles ← Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ())
+      (preparePreviewState externalState)
     let externalBlockKey := Informal.PreviewCache.statementKey (Name.mkSimple "external.markup")
     let externalMarkupOnlyKey := Informal.PreviewManifest.externalMarkupEntryKey (Name.mkSimple "external.markup")
     let some externalBlockEntry := externalFiles.manifest.previews.find? (fun entry => entry.key == externalBlockKey)
       | return false
     let (_witnessOut, witnessState) ← renderManualDocHtmlStringAndState extension_impls% externalMarkupWitnessDoc
-    let witnessFiles ← Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ()) witnessState
-    let witnessFilesNoRender ← Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ()) witnessState
+    let preparedWitnessState := preparePreviewState witnessState
+    let witnessFiles ← Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ()) preparedWitnessState
+    let witnessFilesNoRender ← Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ()) preparedWitnessState
       ({ mode := .none } : Informal.ExternalMarkupRender.Config)
-    let witnessFilesNoNotice ← Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ()) witnessState
+    let witnessFilesNoNotice ← Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ()) preparedWitnessState
       ({ showSourceNotice := false } : Informal.ExternalMarkupRender.Config)
     let witnessKey := Informal.PreviewManifest.externalMarkupEntryKey (Name.mkSimple "external.witness")
     let some witnessEntry := witnessFiles.manifest.previews.find? (fun entry => entry.key == witnessKey)
@@ -832,12 +840,14 @@ external markup.
     let some witnessHtmlNoNotice := witnessFilesNoNotice.htmlCache.findHtml? witnessKey
       | return false
     let (_markdownOut, markdownState) ← renderManualDocHtmlStringAndState extension_impls% externalMarkdownWitnessDoc
-    let markdownFiles ← Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ()) markdownState
+    let markdownFiles ← Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ())
+      (preparePreviewState markdownState)
     let markdownKey := Informal.PreviewManifest.externalMarkupEntryKey (Name.mkSimple "external.markdown.witness")
     let some markdownHtml := markdownFiles.htmlCache.findHtml? markdownKey
       | return false
     let (_bodylessOut, bodylessState) ← renderManualDocHtmlStringAndState extension_impls% externalBodylessLeanWitnessDoc
-    let bodylessFiles ← Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ()) bodylessState
+    let bodylessFiles ← Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ())
+      (preparePreviewState bodylessState)
     let bodylessKey := Informal.PreviewManifest.externalMarkupEntryKey (Name.mkSimple "external.bodyless.lean")
     let some bodylessEntry := bodylessFiles.manifest.previews.find? (fun entry => entry.key == bodylessKey)
       | return false
@@ -846,7 +856,8 @@ external markup.
     let (_punctuationOut, punctuationState) ←
       renderManualDocHtmlStringAndState extension_impls% externalPunctuationBodylessLeanWitnessDoc
     let punctuationFiles ←
-      Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ()) punctuationState
+      Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ())
+        (preparePreviewState punctuationState)
     let punctuationLabel := Name.mkSimple "Chapter4:Theorem4.2.1"
     let punctuationKey := Informal.PreviewManifest.externalMarkupEntryKey punctuationLabel
     let some punctuationEntry := punctuationFiles.manifest.previews.find? (fun entry => entry.key == punctuationKey)
@@ -888,7 +899,8 @@ external markup.
       | return false
     let brokenBodylessLossMessage := brokenBodylessLoss.warningMessage
     let (_sourcedWitnessOut, sourcedWitnessState) ← renderManualDocHtmlStringAndState extension_impls% sourcedExternalMarkupWitnessDoc
-    let sourcedWitnessFiles ← Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ()) sourcedWitnessState
+    let sourcedWitnessFiles ← Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ())
+      (preparePreviewState sourcedWitnessState)
     let sourcedWitnessKey :=
       Informal.PreviewManifest.externalMarkupEntryKey (Name.mkSimple "external.sourced.witness")
     let some sourcedWitnessEntry :=

--- a/tests/VersoBlueprintTests/BlueprintPreviewSource.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewSource.lean
@@ -196,7 +196,8 @@ namespace Verso.VersoBlueprintTests.BlueprintPreviewSource
       Verso.VersoBlueprintTests.BlueprintPreviewSource.Provider.externalMarkupGraphPreviewSourceDoc
     let label := Name.mkSimple "preview.external_graph_bodyless"
     let externalKey := Informal.PreviewSource.externalMarkupKey label
-    let files ← Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ()) st
+    let files ← Informal.PreviewManifest.buildPreviewDataFiles extension_impls% (fun _ => pure ())
+      (Informal.PreviewManifest.PreparedPreviewState.prepare st)
       ({ mode := .none } : Informal.ExternalMarkupRender.Config)
     let some entry := files.manifest.previews.find? (fun entry => entry.key == externalKey)
       | return false

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/Graph.lean
@@ -190,7 +190,8 @@ Base statement for graph preview mode option coverage.
           Informal.TraversalIndex.Graphs.domainName malformedKey (Lean.Json.str "malformed")
     let errors ← IO.mkRef #[]
     let files ← Informal.PreviewManifest.buildPreviewDataFiles manualImpls
-      (fun msg => errors.modify (·.push msg)) state
+      (fun msg => errors.modify (·.push msg))
+      (Informal.PreviewManifest.PreparedPreviewState.prepare state)
     let errors ← errors.get
     pure <|
       !files.manifest.graphs.isEmpty &&

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -697,9 +697,17 @@ private def queryReadModeExamples : List (String × List String × Bool) := [
     queryReadModeExamples.map (fun (selector, _, _) => selector) ==
         VersoBlueprint.Vbp.querySelectorLines &&
       (queryReadModeExamples.all fun (_, args, needsGraphData) =>
-        VersoBlueprint.Vbp.queryNeedsGraphData args == needsGraphData) &&
-      VersoBlueprint.Vbp.queryNeedsGraphData ["future-selector"] &&
-      VersoBlueprint.Vbp.queryNeedsGraphData ["node"]
+        match VersoBlueprint.Vbp.parseQueryPlan args with
+        | .ok none => !needsGraphData
+        | .ok (some plan) => plan.needsGraphData == needsGraphData
+        | .error _ => false) &&
+      (match VersoBlueprint.Vbp.parseQueryPlan ["future-selector"] with
+       | .error err => err == "unknown query selector 'future-selector'"
+       | .ok _ => false) &&
+      (match VersoBlueprint.Vbp.parseQueryPlan ["node"] with
+       | .error err =>
+           err == "invalid arguments for query selector 'node'; expected 'node <label>'"
+       | .ok _ => false)
 
 /-- info: true -/
 #guard_msgs in
@@ -1260,14 +1268,20 @@ private def queryReadModeExamples : List (String × List String × Bool) := [
   let site ← freshVbpFixtureRoot
   writeRawManifestOnlySite site (toJson sampleGraphReferenceManifest)
   let strictManifest ← VersoBlueprint.Vbp.readManifestForSite site
-  let queryManifests ← queryReadModeExamples.mapM
+  let queryManifests ← queryReadModeExamples.filterMapM
       (fun (queryMode : String × List String × Bool) => do
         let args := queryMode.2.1
         let needsGraphData := queryMode.2.2
-        let manifest ← VersoBlueprint.Vbp.readManifestForQuery site args
-        pure (manifest, needsGraphData))
-  let unknownManifest ←
-    VersoBlueprint.Vbp.readManifestForQuery site ["future-selector"]
+        match VersoBlueprint.Vbp.parseQueryPlan args with
+        | .ok none => pure none
+        | .ok (some plan) =>
+            let manifest ← VersoBlueprint.Vbp.readManifestForQuery site plan
+            pure (some (manifest, needsGraphData))
+        | .error err => throw <| IO.userError err)
+  let unknownRejectedBeforeRead :=
+    match VersoBlueprint.Vbp.parseQueryPlan ["future-selector"] with
+    | .error _ => true
+    | .ok _ => false
   pure <|
     strictManifest.graphs.size == 1 &&
       queryManifests.all (fun (manifest, needsGraphData) =>
@@ -1276,7 +1290,7 @@ private def queryReadModeExamples : List (String × List String × Bool) := [
               (fun entry : Informal.PreviewManifest.Entry => entry.key) ==
             sampleGraphReferenceManifest.previews.map
               (fun entry : Informal.PreviewManifest.Entry => entry.key)) &&
-      unknownManifest.graphs.size == 1
+      unknownRejectedBeforeRead
 
 /-- info: true -/
 #guard_msgs in
@@ -1292,7 +1306,11 @@ private def queryReadModeExamples : List (String × List String × Bool) := [
         if needsGraphData then
           pure none
         else
-          some <$> VersoBlueprint.Vbp.readManifestForQuery site args)
+          match VersoBlueprint.Vbp.parseQueryPlan args with
+          | .ok none => pure none
+          | .ok (some plan) =>
+              some <$> VersoBlueprint.Vbp.readManifestForQuery site plan
+          | .error err => throw <| IO.userError err)
   let strictRejected ←
     try
       let _ ← VersoBlueprint.Vbp.readManifestForSite site
@@ -1300,23 +1318,24 @@ private def queryReadModeExamples : List (String × List String × Bool) := [
     catch _ =>
       pure true
   let workQueueRejected ←
-    try
-      let _ ← VersoBlueprint.Vbp.readManifestForQuery site ["work-queue"]
-      pure false
-    catch _ =>
-      pure true
-  let unknownRejected ←
-    try
-      let _ ← VersoBlueprint.Vbp.readManifestForQuery site ["future-selector"]
-      pure false
-    catch _ =>
-      pure true
+    match VersoBlueprint.Vbp.parseQueryPlan ["work-queue"] with
+    | .ok (some plan) =>
+        try
+          let _ ← VersoBlueprint.Vbp.readManifestForQuery site plan
+          pure false
+        catch _ =>
+          pure true
+    | _ => pure false
+  let unknownRejectedBeforeRead :=
+    match VersoBlueprint.Vbp.parseQueryPlan ["future-selector"] with
+    | .error _ => true
+    | .ok _ => false
   pure <|
     graphFreeManifests.all (fun manifest =>
       manifest.previews.size == sampleManifest.previews.size && manifest.graphs.isEmpty) &&
       strictRejected &&
       workQueueRejected &&
-      unknownRejected
+      unknownRejectedBeforeRead
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/harness/test_verso_blueprint_skill.py
+++ b/tests/harness/test_verso_blueprint_skill.py
@@ -51,6 +51,7 @@ class VersoBlueprintSkillTests(unittest.TestCase):
         self.assertIn("`--port` is accepted only with `--serve`", text)
         self.assertIn('"apiStability":"unstable"', text)
         self.assertIn("discoveryErrors", text)
+        self.assertIn("validated before generated data is read", text)
         self.assertIn("Query reads the semantic manifest only", text)
         self.assertIn("topLevelBlueprintModuleGuess", text)
         self.assertIn("chapterCandidateGuesses", text)


### PR DESCRIPTION
This PR makes generated-data construction phases explicit and removes three ways those phases could drift:

- preview-data callers now pass `PreparedPreviewState`, so relation indexes are built once in `O(blocks + uses)` instead of retaining hidden worst-case `O(blocks²)` fallback scans;
- finalization retains membership-only key sets rather than full manifest/cache indexes; on the current FLT artifact (586 manifest entries, 13 groups, and 586 cache entries), this removes 1,185 auxiliary value slots and the entire group index while preserving the same 1,172 membership keys;
- `vbp query` parses one `QueryPlan` before artifact I/O, with selector syntax, help text, graph-read mode, and execution declared together. Unknown and malformed selectors now read zero generated files.

Generated manifest/cache schemas and output are unchanged.

Backport v4.32.0: #390