### PR TITLE
chore: refresh reference Blueprint catalog

### DIFF
--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -63,7 +63,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "9220a24438ab2e3aa00e734dd00dfa2ddc12f8d6",
+          "ref": "0121bd1bcc16f715af1a1b967cc54b809693e133",
           "publish_reference": true
         }
       ],
@@ -88,7 +88,7 @@
       "targets": [
         {
           "release": "v4.33.0",
-          "ref": "4959dcd22133cebf2697919d0c822874115a95cd",
+          "ref": "bd61292109bf01d6ffb4b262aa10d245fdcf1d5d",
           "publish_reference": true,
           "reference_toolchain": "v4.33.0-rc1"
         }
@@ -114,7 +114,7 @@
       "targets": [
         {
           "release": "v4.33.0",
-          "ref": "15f3cc5552342b78a399043c88f581168dabfd1a",
+          "ref": "1d40dcbe5c152f03fb9156362100587fcfc6ec9c",
           "publish_reference": true,
           "reference_toolchain": "v4.33.0-rc1"
         }


### PR DESCRIPTION
This PR refreshes the maintained reference Blueprint catalog after advancing the wrappers to the current VBP release heads.

- Point v4.33 FLT at bd612921 and Carleson at 1d40dcbe.
- Point v4.32 Sphere Packing at 0121bd1b.
- Keep each Blueprint only on its intended maintained release line.

Backport v4.32.0: #400