### PR TITLE
[backport v4.33.0] chore: update release Pages targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,9 +384,8 @@ reference projects publish on each Lean release line. Maintainers can inspect
 the current checkout's selected projects with
 `python3 -m scripts.blueprint_reference_harness projects`.
 
-Each external Blueprint is published only for its explicitly declared release
-targets. Noperthedron currently targets `v4.33.0`; FLT and Carleson target both
-`v4.33.0` and `v4.34.0`.
+Each external Blueprint is published only for its intended current release.
+Noperthedron currently targets `v4.33.0`; FLT and Carleson target `v4.34.0`.
 [Sphere Packing](https://github.com/ejgallego/verso-sphere-packing) remains on
 the retired `v4.32.0` line and is temporarily absent from the active catalog
 until it catches up. The in-repo starter template is a CI fixture rather than a
@@ -395,10 +394,8 @@ public reference entry; it continues to validate every maintained release line.
 - [`ejgallego/verso-noperthedron`](https://github.com/ejgallego/verso-noperthedron),
   [rendered site for v4.33.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.33.0/noperthedron/)
 - [`ejgallego/verso-flt`](https://github.com/ejgallego/verso-flt),
-  [rendered site for v4.33.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.33.0/verso-flt/),
   [rendered site for v4.34.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.34.0/verso-flt/)
 - [`ejgallego/verso-carleson`](https://github.com/ejgallego/verso-carleson),
-  [rendered site for v4.33.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.33.0/verso-carleson/),
   [rendered site for v4.34.0](https://leanprover.github.io/verso-blueprint/reference-blueprints/v4.34.0/verso-carleson/)
 
 ## Rendered Test Blueprints

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -985,7 +985,8 @@ The harness is now project-driven rather than hardcoded to one project.
   `publish_reference: true` marker for the release-facing published catalog
 - keep each external Blueprint on its one intended current release target;
   move that target when the project advances instead of retaining published
-  legacy targets for older releases
+  legacy targets for older releases; manifest loading rejects external projects
+  with more than one target so this cannot silently expand the build matrix
 - prefer `lake exe vbp build` for package-local generation; once running, VBP
   reuses its loaded Lake workspace for discovery and the workspace's Lean-file
   runner. If the harness must drive an external project explicitly, use

--- a/scripts/blueprint_harness_projects.py
+++ b/scripts/blueprint_harness_projects.py
@@ -230,6 +230,11 @@ def _load_project_targets(
     raw_targets = entry.get("targets")
     if not isinstance(raw_targets, list) or not raw_targets:
         raise ValueError(f"{context}: expected non-empty `targets` list")
+    if source_kind == GIT_CHECKOUT_SOURCE_KIND and len(raw_targets) != 1:
+        raise ValueError(
+            f"{context}: external reference projects must declare exactly one target; "
+            "move the existing target when bumping toolchains instead of retaining legacy targets"
+        )
 
     targets: list[HarnessProjectTarget] = []
     seen_releases: set[str] = set()

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -38,7 +38,7 @@
       "targets": [
         {
           "release": "v4.33.0",
-          "ref": "a544f69b2337f3ee072d1d0ddd93d4dfce776f56",
+          "ref": "109a7936a96707c5e233a1794b9e97ea7f5b51ac",
           "publish_reference": true
         }
       ],
@@ -69,7 +69,7 @@
         },
         {
           "release": "v4.34.0",
-          "ref": "f139c672f01368ec1046223a6d6c452f42c83068",
+          "ref": "071a39d68f5c6bc220c6f0b072b8f13ef2c7aa4d",
           "reference_toolchain": "v4.34.0-rc2",
           "publish_reference": true
         }
@@ -101,7 +101,7 @@
         },
         {
           "release": "v4.34.0",
-          "ref": "3388727088a0b6d211c1d3b29ed19aa4b2350305",
+          "ref": "ff7e1e6e4d0122f5eb5fc2b5eed5d9dfd78dfb7c",
           "reference_toolchain": "v4.34.0-rc2",
           "publish_reference": true
         }

--- a/tests/harness/projects.json
+++ b/tests/harness/projects.json
@@ -62,12 +62,6 @@
       },
       "targets": [
         {
-          "release": "v4.33.0",
-          "ref": "45bd64912956de1905489f63e53ab92a1cf5deec",
-          "reference_toolchain": "v4.33.0",
-          "publish_reference": true
-        },
-        {
           "release": "v4.34.0",
           "ref": "071a39d68f5c6bc220c6f0b072b8f13ef2c7aa4d",
           "reference_toolchain": "v4.34.0-rc2",
@@ -93,12 +87,6 @@
         "project_root": "."
       },
       "targets": [
-        {
-          "release": "v4.33.0",
-          "ref": "43a4a82e00fb2e107a535f97c779dcce237a78aa",
-          "reference_toolchain": "v4.33.0",
-          "publish_reference": true
-        },
         {
           "release": "v4.34.0",
           "ref": "ff7e1e6e4d0122f5eb5fc2b5eed5d9dfd78dfb7c",

--- a/tests/harness/test_blueprint_harness_projects.py
+++ b/tests/harness/test_blueprint_harness_projects.py
@@ -206,19 +206,17 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
             if expected_ref is not None:
                 self.assertEqual(project.ref, expected_ref)
 
-    def assert_maintained_release_targets(
+    def assert_single_maintained_release_target(
         self,
         project: HarnessProject,
         release_ids: set[str],
         *,
         publish_reference: bool | None = None,
     ) -> None:
-        self.assertTrue(project.targets)
-        self.assertLessEqual({target.release for target in project.targets}, release_ids)
+        self.assertEqual(len(project.targets), 1)
+        self.assertIn(project.targets[0].release, release_ids)
         if publish_reference is not None:
-            self.assertTrue(
-                all(target.publish_reference is publish_reference for target in project.targets)
-            )
+            self.assertEqual(project.targets[0].publish_reference, publish_reference)
 
     def test_default_manifest_contains_release_projects(self) -> None:
         manifest = default_project_manifest(PACKAGE_ROOT)
@@ -276,7 +274,7 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         for project in projects[1:]:
             self.assertTrue(project.git_checkout)
             self.assertEqual(project.repository, expected_external_repositories[project.project_id])
-            self.assert_maintained_release_targets(
+            self.assert_single_maintained_release_target(
                 project, release_id_set, publish_reference=True
             )
             external_release_ids.update(target.release for target in project.targets)
@@ -1062,6 +1060,44 @@ class BlueprintHarnessProjectsTests(unittest.TestCase):
         self.assertTrue(projects[0].git_checkout)
         self.assertEqual(projects[0].generate_command, VBP_BUILD_OUTPUT_COMMAND)
         self.assertEqual(projects[0].targets[0].reference_toolchain, "v4.29.0-rc1")
+
+    def test_git_checkout_project_rejects_legacy_release_target(self) -> None:
+        manifest_data = external_catalog_data(
+            vbp_toolchain="v4.33.1",
+            reference_toolchain="v4.33.1",
+        )
+        projects = manifest_data["projects"]
+        self.assertIsInstance(projects, list)
+        project = projects[0]
+        self.assertIsInstance(project, dict)
+        targets = project["targets"]
+        self.assertIsInstance(targets, list)
+        targets.insert(
+            0,
+            {
+                "release": "v4.32.0",
+                "ref": "legacy-reference-ref",
+                "reference_toolchain": "v4.32.0",
+            },
+        )
+        release_targets = manifest_data["release_targets"]
+        self.assertIsInstance(release_targets, list)
+        release_targets.insert(
+            0,
+            {
+                "id": "v4.32.0",
+                "toolchain": "v4.32.0",
+                "verso_ref": "v4.32.0",
+                "branch": "v4.32.0",
+                "deploy_pages": True,
+            },
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "external reference projects must declare exactly one target",
+        ):
+            load_project_catalog_data(manifest_data, "legacy-targets.json")
 
     def test_in_repo_command_project_is_supported(self) -> None:
         manifest_data = {


### PR DESCRIPTION
## Summary
Backport #437 to `v4.33.0`.

## Primary Review
- Primary review: #437
- Keep review comments on #437 unless this backport diverges materially.

## Scope
- Backport the already-reviewed default-development change onto `v4.33.0`.
- Keep this PR limited to release-line-specific conflict resolution.
- Preserve one-to-one commit provenance with `cherry-pick -x`.

## Backport Delta
- PR #438 already landed the first three source commits; this follow-up represents them as empty provenance commits so the paired series remains one-to-one.
- Apply the finalized merged Noperthedron, FLT, and Carleson revisions to the controller catalog.
- Enforce the same single-current-target invariant as #437, leaving only Noperthedron selected by the v4.33 checkout.