### PR TITLE
chore: update release Pages targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,9 +384,8 @@ reference projects publish on each Lean release line. Maintainers can inspect
 the current checkout's selected projects with
 `python3 -m scripts.blueprint_reference_harness projects`.
 
-Each external Blueprint is published only for its explicitly declared release
-targets. Noperthedron currently targets `v4.33.0`; FLT and Carleson target both
-`v4.33.0` and `v4.34.0`.
+Each external Blueprint is published only for its intended current release.
+Noperthedron currently targets `v4.33.0`; FLT and Carleson target `v4.34.0`.
 [Sphere Packing](https://github.com/ejgallego/verso-sphere-packing) remains on
 the retired `v4.32.0` line and is temporarily absent from the active catalog
 until it catches up. The in-repo starter template is a CI fixture rather than a
@@ -395,10 +394,8 @@ public reference entry; it continues to validate every maintained release line.
 - [`ejgallego/verso-noperthedron`](https://github.com/ejgallego/verso-noperthedron),
   [rendered site for v4.33.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.33.0/noperthedron/)
 - [`ejgallego/verso-flt`](https://github.com/ejgallego/verso-flt),
-  [rendered site for v4.33.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.33.0/verso-flt/),
   [rendered site for v4.34.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.34.0/verso-flt/)
 - [`ejgallego/verso-carleson`](https://github.com/ejgallego/verso-carleson),
-  [rendered site for v4.33.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.33.0/verso-carleson/),
   [rendered site for v4.34.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.34.0/verso-carleson/)
 
 ## Rendered Test Blueprints

--- a/README.md
+++ b/README.md
@@ -384,8 +384,9 @@ reference projects publish on each Lean release line. Maintainers can inspect
 the current checkout's selected projects with
 `python3 -m scripts.blueprint_reference_harness projects`.
 
-Each external Blueprint is published only for its intended current release.
-Noperthedron, FLT, and Carleson currently target `v4.33.0`.
+Each external Blueprint is published only for its explicitly declared release
+targets. Noperthedron currently targets `v4.33.0`; FLT and Carleson target both
+`v4.33.0` and `v4.34.0`.
 [Sphere Packing](https://github.com/ejgallego/verso-sphere-packing) remains on
 the retired `v4.32.0` line and is temporarily absent from the active catalog
 until it catches up. The in-repo starter template is a CI fixture rather than a
@@ -394,9 +395,11 @@ public reference entry; it continues to validate every maintained release line.
 - [`ejgallego/verso-noperthedron`](https://github.com/ejgallego/verso-noperthedron),
   [rendered site for v4.33.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.33.0/noperthedron/)
 - [`ejgallego/verso-flt`](https://github.com/ejgallego/verso-flt),
-  [rendered site for v4.33.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.33.0/verso-flt/)
+  [rendered site for v4.33.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.33.0/verso-flt/),
+  [rendered site for v4.34.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.34.0/verso-flt/)
 - [`ejgallego/verso-carleson`](https://github.com/ejgallego/verso-carleson),
-  [rendered site for v4.33.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.33.0/verso-carleson/)
+  [rendered site for v4.33.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.33.0/verso-carleson/),
+  [rendered site for v4.34.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.34.0/verso-carleson/)
 
 ## Rendered Test Blueprints
 

--- a/branch-policy.json
+++ b/branch-policy.json
@@ -7,7 +7,7 @@
   "release_targets": [
     {
       "id": "v4.33.0",
-      "toolchain": "v4.33.0",
+      "toolchain": "v4.33.1",
       "verso_ref": "v4.33.0",
       "branch": "v4.33.0",
       "deploy_pages": true
@@ -17,7 +17,7 @@
       "toolchain": "v4.34.0",
       "verso_ref": "v4.34.0",
       "branch": "v4.34.0",
-      "deploy_pages": false
+      "deploy_pages": true
     }
   ]
 }

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -996,7 +996,8 @@ The harness is now project-driven rather than hardcoded to one project.
   `publish_reference: true` marker for the release-facing published catalog
 - keep each external Blueprint on its one intended current release target;
   move that target when the project advances instead of retaining published
-  legacy targets for older releases
+  legacy targets for older releases; manifest loading rejects external projects
+  with more than one target so this cannot silently expand the build matrix
 - prefer `lake exe vbp build` for package-local generation; once running, VBP
   reuses its loaded Lake workspace for discovery and the workspace's Lean-file
   runner. If the harness must drive an external project explicitly, use

--- a/scripts/blueprint_harness_branches.py
+++ b/scripts/blueprint_harness_branches.py
@@ -7,6 +7,7 @@ import subprocess
 from pathlib import Path
 
 from scripts.blueprint_harness_releases import (
+    lean_release_family,
     normalize_lean_release_ref,
     release_branch_from_lean_ref,
 )
@@ -70,7 +71,29 @@ def active_release_branch(repo_root: Path) -> str:
     toolchain_path = repo_root / "lean-toolchain"
     if not toolchain_path.exists():
         raise SystemExit(f"[blueprint-harness] missing lean toolchain file: {toolchain_path}")
-    return release_branch_from_lean_ref(toolchain_path.read_text(encoding="utf-8"))
+    toolchain_branch = release_branch_from_lean_ref(toolchain_path.read_text(encoding="utf-8"))
+
+    policy_path = branch_policy_path(repo_root)
+    if not policy_path.exists():
+        return toolchain_branch
+    policy = load_branch_policy_text(
+        policy_path.read_text(encoding="utf-8"), source_path=policy_path
+    )
+    matching_targets = [
+        target
+        for target in policy.release_targets
+        if lean_release_family(target.release_id) == lean_release_family(toolchain_branch)
+    ]
+    if len(matching_targets) == 1:
+        return matching_targets[0].release_id
+    if not matching_targets:
+        return toolchain_branch
+
+    matching_ids = ", ".join(target.release_id for target in matching_targets)
+    raise SystemExit(
+        f"[blueprint-harness] ambiguous release targets for Lean toolchain `{toolchain_branch}`: "
+        f"{matching_ids}"
+    )
 
 
 def branch_policy_path(checkout_root: Path) -> Path:

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -625,7 +625,12 @@ def command_with_pdf(command: tuple[str, ...]) -> tuple[str, ...]:
     return (*command, "--pdf")
 
 
-def project_manifest_entry(project: HarnessProject, *, include_pdf: bool = False) -> dict[str, object]:
+def project_manifest_entry(
+    project: HarnessProject,
+    *,
+    release_toolchain: str,
+    include_pdf: bool = False,
+) -> dict[str, object]:
     if project.selected_release is None:
         raise ValueError(f"project `{project.project_id}` is missing selected release metadata")
 
@@ -644,7 +649,7 @@ def project_manifest_entry(project: HarnessProject, *, include_pdf: bool = False
     if (
         project.selected_reference_toolchain is not None
         and project.selected_reference_toolchain
-        != normalize_lean_release_ref(project.selected_release)
+        != normalize_lean_release_ref(release_toolchain)
     ):
         target["reference_toolchain"] = project.selected_reference_toolchain
 
@@ -688,7 +693,13 @@ def release_project_manifest(
     return {
         "version": 2,
         "release_targets": [release_target_manifest_entry(target)],
-        "projects": [project_manifest_entry(project, include_pdf=include_pdf)],
+        "projects": [
+            project_manifest_entry(
+                project,
+                release_toolchain=target.release_toolchain,
+                include_pdf=include_pdf,
+            )
+        ],
     }
 
 

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -230,6 +230,11 @@ def _load_project_targets(
     raw_targets = entry.get("targets")
     if not isinstance(raw_targets, list) or not raw_targets:
         raise ValueError(f"{context}: expected non-empty `targets` list")
+    if source_kind == GIT_CHECKOUT_SOURCE_KIND and len(raw_targets) != 1:
+        raise ValueError(
+            f"{context}: external reference projects must declare exactly one target; "
+            "move the existing target when bumping toolchains instead of retaining legacy targets"
+        )
 
     targets: list[HarnessProjectTarget] = []
     seen_releases: set[str] = set()

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -38,7 +38,7 @@
       "targets": [
         {
           "release": "v4.33.0",
-          "ref": "58e5b7e3ce38cc059d0dcd4f5604c666356026bb",
+          "ref": "a544f69b2337f3ee072d1d0ddd93d4dfce776f56",
           "publish_reference": true
         }
       ],
@@ -63,7 +63,14 @@
       "targets": [
         {
           "release": "v4.33.0",
-          "ref": "bdba3568faf918df1aa3024c1e69df98e26b7e5d",
+          "ref": "45bd64912956de1905489f63e53ab92a1cf5deec",
+          "reference_toolchain": "v4.33.0",
+          "publish_reference": true
+        },
+        {
+          "release": "v4.34.0",
+          "ref": "f139c672f01368ec1046223a6d6c452f42c83068",
+          "reference_toolchain": "v4.34.0-rc2",
           "publish_reference": true
         }
       ],
@@ -88,7 +95,14 @@
       "targets": [
         {
           "release": "v4.33.0",
-          "ref": "8810e9d67c7048705fbea66d6f5cf1bacb34f254",
+          "ref": "43a4a82e00fb2e107a535f97c779dcce237a78aa",
+          "reference_toolchain": "v4.33.0",
+          "publish_reference": true
+        },
+        {
+          "release": "v4.34.0",
+          "ref": "3388727088a0b6d211c1d3b29ed19aa4b2350305",
+          "reference_toolchain": "v4.34.0-rc2",
           "publish_reference": true
         }
       ],

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -38,7 +38,7 @@
       "targets": [
         {
           "release": "v4.33.0",
-          "ref": "a544f69b2337f3ee072d1d0ddd93d4dfce776f56",
+          "ref": "109a7936a96707c5e233a1794b9e97ea7f5b51ac",
           "publish_reference": true
         }
       ],
@@ -69,7 +69,7 @@
         },
         {
           "release": "v4.34.0",
-          "ref": "f139c672f01368ec1046223a6d6c452f42c83068",
+          "ref": "071a39d68f5c6bc220c6f0b072b8f13ef2c7aa4d",
           "reference_toolchain": "v4.34.0-rc2",
           "publish_reference": true
         }
@@ -101,7 +101,7 @@
         },
         {
           "release": "v4.34.0",
-          "ref": "3388727088a0b6d211c1d3b29ed19aa4b2350305",
+          "ref": "ff7e1e6e4d0122f5eb5fc2b5eed5d9dfd78dfb7c",
           "reference_toolchain": "v4.34.0-rc2",
           "publish_reference": true
         }

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -62,12 +62,6 @@
       },
       "targets": [
         {
-          "release": "v4.33.0",
-          "ref": "45bd64912956de1905489f63e53ab92a1cf5deec",
-          "reference_toolchain": "v4.33.0",
-          "publish_reference": true
-        },
-        {
           "release": "v4.34.0",
           "ref": "071a39d68f5c6bc220c6f0b072b8f13ef2c7aa4d",
           "reference_toolchain": "v4.34.0-rc2",
@@ -93,12 +87,6 @@
         "project_root": "."
       },
       "targets": [
-        {
-          "release": "v4.33.0",
-          "ref": "43a4a82e00fb2e107a535f97c779dcce237a78aa",
-          "reference_toolchain": "v4.33.0",
-          "publish_reference": true
-        },
         {
           "release": "v4.34.0",
           "ref": "ff7e1e6e4d0122f5eb5fc2b5eed5d9dfd78dfb7c",

--- a/tests/harness/test_blueprint_harness_branches.py
+++ b/tests/harness/test_blueprint_harness_branches.py
@@ -51,6 +51,23 @@ class BlueprintHarnessBranchPolicyTests(unittest.TestCase):
 
             self.assertEqual(branches_mod.active_release_branch(root), SAMPLE_NEXT_RELEASE)
 
+    def test_active_release_branch_uses_policy_release_id_for_point_toolchain(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write(root / "lean-toolchain", f"{lean_toolchain('v4.29.1')}\n")
+            self.write(
+                root / "branch-policy.json",
+                branch_policy_json(
+                    default_dev=SAMPLE_NEXT_RELEASE,
+                    release_targets=[
+                        release_target(SAMPLE_DEFAULT_RELEASE, toolchain="v4.29.1"),
+                        release_target(SAMPLE_NEXT_RELEASE),
+                    ],
+                ),
+            )
+
+            self.assertEqual(branches_mod.active_release_branch(root), SAMPLE_DEFAULT_RELEASE)
+
     def test_load_branch_policy_reads_required_backport_branches(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -211,17 +211,19 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             if expected_ref is not None:
                 self.assertEqual(project.ref, expected_ref)
 
-    def assert_single_maintained_release_target(
+    def assert_maintained_release_targets(
         self,
         project: HarnessProject,
         release_ids: set[str],
         *,
         publish_reference: bool | None = None,
     ) -> None:
-        self.assertEqual(len(project.targets), 1)
-        self.assertIn(project.targets[0].release, release_ids)
+        self.assertTrue(project.targets)
+        self.assertLessEqual({target.release for target in project.targets}, release_ids)
         if publish_reference is not None:
-            self.assertEqual(project.targets[0].publish_reference, publish_reference)
+            self.assertTrue(
+                all(target.publish_reference is publish_reference for target in project.targets)
+            )
 
     def test_default_manifest_contains_release_projects(self) -> None:
         manifest = default_project_manifest(PACKAGE_ROOT)
@@ -280,12 +282,17 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             "verso-flt": "https://github.com/ejgallego/verso-flt.git",
             "verso-carleson": "https://github.com/ejgallego/verso-carleson.git",
         }
+        external_release_ids: set[str] = set()
         for project in projects[1:]:
             self.assertTrue(project.git_checkout)
             self.assertEqual(project.repository, expected_external_repositories[project.project_id])
-            self.assert_single_maintained_release_target(project, release_id_set, publish_reference=True)
+            self.assert_maintained_release_targets(
+                project, release_id_set, publish_reference=True
+            )
+            external_release_ids.update(target.release for target in project.targets)
             self.assertIsNone(project.build_command)
             self.assertEqual(project.generate_command, VBP_BUILD_OUTPUT_COMMAND)
+        self.assertEqual(external_release_ids, release_id_set)
 
     def test_selected_project_toolchain_uses_selected_release(self) -> None:
         project = external_project(selected_release="v4.29.0")
@@ -812,7 +819,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                     "release_targets": [
                         {
                             "id": "v4.28.0",
-                            "toolchain": "v4.28.0",
+                            "toolchain": "v4.28.1",
                             "verso_ref": "v4.28.0",
                             "branch": "v4.28.0",
                             "deploy_pages": True,
@@ -837,6 +844,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
                                 {
                                     "release": "v4.28.0",
                                     "ref": "old-controller-ref",
+                                    "reference_toolchain": "v4.28.0",
                                     "publish_reference": True,
                                 }
                             ],
@@ -919,7 +927,13 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         }
         self.assertEqual(
             manifest_by_project["old-release-project"]["projects"][0]["targets"],
-            [{"release": "v4.28.0", "ref": "old-controller-ref"}],
+            [
+                {
+                    "release": "v4.28.0",
+                    "ref": "old-controller-ref",
+                    "reference_toolchain": "v4.28.0",
+                }
+            ],
         )
         self.assertEqual(
             manifest_by_project["old-release-project"]["projects"][0]["source"]["project_root"],

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -211,19 +211,17 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             if expected_ref is not None:
                 self.assertEqual(project.ref, expected_ref)
 
-    def assert_maintained_release_targets(
+    def assert_single_maintained_release_target(
         self,
         project: HarnessProject,
         release_ids: set[str],
         *,
         publish_reference: bool | None = None,
     ) -> None:
-        self.assertTrue(project.targets)
-        self.assertLessEqual({target.release for target in project.targets}, release_ids)
+        self.assertEqual(len(project.targets), 1)
+        self.assertIn(project.targets[0].release, release_ids)
         if publish_reference is not None:
-            self.assertTrue(
-                all(target.publish_reference is publish_reference for target in project.targets)
-            )
+            self.assertEqual(project.targets[0].publish_reference, publish_reference)
 
     def test_default_manifest_contains_release_projects(self) -> None:
         manifest = default_project_manifest(PACKAGE_ROOT)
@@ -286,7 +284,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         for project in projects[1:]:
             self.assertTrue(project.git_checkout)
             self.assertEqual(project.repository, expected_external_repositories[project.project_id])
-            self.assert_maintained_release_targets(
+            self.assert_single_maintained_release_target(
                 project, release_id_set, publish_reference=True
             )
             external_release_ids.update(target.release for target in project.targets)
@@ -1073,6 +1071,44 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertTrue(projects[0].git_checkout)
         self.assertEqual(projects[0].generate_command, VBP_BUILD_OUTPUT_COMMAND)
         self.assertEqual(projects[0].targets[0].reference_toolchain, "v4.29.0-rc1")
+
+    def test_git_checkout_project_rejects_legacy_release_target(self) -> None:
+        manifest_data = external_catalog_data(
+            vbp_toolchain="v4.33.1",
+            reference_toolchain="v4.33.1",
+        )
+        projects = manifest_data["projects"]
+        self.assertIsInstance(projects, list)
+        project = projects[0]
+        self.assertIsInstance(project, dict)
+        targets = project["targets"]
+        self.assertIsInstance(targets, list)
+        targets.insert(
+            0,
+            {
+                "release": "v4.32.0",
+                "ref": "legacy-reference-ref",
+                "reference_toolchain": "v4.32.0",
+            },
+        )
+        release_targets = manifest_data["release_targets"]
+        self.assertIsInstance(release_targets, list)
+        release_targets.insert(
+            0,
+            {
+                "id": "v4.32.0",
+                "toolchain": "v4.32.0",
+                "verso_ref": "v4.32.0",
+                "branch": "v4.32.0",
+                "deploy_pages": True,
+            },
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "external reference projects must declare exactly one target",
+        ):
+            load_project_catalog_data(manifest_data, "legacy-targets.json")
 
     def test_in_repo_command_project_is_supported(self) -> None:
         manifest_data = {

--- a/tests/harness/test_blueprint_harness_toolchains.py
+++ b/tests/harness/test_blueprint_harness_toolchains.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from scripts.blueprint_harness_branches import active_release_branch
 from scripts.blueprint_harness_project_commands import OFFICIAL_BLUEPRINT_REQUIRE_PATTERN
+from scripts.blueprint_harness_releases import lean_release_family, lean_release_subversion
 import scripts.blueprint_harness_toolchains as toolchains_mod
 from tests.harness.release_fixtures import (
     SAMPLE_DEFAULT_RC_REF,
@@ -341,9 +342,16 @@ class BlueprintHarnessToolchainTests(unittest.TestCase):
         assert slides_match is not None
         verso_ref = verso_match.group("ref")
         slides_ref = slides_match.group("ref")
-        self.assertTrue(verso_ref == lean_ref or re.fullmatch(r"[0-9a-f]{40}", verso_ref))
+
+        def assert_compatible_release_pin(ref: str) -> None:
+            if re.fullmatch(r"[0-9a-f]{40}", ref):
+                return
+            self.assertEqual(lean_release_family(ref), lean_release_family(lean_ref))
+            self.assertLessEqual(lean_release_subversion(ref), lean_release_subversion(lean_ref))
+
+        assert_compatible_release_pin(verso_ref)
         self.assertEqual(verso_ref, manifest_refs["verso"])
-        self.assertEqual(slides_ref, lean_ref)
+        assert_compatible_release_pin(slides_ref)
         self.assertEqual(slides_ref, manifest_refs["«verso-slides»"])
 
 


### PR DESCRIPTION
This PR enables the Lean 4.34 Pages catalog with RC2-compatible FLT and Carleson revisions, updates the maintained v4.33 toolchain/catalog for Lean 4.33.1, and makes release-line checks point-release aware. It also enforces one current target per external reference Blueprint, so moving a project to a new release removes its legacy target instead of silently expanding the build matrix.

Reference integration updates: ejgallego/verso-flt#21, ejgallego/verso-carleson#25, and ejgallego/verso-noperthedron#11.

Backport v4.33.0: #439