### PR TITLE
[backport v4.32.0] chore: refresh Noperthedron reference

### DIFF
--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -31,7 +31,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "1164e3545a3b685a1afa474be9c68025270b2314",
+          "ref": "dc8ca41ebce328933d212e0e30444fdd1711a442",
           "publish_reference": true
         }
       ],


### PR DESCRIPTION
## Summary
Backport #417 to `v4.32.0`.

## Primary Review
- Primary review: #417
- Keep review comments on #417 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.32.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- No intentional release-specific changes.
- If conflict resolution requires deviations from the default-development PR, describe them here.
