### PR TITLE
chore: refresh reference blueprint catalog

### DIFF
--- a/.github/workflows/reference-blueprints.yml
+++ b/.github/workflows/reference-blueprints.yml
@@ -33,9 +33,24 @@ jobs:
         env:
           BP_DEFAULT_DEV_BRANCH: ${{ github.event.repository.default_branch }}
           BP_RELEASE_ID: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
+          BP_EVENT_NAME: ${{ github.event_name }}
+          BP_BEFORE_SHA: ${{ github.event.before }}
         run: |
           manifest_path=tests/harness/projects.json
-          if [ "$BP_RELEASE_ID" != "$BP_DEFAULT_DEV_BRANCH" ]; then
+          use_local_catalog=false
+          if [ "$BP_RELEASE_ID" = "$BP_DEFAULT_DEV_BRANCH" ]; then
+            use_local_catalog=true
+          elif [ "$BP_EVENT_NAME" = "pull_request" ]; then
+            git fetch --no-tags origin "$BP_RELEASE_ID"
+            if ! git diff --quiet "origin/$BP_RELEASE_ID"...HEAD -- "$manifest_path"; then
+              use_local_catalog=true
+            fi
+          elif [ "$BP_EVENT_NAME" = "push" ] &&
+              git rev-parse --verify --quiet "${BP_BEFORE_SHA}^{commit}" >/dev/null &&
+              ! git diff --quiet "$BP_BEFORE_SHA" HEAD -- "$manifest_path"; then
+            use_local_catalog=true
+          fi
+          if [ "$use_local_catalog" != true ]; then
             git fetch --no-tags origin "$BP_DEFAULT_DEV_BRANCH"
             manifest_path=_out/controller-projects.json
             mkdir -p "$(dirname "$manifest_path")"

--- a/README.md
+++ b/README.md
@@ -385,12 +385,12 @@ the current checkout's selected projects with
 `python3 -m scripts.blueprint_reference_harness projects`.
 
 Each external Blueprint is published only for its intended current release.
-Noperthedron and Sphere Packing currently target `v4.32.0`; FLT and Carleson
-target `v4.33.0`. The in-repo starter template is a CI fixture rather than a
-public reference entry; it continues to validate every maintained release line.
+Noperthedron, FLT, and Carleson currently target `v4.33.0`; Sphere Packing
+remains on `v4.32.0`. The in-repo starter template is a CI fixture rather than
+a public reference entry; it continues to validate every maintained release line.
 
 - [`ejgallego/verso-noperthedron`](https://github.com/ejgallego/verso-noperthedron),
-  [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/noperthedron/)
+  [rendered site for v4.33.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.33.0/noperthedron/)
 - [`ejgallego/verso-sphere-packing`](https://github.com/ejgallego/verso-sphere-packing),
   [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/spherepackingblueprint/)
 - [`ejgallego/verso-flt`](https://github.com/ejgallego/verso-flt),

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -36,8 +36,8 @@
       },
       "targets": [
         {
-          "release": "v4.32.0",
-          "ref": "dc8ca41ebce328933d212e0e30444fdd1711a442",
+          "release": "v4.33.0",
+          "ref": "58e5b7e3ce38cc059d0dcd4f5604c666356026bb",
           "publish_reference": true
         }
       ],
@@ -62,7 +62,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "bbeb73a885019de8684973db10fbb4dca4c33752",
+          "ref": "c7eee39480088000d2b7e7245a7be3b8bd43e6fb",
           "publish_reference": true
         }
       ],
@@ -87,9 +87,8 @@
       "targets": [
         {
           "release": "v4.33.0",
-          "ref": "330641da6551c4f5ddf7ff96173aeb500c684868",
-          "publish_reference": true,
-          "reference_toolchain": "v4.33.0-rc1"
+          "ref": "bdba3568faf918df1aa3024c1e69df98e26b7e5d",
+          "publish_reference": true
         }
       ],
       "generate_command": [
@@ -113,9 +112,8 @@
       "targets": [
         {
           "release": "v4.33.0",
-          "ref": "7c3df4b5c219a7493aeaa0febe3b34c48bd512df",
-          "publish_reference": true,
-          "reference_toolchain": "v4.33.0-rc1"
+          "ref": "8810e9d67c7048705fbea66d6f5cf1bacb34f254",
+          "publish_reference": true
         }
       ],
       "generate_command": [

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -669,6 +669,8 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertIn("--project ${{ matrix.project_id }}", workflow_text)
         self.assertIn("Select controller catalog", workflow_text)
         self.assertIn("origin/$BP_DEFAULT_DEV_BRANCH:tests/harness/projects.json", workflow_text)
+        self.assertIn('git diff --quiet "origin/$BP_RELEASE_ID"...HEAD', workflow_text)
+        self.assertIn('git diff --quiet "$BP_BEFORE_SHA" HEAD', workflow_text)
         self.assertIn("BP_REFERENCE_PROJECT_MANIFEST", workflow_text)
         self.assertIn("--manifest _out/reference-projects/${{ matrix.project_id }}.json", workflow_text)
         self.assertIn("--release ${{ needs.resolve-reference-release.outputs.release_id }}", workflow_text)


### PR DESCRIPTION
Refresh the published reference catalog after moving Noperthedron, FLT, and Carleson to final Lean v4.33.0. Sphere Packing remains the only v4.32.0 external reference. Maintenance-line catalog PRs now validate their checked-out catalog when it changes, preventing obsolete base-catalog targets from being built.

Backport v4.32.0: #428