### PR TITLE
chore: refresh Noperthedron reference

### DIFF
--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -38,7 +38,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "1164e3545a3b685a1afa474be9c68025270b2314",
+          "ref": "dc8ca41ebce328933d212e0e30444fdd1711a442",
           "publish_reference": true
         }
       ],


### PR DESCRIPTION
This PR refreshes the published Noperthedron reference to its normalized Lean v4.32.0 wrapper. The wrapper now uses the current shared harness and the current VersoBlueprint v4.32.0 resolution, with obsolete downstream RC1 compatibility deltas removed.

Backport v4.32.0: #418
