### PR TITLE
[backport v4.32.0] chore: refresh reference Blueprint catalog

### DIFF
--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -49,7 +49,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "7f7fb9eb8770497625d5155af52921281093fe2b",
+          "ref": "9220a24438ab2e3aa00e734dd00dfa2ddc12f8d6",
           "publish_reference": true
         }
       ],


### PR DESCRIPTION
## Summary
Backport #392 to `v4.32.0`.

## Primary Review
- Primary review: #392
- Keep review comments on #392 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.32.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- The v4.32 catalog updates Sphere Packing only.
- FLT and Carleson are intentionally absent because their current supported targets are v4.33; the maintenance line must not build legacy wrapper versions.