### PR TITLE
[backport v4.32.0] chore: sync reference Blueprint catalog

### DIFF
--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -49,7 +49,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "0121bd1bcc16f715af1a1b967cc54b809693e133",
+          "ref": "f6ed58242cf0e8e523df5598e161ff6d4727a04f",
           "publish_reference": true
         }
       ],


### PR DESCRIPTION
## Summary
Backport #405 to `v4.32.0`.

## Primary Review
- Primary review: #405
- Keep review comments on #405 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.32.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- Update only the v4.32 Sphere Packing catalog ref to f6ed5824.
- Intentionally omit the v4.33-only FLT and Carleson catalog changes; maintained Blueprints build only on their latest supported release.