### PR TITLE
chore: refresh Carleson reference Blueprint

### DIFF
--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -114,7 +114,7 @@
       "targets": [
         {
           "release": "v4.33.0",
-          "ref": "d2efbf090239c3c2d87fdaecac5d90c4a8d61b36",
+          "ref": "7c3df4b5c219a7493aeaa0febe3b34c48bd512df",
           "publish_reference": true,
           "reference_toolchain": "v4.33.0-rc1"
         }


### PR DESCRIPTION
This PR updates the published v4.33 Carleson reference Blueprint target to the latest wrapper revision.

Backport v4.32.0: exempt: catalog-only update for a v4.33-only reference target
