### PR TITLE
[backport v4.32.0] perf: retain elaborated Blueprint directive bodies

### DIFF
--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -1,6 +1,6 @@
 # Blueprint Roadmap
 
-Last reviewed: 2026-07-16
+Last reviewed: 2026-08-09
 
 This document tracks repository-local engineering work for `verso-blueprint`.
 Scoped planning cards live under [`roadmap/`](./roadmap/). Requests that should
@@ -146,9 +146,9 @@ Work:
    requirements onto `PreviewManifest.Entry`; remaining candidates include
    repeated traversal-store decoding and validation-message assembly patterns
    across preview, source, and status data
-2. revisit `Informal.Environment.InProgress` after the widget path no longer
-   needs elaboration-time syntax; today it remains separate from `Data.Node`
-   because it owns directive-stack state, preview blocks, and `elabStx`
+2. keep `Informal.Environment.InProgress` separate from `Data.Node` while it
+   owns directive-stack state and typed preview blocks; attribute docstring term
+   syntax belongs only to persisted `InformalData`
 3. keep `Informal.Environment.State` as the persisted semantic store and
    traversal indexes as rendered-site projections; consolidate only if the
    replacement keeps numbering, hrefs, preview ids, and HTML-cache keys

--- a/src/VersoBlueprint/Environment.lean
+++ b/src/VersoBlueprint/Environment.lean
@@ -18,9 +18,9 @@ open Informal.Data
 Elaboration-time builder for a node that is currently open on the directive
 stack.
 
-This intentionally stays separate from `Data.Node`: it carries phase-specific
-inputs such as preview blocks and elaboration syntax before the final persisted
-semantic node can be assembled.
+This intentionally stays separate from `Data.Node`: it carries directive-stack
+metadata and typed preview blocks before the final persisted semantic node can
+be assembled.
 -/
 structure InProgress where
   label : Label
@@ -34,7 +34,6 @@ structure InProgress where
   prUrl : Option String := none
   deps : Array UseRef := #[]
   previewBlocks : Array (Verso.Doc.Block Verso.Genre.Manual) := #[]
-  elabStx : Array Syntax := #[]
 deriving Inhabited, Repr
 
 inductive ImportedConflictKind where
@@ -192,7 +191,7 @@ initialize informalExt : PersistentEnvExtension Entry Entry State ←
             else
               (dataAcc, groupAcc, authorAcc.insert label info, leanNameAcc, conflictsAcc)
       pure { data, groups, authors, leanNameLabels, importedConflicts := sortImportedConflicts importedConflicts }
-    -- Strip transient elaboration cache before exporting nodes to the environment.
+    -- Prefer typed preview blocks and strip redundant term syntax before export.
     exportEntriesFnEx env := fun state =>
       let nodeEntries := state.localData.toArray.map fun (name, node) =>
         let statement := node.statement.map fun s =>
@@ -311,7 +310,6 @@ def pop (ref : Syntax) : m Nat := do
           stx := ref
           deps := cur.deps
           previewBlocks := cur.previewBlocks
-          elabStx := cur.elabStx
         }
         let data ← state.data.register
           cur.label cur.kind payload cur.codeHint cur.parent cur.priority cur.owner cur.tags cur.effort cur.prUrl
@@ -344,16 +342,6 @@ def addUse (stx : Syntax) (useRef : UseRef) : m Unit := do
 
 def addDep (stx : Syntax) (dep : Name) : m Unit := do
   addUse stx { label := dep }
-
-def setStatementElab (stxs : Array Syntax) : m Unit := do
-  match (informalExt.getState (← getEnv)).stack with
-  | [] => pure ()
-  | cur :: rest =>
-    match cur.kind with
-    | .proof => pure ()
-    | .statement _ =>
-      let cur := { cur with elabStx := stxs }
-      modify fun state => { state with stack := cur :: rest }
 
 def setPreviewBlocks (blocks : Array (Verso.Doc.Block Verso.Genre.Manual)) : m Unit := do
   match (informalExt.getState (← getEnv)).stack with

--- a/src/VersoBlueprint/Informal/Block.lean
+++ b/src/VersoBlueprint/Informal/Block.lean
@@ -27,7 +27,6 @@ import VersoBlueprint.Informal.CodeSummary
 import VersoBlueprint.Informal.ExternalCode
 import VersoBlueprint.Informal.ExternalMarkupRender
 import VersoBlueprint.Lib.ExtensionDecode
-import VersoBlueprint.PreviewRender
 import VersoBlueprint.Resolve
 import VersoBlueprint.Source.Metadata
 import VersoBlueprint.TeX
@@ -225,6 +224,40 @@ private def parseDirectiveSourceMetadata
     logErrorAt block m!"Label {cfg.label} has a metadata block after visible content; Blueprint source metadata must be the first block inside the directive"
   pure { sourceRef?, body }
 
+private unsafe def retainElaboratedBlocksUnsafe (stxs : Array (TSyntax `term)) :
+    TermElabM (Array (Doc.Block Genre.Manual) × TSyntax `term) := do
+  if stxs.isEmpty then
+    pure (#[], ← `(#[]))
+  else
+    let blockType ← Term.elabType (← `(Doc.Block Genre.Manual))
+    let arrayType := mkApp (.const ``Array [0]) blockType
+    let arraySyntax ← `(#[$stxs,*])
+    let arrayExpr ← Term.elabTermAndSynthesize arraySyntax (some arrayType)
+    let arrayExpr ← instantiateMVars arrayExpr
+    let name ← mkFreshUserName `blueprintDirectiveBodyBlocks
+    let decl := Declaration.defnDecl {
+      name
+      levelParams := []
+      type := arrayType
+      value := arrayExpr
+      hints := .abbrev
+      safety := .safe
+    }
+    Term.ensureNoUnassignedMVars decl
+    -- This dynamically compiled declaration must remain a single reusable
+    -- environment constant for preview evaluation and final reconstruction.
+    withOptions (·.setBool `compiler.extract_closed false) <|
+      addAndCompile decl
+    let blocks ← Meta.evalExpr
+      (Array (Doc.Block Genre.Manual)) arrayType (.const name [])
+    let reference ← ``($(mkIdent name))
+    pure (blocks, reference)
+
+@[implemented_by retainElaboratedBlocksUnsafe]
+private opaque retainElaboratedBlocks
+    (stxs : Array (TSyntax `term)) :
+    TermElabM (Array (Doc.Block Genre.Manual) × TSyntax `term)
+
 private def expanderImpl (kind : Data.NodeKind) (isProof : Bool := false) : DirectiveExpanderOf Config
   | cfg, contents => do
     let blockRef ← getRef
@@ -237,7 +270,8 @@ private def expanderImpl (kind : Data.NodeKind) (isProof : Bool := false) : Dire
     let contents ← parsedContents.body.mapM elabBlock
     if !accepted then
       return ← ``(Block.concat #[$contents,*])
-    let previewBlocks ← liftM <| Informal.evalElaboratedBlocks (contents.map (·.raw))
+    let (previewBlocks, retainedContents) ←
+      liftM <| retainElaboratedBlocks contents
     Environment.setPreviewBlocks previewBlocks
     let count ← Environment.pop blockRef
     liftM <| DependencyAnalysis.attachInferredUseRefs label blockRef { proof := resolved.proofUses }
@@ -298,7 +332,7 @@ private def expanderImpl (kind : Data.NodeKind) (isProof : Bool := false) : Dire
       priority := node?.bind (·.priority)
       prUrl := node?.bind (·.prUrl)
     }
-    ``(Block.other (Block.informal $(quote data)) #[$contents,*])
+    ``(Block.other (Block.informal $(quote data)) $retainedContents)
 
 private def directiveName (kind : Data.NodeKind) (isProof : Bool): String :=
   if isProof then "proof" else (toString kind).toLower

--- a/tests/VersoBlueprintTests/BlueprintInformal/Structure.lean
+++ b/tests/VersoBlueprintTests/BlueprintInformal/Structure.lean
@@ -4,14 +4,48 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Emilio J. Gallego Arias
 -/
 
+import VersoBlueprintTests.Blueprint.Support
 import VersoBlueprintTests.BlueprintInformal.Shared
 
 open Lean
 open Verso Genre Manual
 open Informal
+open Verso.VersoBlueprintTests.Blueprint.Support
 open Verso.VersoBlueprintTests.BlueprintInformal.Shared
 
 namespace Verso.VersoBlueprintTests.BlueprintInformal.Structure
+
+private def manualImpls : ExtensionImpls := extension_impls%
+
+elab "retainedBlueprintBodyBlock" : term => do
+  logInfo "retained Blueprint body elaborated"
+  Lean.Elab.Term.elabTerm
+    (← ``((Verso.Doc.Block.para #[Verso.Doc.Inline.text "Retained body output."] :
+      Verso.Doc.Block Verso.Genre.Manual))) none
+
+@[code_block]
+def retainedBodyProbe : Verso.Doc.Elab.CodeBlockExpanderOf Unit
+  | _, _ => do
+    `(retainedBlueprintBodyBlock)
+
+/--
+info: retained Blueprint body elaborated
+-/
+#guard_msgs in
+#docs (Manual) retainedBodyDoc "Retained Body" :=
+:::::::
+:::definition "retained.body"
+```retainedBodyProbe
+probe
+```
+:::
+:::::::
+
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let out ← renderManualDocHtmlString manualImpls retainedBodyDoc
+  pure <| hasSubstr out "Retained body output."
 
 #docs (Manual) groupHeaderDoc "Group Header" :=
 :::::::


### PR DESCRIPTION
## Summary
Backport #419 to `v4.32.0`.

## Primary Review
- Primary review: #419
- Keep review comments on #419 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.32.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- v4.32 predates the consolidated performance roadmap and UPC-0018 card, so their resolution-only documentation is omitted.
- The implementation, regression test, and obsolete-state cleanup are otherwise unchanged.