### PR TITLE
chore: refresh reference Blueprint catalog

### DIFF
--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -63,7 +63,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "7f7fb9eb8770497625d5155af52921281093fe2b",
+          "ref": "9220a24438ab2e3aa00e734dd00dfa2ddc12f8d6",
           "publish_reference": true
         }
       ],
@@ -88,7 +88,7 @@
       "targets": [
         {
           "release": "v4.33.0",
-          "ref": "e4f15950fc128b024fc1872d7178d30b29094e64",
+          "ref": "4959dcd22133cebf2697919d0c822874115a95cd",
           "publish_reference": true,
           "reference_toolchain": "v4.33.0-rc1"
         }
@@ -114,7 +114,7 @@
       "targets": [
         {
           "release": "v4.33.0",
-          "ref": "275d7562958693065a012a74026432b3bd6598b7",
+          "ref": "15f3cc5552342b78a399043c88f581168dabfd1a",
           "publish_reference": true,
           "reference_toolchain": "v4.33.0-rc1"
         }


### PR DESCRIPTION
This PR points the reference Blueprint catalog at the final remotely validated wrapper revisions.

- Refresh Sphere Packing, FLT, and Carleson refs after their post-controller full site/PDF checks passed.

Backport v4.32.0: #393