### PR TITLE
[backport v4.33.0] perf: accelerate Blueprint generation with precompiled modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,9 +459,10 @@ project discovery, build/serve previews, generated-data queries, and
 post-edit checks.
 
 `lake exe vbp build` is the normal Blueprint generation interface for projects.
-It discovers the project generator entry point and runs it through Lake's Lean
-wrapper internally. Treat `vbp` query JSON as an unstable agent interface, not a
-public compatibility contract and not part of the documented integration API.
+Once running, VBP loads the project workspace and reuses it for both generator
+discovery and Lake's Lean-file runner. Treat `vbp` query JSON as an unstable
+agent interface, not a public compatibility contract and not part of the
+documented integration API.
 
 ### Maintainer CLI Split
 

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -182,8 +182,9 @@ that the included GitHub Pages workflow uses. Internally that script uses:
 lake exe vbp build
 ```
 
-The project helper builds the Lean library artifacts, prepares the generator
-file, and then runs the generator through Lake's Lean wrapper:
+Once running, the project helper loads the Lake workspace and reuses it for
+generator discovery and Lake's Lean-file runner. The runner builds the
+generator's imports and executes it. The corresponding lower-level command is:
 
 ```bash
 lake lean ProjectTemplateMain.lean -- --run ProjectTemplateMain.lean --output _out/site

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -986,12 +986,10 @@ The harness is now project-driven rather than hardcoded to one project.
 - keep each external Blueprint on its one intended current release target;
   move that target when the project advances instead of retaining published
   legacy targets for older releases
-- prefer `lake exe vbp build` for package-local generation; if the harness must
-  drive an external project explicitly, build only the Blueprint library's OLean
-  dependency closure with `lake build +<BlueprintLibrary>:olean`, followed by
-  `lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean ...` when the
-  harness must drive an external project explicitly; do not use Lake's default
-  `leanArts` facet because it also emits C
+- prefer `lake exe vbp build` for package-local generation; once running, VBP
+  reuses its loaded Lake workspace for discovery and the workspace's Lean-file
+  runner. If the harness must drive an external project explicitly, use
+  `lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean ...`
 - the harness currently rewrites the cloned `lakefile.lean` dependency line so
   external test projects exercise the local `VersoBlueprint` checkout instead
   of the committed upstream dependency

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -1163,19 +1163,15 @@ lake exe vbp build
 lake exe vbp build --serve
 ```
 
-It builds the Blueprint library's OLean dependency closure, prepares and runs
-the generator, and optionally serves the result. When a maintainer harness or
-advanced CI job must drive those stages explicitly, the equivalent lower-level
-shape is:
+Once running, it loads the project workspace and reuses it for generator
+discovery and Lake's Lean-file runner. The runner builds the generator's
+imports and executes it; VBP can then optionally serve the result. When a
+maintainer harness or advanced CI job cannot use `vbp`, the equivalent
+lower-level command is:
 
 ```bash
-lake build +<BlueprintLibrary>:olean
 lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean --output _out/site
 ```
-
-Keep the explicit `:olean` facet. The default `leanArts` facet also emits C and
-can accidentally turn a Blueprint generation run into a native dependency
-build.
 
 The project helper can emit TeX and compile a PDF in the same run:
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -6,6 +6,7 @@ require «verso-slides» from git "https://github.com/leanprover/verso-slides"@"
 require proofwidgets from git "https://github.com/leanprover-community/ProofWidgets4"@"v0.0.104"
 
 package VersoBlueprint where
+  -- Verso's precompiled-module support requires Lean 4.34.
   precompileModules := false
   leanOptions := #[⟨`experimental.module, true⟩]
 

--- a/skills/verso-blueprint/references/vbp.md
+++ b/skills/verso-blueprint/references/vbp.md
@@ -44,21 +44,16 @@ Defaults:
 
 `discover` reports the Lake-backed package, generator entry point, generator module, generator source file, and default output paths. Fields ending in `Guess`, such as `topLevelBlueprintModuleGuess` and `chapterCandidateGuesses`, are convention-based hints for agents and may be null or incomplete. The JSON includes `"apiStability":"unstable"` and a `discoveryErrors` array. When Lake workspace discovery fails or no generator entry point can be found, package and generator fields are null and `discoveryErrors` explains why.
 
-`build` discovers the generator entry point directly, builds only the
-Blueprint library's OLean dependency closure, prepares/elaborates the generator
-file with Lake, then runs the generator through Lean's interpreter:
+Once running, `build` loads the project workspace and reuses it to discover the
+generator and invoke Lake's Lean-file runner. The runner builds the generator's
+imports and executes the generator through Lean's interpreter:
 
 ```bash
-lake build +<BlueprintLibrary>:olean
-lake lean <GeneratorMain>.lean
 lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean --output <output>
 ```
 
-The explicit `:olean` facet is important for Mathlib consumers: Lake's default
-`leanArts` facet also emits C and can otherwise trigger an unintended native
-dependency rebuild.
-
-`build --verbose` passes `--verbose` through to the generator run, enabling Blueprint generation phase progress after the Lake package build completes.
+`build --verbose` passes `--verbose` through to the generator run, enabling
+Blueprint generation phase progress after Lake has prepared the generator.
 Pass `--pdf` to build `_out/site/pdf/main.pdf` from the generated TeX output.
 `--pdf-engine <cmd>` and `--pdf-runs <n>` are forwarded to the generator when
 the local project's `vbp` binary supports them; run `lake exe vbp --help` for the
@@ -67,8 +62,9 @@ exact local flag surface.
 `build --serve` builds once, then serves `<output>/html-multi` with a local static server and keeps running. Without `--port`, it tries port `8000` and falls back to an available port. With `--serve --port <n>`, it fails if the requested port is unavailable. `--port` is accepted only with `--serve`. The command prints the actual preview URL.
 
 `discover`, `query`, and `check` print compact JSON to stdout on success.
-`build` streams the attached Lake/generator stdout and stderr. If a build stage
-fails, `vbp` writes `vbp build: <stage> failed ...` to stderr and exits nonzero.
+`build` streams the attached Lake/generator stdout and stderr. If the generator
+run fails, `vbp` writes `vbp build: generator run failed ...` to stderr and
+exits nonzero.
 Argument errors print to stderr and exit with code 2. Missing or inconsistent
 generated data also prints an error to stderr and exits nonzero.
 
@@ -109,8 +105,6 @@ The command exits nonzero when generated data is missing, malformed, or internal
 For older projects, inspect the generator entry point, then use:
 
 ```bash
-lake build +<BlueprintLibrary>:olean
-lake lean <GeneratorMain>.lean
 lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean --output _out/site
 lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean --dump-manifest
 lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean --dump-html-cache

--- a/src/VersoBlueprint/VbpMain.lean
+++ b/src/VersoBlueprint/VbpMain.lean
@@ -85,23 +85,32 @@ def generatorModuleFromFile (path : FilePath) : String :=
       text
   text.replace "/" "."
 
-/-- Build only the Blueprint library's OLean dependency closure.
-
-The default `leanArts` facet also emits C, which can turn a Blueprint build in
-a Mathlib consumer into an accidental native rebuild of Mathlib. -/
-def packageOLeanTarget (packageName : String) : String :=
-  s!"+{packageName}:olean"
-
 structure ProjectInfo where
+  workspace : Lake.Workspace
   packageName : String
   generatorFile : FilePath
   generatorModule : String
 
+private def findLakeInstallForLean
+    (leanInstall : Lake.LeanInstall) : BaseIO (Option Lake.LakeInstall) := do
+  if let some home ← IO.getEnv "LAKE_HOME" then
+    let home := FilePath.mk home
+    if home == leanInstall.sysroot then
+      return some <| Lake.LakeInstall.ofLean leanInstall
+    else
+      return some { home }
+  let colocatedLake := leanInstall.binDir / Lake.lakeExe
+  if ← colocatedLake.pathExists then
+    return some <| Lake.LakeInstall.ofLean leanInstall
+  Lake.findLakeInstall?
+
 private def loadWorkspace : IO (Except String Lake.Workspace) := do
   let cwd ← IO.currentDir
-  let (elanInstall?, leanInstall?, lakeInstall?) ← Lake.findInstall?
+  let elanInstall? ← Lake.findElanInstall?
+  let leanInstall? ← Lake.findLeanInstall?
   let some leanInstall := leanInstall?
     | pure (.error "could not detect a Lean installation")
+  let lakeInstall? ← findLakeInstallForLean leanInstall
   let some lakeInstall := lakeInstall?
     | pure (.error "could not detect the configuration of the Lake installation")
   match ← (Lake.Env.compute lakeInstall leanInstall elanInstall?).toBaseIO with
@@ -187,6 +196,7 @@ private def projectInfo : IO (Except String ProjectInfo) := do
           pure (.error s!"could not find a Blueprint generator entry point; expected one of {candidates} or a root-level Lean file with `def main` using VersoBlueprint.PreviewManifest")
       | some generatorFile =>
           pure (.ok {
+            workspace,
             packageName,
             generatorFile,
             generatorModule := generatorModuleFromFile generatorFile
@@ -249,8 +259,7 @@ structure BuildOptions where
   port? : Option Nat := none
 
 structure BuildPlan where
-  packageOLeanTarget : String
-  generatorPrepareArgs : Array String
+  generatorFile : FilePath
   generatorArgs : Array String
 
 private def maxTcpPort : Nat := 65535
@@ -328,44 +337,27 @@ partial def parseSiteOptions : List String → SiteOptions → Except String Sit
   | "--site" :: [], _ => .error "missing value after --site"
   | arg :: args, opts => parseSiteOptions args { opts with rest := arg :: opts.rest }
 
-private def formatCommand (cmd : String) (args : Array String) : String :=
-  String.intercalate " " (cmd :: args.toList)
-
 private def runAttached (cmd : String) (args : Array String) : IO UInt32 := do
   let child ← IO.Process.spawn { cmd, args }
   child.wait
 
-private def runBuildStage (stage cmd : String) (args : Array String) : IO UInt32 := do
-  let code ← runAttached cmd args
+private def runGenerator (workspace : Lake.Workspace) (plan : BuildPlan) : IO UInt32 := do
+  let code ← workspace.evalLeanFile plan.generatorFile plan.generatorArgs
   unless code == 0 do
-    IO.eprintln s!"vbp build: {stage} failed with exit code {code}: {formatCommand cmd args}"
+    IO.eprintln s!"vbp build: generator run failed with exit code {code}: {plan.generatorFile}"
   pure code
 
-private structure BuildStage where
-  stage : String
-  cmd : String
-  args : Array String
-
-private partial def runBuildStages : List BuildStage → IO UInt32
-  | [] => pure 0
-  | stage :: rest => do
-      let code ← runBuildStage stage.stage stage.cmd stage.args
-      if code == 0 then
-        runBuildStages rest
-      else
-        pure code
-
 /--
-Run a generator through Lake's Lean wrapper.
+Run a generator through Lake's Lean setup.
 
 The raw environment-wrapped Lean interpreter form does not load package native
-libraries such as MD4Lean. The `lake lean Foo.lean -- --run Foo.lean ...` form
-does, while still using the package environment that the entry point needs.
+libraries such as MD4Lean. `Lake.Workspace.evalLeanFile` is the implementation
+behind `lake lean`; it builds the generator's imports, constructs the required
+module setup, and loads package native libraries while reusing the workspace
+that VBP already loaded for project discovery.
 -/
-private def generatorRunArgs (generatorFile output : FilePath) (verbose : Bool) : Array String :=
-  let args :=
-    #["lean", generatorFile.toString, "--", "--run", generatorFile.toString,
-      "--output", output.toString]
+def generatorLeanArgs (generatorFile output : FilePath) (verbose : Bool) : Array String :=
+  let args := #["--run", generatorFile.toString, "--output", output.toString]
   if verbose then
     args ++ #["--verbose"]
   else
@@ -381,15 +373,14 @@ private def pdfGeneratorArgs (opts : BuildOptions) : Array String :=
   | some runs => args ++ #[Informal.PreviewManifest.pdfRunsFlag, toString runs]
   | none => args
 
-private def buildPlan (opts : BuildOptions) : IO (Except String BuildPlan) := do
+private def buildPlan (opts : BuildOptions) : IO (Except String (Lake.Workspace × BuildPlan)) := do
   match ← projectInfo with
   | .error err => pure (.error err)
   | .ok info =>
-      pure (.ok {
-        packageOLeanTarget := packageOLeanTarget info.packageName,
-        generatorPrepareArgs := #["lean", info.generatorFile.toString],
-        generatorArgs := generatorRunArgs info.generatorFile opts.output opts.verbose ++ pdfGeneratorArgs opts
-      })
+      pure (.ok (info.workspace, {
+        generatorFile := info.generatorFile
+        generatorArgs := generatorLeanArgs info.generatorFile opts.output opts.verbose ++ pdfGeneratorArgs opts
+      }))
 
 private def serveScript : String := String.intercalate "\n" [
   "import functools, http.server, socketserver, sys",
@@ -438,12 +429,8 @@ def build (args : List String) : IO UInt32 := do
           | .error err =>
               IO.eprintln err
               pure 1
-          | .ok plan =>
-              let code ← runBuildStages [
-                { stage := "package OLean build", cmd := "lake", args := #["build", plan.packageOLeanTarget] },
-                { stage := "generator preparation", cmd := "lake", args := plan.generatorPrepareArgs },
-                { stage := "generator run", cmd := "lake", args := plan.generatorArgs }
-              ]
+          | .ok (workspace, plan) =>
+              let code ← runGenerator workspace plan
               if code != 0 then
                 pure code
               else if opts.serve then

--- a/tests/VersoBlueprintTests/Vbp.lean
+++ b/tests/VersoBlueprintTests/Vbp.lean
@@ -534,9 +534,18 @@ private def graphNodePreviewKeys
         "ProjectTemplateMain" &&
       VersoBlueprint.Vbp.Main.generatorModuleFromFile
           (System.FilePath.mk "Blueprint" / "Main.lean") ==
-        "Blueprint.Main" &&
-      VersoBlueprint.Vbp.Main.packageOLeanTarget "ProjectTemplate" == "+ProjectTemplate:olean" &&
-      VersoBlueprint.Vbp.Main.packageOLeanTarget "Contents" == "+Contents:olean"
+        "Blueprint.Main"
+
+/-- info: true -/
+#guard_msgs in
+#eval
+  show Bool from
+    VersoBlueprint.Vbp.Main.generatorLeanArgs
+        "ProjectTemplateMain.lean" "_out/site" false ==
+      #["--run", "ProjectTemplateMain.lean", "--output", "_out/site"] &&
+    VersoBlueprint.Vbp.Main.generatorLeanArgs
+        "ProjectTemplateMain.lean" "_out/site" true ==
+      #["--run", "ProjectTemplateMain.lean", "--output", "_out/site", "--verbose"]
 
 /-- info: true -/
 #guard_msgs in

--- a/tests/harness/test_blueprint_harness_toolchains.py
+++ b/tests/harness/test_blueprint_harness_toolchains.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from pathlib import Path
+import json
+import re
 import tempfile
 import unittest
+from pathlib import Path
 
 from scripts.blueprint_harness_branches import active_release_branch
 from scripts.blueprint_harness_project_commands import OFFICIAL_BLUEPRINT_REQUIRE_PATTERN
@@ -323,10 +325,12 @@ class BlueprintHarnessToolchainTests(unittest.TestCase):
         assert match is not None
         self.assertEqual(match.group("ref"), active_release_branch(PACKAGE_ROOT))
 
-    def test_root_release_dependencies_track_the_exact_lean_release_ref(self) -> None:
+    def test_root_release_dependencies_track_managed_release_pins(self) -> None:
         text = (PACKAGE_ROOT / "lakefile.lean").read_text(encoding="utf-8")
         verso_match = next(toolchains_mod.VERSO_REQUIRE_PATTERN.finditer(text), None)
         slides_match = next(toolchains_mod.VERSO_SLIDES_REQUIRE_PATTERN.finditer(text), None)
+        manifest = json.loads((PACKAGE_ROOT / "lake-manifest.json").read_text(encoding="utf-8"))
+        manifest_refs = {package["name"]: package["inputRev"] for package in manifest["packages"]}
         lean_ref = toolchains_mod.normalize_lean_release_ref(
             (PACKAGE_ROOT / "lean-toolchain").read_text(encoding="utf-8")
         )
@@ -335,8 +339,12 @@ class BlueprintHarnessToolchainTests(unittest.TestCase):
         self.assertIsNotNone(slides_match)
         assert verso_match is not None
         assert slides_match is not None
-        self.assertEqual(verso_match.group("ref"), lean_ref)
-        self.assertEqual(slides_match.group("ref"), lean_ref)
+        verso_ref = verso_match.group("ref")
+        slides_ref = slides_match.group("ref")
+        self.assertTrue(verso_ref == lean_ref or re.fullmatch(r"[0-9a-f]{40}", verso_ref))
+        self.assertEqual(verso_ref, manifest_refs["verso"])
+        self.assertEqual(slides_ref, lean_ref)
+        self.assertEqual(slides_ref, manifest_refs["«verso-slides»"])
 
 
 if __name__ == "__main__":

--- a/tests/harness/test_verso_blueprint_skill.py
+++ b/tests/harness/test_verso_blueprint_skill.py
@@ -35,7 +35,6 @@ class VersoBlueprintSkillTests(unittest.TestCase):
         self.assertIn("`build --verbose` passes `--verbose` through to the generator run", text)
         self.assertIn("lake exe vbp query [--site <dir>] <selector>", text)
         self.assertIn("lake exe vbp check [--site <dir>]", text)
-        self.assertIn("lake lean <GeneratorMain>.lean", text)
         self.assertIn("lake lean <GeneratorMain>.lean -- --run <GeneratorMain>.lean --output <output>", text)
         self.assertIn("selectors`: query selector forms", text)
         self.assertIn("does not require generated Blueprint data", text)
@@ -56,7 +55,7 @@ class VersoBlueprintSkillTests(unittest.TestCase):
         self.assertIn("topLevelBlueprintModuleGuess", text)
         self.assertIn("chapterCandidateGuesses", text)
         self.assertIn("print compact JSON to stdout on success", text)
-        self.assertIn("writes `vbp build: <stage> failed ...` to stderr", text)
+        self.assertIn("writes `vbp build: generator run failed ...` to stderr", text)
         self.assertIn("fully unstable", text)
         self.assertIn("Fallback Without `vbp`", text)
 
@@ -76,8 +75,9 @@ class VersoBlueprintSkillTests(unittest.TestCase):
     def test_readme_marks_vbp_json_unstable(self) -> None:
         text = (PACKAGE_ROOT / "README.md").read_text(encoding="utf-8")
         self.assertIn("Treat `vbp` query JSON as an unstable", text)
-        self.assertIn("not a public compatibility contract", " ".join(text.split()))
-        self.assertIn("not part of the documented integration API", text)
+        normalized = " ".join(text.split())
+        self.assertIn("not a public compatibility contract", normalized)
+        self.assertIn("not part of the documented integration API", normalized)
 
     def test_maintainer_guide_records_vbp_boundary(self) -> None:
         text = (PACKAGE_ROOT / "doc" / "MAINTAINER_GUIDE.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
Backport #433 to `v4.33.0`.

## Primary Review
- Primary review: #433
- Keep review comments on #433 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.33.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- Retain the Lean 4.33 dependency and toolchain pins.
- Keep `precompileModules := false`, because the precompiled-module setup does not work on Lean 4.33.
- Apply the single-workspace VBP generator path and its documentation/tests.