### PR TITLE
[backport v4.32.0] refactor: make renderer state preparation explicit

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -172,10 +172,17 @@ In practice:
 Generator-side data flow is source-to-traversal-to-public JSON. During Manual
 traversal, Blueprint records preview identities, rendered bodies, Lean-code
 associations, citations, graph data, and external-markup witnesses in traversal
-state and traversal domains. Before assembly, the state crosses the explicit
-`PreparedPreviewState` boundary, which installs the relation indexes consumed by
-manifest construction. The standard HTML pipeline supplies an already-prepared
-state; direct callers use `PreparedPreviewState.prepare`.
+state and traversal domains. Before HTML emission, the standard pipeline crosses
+the explicit `PreparedRendererState` boundary. Renderer preparation applies the
+Blueprint HTML asset patches and owns the `PreparedPreviewState` that installs
+the relation indexes consumed by manifest construction. Verso's HTML emitters
+receive the projected traversal state, while Blueprint post-render
+`BlueprintExtraStep`s receive the prepared wrapper and therefore cannot assume
+that a raw state was patched by an earlier caller. Direct preview-data callers
+cross the narrower boundary with `PreparedPreviewState.prepare`. Custom steps
+passed to `blueprintMain` or `blueprintMainWithPreviewData` use
+`BlueprintExtraStep`; steps that need Verso's raw traversal state project it
+explicitly with `PreparedRendererState.state`.
 `Informal.PreviewManifest.buildPreviewDataFiles` then assembles a
 `PreviewDataModel` and crosses its `finish` boundary into the emission-ready
 semantic manifest/rendered-fragment-cache `Files` pair. The final type has a

--- a/doc/DESIGN_RATIONALE.md
+++ b/doc/DESIGN_RATIONALE.md
@@ -719,18 +719,33 @@ The generation boundary is:
 ```text
 Lean/Verso source modules
   -> Manual traversal state and traversal domains
-  -> PreviewManifest.buildPreviewDataFiles
-  -> blueprint-manifest.json and blueprint-html-cache.json
+  -> PreparedRendererState
+       |-> projected TraverseState -> Manual HTML emission
+       `-> BlueprintExtraStep post-render steps
+             `-> PreparedPreviewState
+                   -> PreviewManifest.buildPreviewDataFiles
+                   -> blueprint-manifest.json and blueprint-html-cache.json
   -> generated ESM APIs and browser/custom clients
 ```
 
 Traversal domains are richer than rendered page HTML. They carry semantic
 payloads for the current generator process, including bodyless directives whose
-visible text comes from an external source. Relation indexes are installed once
-when traversal state becomes `PreparedPreviewState`; manifest assembly does not
-silently recover missing indexes by rescanning all stored blocks.
-For `b` stored blocks and `e` dependency uses, preparation is `O(b + e)` and
-relation assembly consumes the cached rows; direct construction therefore
+visible text comes from an external source. The standard renderer turns raw
+traversal output into `PreparedRendererState` once, applying Blueprint's HTML
+asset patches and retaining a `PreparedPreviewState` projection for generated
+data. Verso's emitters receive the underlying traversal state, but Blueprint
+post-render steps receive the prepared wrapper; there is no raw-state escape
+hatch that lets preview-data emission merely assert that another caller already
+installed the required indexes. Direct preview-data callers explicitly create
+the narrower `PreparedPreviewState`.
+
+For `a` HTML assets, `b` stored blocks, and `e` dependency uses, renderer-state
+preparation is `O(a + b + e)`: the asset patch is linear in the asset set and
+relation-index construction is `O(b + e)`. The wrapper and its preview-state
+projection are `O(1)`, so each immediate, delayed-save, or resumed-emission path
+still performs one preparation pass. Resumed persisted state crosses the
+boundary again because its serialized raw type cannot witness preparation.
+Relation assembly consumes the cached rows; direct construction therefore
 cannot regress to the former `O(b²)` full-store fallback path.
 `buildPreviewDataFiles` is the normalization point where those traversal facts
 become documented generated data. It must therefore decide from traversal

--- a/src/VersoBlueprint/PreviewManifest.lean
+++ b/src/VersoBlueprint/PreviewManifest.lean
@@ -596,9 +596,6 @@ private def writeBuildMetadataHtml
   | some html => IO.FS.writeFile path html
   | none => Verso.reportError s!"Blueprint build metadata: could not find title page heading in {path}"
 
-def emitBuildMetadata (metadata : BuildMetadata) : ExtraStep := fun mode cfg _state _text => do
-  writeBuildMetadataHtml metadata (outDirForMode cfg mode / "index.html")
-
 private def highlightedDocstringInnerTextRead : String :=
   "const str = d.innerText;"
 
@@ -677,11 +674,6 @@ private def patchBlueprintHtmlAssets (assets : HtmlAssets) : HtmlAssets :=
       Std.HashSet.ofArray <|
         assets.extraJs.toArray.map patchHighlightedStartupJs
   }
-
-private def patchBlueprintTraverseState (state : TraverseState) : TraverseState :=
-  state
-    |>.modifyHtmlAssets patchBlueprintHtmlAssets
-    |> Informal.RelatedPanel.patchRelationCaches
 
 def manifestFilename : String := "blueprint-manifest.json"
 
@@ -1209,8 +1201,36 @@ structure PreparedPreviewState where private mk ::
 def PreparedPreviewState.prepare (state : TraverseState) : PreparedPreviewState :=
   PreparedPreviewState.mk (Informal.RelatedPanel.patchRelationCaches state)
 
-private def PreparedPreviewState.ofPatched (state : TraverseState) : PreparedPreviewState :=
-  PreparedPreviewState.mk state
+/--
+Traversal state prepared for Blueprint HTML rendering and post-render steps.
+
+Renderer preparation installs the Blueprint HTML asset patches and crosses the
+preview-data preparation boundary exactly once. Post-render steps receive this
+type so they cannot assume that a raw traversal state was prepared elsewhere.
+-/
+structure PreparedRendererState where private mk ::
+  /-- Preview-data view of the same prepared traversal state. -/
+  previewState : PreparedPreviewState
+
+/-- Apply every Blueprint renderer-state patch after Manual traversal. -/
+def PreparedRendererState.prepare (state : TraverseState) : PreparedRendererState :=
+  PreparedRendererState.mk <| PreparedPreviewState.prepare <|
+    state.modifyHtmlAssets patchBlueprintHtmlAssets
+
+/-- The underlying traversal state used by Verso's HTML emitters. -/
+def PreparedRendererState.state (preparedState : PreparedRendererState) : TraverseState :=
+  preparedState.previewState.state
+
+/--
+Blueprint-specific post-render step whose traversal state has crossed the
+renderer-preparation boundary.
+-/
+abbrev BlueprintExtraStep :=
+  Verso.Genre.Manual.Mode → Verso.Genre.Manual.Config → PreparedRendererState →
+    Part Manual → BuildLogT IO Unit
+
+def emitBuildMetadata (metadata : BuildMetadata) : BlueprintExtraStep := fun mode cfg _state _text => do
+  writeBuildMetadataHtml metadata (outDirForMode cfg mode / "index.html")
 
 /--
 Assembled preview-data candidates before rendered-preview references are
@@ -2619,12 +2639,13 @@ when traversal-preview metadata was lost before export.
 def emitBlueprintPreviewData
     (extensionImpls : ExtensionImpls)
     (externalMarkupConfig : Informal.ExternalMarkupRender.Config := {}) :
-    ExtraStep := fun mode cfg state _text => do
+    BlueprintExtraStep := fun mode cfg preparedState _text => do
   let logger : Verso.Logger IO ← read
   let logError := fun msg => logger.reportError msg
   let modeDescription := htmlModeDescription mode
+  let state := preparedState.state
   let files ← buildPreviewDataFiles extensionImpls logError
-    (PreparedPreviewState.ofPatched state) externalMarkupConfig
+    preparedState.previewState externalMarkupConfig
     (verbose := cfg.verbose)
   reportPreviewMetadataLossWarnings logger state files.manifest
   let countSummary :=
@@ -2687,7 +2708,7 @@ private abbrev HtmlEmitter :=
   RenderConfig → Part Manual → TraverseState → EmitM Unit
 
 private def emitBlueprintHtml
-    (extraSteps : List ExtraStep)
+    (extraSteps : List BlueprintExtraStep)
     (how : EmitHtml)
     (mode : Mode)
     (cfg : RenderConfig)
@@ -2703,18 +2724,20 @@ private def emitBlueprintHtml
       let (text', traverseState) ←
         withTimedBuildProgress cfg.verbose s!"{modeDescription} HTML traversal" <|
           traverse cfg text
-      let traverseState := patchBlueprintTraverseState traverseState
+      let preparedState := PreparedRendererState.prepare traverseState
+      let traverseState := preparedState.state
       withTimedBuildProgress cfg.verbose s!"writing {modeDescription} xrefs" <|
         emitXrefsJson (cfg.destination / outDir) traverseState
       withTimedBuildProgress cfg.verbose s!"emitting {modeDescription} HTML" <|
         emit cfg text' traverseState
       for step in extraSteps do
-        step mode cfg.toConfig traverseState text'
+        step mode cfg.toConfig preparedState text'
   | .delay f =>
       let (text', traverseState) ←
         withTimedBuildProgress cfg.verbose s!"{modeDescription} HTML traversal" <|
           traverse cfg text
-      let traverseState := patchBlueprintTraverseState traverseState
+      let preparedState := PreparedRendererState.prepare traverseState
+      let traverseState := preparedState.state
       withTimedBuildProgress cfg.verbose s!"writing {modeDescription} xrefs" <|
         emitXrefsJson (cfg.destination / outDir) traverseState
       withTimedBuildProgress cfg.verbose s!"saving {modeDescription} traversal state to {f}" <|
@@ -2723,17 +2746,18 @@ private def emitBlueprintHtml
       let { text, traverseState } ←
         withTimedBuildProgress cfg.verbose s!"loading {modeDescription} traversal state from {f}" <|
           SavedState.load f
-      let traverseState := patchBlueprintTraverseState traverseState
+      let preparedState := PreparedRendererState.prepare traverseState
+      let traverseState := preparedState.state
       withTimedBuildProgress cfg.verbose s!"emitting {modeDescription} HTML" <|
         emit cfg text traverseState
       for step in extraSteps do
-        step mode cfg.toConfig traverseState text
+        step mode cfg.toConfig preparedState text
 
 def blueprintMain (text : Part Manual)
     (extensionImpls : ExtensionImpls := by exact extension_impls%)
     (options : List String)
     (config : RenderConfig := {})
-    (extraSteps : List ExtraStep := [])
+    (extraSteps : List BlueprintExtraStep := [])
     (pdfOptions : PdfOptions := {}) : IO UInt32 :=
   ReaderT.run go extensionImpls
 where
@@ -2767,7 +2791,7 @@ def blueprintMainWithPreviewData
     (options : List String)
     (extensionImpls : ExtensionImpls)
     (config : RenderConfig := {})
-    (extraSteps : List ExtraStep := []) : IO UInt32 := do
+    (extraSteps : List BlueprintExtraStep := []) : IO UInt32 := do
   let config := withBlueprintAssets config
   let (dumped?, options, externalMarkupConfig) ← handleCliFlags text options extensionImpls config
   if let some code := dumped? then

--- a/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
+++ b/tests/VersoBlueprintTests/BlueprintPreviewWiring/RelatedPanel.lean
@@ -81,7 +81,7 @@ private def cachedStatement
     let state := Informal.TraversalIndex.Nodes.saveData state target (Lean.toJson targetData)
     let state := Informal.TraversalIndex.Nodes.saveData state source (Lean.toJson sourceData)
     let state := Informal.TraversalIndex.Nodes.saveData state empty (Lean.toJson emptyData)
-    let state := Informal.RelatedPanel.patchRelationCaches state
+    let state := Informal.PreviewManifest.PreparedRendererState.prepare state |>.state
     let targetEntries := Informal.TraversalIndex.RelatedPanelUsedByCache.data? state target
     let sourceEntries := Informal.TraversalIndex.RelatedPanelUsedByCache.data? state source
     let emptyEntries := Informal.TraversalIndex.RelatedPanelUsedByCache.data? state empty

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -31,7 +31,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "50252fcd705f47c69e1643d6e55c362da273bec1",
+          "ref": "1164e3545a3b685a1afa474be9c68025270b2314",
           "publish_reference": true
         }
       ],


### PR DESCRIPTION
## Summary
Backport #401 to `v4.32.0`.

## Primary Review
- Primary review: #401
- Keep review comments on #401 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.32.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.
- Pin the coordinated noperthedron migration in [ejgallego/verso-noperthedron#7](https://github.com/ejgallego/verso-noperthedron/pull/7).

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.