### PR TITLE
chore: sync reference Blueprint catalog

### DIFF
--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -63,7 +63,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "0121bd1bcc16f715af1a1b967cc54b809693e133",
+          "ref": "f6ed58242cf0e8e523df5598e161ff6d4727a04f",
           "publish_reference": true
         }
       ],
@@ -88,7 +88,7 @@
       "targets": [
         {
           "release": "v4.33.0",
-          "ref": "bd61292109bf01d6ffb4b262aa10d245fdcf1d5d",
+          "ref": "46b7e5277ff32fd95284bff48e1e351ea074bc91",
           "publish_reference": true,
           "reference_toolchain": "v4.33.0-rc1"
         }
@@ -114,7 +114,7 @@
       "targets": [
         {
           "release": "v4.33.0",
-          "ref": "1d40dcbe5c152f03fb9156362100587fcfc6ec9c",
+          "ref": "defe3fc44da0822d140dce68c467a6533b52006e",
           "publish_reference": true,
           "reference_toolchain": "v4.33.0-rc1"
         }


### PR DESCRIPTION
This PR syncs the maintained reference Blueprint catalog after the wrappers adopted the current VBP release heads.

- Point v4.33 FLT at 46b7e527 and Carleson at defe3fc4.
- Point v4.32 Sphere Packing at f6ed5824.
- Keep each Blueprint only on its intended maintained release line.

Backport v4.32.0: #406