### PR TITLE
chore: sync reference Blueprint catalog

### DIFF
--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -63,7 +63,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "acb97651686fc6208e59066cee7d875e5efe2e59",
+          "ref": "bbeb73a885019de8684973db10fbb4dca4c33752",
           "publish_reference": true
         }
       ],
@@ -88,7 +88,7 @@
       "targets": [
         {
           "release": "v4.33.0",
-          "ref": "52032d62d023c1c705ab7a7de426224248fdd434",
+          "ref": "330641da6551c4f5ddf7ff96173aeb500c684868",
           "publish_reference": true,
           "reference_toolchain": "v4.33.0-rc1"
         }
@@ -114,7 +114,7 @@
       "targets": [
         {
           "release": "v4.33.0",
-          "ref": "aa9292e6358652653d5c6e95f428f1f08e8fab01",
+          "ref": "d2efbf090239c3c2d87fdaecac5d90c4a8d61b36",
           "publish_reference": true,
           "reference_toolchain": "v4.33.0-rc1"
         }


### PR DESCRIPTION
## Summary

Synchronize the maintained reference Blueprint catalog with the consolidated validated wrapper merges.

- FLT: `330641da6551c4f5ddf7ff96173aeb500c684868`
- Carleson: `d2efbf090239c3c2d87fdaecac5d90c4a8d61b36`
- Sphere Packing: `bbeb73a885019de8684973db10fbb4dca4c33752`

## Validation

- 356 Python harness tests pass.
- JSON and diff checks pass.
- Each wrapper passed its full cached HTML+PDF workflow before merge.
- Full controller/reference validation is delegated to this PR's GitHub Actions matrices.
- No local Lean, mathlib, generator, or PDF build was run.

Backport v4.32.0: #413
