### PR TITLE
[backport v4.32.0] chore: sync reference Blueprint catalog

### DIFF
--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -49,7 +49,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "acb97651686fc6208e59066cee7d875e5efe2e59",
+          "ref": "bbeb73a885019de8684973db10fbb4dca4c33752",
           "publish_reference": true
         }
       ],


### PR DESCRIPTION
## Summary

Backport the consolidated maintained reference Blueprint catalog refresh to `v4.32.0`.

## Scope

- Update Sphere Packing to wrapper merge `bbeb73a885019de8684973db10fbb4dca4c33752`.
- Preserve one-to-one provenance from the v4.33 catalog commit via `cherry-pick -x`.
- Keep v4.33-only reference entries out of this release catalog.

## Validation

- 353 Python harness tests pass.
- JSON and diff checks pass.
- Full HTML+PDF validation is delegated to GitHub Actions.
- No local Lean, mathlib, generator, or PDF build was run.

Primary review: #414
