### PR TITLE
[backport v4.32.0] chore: update to Lean v4.33.0

### DIFF
--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -13,8 +13,7 @@
           "release": "v4.32.0"
         },
         {
-          "release": "v4.33.0",
-          "rc": "4.33-rc2"
+          "release": "v4.33.0"
         }
       ],
       "generate_command": ["lake", "exe", "vbp", "build", "--output", "{output_dir}"],


### PR DESCRIPTION
## Summary
Backport #421 to `v4.32.0`.

## Primary Review
- Primary review: #421
- Keep review comments on #421 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.32.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- Retain the v4.32 Lean, Verso, Verso Slides, and manifest pins.
- Remove only the obsolete `4.33-rc2` override from the shared project-template target.