### PR TITLE
perf: retain elaborated Blueprint directive bodies

### DIFF
--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -1,6 +1,6 @@
 # Blueprint Roadmap
 
-Last reviewed: 2026-07-16
+Last reviewed: 2026-08-09
 
 This document tracks repository-local engineering work for `verso-blueprint`.
 Scoped planning cards live under [`roadmap/`](./roadmap/). Requests that should
@@ -146,9 +146,9 @@ Work:
    requirements onto `PreviewManifest.Entry`; remaining candidates include
    repeated traversal-store decoding and validation-message assembly patterns
    across preview, source, and status data
-2. revisit `Informal.Environment.InProgress` after the widget path no longer
-   needs elaboration-time syntax; today it remains separate from `Data.Node`
-   because it owns directive-stack state, preview blocks, and `elabStx`
+2. keep `Informal.Environment.InProgress` separate from `Data.Node` while it
+   owns directive-stack state and typed preview blocks; attribute docstring term
+   syntax belongs only to persisted `InformalData`
 3. keep `Informal.Environment.State` as the persisted semantic store and
    traversal indexes as rendered-site projections; consolidate only if the
    replacement keeps numbering, hrefs, preview ids, and HTML-cache keys

--- a/doc/roadmap/README.md
+++ b/doc/roadmap/README.md
@@ -25,15 +25,14 @@ quantitative source of truth; this index records sequencing and ownership.
 The post-#391 FLT rebaseline is supporting measurement for UPC-0015 and
 UPC-0016 rather than a separate upstream ask. The completed Carleson prefix and
 source-attribution studies similarly refine UPC-0018 rather than creating a new
-general document-assembly card. A subsequent behavior-preserving Blueprint
-prototype satisfied UPC-0018's acceptance criteria without requiring a Verso
-deferred-queue contract.
+general document-assembly card. The behavior-preserving Blueprint retained-body
+implementation resolved UPC-0018 without requiring a Verso deferred-queue
+contract.
 
 | Phase | Cards | Proposed collaboration |
 | --- | --- | --- |
 | Ready for focused upstream patches | [`UPC-0008`](./cards/UPC-0008-highlighted-docstring-performance/README.md), [`UPC-0015`](./cards/UPC-0015-single-owner-compact-xref-emission/README.md), [`UPC-0016`](./cards/UPC-0016-one-pass-manual-html-escaping/README.md) | Review small behavior-preserving changes, attach current-head measurements, and land independently where useful. |
 | Needs Verso/SubVerso design | [`UPC-0017`](./cards/UPC-0017-layout-independent-signature-highlighting-cache/README.md) | Agree which highlighted-signature facts are layout-independent and how token identities remain canonical before implementing cache sharing. |
-| Blueprint-local patch ready | [`UPC-0018`](./cards/UPC-0018-deferred-manual-block-term-elaboration/README.md) | Land retained directive bodies in Blueprint, then resolve the upstream candidate; reopen upstream design only if later evidence demonstrates a general deferred-queue requirement. |
 
 Before publishing new headline percentages, rerun the representative workload
 on current Verso and Blueprint heads. Preserve raw order-balanced runs, require
@@ -104,16 +103,10 @@ work.
 - [`UPC-0013 Bibliography Formatting Boundary`](./cards/UPC-0013-bibliography-formatting-boundary/README.md)
 - [`UPC-0017 Layout-Independent Signature Highlighting Cache`](./cards/UPC-0017-layout-independent-signature-highlighting-cache/README.md)
 
-## Close Candidates
-
-These cards have enough evidence to close as upstream asks once their named
-local landing or final verification step is complete.
-
-- [`UPC-0018 Deferred Manual Block Term Elaboration`](./cards/UPC-0018-deferred-manual-block-term-elaboration/README.md)
-
 ## Resolved Cards
 
 - [`UPC-0005 Verso Slides Extra Head`](./cards/UPC-0005-verso-slides-extra-head/README.md)
+- [`UPC-0018 Deferred Manual Block Term Elaboration`](./cards/UPC-0018-deferred-manual-block-term-elaboration/README.md)
 
 ## Card Rules
 

--- a/doc/roadmap/cards/UPC-0018-deferred-manual-block-term-elaboration/README.md
+++ b/doc/roadmap/cards/UPC-0018-deferred-manual-block-term-elaboration/README.md
@@ -1,6 +1,6 @@
 # UPC-0018 Deferred Manual Block Term Elaboration
 
-Status: close-candidate
+Status: resolved
 Kind: performance
 Priority: high
 Origin: upstream-verso
@@ -14,11 +14,10 @@ Related cards: UPC-0017
 
 ## Summary
 
-Blueprint should reuse the elaborated directive-body work already performed for
+Blueprint now reuses the elaborated directive-body work already performed for
 preview evaluation instead of embedding the same body syntax in a deferred block
-term that Lean elaborates again when the document closes. A Blueprint-local
-representation prototype now demonstrates that reuse without requiring a Verso
-queue contract.
+term that Lean elaborates again when the document closes. The Blueprint-local
+representation requires no Verso queue contract.
 
 ## Impact
 
@@ -34,7 +33,7 @@ removed directive bodies only from the final deferred terms saved 7.40s of
 directive term elaboration. This is an upper bound for reuse, not an acceptable
 implementation.
 
-A behavior-preserving Blueprint prototype now retains each accepted directive's
+A behavior-preserving Blueprint implementation retains each accepted directive's
 elaborated body in an internal compiled array definition, evaluates that same
 definition for preview data, and refers to it during final document assembly.
 In a bracketed candidate/baseline/candidate comparison, mean candidate user CPU
@@ -45,12 +44,10 @@ threshold.
 
 ## Roadmap Decision
 
-Land the validated retained-body implementation as a Blueprint-local patch. It
-uses existing Lean elaborator facilities and does not require a Verso
-deferred-queue change, so this upstream card is now a `close-candidate`. Resolve
-it once the local implementation lands. Reopen upstream design only if later
-evidence demonstrates a general queue contract that cannot be expressed at the
-Blueprint directive boundary.
+Resolved by the retained-body implementation in Blueprint. It uses existing
+Lean elaborator facilities and does not require a Verso deferred-queue change.
+Reopen upstream design only if later evidence demonstrates a general queue
+contract that cannot be expressed at the Blueprint directive boundary.
 
 ## Reproduction Status
 
@@ -60,7 +57,7 @@ project with Lean `v4.33.0-rc1`. Dependency compilation, native executable
 generation, traversal, and HTML rendering were excluded. Prefixes ended only at
 complete top-level block boundaries and all elaborated successfully.
 
-The behavior-preserving prototype was then measured on Blueprint base
+The behavior-preserving implementation was then measured on Blueprint base
 `1ff5697c`, Carleson revision `15f3cc5552342b78a399043c88f581168dabfd1a`, and
 the same pinned Lean `v4.33.0-rc1` reference environment. Package regression
 tests used the current `v4.33.0-rc2` development toolchain.
@@ -97,7 +94,7 @@ but would not reduce whole-module time.
 
 This card owns the now-resolved ownership question around reuse of Blueprint
 directive-body elaboration between preview evaluation and final document
-construction. The prototype demonstrates a Blueprint-local boundary and no
+construction. The implementation demonstrates a Blueprint-local boundary and no
 current Verso queue requirement. UPC-0017 owns external-declaration signature
 conversion during incremental directive elaboration. Syntax assembly,
 reconstruction JSON, the outer `VersoDoc` definition, `saveRefsInEnv`, math
@@ -154,6 +151,25 @@ peak RSS was 314,322 KiB (5.7%) lower, and the `.olean` was 1,400,336 bytes
 (3.3%) smaller. Both candidate `.olean` files were byte-identical, with SHA-256
 `01cef9777771525e06a75cb717821d48019fa99c3e2677206a525eea989e7e0b`.
 
+A matched structured-profiler comparison isolated the finalization effect:
+
+| Structured trace | Complete traced span | Final block | Final share | Peak RSS |
+| --- | ---: | ---: | ---: | ---: |
+| Baseline | 236.17s | 67.69s | 28.7% | 6,062,788 KiB |
+| Candidate | 237.76s | 53.02s | 22.3% | 5,499,224 KiB |
+| Difference | +1.58s | **-14.67s** | -6.4 points | **-563,564 KiB** |
+
+The 21.7% final-block reduction came from the expected elaborator leaves:
+application arguments fell by 8.96s and `let` terms by 6.07s, while unrelated
+final-command residual time remained stable.
+
+Compiling only the affected owner-module translation unit checked the native
+artifact consequence without rebuilding 8,306 cached Mathlib C files and 117
+Carleson C files. Generated C grew by 366,379 bytes (1.6%) and the object file
+by 222,208 bytes (1.2%) because the implementation adds one retained definition
+per accepted directive. Loadable object sections nevertheless fell by 18,921
+bytes (0.15%), including 21,473 fewer bytes of executable text.
+
 The complete candidate Carleson site passed `vbp check` with 531 manifest and
 531 HTML-cache entries. Baseline and candidate trees contained the same 176
 files; their raw differences reduced to the live timestamp, Lean per-run
@@ -172,7 +188,5 @@ the durable summary.
 
 ## Current Workaround
 
-A Blueprint-local implementation is ready for a separate landing PR. Until it
-lands, released Blueprint versions retain evaluated preview values but not
-reusable elaborated body references, so owner modules still pay the second
-elaboration. No upstream Verso change is required by the validated design.
+None. Blueprint retains reusable elaborated body references locally, and no
+upstream Verso change is required by the validated design.

--- a/src/VersoBlueprint/Environment.lean
+++ b/src/VersoBlueprint/Environment.lean
@@ -18,9 +18,9 @@ open Informal.Data
 Elaboration-time builder for a node that is currently open on the directive
 stack.
 
-This intentionally stays separate from `Data.Node`: it carries phase-specific
-inputs such as preview blocks and elaboration syntax before the final persisted
-semantic node can be assembled.
+This intentionally stays separate from `Data.Node`: it carries directive-stack
+metadata and typed preview blocks before the final persisted semantic node can
+be assembled.
 -/
 structure InProgress where
   label : Label
@@ -34,7 +34,6 @@ structure InProgress where
   prUrl : Option String := none
   deps : Array UseRef := #[]
   previewBlocks : Array (Verso.Doc.Block Verso.Genre.Manual) := #[]
-  elabStx : Array Syntax := #[]
 deriving Inhabited, Repr
 
 inductive ImportedConflictKind where
@@ -192,7 +191,7 @@ initialize informalExt : PersistentEnvExtension Entry Entry State ←
             else
               (dataAcc, groupAcc, authorAcc.insert label info, leanNameAcc, conflictsAcc)
       pure { data, groups, authors, leanNameLabels, importedConflicts := sortImportedConflicts importedConflicts }
-    -- Strip transient elaboration cache before exporting nodes to the environment.
+    -- Prefer typed preview blocks and strip redundant term syntax before export.
     exportEntriesFnEx env := fun state =>
       let nodeEntries := state.localData.toArray.map fun (name, node) =>
         let statement := node.statement.map fun s =>
@@ -311,7 +310,6 @@ def pop (ref : Syntax) : m Nat := do
           stx := ref
           deps := cur.deps
           previewBlocks := cur.previewBlocks
-          elabStx := cur.elabStx
         }
         let data ← state.data.register
           cur.label cur.kind payload cur.codeHint cur.parent cur.priority cur.owner cur.tags cur.effort cur.prUrl
@@ -344,16 +342,6 @@ def addUse (stx : Syntax) (useRef : UseRef) : m Unit := do
 
 def addDep (stx : Syntax) (dep : Name) : m Unit := do
   addUse stx { label := dep }
-
-def setStatementElab (stxs : Array Syntax) : m Unit := do
-  match (informalExt.getState (← getEnv)).stack with
-  | [] => pure ()
-  | cur :: rest =>
-    match cur.kind with
-    | .proof => pure ()
-    | .statement _ =>
-      let cur := { cur with elabStx := stxs }
-      modify fun state => { state with stack := cur :: rest }
 
 def setPreviewBlocks (blocks : Array (Verso.Doc.Block Verso.Genre.Manual)) : m Unit := do
   match (informalExt.getState (← getEnv)).stack with

--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -27,7 +27,6 @@ import VersoBlueprint.Informal.CodeSummary
 import VersoBlueprint.Informal.ExternalCode
 import VersoBlueprint.Informal.ExternalMarkupRender
 import VersoBlueprint.Lib.ExtensionDecode
-import VersoBlueprint.PreviewRender
 import VersoBlueprint.Resolve
 import VersoBlueprint.Source.Metadata
 import VersoBlueprint.TeX
@@ -225,6 +224,40 @@ private def parseDirectiveSourceMetadata
     logErrorAt block m!"Label {cfg.label} has a metadata block after visible content; Blueprint source metadata must be the first block inside the directive"
   pure { sourceRef?, body }
 
+private unsafe def retainElaboratedBlocksUnsafe (stxs : Array (TSyntax `term)) :
+    TermElabM (Array (Doc.Block Genre.Manual) × TSyntax `term) := do
+  if stxs.isEmpty then
+    pure (#[], ← `(#[]))
+  else
+    let blockType ← Term.elabType (← `(Doc.Block Genre.Manual))
+    let arrayType := mkApp (.const ``Array [0]) blockType
+    let arraySyntax ← `(#[$stxs,*])
+    let arrayExpr ← Term.elabTermAndSynthesize arraySyntax (some arrayType)
+    let arrayExpr ← instantiateMVars arrayExpr
+    let name ← mkFreshUserName `blueprintDirectiveBodyBlocks
+    let decl := Declaration.defnDecl {
+      name
+      levelParams := []
+      type := arrayType
+      value := arrayExpr
+      hints := .abbrev
+      safety := .safe
+    }
+    Term.ensureNoUnassignedMVars decl
+    -- This dynamically compiled declaration must remain a single reusable
+    -- environment constant for preview evaluation and final reconstruction.
+    withOptions (·.setBool `compiler.extract_closed false) <|
+      addAndCompile decl
+    let blocks ← Meta.evalExpr
+      (Array (Doc.Block Genre.Manual)) arrayType (.const name [])
+    let reference ← ``($(mkIdent name))
+    pure (blocks, reference)
+
+@[implemented_by retainElaboratedBlocksUnsafe]
+private opaque retainElaboratedBlocks
+    (stxs : Array (TSyntax `term)) :
+    TermElabM (Array (Doc.Block Genre.Manual) × TSyntax `term)
+
 private def expanderImpl (kind : Data.NodeKind) (isProof : Bool := false) : DirectiveExpanderOf Config
   | cfg, contents => do
     let blockRef ← getRef
@@ -237,7 +270,8 @@ private def expanderImpl (kind : Data.NodeKind) (isProof : Bool := false) : Dire
     let contents ← parsedContents.body.mapM elabBlock
     if !accepted then
       return ← ``(Block.concat #[$contents,*])
-    let previewBlocks ← liftM <| Informal.evalElaboratedBlocks (contents.map (·.raw))
+    let (previewBlocks, retainedContents) ←
+      liftM <| retainElaboratedBlocks contents
     Environment.setPreviewBlocks previewBlocks
     let count ← Environment.pop blockRef
     liftM <| DependencyAnalysis.attachInferredUseRefs label blockRef { proof := resolved.proofUses }
@@ -298,7 +332,7 @@ private def expanderImpl (kind : Data.NodeKind) (isProof : Bool := false) : Dire
       priority := node?.bind (·.priority)
       prUrl := node?.bind (·.prUrl)
     }
-    ``(Block.other (Block.informal $(quote data)) #[$contents,*])
+    ``(Block.other (Block.informal $(quote data)) $retainedContents)
 
 private def directiveName (kind : Data.NodeKind) (isProof : Bool): String :=
   if isProof then "proof" else (toString kind).toLower

--- a/tests/VersoBlueprintTests/BlueprintInformal/Structure.lean
+++ b/tests/VersoBlueprintTests/BlueprintInformal/Structure.lean
@@ -4,14 +4,48 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Emilio J. Gallego Arias
 -/
 
+import VersoBlueprintTests.Blueprint.Support
 import VersoBlueprintTests.BlueprintInformal.Shared
 
 open Lean
 open Verso Genre Manual
 open Informal
+open Verso.VersoBlueprintTests.Blueprint.Support
 open Verso.VersoBlueprintTests.BlueprintInformal.Shared
 
 namespace Verso.VersoBlueprintTests.BlueprintInformal.Structure
+
+private def manualImpls : ExtensionImpls := extension_impls%
+
+elab "retainedBlueprintBodyBlock" : term => do
+  logInfo "retained Blueprint body elaborated"
+  Lean.Elab.Term.elabTerm
+    (← ``((Verso.Doc.Block.para #[Verso.Doc.Inline.text "Retained body output."] :
+      Verso.Doc.Block Verso.Genre.Manual))) none
+
+@[code_block]
+def retainedBodyProbe : Verso.Doc.Elab.CodeBlockExpanderOf Unit
+  | _, _ => do
+    `(retainedBlueprintBodyBlock)
+
+/--
+info: retained Blueprint body elaborated
+-/
+#guard_msgs in
+#docs (Manual) retainedBodyDoc "Retained Body" :=
+:::::::
+:::definition "retained.body"
+```retainedBodyProbe
+probe
+```
+:::
+:::::::
+
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let out ← renderManualDocHtmlString manualImpls retainedBodyDoc
+  pure <| hasSubstr out "Retained body output."
 
 #docs (Manual) groupHeaderDoc "Group Header" :=
 :::::::


### PR DESCRIPTION
This PR retains each accepted Blueprint directive body in one internal compiled definition, reusing the elaborated value for preview data and the final document instead of elaborating the body syntax twice. It also removes the obsolete directive-stack syntax cache and resolves UPC-0018.

On the profiled Carleson owner module, the matched structured final-document span fell from 67.69s to 53.02s (21.7%), with the reduction in the expected application-argument and `let` elaboration leaves. Blueprint output remains equivalent, and a focused regression checks both single elaboration and rendered body content.

Backport v4.32.0: #420