### PR TITLE
[backport v4.32.0] perf: scan external hover markers once

### DIFF
--- a/src/VersoBlueprint/ExternalDeclRender.lean
+++ b/src/VersoBlueprint/ExternalDeclRender.lean
@@ -80,6 +80,9 @@ private def externalDeclHoverInlineMarkerPrefix : String :=
 private def externalDeclHoverInlineMarkerSuffix : String :=
   "></span>"
 
+private def externalDeclHoverMarkerNamePrefix : String :=
+  "data-bp-external-hover-"
+
 private inductive ExternalDeclHoverMarkerKind where
   | attr
   | inline
@@ -108,20 +111,18 @@ private def parseExternalDeclHoverInlineMarker?
   else
     none
 
-private def findNextExternalDeclHoverMarker?
+private partial def findNextExternalDeclHoverMarker?
     (html : String) (pos : html.Pos) :
-    Option (ExternalDeclHoverMarkerKind × html.Pos) :=
-  let attrPos? := pos.find? externalDeclHoverLocalAttrPrefix
-  let inlinePos? := pos.find? externalDeclHoverInlineMarkerPrefix
-  match attrPos?, inlinePos? with
-  | none, none => none
-  | some attrPos, none => some (.attr, attrPos)
-  | none, some inlinePos => some (.inline, inlinePos)
-  | some attrPos, some inlinePos =>
-      if attrPos <= inlinePos then
-        some (.attr, attrPos)
-      else
-        some (.inline, inlinePos)
+    Option (ExternalDeclHoverMarkerKind × html.Pos) := do
+  let markerNamePos ← pos.find? externalDeclHoverMarkerNamePrefix
+  if (html.sliceFrom markerNamePos).startsWith externalDeclHoverLocalAttrPrefix then
+    some (.attr, markerNamePos)
+  else
+    let inlinePos := markerNamePos.prevn "<span ".length
+    if (html.sliceFrom inlinePos).startsWith externalDeclHoverInlineMarkerPrefix then
+      some (.inline, inlinePos)
+    else
+      markerNamePos.next?.bind (findNextExternalDeclHoverMarker? html)
 
 private partial def rewriteExternalDeclHoverTemplateLoop
     (html : String)

--- a/tests/VersoBlueprintTests/ExternalDeclRender.lean
+++ b/tests/VersoBlueprintTests/ExternalDeclRender.lean
@@ -191,6 +191,24 @@ private def htmlTestContext :
 /-- info: true -/
 #guard_msgs in
 #eval
+  let rendered : Informal.ExternalDeclRenderedHtml := {
+    html :=
+      "before data-bp-external-hover-local=\"1\" " ++
+      "literal data-bp-external-hover-not-a-marker " ++
+      "<span data-bp-external-hover-inline-local=\"2\"></span> after"
+    hoverPayloads := #[]
+  }
+  let rewrites : Array Informal.ExternalDeclHoverRewrite := #[
+    { localId := 1, attrReplacement := "data-verso-hover=\"11\"", inlineReplacement := "" },
+    { localId := 2, attrReplacement := "data-verso-hover=\"12\"", inlineReplacement := "INLINE" }
+  ]
+  rendered.rewriteHovers rewrites ==
+    "before data-verso-hover=\"11\" " ++
+    "literal data-bp-external-hover-not-a-marker INLINE after"
+
+/-- info: true -/
+#guard_msgs in
+#eval
   show Lean.CoreM Bool from do
     let opts ← Lean.getOptions
     let ref ← Informal.externalRefSnapshotAtCurrentDir opts (Informal.Data.ExternalRef.ofName `Nat.add)


### PR DESCRIPTION
## Summary
Backport #391 to `v4.32.0`.

## Primary Review
- Primary review: #391
- Keep review comments on #391 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.32.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.
