### PR TITLE
[backport v4.32.0] chore: refresh reference blueprint catalog

### DIFF
--- a/.github/workflows/reference-blueprints.yml
+++ b/.github/workflows/reference-blueprints.yml
@@ -33,9 +33,24 @@ jobs:
         env:
           BP_DEFAULT_DEV_BRANCH: ${{ github.event.repository.default_branch }}
           BP_RELEASE_ID: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
+          BP_EVENT_NAME: ${{ github.event_name }}
+          BP_BEFORE_SHA: ${{ github.event.before }}
         run: |
           manifest_path=tests/harness/projects.json
-          if [ "$BP_RELEASE_ID" != "$BP_DEFAULT_DEV_BRANCH" ]; then
+          use_local_catalog=false
+          if [ "$BP_RELEASE_ID" = "$BP_DEFAULT_DEV_BRANCH" ]; then
+            use_local_catalog=true
+          elif [ "$BP_EVENT_NAME" = "pull_request" ]; then
+            git fetch --no-tags origin "$BP_RELEASE_ID"
+            if ! git diff --quiet "origin/$BP_RELEASE_ID"...HEAD -- "$manifest_path"; then
+              use_local_catalog=true
+            fi
+          elif [ "$BP_EVENT_NAME" = "push" ] &&
+              git rev-parse --verify --quiet "${BP_BEFORE_SHA}^{commit}" >/dev/null &&
+              ! git diff --quiet "$BP_BEFORE_SHA" HEAD -- "$manifest_path"; then
+            use_local_catalog=true
+          fi
+          if [ "$use_local_catalog" != true ]; then
             git fetch --no-tags origin "$BP_DEFAULT_DEV_BRANCH"
             manifest_path=_out/controller-projects.json
             mkdir -p "$(dirname "$manifest_path")"

--- a/README.md
+++ b/README.md
@@ -384,19 +384,14 @@ reference projects publish on each Lean release line. Maintainers can inspect
 the current checkout's selected projects with
 `python3 -m scripts.blueprint_reference_harness projects`.
 
-Each external Blueprint is published only for its intended current release,
-currently `v4.32.0`. The in-repo starter template is a CI fixture rather than a
-public reference entry; it continues to validate every maintained release
-line.
+Each external Blueprint is published only for its intended current release.
+Sphere Packing is the remaining external reference on `v4.32.0`; the other
+reference blueprints have moved to `v4.33.0` and are not built on this release
+line. The in-repo starter template is a CI fixture rather than a public
+reference entry; it continues to validate every maintained release line.
 
-- [`ejgallego/verso-noperthedron`](https://github.com/ejgallego/verso-noperthedron),
-  [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/noperthedron/)
 - [`ejgallego/verso-sphere-packing`](https://github.com/ejgallego/verso-sphere-packing),
   [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/spherepackingblueprint/)
-- [`ejgallego/verso-flt`](https://github.com/ejgallego/verso-flt),
-  [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/verso-flt/)
-- [`ejgallego/verso-carleson`](https://github.com/ejgallego/verso-carleson),
-  [rendered site for v4.32.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.32.0/verso-carleson/)
 
 ## Rendered Test Blueprints
 

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -20,24 +20,6 @@
       "site_subdir": "html-multi"
     },
     {
-      "id": "noperthedron",
-      "description": "Mathlib-heavy external blueprint project kept for generation coverage.",
-      "source": {
-        "kind": "git_checkout",
-        "repository": "https://github.com/ejgallego/verso-noperthedron.git",
-        "project_root": "."
-      },
-      "targets": [
-        {
-          "release": "v4.32.0",
-          "ref": "dc8ca41ebce328933d212e0e30444fdd1711a442",
-          "publish_reference": true
-        }
-      ],
-      "generate_command": ["lake", "exe", "vbp", "build", "--output", "{output_dir}"],
-      "site_subdir": "html-multi"
-    },
-    {
       "id": "spherepackingblueprint",
       "description": "External blueprint project without project-specific browser regressions.",
       "source": {
@@ -48,7 +30,7 @@
       "targets": [
         {
           "release": "v4.32.0",
-          "ref": "bbeb73a885019de8684973db10fbb4dca4c33752",
+          "ref": "c7eee39480088000d2b7e7245a7be3b8bd43e6fb",
           "publish_reference": true
         }
       ],

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -231,7 +231,6 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             [project.project_id for project in projects],
             [
                 "project-template",
-                "noperthedron",
                 "spherepackingblueprint",
             ],
         )
@@ -256,7 +255,6 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         if current_release.deploy_pages:
             self.assertTrue(resolve_projects_for_release(catalog, current_release.release_id, None))
         expected_external_repositories = {
-            "noperthedron": "https://github.com/ejgallego/verso-noperthedron.git",
             "spherepackingblueprint": "https://github.com/ejgallego/verso-sphere-packing.git",
         }
         for project in projects[1:]:
@@ -651,6 +649,8 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertIn("--project ${{ matrix.project_id }}", workflow_text)
         self.assertIn("Select controller catalog", workflow_text)
         self.assertIn("origin/$BP_DEFAULT_DEV_BRANCH:tests/harness/projects.json", workflow_text)
+        self.assertIn('git diff --quiet "origin/$BP_RELEASE_ID"...HEAD', workflow_text)
+        self.assertIn('git diff --quiet "$BP_BEFORE_SHA" HEAD', workflow_text)
         self.assertIn("BP_REFERENCE_PROJECT_MANIFEST", workflow_text)
         self.assertIn("--manifest _out/reference-projects/${{ matrix.project_id }}.json", workflow_text)
         self.assertIn("--release ${{ needs.resolve-reference-release.outputs.release_id }}", workflow_text)


### PR DESCRIPTION
## Summary
Backport #427 to `v4.32.0`.

## Primary Review
- Primary review: #427
- Keep review comments on #427 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.32.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- Keep Sphere Packing as the sole external v4.32 reference and refresh its wrapper pin.
- Remove the obsolete v4.32 Noperthedron catalog entry, README link, and matching catalog-test expectation because Noperthedron now targets v4.33 only.
- Use the checked-out catalog for this catalog-changing PR so CI builds Sphere Packing only, rather than the base branch old Noperthedron target.