### PR TITLE
chore: sync reference Blueprint catalog

### DIFF
--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -63,7 +63,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "f6ed58242cf0e8e523df5598e161ff6d4727a04f",
+          "ref": "acb97651686fc6208e59066cee7d875e5efe2e59",
           "publish_reference": true
         }
       ],
@@ -88,7 +88,7 @@
       "targets": [
         {
           "release": "v4.33.0",
-          "ref": "46b7e5277ff32fd95284bff48e1e351ea074bc91",
+          "ref": "52032d62d023c1c705ab7a7de426224248fdd434",
           "publish_reference": true,
           "reference_toolchain": "v4.33.0-rc1"
         }
@@ -114,7 +114,7 @@
       "targets": [
         {
           "release": "v4.33.0",
-          "ref": "defe3fc44da0822d140dce68c467a6533b52006e",
+          "ref": "aa9292e6358652653d5c6e95f428f1f08e8fab01",
           "publish_reference": true,
           "reference_toolchain": "v4.33.0-rc1"
         }


### PR DESCRIPTION
Sync the maintained reference Blueprint catalog after the wrappers adopted the current VBP release heads.

- Point v4.33 FLT at 52032d62 and Carleson at aa9292e6.
- Point v4.32 Sphere Packing at acb97651.
- Keep each Blueprint only on its intended maintained release line.
- Preserve the existing reference toolchain pins and PDF publication policy.

Backport v4.32.0: #408